### PR TITLE
Format Prelude using `dhall-format`

### DIFF
--- a/Prelude/Bool/and
+++ b/Prelude/Bool/and
@@ -10,8 +10,9 @@ Examples:
 ./and ([] : List Bool) = True
 ```
 -}
-let and : List Bool → Bool
-    =   λ(xs : List Bool)
-    →   List/fold Bool xs Bool (λ(l : Bool) → λ(r : Bool) → l && r) True
+    let and
+        : List Bool → Bool
+        =   λ(xs : List Bool)
+          → List/fold Bool xs Bool (λ(l : Bool) → λ(r : Bool) → l && r) True
 
 in  and

--- a/Prelude/Bool/build
+++ b/Prelude/Bool/build
@@ -9,8 +9,9 @@ Examples:
 ./build (λ(bool : Type) → λ(true : bool) → λ(false : bool) → false) = False
 ```
 -}
-let build : (∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool) → Bool
-    =   λ(f : ∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool)
-    →   f Bool True False
+    let build
+        : (∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool) → Bool
+        =   λ(f : ∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool)
+          → f Bool True False
 
 in  build

--- a/Prelude/Bool/even
+++ b/Prelude/Bool/even
@@ -14,8 +14,9 @@ Examples:
 ./even ([] : List Bool) = True
 ```
 -}
-let even : List Bool → Bool
-    =   λ(xs : List Bool)
-    →   List/fold Bool xs Bool (λ(x : Bool) → λ(y : Bool) → x == y) True
+    let even
+        : List Bool → Bool
+        =   λ(xs : List Bool)
+          → List/fold Bool xs Bool (λ(x : Bool) → λ(y : Bool) → x == y) True
 
 in  even

--- a/Prelude/Bool/fold
+++ b/Prelude/Bool/fold
@@ -9,11 +9,12 @@ Examples:
 ./fold False Integer 0 1 = 1
 ```
 -}
-let fold : ∀(b : Bool) → ∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool
-    =   λ(b : Bool)
-    →   λ(bool : Type)
-    →   λ(true : bool)
-    →   λ(false : bool)
-    →   if b then true else false
+    let fold
+        : ∀(b : Bool) → ∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool
+        =   λ(b : Bool)
+          → λ(bool : Type)
+          → λ(true : bool)
+          → λ(false : bool)
+          → if b then true else false
 
 in  fold

--- a/Prelude/Bool/not
+++ b/Prelude/Bool/not
@@ -9,7 +9,4 @@ Examples:
 ./not False = True
 ```
 -}
-let not : Bool → Bool
-    =   λ(b : Bool) → b == False
-
-in  not
+let not : Bool → Bool = λ(b : Bool) → b == False in not

--- a/Prelude/Bool/odd
+++ b/Prelude/Bool/odd
@@ -14,8 +14,9 @@ Examples:
 ./odd ([] : List Bool) = False
 ```
 -}
-let odd : List Bool → Bool
-    =   λ(xs : List Bool)
-    →   List/fold Bool xs Bool (λ(x : Bool) → λ(y : Bool) → x != y) False
+    let odd
+        : List Bool → Bool
+        =   λ(xs : List Bool)
+          → List/fold Bool xs Bool (λ(x : Bool) → λ(y : Bool) → x != y) False
 
 in  odd

--- a/Prelude/Bool/or
+++ b/Prelude/Bool/or
@@ -10,8 +10,9 @@ Examples:
 ./or ([] : List Bool) = False
 ```
 -}
-let or : List Bool → Bool
-    =   λ(xs : List Bool)
-    →   List/fold Bool xs Bool (λ(l : Bool) → λ(r : Bool) → l || r) False
+    let or
+        : List Bool → Bool
+        =   λ(xs : List Bool)
+          → List/fold Bool xs Bool (λ(l : Bool) → λ(r : Bool) → l || r) False
 
 in  or

--- a/Prelude/Bool/show
+++ b/Prelude/Bool/show
@@ -10,7 +10,4 @@ Examples:
 ./show False = "False"
 ```
 -}
-let show : Bool → Text
-    =   λ(b : Bool) → if b then "True" else "False"
-
-in  show
+let show : Bool → Text = λ(b : Bool) → if b then "True" else "False" in show

--- a/Prelude/Double/show
+++ b/Prelude/Double/show
@@ -10,7 +10,4 @@ Examples:
 ./show  0.4 =  "0.4"
 ```
 -}
-let show : Double → Text
-    =   Double/show
-
-in  show
+let show : Double → Text = Double/show in show

--- a/Prelude/Integer/show
+++ b/Prelude/Integer/show
@@ -10,7 +10,4 @@ Examples:
 ./show  0 =  "0"
 ```
 -}
-let show : Integer → Text
-    =   Integer/show
-
-in  show
+let show : Integer → Text = Integer/show in show

--- a/Prelude/List/all
+++ b/Prelude/List/all
@@ -10,10 +10,11 @@ Examples:
 ./all Natural Natural/even ([] : List Natural) = True
 ```
 -}
-let all : ∀(a : Type) → (a → Bool) → List a → Bool
-    =   λ(a : Type)
-    →   λ(f : a → Bool)
-    →   λ(xs : List a)
-    →   List/fold a xs Bool (λ(x : a) → λ(r : Bool) → f x && r) True
+    let all
+        : ∀(a : Type) → (a → Bool) → List a → Bool
+        =   λ(a : Type)
+          → λ(f : a → Bool)
+          → λ(xs : List a)
+          → List/fold a xs Bool (λ(x : a) → λ(r : Bool) → f x && r) True
 
 in  all

--- a/Prelude/List/any
+++ b/Prelude/List/any
@@ -10,10 +10,11 @@ Examples:
 ./any Natural Natural/even ([] : List Natural) = False
 ```
 -}
