### PR TITLE
Remove unnecessary parentheses when printing `if`

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -619,18 +619,18 @@ prettyExprB (BoolIf a b c) =
             <>  prettyExprA a
             <>  Pretty.hardline
             <>  "then  "
-            <>  prettyExprB b
+            <>  prettyExprA b
             <>  Pretty.hardline
             <>  "else  "
-            <>  prettyExprC c
+            <>  prettyExprA c
             )
 
     short = "if "
         <>  prettyExprA a
         <>  " then "
-        <>  prettyExprB b
+        <>  prettyExprA b
         <>  " else "
-        <>  prettyExprC c
+        <>  prettyExprA c
 
 prettyExprB a0@(Pi _ _ _) =
     arrows (fmap duplicate (docs a0))
@@ -1059,9 +1059,9 @@ buildExprB (BoolIf a b c) =
         "if "
     <>  buildExprA a
     <>  " then "
-    <>  buildExprB b
+    <>  buildExprA b
     <>  " else "
-    <>  buildExprC c
+    <>  buildExprA c
 buildExprB (Pi "_" b c) =
         buildExprC b
     <>  " → "


### PR DESCRIPTION
Printing nested `if`/`then`/`else` expressions would result in unnecessary
parentheses, like this:

    if a then b else (if c then d else e)

This is because of a mismatch between the rendering code and the parsing code:

* The parsing code says that `if`/`then`/`else` expressions can be nested
  without parentheses
* The rendering code required parentheses around nested `if`/`then`/`else`
  expressions

This change updates the rendering code to match the parsing code, which removes
the unnecessary parentheses