### PR TITLE
Improve pretty-printing of `if`/`then`/`else`

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -610,28 +610,27 @@ prettyExprB a0@(Lam _ _ _) = arrows (fmap duplicate (docs a0))
             <>  ")"
     docs (Note  _ c) = docs c
     docs          c  = [ prettyExprB c ]
-prettyExprB (BoolIf a b c) =
-    Pretty.group (Pretty.flatAlt long short)
+prettyExprB a0@(BoolIf _ _ _) =
+    enclose' "" "      " " else " (Pretty.hardline <> "else  ") (fmap duplicate (docs a0))
   where
-    long =
-         Pretty.align
-            (   "if    "
+    docs (BoolIf a b c) =
+        Pretty.group (Pretty.flatAlt long short) : docs c
+      where
+        long =
+             Pretty.align
+                (   "if    "
+                <>  prettyExprA a
+                <>  Pretty.hardline
+                <>  "then  "
+                <>  prettyExprA b
+                )
+
+        short = "if "
             <>  prettyExprA a
-            <>  Pretty.hardline
-            <>  "then  "
+            <>  " then "
             <>  prettyExprA b
-            <>  Pretty.hardline
-            <>  "else  "
-            <>  prettyExprA c
-            )
-
-    short = "if "
-        <>  prettyExprA a
-        <>  " then "
-        <>  prettyExprA b
-        <>  " else "
-        <>  prettyExprA c
-
+    docs (Note  _    c) = docs c
+    docs             c  = [ prettyExprB c ]
 prettyExprB a0@(Pi _ _ _) =
     arrows (fmap duplicate (docs a0))
   where


### PR DESCRIPTION
This improves the output when pretty-printing nested `if`/`then`/`else`
expressions

Before this change, nested `if`/`then`/`else` expressions might render like
this in multi-line form:

```haskell
if predicate0
then expression0
else if predicate 1
     then expression1
     else if predicate2
          then expression2
          else expression3
```

After this change they will now render like this:

```haskell
      if predicate0 then expression0
else  if predicate1 then expression1
else  if predicate2 then expression2
else  expression3
```

.. and if horizontal space is really scarce then they will render like this:

```haskell
      if predicate0
      then expression0
else  if predicate1
      then expression1
else  if predicate2
      then expression2
else  expression3
```