-let any : ∀(a : Type) → (a → Bool) → List a → Bool
-    =   λ(a : Type)
-    →   λ(f : a → Bool)
-    →   λ(xs : List a)
-    →   List/fold a xs Bool (λ(x : a) → λ(r : Bool) → f x || r) False
+    let any
+        : ∀(a : Type) → (a → Bool) → List a → Bool
+        =   λ(a : Type)
+          → λ(f : a → Bool)
+          → λ(xs : List a)
+          → List/fold a xs Bool (λ(x : a) → λ(r : Bool) → f x || r) False
 
 in  any

--- a/Prelude/List/build
+++ b/Prelude/List/build
@@ -23,10 +23,10 @@ Text
 = [] : List Text
 ```
 -}
-let build
-    :   ∀(a : Type)
-    →   (∀(list : Type) → ∀(cons : a → list → list) → ∀(nil : list) → list)
-    →   List a
-    =   List/build
+    let build
+        :   ∀(a : Type)
+          → (∀(list : Type) → ∀(cons : a → list → list) → ∀(nil : list) → list)
+          → List a
+        = List/build
 
 in  build

--- a/Prelude/List/concat
+++ b/Prelude/List/concat
@@ -23,28 +23,21 @@ Examples:
 ./concat Integer ([] : List (List Integer)) = [] : List Integer
 ```
 -}
-let concat : ∀(a : Type) → List (List a) → List a
-    =   λ(a : Type)
-    →   λ(xss : List (List a))
-    →   List/build
-        a
-        (   λ(list : Type)
-        →   λ(cons : a → list → list)
-        →   λ(nil : list)
-        →   List/fold
-            (List a)
-            xss
-            list
-            (   λ(xs : List a)
-            →   λ(ys : list)
-            →   List/fold
-                a
-                xs
+    let concat
+        : ∀(a : Type) → List (List a) → List a
+        =   λ(a : Type)
+          → λ(xss : List (List a))
+          → List/build
+            a
+            (   λ(list : Type)
+              → λ(cons : a → list → list)
+              → λ(nil : list)
+              → List/fold
+                (List a)
+                xss
                 list
-                cons
-                ys
+                (λ(xs : List a) → λ(ys : list) → List/fold a xs list cons ys)
+                nil
             )
-            nil
-        )
 
 in  concat

--- a/Prelude/List/concatMap
+++ b/Prelude/List/concatMap
@@ -12,16 +12,17 @@ Examples:
 = [] : List Natural
 ```
 -}
-let concatMap : ∀(a : Type) → ∀(b : Type) → (a → List b) → List a → List b
-    =   λ(a : Type)
-    →   λ(b : Type)
-    →   λ(f : a → List b)
-    →   λ(xs : List a)
-    →   List/build
-        b
-        (   λ(list : Type)
-        →   λ(cons : b → list → list)
-        →   List/fold a xs list (λ(x : a) → List/fold b (f x) list cons)
-        )
+    let concatMap
+        : ∀(a : Type) → ∀(b : Type) → (a → List b) → List a → List b
+        =   λ(a : Type)
+          → λ(b : Type)
+          → λ(f : a → List b)
+          → λ(xs : List a)
+          → List/build
+            b
+            (   λ(list : Type)
+              → λ(cons : b → list → list)
+              → List/fold a xs list (λ(x : a) → List/fold b (f x) list cons)
+            )
 
 in  concatMap

--- a/Prelude/List/filter
+++ b/Prelude/List/filter
@@ -11,19 +11,20 @@ Examples:
 = [+3, +5] : List Natural
 ```
 -}
-let filter : ∀(a : Type) → (a → Bool) → List a → List a
-    =   λ(a : Type)
-    →   λ(f : a → Bool)
-    →   λ(xs : List a)
-    →   List/build
-        a
-        (   λ(list : Type)
-        →   λ(cons : a → list → list)
-        →   List/fold
+    let filter
+        : ∀(a : Type) → (a → Bool) → List a → List a
+        =   λ(a : Type)
+          → λ(f : a → Bool)
+          → λ(xs : List a)
+          → List/build
             a
-            xs
-            list
-            (λ(x : a) → λ(xs : list) → if f x then cons x xs else xs)
-        )
+            (   λ(list : Type)
+              → λ(cons : a → list → list)
+              → List/fold
+                a
+                xs
+                list
+                (λ(x : a) → λ(xs : list) → if f x then cons x xs else xs)
+            )
 
 in  filter

--- a/Prelude/List/fold
+++ b/Prelude/List/fold
@@ -34,13 +34,13 @@ Examples:
 →   cons +2 (cons +3 (cons +5 nil))
 ```
 -}
-let fold
-    :   ∀(a : Type)
-    →   List a
-    →   ∀(list : Type)
-    →   ∀(cons : a → list → list)
-    →   ∀(nil : list)
-    →   list
-    =   List/fold
+    let fold
+        :   ∀(a : Type)
+          → List a
+          → ∀(list : Type)
+          → ∀(cons : a → list → list)
+          → ∀(nil : list)
+          → list
+        = List/fold
 
 in  fold

--- a/Prelude/List/generate
+++ b/Prelude/List/generate
@@ -10,28 +10,29 @@ Examples:
 ./generate +0 Bool Natural/even = [] : List Bool
 ```
 -}
