### PR TITLE
Fix type-checking bug that permits infinite loop

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -81,6 +81,7 @@ Extra-Source-Files:
     Prelude/Text/concatMap
     Prelude/Text/concatMapSep
     Prelude/Text/concatSep
+    tests/regression/*.dhall
 
 Source-Repository head
     Type: git

--- a/src/Dhall/TypeCheck.hs
+++ b/src/Dhall/TypeCheck.hs
@@ -129,6 +129,7 @@ typeWith ctx e@(Var (V x n)     ) = do
         Nothing -> Left (TypeError ctx e (UnboundVariable x))
         Just a  -> return a
 typeWith ctx   (Lam x _A  b     ) = do
+    _ <- typeWith ctx _A
     let ctx' = fmap (Dhall.Core.shift 1 (V x 0)) (Dhall.Context.insert x _A ctx)
     _B <- typeWith ctx' b
     let p = Pi x _A _B
@@ -140,6 +141,7 @@ typeWith ctx e@(Pi  x _A _B     ) = do
         Const k -> return k
         _       -> Left (TypeError ctx e (InvalidInputType _A))
 
+    _ <- typeWith ctx _A
     let ctx' = fmap (Dhall.Core.shift 1 (V x 0)) (Dhall.Context.insert x _A ctx)
     tB <- fmap Dhall.Core.normalize (typeWith ctx' _B)
     kB <- case tB of
@@ -191,6 +193,7 @@ typeWith ctx e@(Let f mt r b ) = do
         Nothing -> do
             return ()
         Just t  -> do
+            _ <- typeWith ctx t
             let nf_t  = Dhall.Core.normalize t
             let nf_tR = Dhall.Core.normalize tR
             if propEqual nf_tR nf_t

--- a/tests/regression/issue151a.dhall
+++ b/tests/regression/issue151a.dhall
@@ -1,0 +1,1 @@
+let foo : (\(x : A) -> x x) (\(x : A) -> x x) = 1 in foo

--- a/tests/regression/issue151b.dhall
+++ b/tests/regression/issue151b.dhall
@@ -1,0 +1,1 @@
+\(omega : ((\(x : A) -> x x) (\(x : A) -> x x))) -> omega 1


### PR DESCRIPTION
Fixes #151

Dhall is based on a pure type system that has the following rule:

    Γ ⊢ A : s
    ────────────────
    Γ, x : A ⊢ x : A

    Γ ⊢ b : B   Γ ⊢ A : s
    ────────────────
    Γ, x : A ⊢ b : B

... which both enforce that all terms in the context have to be type-checked
themselves before you can use the context to type-check other terms

You can introduce type-checking bugs if you don't type-check terms before adding
them to the context.  The reason why is that the type-checking logic often
normalizes types retrieved from the context and this normalization is not safe
if the terms have not been type-checked first.  Ill-typed terms can introduce
infinite loops when normalized, such as the following term:

    (λ(x : A) → x x) (λ(x : A) → x x)

Dhall's type-checking logic had exactly this issue before this change due to
not type-checking terms added to the context.  This change fixes the problem
and also adds a regression test to prevent this problem from recurring.