### PR TITLE
Fix type-checking bugs in `let`

### DIFF
--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -23,6 +23,9 @@ regressionTests =
         [ issue96
         , issue126
         , parsing0
+        , typeChecking0
+        , typeChecking1
+        , typeChecking2
         , unnamedFields
         , trailingSpaceAfterStringLiterals
         ]
@@ -95,6 +98,44 @@ typeChecking0 = Test.Tasty.HUnit.testCase "Type-checking regression #0" (do
     --
     -- This bug was originally reported in issue #10
     _ <- Util.code "let Day : Type = Natural in λ(x : Day) → x"
+    return () )
+
+typeChecking1 :: TestTree
+typeChecking1 = Test.Tasty.HUnit.testCase "Type-checking regression #1" (do
+    -- There used to be a bug in the type-checking logic when inferring the
+    -- type of `let`.  Specifically, given an expression of the form:
+    --
+    --     let x : t = e1 in e2
+    --
+    -- ... the type-checker would not substitute `x` for `e1` in the inferred
+    -- of the `let` expression.  This meant that if the inferred type contained
+    -- any references to `x` then these references would escape their scope and
+    -- result in unbound variable exceptions
+    --
+    -- This regression test exercises that code path by creating a `let`
+    -- expression where the inferred type before substitution (`∀(x : b) → b` in
+    -- this example), contains a reference to the `let`-bound variable (`b`)
+    -- that needs to be substituted with `a` in order to produce the final
+    -- correct inferred type (`∀(x : a) → a`).  If this test passes then
+    -- substitution worked correctly.  If substitution doesn't occur then you
+    -- expect an `Unbound variable` error from `b` escaping its scope due to
+    -- being returned as part of the inferred type
+    _ <- Util.code "λ(a : Type) → let b : Type = a in λ(x : b) → x"
+    return () )
+
+typeChecking2 :: TestTree
+typeChecking2 = Test.Tasty.HUnit.testCase "Type-checking regression #2" (do
+    -- There used to be a bug in the type-checking logic where `let` bound
+    -- variables would not correctly shadow variables of the same name when
+    -- inferring the type of of the `let` expression
+    --
+    -- This example exercises this code path with a `let` expression where the
+    -- `let`-bound variable (`a`) has the same name as its own type (`a`).  If
+    -- shadowing works correctly then the final `a` in the expression should
+    -- refer to the `let`-bound variable and not its type.  An invalid reference
+    -- to the shadowed type `a` would result in an invalid dependently typed
+    -- function
+    _ <- Util.code "λ(a : Type) → λ(x : a) → let a : a = x in a"
     return () )
 
 trailingSpaceAfterStringLiterals :: TestTree


### PR DESCRIPTION
Fixes #135

Dhall requires that a `let` expression of the form:

```haskell
let x : t = e1 in e2
```

... should behave the same as the following equivalent lambda expression:

```haskell
(λ(x : t) → e2) e1
```

... meaning that if one type-checks then the other should type-check and (vice
versa) if one does not type-check then the other should not type-check.  The
only difference should be either:

* the error message changes (i.e. to be more `let`-specific)
* the order in which errors are checked might differ

I used equational reasoning to discover two corner cases where the two
expressions diverged in their type-checking behavior.  This change fixes that
and includes two regression tests to capture the two corner cases to prevent
this problem from recurring