-let generate : Natural → ∀(a : Type) → (Natural → a) → List a
-    =   λ(n : Natural)
-    →   λ(a : Type)
-    →   λ(f : Natural → a)
-    →   List/build
-        a
-        (   λ(list : Type)
-        →   λ(cons : a → list → list)
-        →   List/fold
-            { index : Natural, value : {} }
-            (   List/indexed
-                {}
-                (   List/build
+    let generate
+        : Natural → ∀(a : Type) → (Natural → a) → List a
+        =   λ(n : Natural)
+          → λ(a : Type)
+          → λ(f : Natural → a)
+          → List/build
+            a
+            (   λ(list : Type)
+              → λ(cons : a → list → list)
+              → List/fold
+                { index : Natural, value : {} }
+                ( List/indexed
+                  {}
+                  ( List/build
                     {}
                     (   λ(list : Type)
-                    →   λ(cons : {} → list → list)
-                    →   Natural/fold n list (cons {=})
+                      → λ(cons : {} → list → list)
+                      → Natural/fold n list (cons {=})
                     )
+                  )
                 )
+                list
+                (λ(x : { index : Natural, value : {} }) → cons (f x.index))
             )
-            list
-            (λ(x : { index : Natural, value : {} }) → cons (f x.index))
-        )
 
 in  generate

--- a/Prelude/List/head
+++ b/Prelude/List/head
@@ -9,7 +9,4 @@ Examples:
 ./head Integer ([] : List Integer) = [] : Optional Integer
 ```
 -}
-let head : ∀(a : Type) → List a → Optional a
-    =   List/head
-
-in  head
+let head : ∀(a : Type) → List a → Optional a = List/head in head

--- a/Prelude/List/indexed
+++ b/Prelude/List/indexed
@@ -14,7 +14,8 @@ Examples:
 = [] : List { index : Natural, value : Bool }
 ```
 -}
-let indexed : ∀(a : Type) → List a → List { index : Natural, value : a }
-    =   List/indexed
+    let indexed
+        : ∀(a : Type) → List a → List { index : Natural, value : a }
+        = List/indexed
 
 in  indexed

--- a/Prelude/List/iterate
+++ b/Prelude/List/iterate
@@ -12,31 +12,32 @@ Examples:
 = [] : List Natural
 ```
 -}
-let iterate : Natural → ∀(a : Type) → (a → a) → a → List a
-    =   λ(n : Natural)
-    →   λ(a : Type)
-    →   λ(f : a → a)
-    →   λ(x : a)
-    →   List/build
-        a
-        (   λ(list : Type)
-        →   λ(cons : a → list → list)
-        →   List/fold
-            { index : Natural, value : {} }
-            (   List/indexed
-                {}
-                (   List/build
+    let iterate
+        : Natural → ∀(a : Type) → (a → a) → a → List a
+        =   λ(n : Natural)
+          → λ(a : Type)
+          → λ(f : a → a)
+          → λ(x : a)
+          → List/build
+            a
+            (   λ(list : Type)
+              → λ(cons : a → list → list)
+              → List/fold
+                { index : Natural, value : {} }
+                ( List/indexed
+                  {}
+                  ( List/build
                     {}
                     (   λ(list : Type)
-                    →   λ(cons : {} → list → list)
-                    →   Natural/fold n list (cons {=})
+                      → λ(cons : {} → list → list)
+                      → Natural/fold n list (cons {=})
                     )
+                  )
+                )
+                list
+                (   λ(y : { index : Natural, value : {} })
+                  → cons (Natural/fold y.index a f x)
                 )
             )
-            list
-            (   λ(y : { index : Natural, value : {} })
-            →   cons (Natural/fold y.index a f x)
-            )
-        )
 
 in  iterate

--- a/Prelude/List/last
+++ b/Prelude/List/last
@@ -9,7 +9,4 @@ Examples:
 ./last Integer ([] : List Integer) = [] : Optional Integer
 ```
 -}
-let last : ∀(a : Type) → List a → Optional a
-    =   List/last
-
-in  last
+let last : ∀(a : Type) → List a → Optional a = List/last in last

--- a/Prelude/List/length
+++ b/Prelude/List/length
@@ -9,7 +9,4 @@ Examples:
 ./length Integer ([] : List Integer) = +0
 ```
 -}
-let length : ∀(a : Type) → List a → Natural
-    =   List/length
-
-in  length
+let length : ∀(a : Type) → List a → Natural = List/length in length

--- a/Prelude/List/map
+++ b/Prelude/List/map
@@ -11,16 +11,17 @@ Examples:
 = [] : List Bool
 ```
 -}
-let map : ∀(a : Type) → ∀(b : Type) → (a → b) → List a → List b
-    =   λ(a : Type)
-    →   λ(b : Type)
-    →   λ(f : a → b)
-    →   λ(xs : List a)
-    →   List/build
-        b
-        (   λ(list : Type)
-        →   λ(cons : b → list → list)
-        →   List/fold a xs list (λ(x : a) → cons (f x))
-        )
+    let map
+        : ∀(a : Type) → ∀(b : Type) → (a → b) → List a → List b
+        =   λ(a : Type)
+          → λ(b : Type)
+          → λ(f : a → b)
+          → λ(xs : List a)
+          → List/build
+            b
+            (   λ(list : Type)
+              → λ(cons : b → list → list)
+              → List/fold a xs list (λ(x : a) → cons (f x))
+            )
 
 in  map

--- a/Prelude/List/null
+++ b/Prelude/List/null
@@ -9,7 +9,8 @@ Examples:
 ./null Integer ([] : List Integer) = True
 ```
 -}
-let null : ∀(a : Type) → List a → Bool
-    =   λ(a : Type) → λ(xs : List a) → Natural/isZero (List/length a xs)
+    let null
+        : ∀(a : Type) → List a → Bool
+        = λ(a : Type) → λ(xs : List a) → Natural/isZero (List/length a xs)
 
 in  null

--- a/Prelude/List/replicate
+++ b/Prelude/List/replicate
@@ -9,15 +9,16 @@ Examples:
 ./replicate +0 Integer 1 = [] : List Integer
 ```
 -}
-let replicate : Natural → ∀(a : Type) → a → List a
-    =   λ(n : Natural)
-    →   λ(a : Type)
-    →   λ(x : a)
-    →   List/build
-        a
-        (   λ(list : Type)
-        →   λ(cons : a → list → list)
-        →   Natural/fold n list (cons x)
-        )
+    let replicate
+        : Natural → ∀(a : Type) → a → List a
+        =   λ(n : Natural)
+          → λ(a : Type)
+          → λ(x : a)
+          → List/build
+            a
+            (   λ(list : Type)
+              → λ(cons : a → list → list)
+              → Natural/fold n list (cons x)
+            )
 
 in  replicate

