### PR TITLE
Optimize `Natural/fold` and `List/fold`

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -1713,6 +1713,27 @@ subst _ _ (Embed p) = Embed p
 normalize ::  Expr s a -> Expr t a
 normalize = normalizeWith (const Nothing)
 
+{-| This function is used to determine whether folds like @Natural/fold@ or
+    @List/fold@ should be lazy or strict in their accumulator based on the type
+    of the accumulator
+
+    If this function returns `True`, then they will be strict in their
+    accumulator since we can guarantee an upper bound on the amount of work to
+    normalize the accumulator on each step of the loop.  If this function
+    returns `False` then they will be lazy in their accumulator and only
+    normalize the final result at the end of the fold
+-}
+boundedType :: Expr s a -> Bool
+boundedType Bool             = True
+boundedType Natural          = True
+boundedType Integer          = True
+boundedType Double           = True
+boundedType Text             = True
+boundedType (App List _)     = False
+boundedType (App Optional t) = boundedType t
+boundedType (Record kvs)     = all boundedType kvs
+boundedType (Union kvs)      = all boundedType kvs
+boundedType _                = False
 
 {-| Reduce an expression to its normal form, performing beta reduction and applying
     any custom definitions.
@@ -1769,11 +1790,17 @@ normalizeWith ctx e0 = loop (shift 0 "_" e0)
             App (App OptionalBuild _) (App (App OptionalFold _) e') -> loop e'
             App (App OptionalFold _) (App (App OptionalBuild _) e') -> loop e'
 
-            App (App (App (App NaturalFold (NaturalLit n0)) _) succ') zero ->
-                loop (go n0)
+            App (App (App (App NaturalFold (NaturalLit n0)) t) succ') zero ->
+                if boundedType (loop t) then strict else lazy
               where
-                go !0 = zero
-                go !n = App succ' (go (n - 1))
+                strict =       strictLoop n0
+                lazy   = loop (  lazyLoop n0)
+
+                strictLoop !0 = loop zero
+                strictLoop !n = loop (App succ' (strictLoop (n - 1)))
+
+                lazyLoop !0 = zero
+                lazyLoop !n = App succ' (lazyLoop (n - 1))
             App NaturalBuild k
                 | check     -> NaturalLit n
                 | otherwise -> App f' a'
@@ -1831,10 +1858,17 @@ normalizeWith ctx e0 = loop (shift 0 "_" e0)
                     go (App (App (Var "Cons") _) e') = go e'
                     go (Var "Nil")                   = True
                     go  _                            = False
-            App (App (App (App (App ListFold _) (ListLit _ xs)) _) cons) nil ->
-                loop (Data.Vector.foldr cons' nil xs)
+            App (App (App (App (App ListFold _) (ListLit _ xs)) t) cons) nil ->
+                if boundedType (loop t) then strict else lazy
               where
-                cons' y ys = App (App cons y) ys
+                strict =       Data.Vector.foldr strictCons strictNil xs
+                lazy   = loop (Data.Vector.foldr   lazyCons   lazyNil xs)
+
+                strictNil = loop nil
+                lazyNil   =      nil
+
+                strictCons y ys = loop (App (App cons y) ys)
+                lazyCons   y ys =       App (App cons y) ys
             App (App ListLength _) (ListLit _ ys) ->
                 NaturalLit (fromIntegral (Data.Vector.length ys))
             App (App ListHead t) (ListLit _ ys) ->


### PR DESCRIPTION
This change modifies the behavior of `Natural/fold` and `List/fold` to
intelligently switch between a lazy or strict accumulator based on the
type of the accumulator

In some cases you want a strict accumulator, such as the following example
code:

```haskell
Natural/fold +3000 Text (λ(x : Text) → x ++ "!") ""
```

With a strict accumulator this runs almost instantly and without a strict
accumulator this takes a very long time to complete

In other cases you want a lazy accumulator, such as the following example:

```haskell
let generate = ./Prelude/List/generate
in  generate +6000 Natural (λ(x : Natural) → x)
```

This runs significantly more quickly with a lazy accumulator because the
accumulator is a list that grows on each iteration of the loop.  If the
accumulator is strict then you have to normalize the entire list on each
iteration which results in quadratic time complexity.  A lazy accumulator only
incurs linear time complexity

The solution is to modify each fold to take advantage of the fact that Dhall
knows the type of the accumulator without doing any type inference since the
type is passed as an argument to the fold.  Dhall inspects the type of the
accumulator to determine whether or not the fold should be strict:

* if the accumulator type has an upper bound on its size then be strict
* otherwise be lazy