### PR TITLE
Make it work with Stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,2 @@
-resolver: lts-9.0
+resolver: lts-9.6
+


### PR DESCRIPTION
prettyprinter's constraint doesn't match on lts-9.0. You get the following error when building with stack:

```
Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for dhall-1.6.0:
    prettyprinter-1.1 must match >=1.1.1 && <1.2 (latest applicable is 1.1.1)
needed since dhall-1.6.0 is a build target.
```

This PR fixes it.