--- a/Prelude/List/reverse
+++ b/Prelude/List/reverse
@@ -9,7 +9,4 @@ Examples:
 ./reverse Integer ([] : List Integer) = [] : List Integer
 ```
 -}
-let reverse : ∀(a : Type) → List a → List a
-    =   List/reverse
-
-in  reverse
+let reverse : ∀(a : Type) → List a → List a = List/reverse in reverse

--- a/Prelude/List/shifted
+++ b/Prelude/List/shifted
@@ -36,45 +36,53 @@ Bool
 = [] : List { index : Natural, value : Bool }
 ```
 -}
-let shifted
-    :   ∀(a : Type)
-    →   List (List { index : Natural, value : a})
-    →   List { index : Natural, value : a }
-    =   λ(a : Type)
-    →   λ(kvss : List (List { index : Natural, value : a }))
-    →   List/build
-        { index : Natural, value : a }
-        (   λ(list : Type)
-        →   λ(cons : { index : Natural, value : a } → list → list)
-        →   λ(nil  : list)
-        →   let result =
-                List/fold
-                (List { index : Natural, value : a })
-                kvss
-                { count : Natural, diff : Natural → list }
-                (   λ(kvs : List { index : Natural, value : a })
-                →   λ(y : { count : Natural, diff : Natural → list })
-                →   let length = List/length { index : Natural, value : a } kvs
-                in  { count = y.count + length
-                    , diff  =
-                            λ(n : Natural)
-                        →   List/fold
-                            { index : Natural, value : a }
-                            kvs
-                            list
-                            (   λ(kvOld : { index : Natural, value : a })
-                            →   λ(z  : list)
-                            →   let kvNew =
-                                    { index = kvOld.index + n
-                                    , value = kvOld.value
-                                    }
-                            in  cons kvNew z
-                            )
-                            (y.diff (n + length))
-                    }
-                )
-                { count = +0, diff = λ(_ : Natural) → nil }
-            in  result.diff +0
-        )
+    let shifted
+        :   ∀(a : Type)
+          → List (List { index : Natural, value : a })
+          → List { index : Natural, value : a }
+        =   λ(a : Type)
+          → λ(kvss : List (List { index : Natural, value : a }))
+          → List/build
+            { index : Natural, value : a }
+            (   λ(list : Type)
+              → λ(cons : { index : Natural, value : a } → list → list)
+              → λ(nil : list)
+              →     let result =
+                          List/fold
+                          (List { index : Natural, value : a })
+                          kvss
+                          { count : Natural, diff : Natural → list }
+                          (   λ(kvs : List { index : Natural, value : a })
+                            → λ(y : { count : Natural, diff : Natural → list })
+                            →     let length =
+                                        List/length
+                                        { index : Natural, value : a }
+                                        kvs
+                              
+                              in  { count = y.count + length
+                                  , diff  =
+                                        λ(n : Natural)
+                                      → List/fold
+                                        { index : Natural, value : a }
+                                        kvs
+                                        list
+                                        (   λ ( kvOld
+                                              : { index : Natural, value : a }
+                                              )
+                                          → λ(z : list)
+                                          →     let kvNew =
+                                                      { index = kvOld.index + n
+                                                      , value = kvOld.value
+                                                      }
+                                            
+                                            in  cons kvNew z
+                                        )
+                                        (y.diff (n + length))
+                                  }
+                          )
+                          { count = +0, diff = λ(_ : Natural) → nil }
+                
+                in  result.diff +0
+            )
 
 in  shifted

--- a/Prelude/List/unzip
+++ b/Prelude/List/unzip
@@ -20,36 +20,36 @@ Bool
 = { _1 = [] : List Text, _2 = [] : List Bool }
 ```
 -}
-let unzip
-    :   ∀(a : Type)
-    →   ∀(b : Type)
-    →   List { _1 : a, _2 : b }
-    →   { _1 : List a, _2 : List b }
-    =   λ(a : Type)
-    →   λ(b : Type)
-    →   λ(xs : List { _1 : a, _2 : b })
-    →   { _1 =
-            List/build
-            a
-            (   λ(list : Type)
-            →   λ(cons : a → list → list)
-            →   List/fold
-                { _1 : a, _2 : b }
-                xs
-                list
-                (λ(x : { _1 : a, _2 : b }) → cons x._1)
-            )
-        , _2 =
-            List/build
-            b
-            (   λ(list : Type)
-            →   λ(cons : b → list → list)
-            →   List/fold
-                { _1 : a, _2 : b }
-                xs
-                list
-                (λ(x : { _1 : a, _2 : b }) → cons x._2)
-            )
-        }
+    let unzip
+        :   ∀(a : Type)
+          → ∀(b : Type)
+          → List { _1 : a, _2 : b }
+          → { _1 : List a, _2 : List b }
+        =   λ(a : Type)
+          → λ(b : Type)
+          → λ(xs : List { _1 : a, _2 : b })
+          → { _1 =
+                List/build
+                a
+                (   λ(list : Type)
+                  → λ(cons : a → list → list)
+                  → List/fold
+                    { _1 : a, _2 : b }
+                    xs
+                    list
+                    (λ(x : { _1 : a, _2 : b }) → cons x._1)
+                )
+            , _2 =
+                List/build
+                b
+                (   λ(list : Type)
+                  → λ(cons : b → list → list)
+                  → List/fold
+                    { _1 : a, _2 : b }
+                    xs
+                    list
+                    (λ(x : { _1 : a, _2 : b }) → cons x._2)
+                )
+            }
 
 in  unzip

--- a/Prelude/Monoid
+++ b/Prelude/Monoid
@@ -36,7 +36,4 @@ Examples:
     : ./Monoid Text
 ```
 -}
-let Monoid : ∀(m : Type) → Type
-    =   λ(m : Type) → List m → m
-
-in  Monoid
+let Monoid : ∀(m : Type) → Type = λ(m : Type) → List m → m in Monoid

