### PR TITLE
Change `shell.nix` to stay in sync with `release.nix`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,1 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
-
-let
-
-  inherit (nixpkgs) pkgs;
-
-  haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
-                       else pkgs.haskell.packages.${compiler};
-
-  drv = haskellPackages.callPackage ./. {};
-
-in
-
-  if pkgs.lib.inNixShell then drv.env else drv
+(import ./release.nix).dhall.env


### PR DESCRIPTION
This simplifies the `shell.nix` to reuse the `dhall` derivation from
`release.nix` and also ensures that they stay in sync with one another