### PR TITLE
Fix parsing of single quotes in single-quoted strings

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -448,9 +448,7 @@ singleQuoteContinue embedded =
             b <- singleQuoteContinue embedded
             return (textAppend a b)
           where
-            predicate c =
-                    ('\x20' <= c && c <= '\x26'    )
-                ||  ('\x28' <= c && c <= '\x10FFFF')
+            predicate c = '\x20' <= c && c <= '\x10FFFF'
 
         endOfLine = do
             a <- fmap TextLit "\n" <|> fmap TextLit "\r\n"

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -26,6 +26,7 @@ regressionTests =
         [ issue96
         , issue126
         , issue151
+        , issue164
         , parsing0
         , typeChecking0
         , typeChecking1
@@ -106,6 +107,13 @@ issue151 = Test.Tasty.HUnit.testCase "Issue #151" (do
     -- immediately with a type-checking failure.
     shouldNotTypeCheck "./tests/regression/issue151a.dhall"
     shouldNotTypeCheck "./tests/regression/issue151b.dhall" )
+
+issue164 :: TestTree
+issue164 = Test.Tasty.HUnit.testCase "Issue #164" (do
+    -- Verify that parsing should not fail on a single-quote within a
+    -- single-quoted string
+    _ <- Util.code "./tests/regression/issue164.dhall"
+    return () )
 
 parsing0 :: TestTree
 parsing0 = Test.Tasty.HUnit.testCase "Parsing regression #0" (do

--- a/tests/regression/issue164.dhall
+++ b/tests/regression/issue164.dhall
@@ -1,0 +1,1 @@
+''Single quotes like ' should be allowed in a single-quoted string''


### PR DESCRIPTION
Fixes #164

The parser for single-quoted strings did not match the language standard, which
was causing the parser to fail on single quotes.  This fixes the parser to matchthe standard and also adds a test case to prevent against regressions