--- a/Prelude/Natural/build
+++ b/Prelude/Natural/build
@@ -21,13 +21,13 @@ Examples:
 = +0
 ```
 -}
-let build
-    :   (   ∀(natural : Type)
-        →   ∀(succ : natural → natural)
-        →   ∀(zero : natural)
-        →   natural
-        )
-    →   Natural
-    =   Natural/build
+    let build
+        :   (   ∀(natural : Type)
+              → ∀(succ : natural → natural)
+              → ∀(zero : natural)
+              → natural
+            )
+          → Natural
+        = Natural/build
 
 in  build

--- a/Prelude/Natural/enumerate
+++ b/Prelude/Natural/enumerate
@@ -10,29 +10,27 @@ Examples:
 ./enumerate +0 = [] : List Natural
 ```
 -}
-let enumerate : Natural → List Natural
-    =   λ(n : Natural)
-    →   List/build
-        Natural
-        (   λ(list : Type)
-        →   λ(cons : Natural → list → list)
-        →   List/fold
-            { index : Natural, value : {} }
-            (   List/indexed
-                {}
-                (   List/build
+    let enumerate
+        : Natural → List Natural
+        =   λ(n : Natural)
+          → List/build
+            Natural
+            (   λ(list : Type)
+              → λ(cons : Natural → list → list)
+              → List/fold
+                { index : Natural, value : {} }
+                ( List/indexed
+                  {}
+                  ( List/build
                     {}
                     (   λ(list : Type)
-                    →   λ(cons : {} → list → list)
-                    →   Natural/fold
-                        n
-                        list
-                        (cons {=})
+                      → λ(cons : {} → list → list)
+                      → Natural/fold n list (cons {=})
                     )
+                  )
                 )
+                list
+                (λ(x : { index : Natural, value : {} }) → cons x.index)
             )
-            list
-            (λ(x : { index : Natural, value : {} }) → cons x.index)
-        )
 
 in  enumerate

--- a/Prelude/Natural/even
+++ b/Prelude/Natural/even
@@ -9,7 +9,4 @@ Examples:
 ./even +0 = True
 ```
 -}
-let even : Natural → Bool
-    =   Natural/even
-
-in  even
+let even : Natural → Bool = Natural/even in even

--- a/Prelude/Natural/fold
+++ b/Prelude/Natural/fold
@@ -22,12 +22,12 @@ Examples:
 →   succ (succ (succ zero))
 ```
 -}
-let fold
-    :   Natural
-    →   ∀(natural : Type)
-    →   ∀(succ : natural → natural)
-    →   ∀(zero : natural)
-    →   natural
-    =   Natural/fold
+    let fold
+        :   Natural
+          → ∀(natural : Type)
+          → ∀(succ : natural → natural)
+          → ∀(zero : natural)
+          → natural
+        = Natural/fold
 
 in  fold

--- a/Prelude/Natural/isZero
+++ b/Prelude/Natural/isZero
@@ -9,7 +9,4 @@ Examples:
 ./isZero +0 = True
 ```
 -}
-let isZero : Natural → Bool
-    =   Natural/isZero
-
-in  isZero
+let isZero : Natural → Bool = Natural/isZero in isZero

--- a/Prelude/Natural/odd
+++ b/Prelude/Natural/odd
@@ -9,7 +9,4 @@ Examples:
 ./odd +0 = False
 ```
 -}
-let odd : Natural → Bool
-    =   Natural/odd
-
-in  odd
+let odd : Natural → Bool = Natural/odd in odd

--- a/Prelude/Natural/product
+++ b/Prelude/Natural/product
@@ -9,8 +9,14 @@ Examples:
 ./product ([] : List Natural) = +1
 ```
 -}
-let product : List Natural → Natural
-    =   λ(xs : List Natural)
-    →   List/fold Natural xs Natural (λ(l : Natural) → λ(r : Natural) → l * r) +1
+    let product
+        : List Natural → Natural
+        =   λ(xs : List Natural)
+          → List/fold
+            Natural
+            xs
+            Natural
+            (λ(l : Natural) → λ(r : Natural) → l * r)
+            +1
 
 in  product

--- a/Prelude/Natural/show
+++ b/Prelude/Natural/show
@@ -10,7 +10,4 @@ Examples:
 ./show +0 = "+0"
 ```
 -}
-let show : Natural → Text
-    =   Natural/show
-
-in  show
+let show : Natural → Text = Natural/show in show

--- a/Prelude/Natural/sum
+++ b/Prelude/Natural/sum
@@ -9,8 +9,14 @@ Examples:
 ./sum ([] : List Natural) = +0
 ```
 -}
-let sum : List Natural → Natural
-    =   λ(xs : List Natural)
-    →   List/fold Natural xs Natural (λ(l : Natural) → λ(r : Natural) → l + r) +0
+    let sum
+        : List Natural → Natural
+        =   λ(xs : List Natural)
+          → List/fold
+            Natural
+            xs
+            Natural
+            (λ(l : Natural) → λ(r : Natural) → l + r)
+            +0
 
 in  sum

--- a/Prelude/Natural/toInteger
+++ b/Prelude/Natural/toInteger
@@ -9,7 +9,4 @@ Examples:
 ./toInteger +0 = 0
 ```
 -}
-let toInteger : Natural → Integer
-    =   Natural/toInteger
-
-in  toInteger
+let toInteger : Natural → Integer = Natural/toInteger in toInteger

--- a/Prelude/Optional/all
+++ b/Prelude/Optional/all
@@ -10,10 +10,11 @@ Examples:
 ./all Natural Natural/even ([] : Optional Natural) = True
 ```
 -}
-let all : ∀(a : Type) → (a → Bool) → Optional a → Bool
-    =   λ(a : Type)
-    →   λ(f : a → Bool)
-    →   λ(xs : Optional a)
-    →   Optional/fold a xs Bool f True
+    let all
+        : ∀(a : Type) → (a → Bool) → Optional a → Bool
+        =   λ(a : Type)
+          → λ(f : a → Bool)
+          → λ(xs : Optional a)
+          → Optional/fold a xs Bool f True
 
 in  all

--- a/Prelude/Optional/any
+++ b/Prelude/Optional/any
@@ -10,10 +10,11 @@ Examples:
 ./any Natural Natural/even ([] : Optional Natural) = False
 ```
 -}
