### PR TITLE
Add support for SHA-256 integrity checks on imports

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,9 @@
-{ mkDerivation, ansi-wl-pprint, base, bytestring, case-insensitive
-, charset, containers, contravariant, exceptions, http-client
-, http-client-tls, lens, optparse-generic, parsers, prettyprinter
-, stdenv, system-fileio, system-filepath, tasty, tasty-hunit, text
-, text-format, transformers, trifecta, unordered-containers, vector
+{ mkDerivation, ansi-wl-pprint, base, base16-bytestring, bytestring
+, case-insensitive, charset, containers, contravariant, cryptohash
+, exceptions, http-client, http-client-tls, lens, optparse-generic
+, parsers, prettyprinter, stdenv, system-fileio, system-filepath
+, tasty, tasty-hunit, text, text-format, transformers, trifecta
+, unordered-containers, vector
 }:
 mkDerivation {
   pname = "dhall";
@@ -11,10 +12,11 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-wl-pprint base bytestring case-insensitive charset containers
-    contravariant exceptions http-client http-client-tls lens parsers
-    prettyprinter system-fileio system-filepath text text-format
-    transformers trifecta unordered-containers vector
+    ansi-wl-pprint base base16-bytestring bytestring case-insensitive
+    charset containers contravariant cryptohash exceptions http-client
+    http-client-tls lens parsers prettyprinter system-fileio
+    system-filepath text text-format transformers trifecta
+    unordered-containers vector
   ];
   executableHaskellDepends = [
     base optparse-generic prettyprinter system-filepath text trifecta

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -93,11 +93,13 @@ Library
     Build-Depends:
         base                 >= 4.9.0.0  && < 5   ,
         ansi-wl-pprint                      < 0.7 ,
+        base16-bytestring                   < 0.2 ,
         bytestring                          < 0.11,
         case-insensitive                    < 1.3 ,
         charset                             < 0.4 ,
         containers           >= 0.5.0.0  && < 0.6 ,
         contravariant                       < 1.5 ,
+        cryptohash                          < 0.12,
         exceptions           >= 0.8.3    && < 0.9 ,
         http-client          >= 0.4.30   && < 0.6 ,
         http-client-tls      >= 0.2.0    && < 0.4 ,


### PR DESCRIPTION
Related to #162

You can now add `sha256:XXX...XXX` after any import to verify that the import
has the expected hash.  This allows you to purify import code and protect the
code against malicious modifications

This is analogous to an IPFS-style import except that the hash is verified
directly by the interpreter instead of trusting that the IPFS URL has not been
compromised

If this is merged then I'll update the standard to reflect the changes to the grammar