### PR TITLE
Fix pretty-printing of `Text` literals

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -224,13 +224,13 @@ hexNumber = choice [ hexDigit, hexUpper, hexLower ]
 
     hexUpper = do
         c <- Text.Parser.Char.satisfy predicate
-        return (Data.Char.ord c - Data.Char.ord 'A')
+        return (10 + Data.Char.ord c - Data.Char.ord 'A')
       where
         predicate c = 'A' <= c && c <= 'F'
 
     hexLower = do
         c <- Text.Parser.Char.satisfy predicate
-        return (Data.Char.ord c - Data.Char.ord 'a')
+        return (10 + Data.Char.ord c - Data.Char.ord 'a')
       where
         predicate c = 'a' <= c && c <= 'f'
 


### PR DESCRIPTION
Fixes #152

This fixes pretty-printed `Text` literals to be valid Dhall code

This also fixes a bug I found along the way in the parsing of Unicode escape
sequences