-let any : ∀(a : Type) → (a → Bool) → Optional a → Bool
-    =   λ(a : Type)
-    →   λ(f : a → Bool)
-    →   λ(xs : Optional a)
-    →   Optional/fold a xs Bool f False
+    let any
+        : ∀(a : Type) → (a → Bool) → Optional a → Bool
+        =   λ(a : Type)
+          → λ(f : a → Bool)
+          → λ(xs : Optional a)
+          → Optional/fold a xs Bool f False
 
 in  any

--- a/Prelude/Optional/build
+++ b/Prelude/Optional/build
@@ -23,14 +23,14 @@ Integer
 = [] : Optional Integer
 ```
 -}
-let build
-    :   ∀(a : Type)
-    →   (   ∀(optional : Type)
-        →   ∀(just : a → optional)
-        →   ∀(nothing : optional)
-        →   optional
-        )
-    →   Optional a
-    =   Optional/build
+    let build
+        :   ∀(a : Type)
+          → (   ∀(optional : Type)
+              → ∀(just : a → optional)
+              → ∀(nothing : optional)
+              → optional
+            )
+          → Optional a
+        = Optional/build
 
 in  build

--- a/Prelude/Optional/concat
+++ b/Prelude/Optional/concat
@@ -14,14 +14,15 @@ Examples:
 = [] : Optional Integer
 ```
 -}
-let concat : ∀(a : Type) → Optional (Optional a) → Optional a
-    =   λ(a : Type)
-    →   λ(x : Optional (Optional a))
-    →   Optional/fold
-        (Optional a)
-        x
-        (Optional a)
-        (λ(y : Optional a) → y)
-        ([] : Optional a)
+    let concat
+        : ∀(a : Type) → Optional (Optional a) → Optional a
+        =   λ(a : Type)
+          → λ(x : Optional (Optional a))
+          → Optional/fold
+            (Optional a)
+            x
+            (Optional a)
+            (λ(y : Optional a) → y)
+            ([] : Optional a)
 
 in  concat

--- a/Prelude/Optional/filter
+++ b/Prelude/Optional/filter
@@ -11,21 +11,22 @@ Examples:
 = [] : Optional Natural
 ```
 -}
-let filter : ∀(a : Type) → (a → Bool) → Optional a -> Optional a
-    =   λ(a : Type)
-    →   λ(f : a → Bool)
-    →   λ(xs : Optional a)
-    →   Optional/build
-        a
-        (   λ(optional : Type)
-        →   λ(just : a → optional)
-        →   λ(nil : optional)
-        →   Optional/fold
+    let filter
+        : ∀(a : Type) → (a → Bool) → Optional a → Optional a
+        =   λ(a : Type)
+          → λ(f : a → Bool)
+          → λ(xs : Optional a)
+          → Optional/build
             a
-            xs
-            optional
-            (λ(x : a) → if f x then just x else nil)
-            nil
-        )
+            (   λ(optional : Type)
+              → λ(just : a → optional)
+              → λ(nil : optional)
+              → Optional/fold
+                a
+                xs
+                optional
+                (λ(x : a) → if f x then just x else nil)
+                nil
+            )
 
 in  filter

--- a/Prelude/Optional/fold
+++ b/Prelude/Optional/fold
@@ -9,13 +9,13 @@ Examples:
 ./fold Integer ([]  : Optional Integer) Integer (λ(x : Integer) → x) 0 = 0
 ```
 -}
-let fold
-    :   ∀(a : Type)
-    →   Optional a
-    →   ∀(optional : Type)
-    →   ∀(just : a → optional)
-    →   ∀(nothing : optional)
-    →   optional
-    =   Optional/fold
+    let fold
+        :   ∀(a : Type)
+          → Optional a
+          → ∀(optional : Type)
+          → ∀(just : a → optional)
+          → ∀(nothing : optional)
+          → optional
+        = Optional/fold
 
 in  fold

--- a/Prelude/Optional/head
+++ b/Prelude/Optional/head
@@ -20,17 +20,18 @@ Integer
 = [] : Optional Integer
 ```
 -}
-let head : ∀(a : Type) → List (Optional a) → Optional a
-    =   λ(a : Type)
-    →   λ(xs : List (Optional a))
-    →   List/fold
-        (Optional a)
-        xs
-        (Optional a)
-        (   λ(l : Optional a)
-        →   λ(r : Optional a)
-        →   Optional/fold a l (Optional a) (λ(x : a) → [x] : Optional a) r
-        )
-        ([] : Optional a)
+    let head
+        : ∀(a : Type) → List (Optional a) → Optional a
+        =   λ(a : Type)
+          → λ(xs : List (Optional a))
+          → List/fold
+            (Optional a)
+            xs
+            (Optional a)
+            (   λ(l : Optional a)
+              → λ(r : Optional a)
+              → Optional/fold a l (Optional a) (λ(x : a) → [ x ] : Optional a) r
+            )
+            ([] : Optional a)
 
 in  head

--- a/Prelude/Optional/last
+++ b/Prelude/Optional/last
@@ -20,17 +20,18 @@ Integer
 = [] : Optional Integer
 ```
 -}
