### PR TITLE
Fix unbound variable bug

### DIFF
--- a/src/Dhall/TypeCheck.hs
+++ b/src/Dhall/TypeCheck.hs
@@ -175,7 +175,7 @@ typeWith ctx e@(Let f mt r b ) = do
 
     let ctx' = Dhall.Context.insert f tR ctx
     tB  <- typeWith ctx' b
-    ttB <- fmap Dhall.Core.normalize (typeWith ctx tB)
+    ttB <- fmap Dhall.Core.normalize (typeWith ctx' tB)
     kB  <- case ttB of
         Const k -> return k
         -- Don't bother to provide a `let`-specific version of this error

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -85,6 +85,18 @@ parsing0 = Test.Tasty.HUnit.testCase "Parsing regression #0" (do
         Left  e -> Control.Exception.throwIO e
         Right _ -> return () )
 
+typeChecking0 :: TestTree
+typeChecking0 = Test.Tasty.HUnit.testCase "Type-checking regression #0" (do
+    -- There used to be a bug in the type-checking logic where `T` would be
+    -- added to the context when inferring the type of `λ(x : T) → x`, but was
+    -- missing from the context when inferring the kind of the inferred type
+    -- (i.e. the kind of `∀(x : T) → T`).  This led to an unbound variable
+    -- error when inferring the kind
+    --
+    -- This bug was originally reported in issue #10
+    _ <- Util.code "let Day : Type = Natural in λ(x : Day) → x"
+    return ()
+
 trailingSpaceAfterStringLiterals :: TestTree
 trailingSpaceAfterStringLiterals =
     Test.Tasty.HUnit.testCase "Trailing space after string literals" (do

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -95,7 +95,7 @@ typeChecking0 = Test.Tasty.HUnit.testCase "Type-checking regression #0" (do
     --
     -- This bug was originally reported in issue #10
     _ <- Util.code "let Day : Type = Natural in λ(x : Day) → x"
-    return ()
+    return () )
 
 trailingSpaceAfterStringLiterals :: TestTree
 trailingSpaceAfterStringLiterals =


### PR DESCRIPTION
Related to #10

When type-checking the following expression:

```haskell
let Day : Type = Natural in λ(x : Day) → x
```

... Dhall had a bug where it would add `Day : Type` to the context when
inferring the type of `λ(a : Day) → x` (which is `∀(x : Day) → Day`), but `Day`
was missing from the context when inferring the kind of `∀(x : Day) → Day`,
leading to an unbound variable error

This change fixes the bug and adds a regression test to prevent the bug from
recurring