-let last : ∀(a : Type) → List (Optional a) → Optional a
-    =   λ(a : Type)
-    →   λ(xs : List (Optional a))
-    →   List/fold
-        (Optional a)
-        xs
-        (Optional a)
-        (   λ(l : Optional a)
-        →   λ(r : Optional a)
-        →   Optional/fold a r (Optional a) (λ(x : a) → [x] : Optional a) l
-        )
-        ([] : Optional a)
+    let last
+        : ∀(a : Type) → List (Optional a) → Optional a
+        =   λ(a : Type)
+          → λ(xs : List (Optional a))
+          → List/fold
+            (Optional a)
+            xs
+            (Optional a)
+            (   λ(l : Optional a)
+              → λ(r : Optional a)
+              → Optional/fold a r (Optional a) (λ(x : a) → [ x ] : Optional a) l
+            )
+            ([] : Optional a)
 
 in  last

--- a/Prelude/Optional/length
+++ b/Prelude/Optional/length
@@ -9,9 +9,10 @@ Examples:
 ./length Integer ([] : Optional Integer) = +0
 ```
 -}
-let length : ∀(a : Type) → Optional a → Natural
-    =   λ(a : Type)
-    →   λ(xs : Optional a)
-    →   Optional/fold a xs Natural (λ(_ : a) → +1) +0
+    let length
+        : ∀(a : Type) → Optional a → Natural
+        =   λ(a : Type)
+          → λ(xs : Optional a)
+          → Optional/fold a xs Natural (λ(_ : a) → +1) +0
 
 in  length

--- a/Prelude/Optional/map
+++ b/Prelude/Optional/map
@@ -11,16 +11,17 @@ Examples:
 = [] : Optional Bool
 ```
 -}
-let map : ∀(a : Type) → ∀(b : Type) → (a → b) → Optional a → Optional b
-    =   λ(a : Type)
-    →   λ(b : Type)
-    →   λ(f : a → b)
-    →   λ(o : Optional a)
-    →   Optional/fold
-        a
-        o
-        (Optional b)
-        (λ(x : a) → [f x] : Optional b)
-        ([] : Optional b)
+    let map
+        : ∀(a : Type) → ∀(b : Type) → (a → b) → Optional a → Optional b
+        =   λ(a : Type)
+          → λ(b : Type)
+          → λ(f : a → b)
+          → λ(o : Optional a)
+          → Optional/fold
+            a
+            o
+            (Optional b)
+            (λ(x : a) → [ f x ] : Optional b)
+            ([] : Optional b)
 
 in  map

--- a/Prelude/Optional/null
+++ b/Prelude/Optional/null
@@ -9,9 +9,10 @@ Examples:
 ./null Integer ([] : Optional Integer) = True
 ```
 -}
-let null : ∀(a : Type) → Optional a → Bool
-    =   λ(a : Type)
-    →   λ(xs : Optional a)
-    →   Optional/fold a xs Bool (λ(_ : a) → False) True
+    let null
+        : ∀(a : Type) → Optional a → Bool
+        =   λ(a : Type)
+          → λ(xs : Optional a)
+          → Optional/fold a xs Bool (λ(_ : a) → False) True
 
 in  null

--- a/Prelude/Optional/toList
+++ b/Prelude/Optional/toList
@@ -9,9 +9,15 @@ Examples:
 ./toList Integer ([] : Optional Integer) = [] : List Integer
 ```
 -}
-let toList : ∀(a : Type) → Optional a → List a
-    =   λ(a : Type)
-    →   λ(o : Optional a)
-    →   Optional/fold a o (List a) (λ(x : a) → [x] : List a) ([] : List a)
+    let toList
+        : ∀(a : Type) → Optional a → List a
+        =   λ(a : Type)
+          → λ(o : Optional a)
+          → Optional/fold
+            a
+            o
+            (List a)
+            (λ(x : a) → ([ x ] : List a))
+            ([] : List a)
 
 in  toList

--- a/Prelude/Optional/unzip
+++ b/Prelude/Optional/unzip
@@ -14,28 +14,28 @@ Bool
 = { _1 = [] : Optional Text, _2 = [] : Optional Bool }
 ```
 -}
-let unzip
-    :   ∀(a : Type)
-    →   ∀(b : Type)
-    →   Optional { _1 : a, _2 : b }
-    →   { _1 : Optional a, _2 : Optional b }
-    =   λ(a : Type)
-    →   λ(b : Type)
-    →   λ(xs : Optional { _1 : a, _2 : b })
-    →   { _1 =
-            Optional/fold
-            { _1 : a, _2 : b }
-            xs
-            (Optional a)
-            (λ(x : { _1 : a, _2 : b }) → [x._1] : Optional a)
-            ([] : Optional a)
-        , _2 =
-            Optional/fold
-            { _1 : a, _2 : b }
-            xs
-            (Optional b)
-            (λ(x : { _1 : a, _2 : b }) → [x._2] : Optional b)
-            ([] : Optional b)
-        }
+    let unzip
+        :   ∀(a : Type)
+          → ∀(b : Type)
+          → Optional { _1 : a, _2 : b }
+          → { _1 : Optional a, _2 : Optional b }
+        =   λ(a : Type)
+          → λ(b : Type)
+          → λ(xs : Optional { _1 : a, _2 : b })
+          → { _1 =
+                Optional/fold
+                { _1 : a, _2 : b }
+                xs
+                (Optional a)
+                (λ(x : { _1 : a, _2 : b }) → [ x._1 ] : Optional a)
+                ([] : Optional a)
+            , _2 =
+                Optional/fold
+                { _1 : a, _2 : b }
+                xs
+                (Optional b)
+                (λ(x : { _1 : a, _2 : b }) → [ x._2 ] : Optional b)
+                ([] : Optional b)
+            }
 
 in  unzip

--- a/Prelude/Text/concat
+++ b/Prelude/Text/concat
@@ -9,8 +9,9 @@ Examples:
 ./concat ([] : List Text) = ""
 ```
 -}
-let concat : List Text → Text
-    =   λ(xs : List Text)
-    →   List/fold Text xs Text (λ(x : Text) → λ(y : Text) → x ++ y) ""
+    let concat
+        : List Text → Text
+        =   λ(xs : List Text)
+          → List/fold Text xs Text (λ(x : Text) → λ(y : Text) → x ++ y) ""
 
 in  concat

--- a/Prelude/Text/concatMap
+++ b/Prelude/Text/concatMap
@@ -11,10 +11,11 @@ Examples:
 = ""
 ```
 -}
-let concatMap : ∀(a : Type) → (a → Text) → List a → Text
-    =   λ(a : Type)
-    →   λ(f : a → Text)
-    →   λ(xs : List a)
-    →   List/fold a xs Text (λ(x : a) → λ(y : Text) → f x ++ y) ""
+    let concatMap
+        : ∀(a : Type) → (a → Text) → List a → Text
+        =   λ(a : Type)
+          → λ(f : a → Text)
+          → λ(xs : List a)
+          → List/fold a xs Text (λ(x : a) → λ(y : Text) → f x ++ y) ""
 
 in  concatMap

--- a/Prelude/Text/concatMapSep
+++ b/Prelude/Text/concatMapSep
@@ -10,38 +10,36 @@ Examples:
 ./concatMapSep ", " Integer Integer/show ([] : List Integer) = ""
 ```
 -}
-let concatMapSep
-    :   ∀(separator : Text) → ∀(a : Type) → (a → Text) → List a → Text
-    =   λ(separator : Text)
-    →   λ(a : Type)
-    →   λ(f : a → Text)
-    →   λ(elements : List a)
-    →   let status
-            =   List/fold
-                a
-                elements
-                < Empty : {} | NonEmpty : Text >
-                (   λ(element : a)
-                →   λ(status : < Empty : {} | NonEmpty : Text >)
-                →   merge
-                    {   Empty
-                        =   λ(_ : {})
-                        →   < NonEmpty = f element
-                            | Empty : {}
-                            >
-                    ,   NonEmpty
-                        =   λ(result : Text)
-                        →   < NonEmpty = f element ++ separator ++ result
-                            | Empty : {}
-                            >
-                    }
-                    status : < Empty : {} | NonEmpty : Text >
-                )
-                < Empty = {=} | NonEmpty : Text >
-    in  merge
-        { Empty    = λ(_ : {}) → ""
-        , NonEmpty = λ(result : Text) → result
-        }
-        status : Text
+    let concatMapSep
+        : ∀(separator : Text) → ∀(a : Type) → (a → Text) → List a → Text
+        =   λ(separator : Text)
+          → λ(a : Type)
+          → λ(f : a → Text)
+          → λ(elements : List a)
+          →     let status =
+                      List/fold
+                      a
+                      elements
+                      < Empty : {} | NonEmpty : Text >
+                      (   λ(element : a)
+                        → λ(status : < Empty : {} | NonEmpty : Text >)
+                        → merge
+                          { Empty    =
+                              λ(_ : {}) → < NonEmpty = f element | Empty : {} >
+                          , NonEmpty =
+                                λ(result : Text)
+                              → < NonEmpty = f element ++ separator ++ result
+                                | Empty    : {}
+                                >
+                          }
+                          status
+                          : < Empty : {} | NonEmpty : Text >
+                      )
+                      < Empty = {=} | NonEmpty : Text >
+            
+            in  merge
+                { Empty = λ(_ : {}) → "", NonEmpty = λ(result : Text) → result }
+                status
+                : Text
 
 in  concatMapSep

--- a/Prelude/Text/concatSep
+++ b/Prelude/Text/concatSep
@@ -9,35 +9,34 @@ Examples:
 ./concatSep ", " ([] : List Text) = ""
 ```
 -}
-let concatSep : ∀(separator : Text) → ∀(elements : List Text) → Text
-    =   λ(separator : Text)
-    →   λ(elements : List Text)
-    →   let status
-            =   List/fold
-                Text
-                elements
-                < Empty : {} | NonEmpty : Text >
-                (   λ(element : Text)
-                →   λ(status : < Empty : {} | NonEmpty : Text >)
-                →   merge
-                    {   Empty
-                        =   λ(_ : {})
-                        →   < NonEmpty = element
-                            | Empty : {}
-                            >
-                    ,   NonEmpty
-                        =   λ(result : Text)
-                        →   < NonEmpty = element ++ separator ++ result
-                            | Empty : {}
-                            >
-                    }
-                    status : < Empty : {} | NonEmpty : Text >
-                )
-                < Empty = {=} | NonEmpty : Text >
-    in  merge
-        { Empty    = λ(_ : {}) → ""
-        , NonEmpty = λ(result : Text) → result
-        }
-        status : Text
+    let concatSep
+        : ∀(separator : Text) → ∀(elements : List Text) → Text
+        =   λ(separator : Text)
+          → λ(elements : List Text)
+          →     let status =
+                      List/fold
+                      Text
+                      elements
+                      < Empty : {} | NonEmpty : Text >
+                      (   λ(element : Text)
+                        → λ(status : < Empty : {} | NonEmpty : Text >)
+                        → merge
+                          { Empty    =
+                              λ(_ : {}) → < NonEmpty = element | Empty : {} >
+                          , NonEmpty =
+                                λ(result : Text)
+                              → < NonEmpty = element ++ separator ++ result
+                                | Empty    : {}
+                                >
+                          }
+                          status
+                          : < Empty : {} | NonEmpty : Text >
+                      )
+                      < Empty = {=} | NonEmpty : Text >
+            
+            in  merge
+                { Empty = λ(_ : {}) → "", NonEmpty = λ(result : Text) → result }
+                status
+                : Text
 
 in  concatSep


### PR DESCRIPTION
I figured we should start to eat our own dogfood and format the Prelude using
`dhall-format`.  I tried it out and was pleased with the results so this change
updates the entire Prelude

The Prelude was already pretty close to what `dhall-format` would output
(indeed, the format of the Prelude inspired `dhall-format`).  The main changes
were:

* Initial `let`s are indented by four spaces
* Some Prelude definitions are formatted to fit on one line

This change also illustrates how the newly updated `dhall-format` successfully
preserves comment headers

I also verified that the change was idempotent: running `dhall-format` a
second time over the Prelude had no effect