### PR TITLE
Change Dhall's integrity check to use an "intensional" hash

### DIFF
--- a/Prelude/Bool/and
+++ b/Prelude/Bool/and
@@ -5,7 +5,7 @@ The `and` function returns `False` if there are any `False` elements in the
 Examples:
 
 ```
-./and ([True, False, True] : List Bool) = False
+./and ([ True, False, True ] : List Bool) = False
 
 ./and ([] : List Bool) = True
 ```

--- a/Prelude/Bool/even
+++ b/Prelude/Bool/even
@@ -5,11 +5,11 @@ returns `False` otherwise
 Examples:
 
 ```
-./even ([False, True, False] : List Bool) = True
+./even ([ False, True, False ] : List Bool) = True
 
-./even ([False, True] : List Bool) = False
+./even ([ False, True ] : List Bool) = False
 
-./even ([False] : List Bool) = False
+./even ([ False ] : List Bool) = False
 
 ./even ([] : List Bool) = True
 ```

--- a/Prelude/Bool/odd
+++ b/Prelude/Bool/odd
@@ -5,11 +5,11 @@ returns `False` otherwise
 Examples:
 
 ```
-./odd ([True, False, True] : List Bool) = False
+./odd ([ True, False, True ] : List Bool) = False
 
-./odd ([True, False] : List Bool) = True
+./odd ([ True, False ] : List Bool) = True
 
-./odd ([True] : List Bool) = True
+./odd ([ True ] : List Bool) = True
 
 ./odd ([] : List Bool) = False
 ```

--- a/Prelude/Bool/or
+++ b/Prelude/Bool/or
@@ -5,7 +5,7 @@ and returns `False` otherwise
 Examples:
 
 ```
-./or ([True, False, True] : List Bool) = True
+./or ([ True, False, True ] : List Bool) = True
 
 ./or ([] : List Bool) = False
 ```

--- a/Prelude/List/all
+++ b/Prelude/List/all
@@ -5,7 +5,7 @@ Returns `True` if the supplied function returns `True` for all elements in the
 Examples:
 
 ```
-./all Natural Natural/even ([+2, +3, +5] : List Natural) = False
+./all Natural Natural/even ([ +2, +3, +5 ] : List Natural) = False
 
 ./all Natural Natural/even ([] : List Natural) = True
 ```

--- a/Prelude/List/any
+++ b/Prelude/List/any
@@ -5,7 +5,7 @@ Returns `True` if the supplied function returns `True` for any element in the
 Examples:
 
 ```
-./any Natural Natural/even ([+2, +3, +5] : List Natural) = True
+./any Natural Natural/even ([ +2, +3, +5 ] : List Natural) = True
 
 ./any Natural Natural/even ([] : List Natural) = False
 ```

--- a/Prelude/List/build
+++ b/Prelude/List/build
@@ -11,7 +11,7 @@ Text
 →   λ(nil : list)
 →   cons "ABC" (cons "DEF" nil)
 )
-= ["ABC", "DEF"] : List Text
+= [ "ABC", "DEF" ] : List Text
 
 ./build
 Text

--- a/Prelude/List/concat
+++ b/Prelude/List/concat
@@ -10,7 +10,7 @@ Examples:
     ,   [5, 6, 7, 8] : List Integer
     ]   : List (List Integer)
 )
-= [0, 1, 2, 3, 4, 5, 6, 7, 8] : List Integer
+= [ 0, 1, 2, 3, 4, 5, 6, 7, 8 ] : List Integer
 
 ./concat Integer
 (   [   [] : List Integer

--- a/Prelude/List/concatMap
+++ b/Prelude/List/concatMap
@@ -6,7 +6,7 @@ Examples:
 
 ```
 ./concatMap Natural Natural (λ(n : Natural) → [n, n]) [+2, +3, +5]
-= [+2, +2, +3, +3, +5, +5] : List Natural
+= [ +2, +2, +3, +3, +5, +5 ] : List Natural
 
 ./concatMap Natural Natural (λ(n : Natural) → [n, n]) ([] : List Natural)
 = [] : List Natural

--- a/Prelude/List/filter
+++ b/Prelude/List/filter
@@ -5,10 +5,10 @@ Examples:
 
 ```
 ./filter Natural Natural/even ([+2, +3, +5] : List Natural)
-= [+2] : List Natural
+= [ +2 ] : List Natural
 
 ./filter Natural Natural/odd ([+2, +3, +5] : List Natural)
-= [+3, +5] : List Natural
+= [ +3, +5 ] : List Natural
 ```
 -}
     let filter

--- a/Prelude/List/fold
+++ b/Prelude/List/fold
@@ -1,7 +1,7 @@
 {-
 `fold` is the primitive function for consuming `List`s
 
-If you treat the list `[x, y, z] : List t` as `cons x (cons y (cons z nil))`,
+If you treat the list `[ x, y, z ] : List t` as `cons x (cons y (cons z nil))`,
 then a `fold` just replaces each `cons` and `nil` with something else
 
 Examples:
@@ -9,7 +9,7 @@ Examples:
 ```
     ./fold
     Natural
-    ([+2, +3, +5] : List Natural)
+    ([ +2, +3, +5 ] : List Natural)
     Natural
     (λ(x : Natural) → λ(y : Natural) → x + y)
     +0
@@ -18,7 +18,7 @@ Examples:
     λ(nil : Natural)
 →   ./fold
     Natural
-    ([+2, +3, +5] : List Natural)
+    ([ +2, +3, +5 ] : List Natural)
     Natural
     (λ(x : Natural) → λ(y : Natural) → x + y)
     nil
@@ -27,7 +27,7 @@ Examples:
     λ(list : Type)
 →   λ(cons : Natural → list → list)
 →   λ(nil : list)
-→   ./fold Natural ([+2, +3, +5] : List Natural) list cons nil
+→   ./fold Natural ([ +2, +3, +5 ] : List Natural) list cons nil
 =   λ(list : Type)
 →   λ(cons : Natural → list → list)
 →   λ(nil : list)

--- a/Prelude/List/generate
+++ b/Prelude/List/generate
@@ -5,7 +5,7 @@ up to but not including the supplied `Natural` number
 Examples:
 
 ```
-./generate +5 Bool Natural/even = [True, False, True, False, True] : List Bool
+./generate +5 Bool Natural/even = [ True, False, True, False, True ] : List Bool
 
 ./generate +0 Bool Natural/even = [] : List Bool
 ```

--- a/Prelude/List/head
+++ b/Prelude/List/head
@@ -4,7 +4,7 @@ Retrieve the first element of the list
 Examples:
 
 ```
-./head Integer ([0, 1, 2] : List Integer) = [0] : Optional Integer
+./head Integer ([ 0, 1, 2 ] : List Integer) = [ 0 ] : Optional Integer
 
 ./head Integer ([] : List Integer) = [] : Optional Integer
 ```

--- a/Prelude/List/indexed
+++ b/Prelude/List/indexed
@@ -4,7 +4,7 @@ Tag each element of the list with its index
 Examples:
 
 ```
-./indexed Bool ([True, False, True] : List Bool)
+./indexed Bool ([ True, False, True ] : List Bool)
 =   [   { index = +0, value = True  }
     ,   { index = +1, value = False }
     ,   { index = +2, value = True  }

--- a/Prelude/List/iterate
+++ b/Prelude/List/iterate
@@ -6,7 +6,7 @@ Examples:
 
 ```
 ./iterate +10 Natural (λ(x : Natural) → x * +2) +1
-= [+1, +2, +4, +8, +16, +32, +64, +128, +256, +512] : List Natural
+= [ +1, +2, +4, +8, +16, +32, +64, +128, +256, +512 ] : List Natural
 
 ./iterate +0 Natural (λ(x : Natural) → x * +2) +1
 = [] : List Natural

--- a/Prelude/List/last
+++ b/Prelude/List/last
@@ -4,7 +4,7 @@ Retrieve the last element of the list
 Examples:
 
 ```
-./last Integer ([0, 1, 2] : List Integer) = [2] : Optional Integer
+./last Integer ([ 0, 1, 2 ] : List Integer) = [ 2 ] : Optional Integer
 
 ./last Integer ([] : List Integer) = [] : Optional Integer
 ```

--- a/Prelude/List/length
+++ b/Prelude/List/length
@@ -4,7 +4,7 @@ Returns the number of elements in a list
 Examples:
 
 ```
-./length Integer ([0, 1, 2] : List Integer) = +3
+./length Integer ([ 0, 1, 2 ] : List Integer) = +3
 
 ./length Integer ([] : List Integer) = +0
 ```

--- a/Prelude/List/map
+++ b/Prelude/List/map
@@ -4,8 +4,8 @@ Tranform a list by applying a function to each element
 Examples:
 
 ```
-./map Natural Bool Natural/even ([+2, +3, +5] : List Natural)
-= [True, False, False] : List Bool
+./map Natural Bool Natural/even ([ +2, +3, +5 ] : List Natural)
+= [ True, False, False ] : List Bool
 
 ./map Natural Bool Natural/even ([] : List Natural)
 = [] : List Bool

--- a/Prelude/List/null
+++ b/Prelude/List/null
@@ -4,7 +4,7 @@ Returns `True` if the `List` is empty and `False` otherwise
 Examples:
 
 ```
-./null Integer ([0, 1, 2] : List Integer) = False
+./null Integer ([ 0, 1, 2 ] : List Integer) = False
 
 ./null Integer ([] : List Integer) = True
 ```

--- a/Prelude/List/replicate
+++ b/Prelude/List/replicate
@@ -4,7 +4,7 @@ Build a list by copying the given element the specified number of times
 Examples:
 
 ```
-./replicate +9 Integer 1 = [1, 1, 1, 1, 1, 1, 1, 1, 1] : List Integer
+./replicate +9 Integer 1 = [ 1, 1, 1, 1, 1, 1, 1, 1, 1 ] : List Integer
 
 ./replicate +0 Integer 1 = [] : List Integer
 ```

--- a/Prelude/List/reverse
+++ b/Prelude/List/reverse
@@ -4,7 +4,7 @@ Reverse a list
 Examples:
 
 ```
-./reverse Integer ([0, 1, 2] : List Integer) = [2, 1, 0] : List Integer
+./reverse Integer ([ 0, 1, 2 ] : List Integer) = [ 2, 1, 0 ] : List Integer
 
 ./reverse Integer ([] : List Integer) = [] : List Integer
 ```

--- a/Prelude/List/unzip
+++ b/Prelude/List/unzip
@@ -12,8 +12,8 @@ Bool
     ,   { _1 = "GHI", _2 = True  }
     ]   : List { _1 : Text, _2 : Bool }
 )
-=   { _1 = ["ABC", "DEF", "GHI"] : List Text
-    , _2 = [True, False, True] : List Bool
+=   { _1 = [ "ABC", "DEF", "GHI" ] : List Text
+    , _2 = [ True, False, True ] : List Bool
     }
 
 ./unzip Text Bool ([] : List { _1 : Text, _2 : Bool })

--- a/Prelude/Natural/enumerate
+++ b/Prelude/Natural/enumerate
@@ -5,7 +5,7 @@ number
 Examples:
 
 ```
-./enumerate +10 = [+0, +1, +2, +3, +4, +5, +6, +7, +8, +9] : List Natural
+./enumerate +10 = [ +0, +1, +2, +3, +4, +5, +6, +7, +8, +9 ] : List Natural
 
 ./enumerate +0 = [] : List Natural
 ```

--- a/Prelude/Natural/product
+++ b/Prelude/Natural/product
@@ -4,7 +4,7 @@ Multiply all the numbers in a `List`
 Examples:
 
 ```
-./product ([+2, +3, +5] : List Natural) = +30
+./product ([ +2, +3, +5 ] : List Natural) = +30
 
 ./product ([] : List Natural) = +1
 ```

--- a/Prelude/Natural/sum
+++ b/Prelude/Natural/sum
@@ -4,7 +4,7 @@ Add all the numbers in a `List`
 Examples:
 
 ```
-./sum ([+2, +3, +5] : List Natural) = +10
+./sum ([ +2, +3, +5 ] : List Natural) = +10
 
 ./sum ([] : List Natural) = +0
 ```

--- a/Prelude/Optional/all
+++ b/Prelude/Optional/all
@@ -5,7 +5,7 @@ and `True` otherwise:
 Examples:
 
 ```
-./all Natural Natural/even ([+3] : Optional Natural) = False
+./all Natural Natural/even ([ +3 ] : Optional Natural) = False
 
 ./all Natural Natural/even ([] : Optional Natural) = True
 ```

--- a/Prelude/Optional/any
+++ b/Prelude/Optional/any
@@ -5,7 +5,7 @@ Returns `True` if the supplied function returns `True` for a present element and
 Examples:
 
 ```
-./any Natural Natural/even ([+2] : Optional Natural) = True
+./any Natural Natural/even ([ +2 ] : Optional Natural) = True
 
 ./any Natural Natural/even ([] : Optional Natural) = False
 ```

--- a/Prelude/Optional/build
+++ b/Prelude/Optional/build
@@ -11,7 +11,7 @@ Integer
 →   λ(nothing : optional)
 →   just 1
 )
-= [1] : Optional Integer
+= [ 1 ] : Optional Integer
 
 ./build
 Integer

--- a/Prelude/Optional/concat
+++ b/Prelude/Optional/concat
@@ -4,10 +4,10 @@ Flatten two `Optional` layers into a single `Optional` layer
 Examples:
 
 ```
-./concat Integer ([[1] : Optional Integer] : Optional (Optional Integer))
-= [1] : Optional Integer
+./concat Integer ([ [ 1 ] : Optional Integer ] : Optional (Optional Integer))
+= [ 1 ] : Optional Integer
 
-./concat Integer ([[] : Optional Integer] : Optional (Optional Integer))
+./concat Integer ([ [] : Optional Integer ] : Optional (Optional Integer))
 = [] : Optional Integer
 
 ./concat Integer ([] : Optional (Optional Integer))

--- a/Prelude/Optional/filter
+++ b/Prelude/Optional/filter
@@ -4,10 +4,10 @@ Only keep an `Optional` element if the supplied function returns `True`
 Examples:
 
 ```
-./filter Natural Natural/even ([+2] : Optional Natural)
-= [+2] : Optional Natural
+./filter Natural Natural/even ([ +2 ] : Optional Natural)
+= [ +2 ] : Optional Natural
 
-./filter Natural Natural/odd ([+2] : Optional Natural)
+./filter Natural Natural/odd ([ +2 ] : Optional Natural)
 = [] : Optional Natural
 ```
 -}

--- a/Prelude/Optional/fold
+++ b/Prelude/Optional/fold
@@ -4,9 +4,9 @@
 Examples:
 
 ```
-./fold Integer ([2] : Optional Integer) Integer (λ(x : Integer) → x) 0 = 2
+./fold Integer ([ 2 ] : Optional Integer) Integer (λ(x : Integer) → x) 0 = 2
 
-./fold Integer ([]  : Optional Integer) Integer (λ(x : Integer) → x) 0 = 0
+./fold Integer ([] : Optional Integer) Integer (λ(x : Integer) → x) 0 = 0
 ```
 -}
     let fold

--- a/Prelude/Optional/head
+++ b/Prelude/Optional/head
@@ -6,14 +6,17 @@ Examples:
 ```
 ./head
 Integer
-(   [[] : Optional Integer, [1] : Optional Integer, [2] : Optional Integer]
+(   [ [   ] : Optional Integer
+    , [ 1 ] : Optional Integer
+    , [ 2 ] : Optional Integer
+    ]
     : List (Optional Integer)
 )
-= [1] : Optional Integer
+= [ 1 ] : Optional Integer
 
 ./head
 Integer
-([[] : Optional Integer, [] : Optional Integer] : List (Optional Integer))
+([ [] : Optional Integer, [] : Optional Integer ] : List (Optional Integer))
 = [] : Optional Integer
 
 ./head Integer ([] : List (Optional Integer))

--- a/Prelude/Optional/last
+++ b/Prelude/Optional/last
@@ -6,14 +6,16 @@ Examples:
 ```
 ./last
 Integer
-(   [[] : Optional Integer, [1] : Optional Integer, [2] : Optional Integer]
-    : List (Optional Integer)
+(   [ [   ] : Optional Integer
+    , [ 1 ] : Optional Integer
+    , [ 2 ] : Optional Integer
+    ] : List (Optional Integer)
 )
-= [2] : Optional Integer
+= [ 2 ] : Optional Integer
 
 ./last
 Integer
-([[] : Optional Integer, [] : Optional Integer] : List (Optional Integer))
+([ [] : Optional Integer, [] : Optional Integer ] : List (Optional Integer))
 = [] : Optional Integer
 
 ./last Integer ([] : List (Optional Integer))

--- a/Prelude/Optional/length
+++ b/Prelude/Optional/length
@@ -4,7 +4,7 @@ Returns `+1` if the `Optional` value is present and `+0` if the value is absent
 Examples:
 
 ```
-./length Integer ([2] : Optional Integer) = +1
+./length Integer ([ 2 ] : Optional Integer) = +1
 
 ./length Integer ([] : Optional Integer) = +0
 ```

--- a/Prelude/Optional/map
+++ b/Prelude/Optional/map
@@ -4,8 +4,8 @@ Transform an `Optional` value with a function
 Examples:
 
 ```
-./map Natural Bool Natural/even ([+3] : Optional Natural)
-= [False] : Optional Bool
+./map Natural Bool Natural/even ([ +3 ] : Optional Natural)
+= [ False ] : Optional Bool
 
 ./map Natural Bool Natural/even ([] : Optional Natural)
 = [] : Optional Bool

--- a/Prelude/Optional/null
+++ b/Prelude/Optional/null
@@ -4,7 +4,7 @@ Returns `True` if the `Optional` value is absent and `False` if present
 Examples:
 
 ```
-./null Integer ([2] : Optional Integer) = False
+./null Integer ([ 2 ] : Optional Integer) = False
 
 ./null Integer ([] : Optional Integer) = True
 ```

--- a/Prelude/Optional/toList
+++ b/Prelude/Optional/toList
@@ -4,7 +4,7 @@ Convert an `Optional` value into the equivalent `List`
 Examples:
 
 ```
-./toList Integer ([1] : Optional Integer) = [1]
+./toList Integer ([ 1 ] : Optional Integer) = [ 1 ]
 
 ./toList Integer ([] : Optional Integer) = [] : List Integer
 ```

--- a/Prelude/Optional/unzip
+++ b/Prelude/Optional/unzip
@@ -7,8 +7,8 @@ Examples:
 ./unzip
 Text
 Bool
-([{ _1 = "ABC", _2 = True  }] : Optional { _1 : Text, _2 : Bool })
-= { _1 = ["ABC"] : Optional Text, _2 = [True] : Optional Bool }
+([ { _1 = "ABC", _2 = True  } ] : Optional { _1 : Text, _2 : Bool })
+= { _1 = [ "ABC" ] : Optional Text, _2 = [ True ] : Optional Bool }
 
 ./unzip Text Bool ([] : Optional { _1 : Text, _2 : Bool })
 = { _1 = [] : Optional Text, _2 = [] : Optional Bool }

--- a/Prelude/Text/concat
+++ b/Prelude/Text/concat
@@ -4,7 +4,7 @@ Concatenate all the `Text` values in a `List`
 Examples:
 
 ```
-./concat (["ABC", "DEF", "GHI"] : List Text) = "ABCDEFGHI"
+./concat ([ "ABC", "DEF", "GHI" ] : List Text) = "ABCDEFGHI"
 
 ./concat ([] : List Text) = ""
 ```

--- a/Prelude/Text/concatMap
+++ b/Prelude/Text/concatMap
@@ -4,7 +4,7 @@ Transform each value in a `List` into `Text` and concatenate the result
 Examples:
 
 ```
-./concatMap Integer (λ(n : Integer) → "${Integer/show n} ") [0, 1, 2]
+./concatMap Integer (λ(n : Integer) → "${Integer/show n} ") [ 0, 1, 2 ]
 = "0 1 2 "
 
 ./concatMap Integer (λ(n : Integer) → "${Integer/show n} ") ([] : List Integer)

--- a/Prelude/Text/concatMapSep
+++ b/Prelude/Text/concatMapSep
@@ -5,7 +5,7 @@ separator in between each value
 Examples:
 
 ```
-./concatMapSep ", " Integer Integer/show [0, 1, 2] = "0, 1, 2"
+./concatMapSep ", " Integer Integer/show [ 0, 1, 2 ] = "0, 1, 2"
 
 ./concatMapSep ", " Integer Integer/show ([] : List Integer) = ""
 ```

--- a/Prelude/Text/concatSep
+++ b/Prelude/Text/concatSep
@@ -4,7 +4,7 @@ Concatenate a `List` of `Text` values with a separator in between each value
 Examples:
 
 ```
-./concatSep ", " ["ABC", "DEF", "GHI"] = "ABC, DEF, GHI"
+./concatSep ", " [ "ABC", "DEF", "GHI" ] = "ABC, DEF, GHI"
 
 ./concatSep ", " ([] : List Text) = ""
 ```

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -75,7 +75,8 @@ import qualified Data.Maybe
 import qualified Data.Text
 import qualified Data.Text.Lazy            as Text
 import qualified Data.Text.Lazy.Builder    as Builder
-import qualified Data.Text.Prettyprint.Doc as Pretty
+import qualified Data.Text.Prettyprint.Doc             as Pretty
+import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
 import qualified Data.Vector
 import qualified Data.Vector.Mutable
 import qualified Filesystem.Path.CurrentOS as Filesystem
@@ -1027,8 +1028,10 @@ prettyUnionLit a b c = angles (front : map adapt (Data.Map.toList c))
     adapt = prettyKeyValue ":" keyLength
 
 -- | Pretty-print a value
-pretty :: Buildable a => a -> Text
-pretty = Builder.toLazyText . build
+pretty :: Pretty a => a -> Text
+pretty = Pretty.renderLazy . Pretty.layoutPretty options . Pretty.pretty
+  where
+   options = Pretty.LayoutOptions { Pretty.layoutPageWidth = Pretty.Unbounded }
 
 -- | Builder corresponding to the @label@ token in "Dhall.Parser"
 buildLabel :: Text -> Builder

--- a/src/Dhall/TypeCheck.hs
+++ b/src/Dhall/TypeCheck.hs
@@ -3152,7 +3152,7 @@ data TypeError s = TypeError
     } deriving (Typeable)
 
 instance Buildable s => Show (TypeError s) where
-    show = Text.unpack . Dhall.Core.pretty
+    show = Text.unpack . Builder.toLazyText . build
 
 instance (Buildable s, Typeable s) => Exception (TypeError s)
 
@@ -3186,7 +3186,7 @@ newtype DetailedTypeError s = DetailedTypeError (TypeError s)
     deriving (Typeable)
 
 instance Buildable s => Show (DetailedTypeError s) where
-    show = Text.unpack . Dhall.Core.pretty
+    show = Text.unpack . Builder.toLazyText . build
 
 instance (Buildable s, Typeable s) => Exception (DetailedTypeError s)
 

--- a/tests/Examples.hs
+++ b/tests/Examples.hs
@@ -275,7 +275,7 @@ exampleTests =
 
 _Bool_and_0 :: TestTree
 _Bool_and_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Bool/and ([True, False, True] : List Bool)"
+    e <- Util.code "./Prelude/Bool/and ([ True, False, True ] : List Bool)"
     Util.assertNormalizesTo e "False" )
 
 _Bool_and_1 :: TestTree
@@ -297,17 +297,17 @@ _Bool_build_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Bool_even_0 :: TestTree
 _Bool_even_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Bool/even ([False, True, False] : List Bool)"
+    e <- Util.code "./Prelude/Bool/even ([ False, True, False ] : List Bool)"
     Util.assertNormalizesTo e "True" )
 
 _Bool_even_1 :: TestTree
 _Bool_even_1 = Test.Tasty.HUnit.testCase "Example #1" (do
-    e <- Util.code "./Prelude/Bool/even ([False, True] : List Bool)"
+    e <- Util.code "./Prelude/Bool/even ([ False, True ] : List Bool)"
     Util.assertNormalizesTo e "False" )
 
 _Bool_even_2 :: TestTree
 _Bool_even_2 = Test.Tasty.HUnit.testCase "Example #2" (do
-    e <- Util.code "./Prelude/Bool/even ([False] : List Bool)"
+    e <- Util.code "./Prelude/Bool/even ([ False ] : List Bool)"
     Util.assertNormalizesTo e "False" )
 
 _Bool_even_3 :: TestTree
@@ -337,17 +337,17 @@ _Bool_not_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Bool_odd_0 :: TestTree
 _Bool_odd_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Bool/odd ([True, False, True] : List Bool)"
+    e <- Util.code "./Prelude/Bool/odd ([ True, False, True ] : List Bool)"
     Util.assertNormalizesTo e "False" )
 
 _Bool_odd_1 :: TestTree
 _Bool_odd_1 = Test.Tasty.HUnit.testCase "Example #1" (do
-    e <- Util.code "./Prelude/Bool/odd ([True, False] : List Bool)"
+    e <- Util.code "./Prelude/Bool/odd ([ True, False ] : List Bool)"
     Util.assertNormalizesTo e "True" )
 
 _Bool_odd_2 :: TestTree
 _Bool_odd_2 = Test.Tasty.HUnit.testCase "Example #2" (do
-    e <- Util.code "./Prelude/Bool/odd ([True] : List Bool)"
+    e <- Util.code "./Prelude/Bool/odd ([ True ] : List Bool)"
     Util.assertNormalizesTo e "True" )
 
 _Bool_odd_3 :: TestTree
@@ -357,7 +357,7 @@ _Bool_odd_3 = Test.Tasty.HUnit.testCase "Example #3" (do
 
 _Bool_or_0 :: TestTree
 _Bool_or_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Bool/or ([True, False, True] : List Bool)"
+    e <- Util.code "./Prelude/Bool/or ([ True, False, True ] : List Bool)"
     Util.assertNormalizesTo e "True" )
 
 _Bool_or_1 :: TestTree
@@ -397,7 +397,7 @@ _Integer_show_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _List_all_0 :: TestTree
 _List_all_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/List/all Natural Natural/even ([+2, +3, +5] : List Natural)"
+    e <- Util.code "./Prelude/List/all Natural Natural/even ([ +2, +3, +5 ] : List Natural)"
     Util.assertNormalizesTo e "False" )
 
 _List_all_1 :: TestTree
@@ -407,7 +407,7 @@ _List_all_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _List_any_0 :: TestTree
 _List_any_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/List/any Natural Natural/even ([+2, +3, +5] : List Natural)"
+    e <- Util.code "./Prelude/List/any Natural Natural/even ([ +2, +3, +5 ] : List Natural)"
     Util.assertNormalizesTo e "True" )
 
 _List_any_1 :: TestTree
@@ -425,7 +425,7 @@ _List_build_0 = Test.Tasty.HUnit.testCase "Example #0" (do
         \→   λ(nil : list)                  \n\
         \→   cons \"ABC\" (cons \"DEF\" nil)\n\
         \)                                  \n"
-    Util.assertNormalizesTo e "[\"ABC\", \"DEF\"] : List Text" )
+    Util.assertNormalizesTo e "[ \"ABC\", \"DEF\" ] : List Text" )
 
 _List_build_1 :: TestTree
 _List_build_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -448,7 +448,7 @@ _List_concat_0 = Test.Tasty.HUnit.testCase "Example #0" (do
         \    ,   [5, 6, 7, 8] : List Integer\n\
         \    ]   : List (List Integer)      \n\
         \)                                  \n"
-    Util.assertNormalizesTo e "[0, 1, 2, 3, 4, 5, 6, 7, 8] : List Integer" )
+    Util.assertNormalizesTo e "[ 0, 1, 2, 3, 4, 5, 6, 7, 8 ] : List Integer" )
 
 _List_concat_1 :: TestTree
 _List_concat_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -465,7 +465,7 @@ _List_concatMap_0 :: TestTree
 _List_concatMap_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
         "./Prelude/List/concatMap Natural Natural (λ(n : Natural) → [n, n]) [+2, +3, +5]"
-    Util.assertNormalizesTo e "[+2, +2, +3, +3, +5, +5] : List Natural" )
+    Util.assertNormalizesTo e "[ +2, +2, +3, +3, +5, +5 ] : List Natural" )
 
 _List_concatMap_1 :: TestTree
 _List_concatMap_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -477,19 +477,19 @@ _List_filter_0 :: TestTree
 _List_filter_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
         "./Prelude/List/filter Natural Natural/even ([+2, +3, +5] : List Natural)"
-    Util.assertNormalizesTo e "[+2] : List Natural" )
+    Util.assertNormalizesTo e "[ +2 ] : List Natural" )
 
 _List_filter_1 :: TestTree
 _List_filter_1 = Test.Tasty.HUnit.testCase "Example #1" (do
     e <- Util.code "./Prelude/List/filter Natural Natural/odd ([+2, +3, +5] : List Natural)"
-    Util.assertNormalizesTo e "[+3, +5] : List Natural" )
+    Util.assertNormalizesTo e "[ +3, +5 ] : List Natural" )
 
 _List_fold_0 :: TestTree
 _List_fold_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
         "./Prelude/List/fold                      \n\
         \Natural                                  \n\
-        \([+2, +3, +5] : List Natural)            \n\
+        \([ +2, +3, +5 ] : List Natural)          \n\
         \Natural                                  \n\
         \(λ(x : Natural) → λ(y : Natural) → x + y)\n\
         \+0                                       \n"
@@ -501,7 +501,7 @@ _List_fold_1 = Test.Tasty.HUnit.testCase "Example #1" (do
         "    λ(nil : Natural)                         \n\
         \→   ./Prelude/List/fold                      \n\
         \    Natural                                  \n\
-        \    ([+2, +3, +5] : List Natural)            \n\
+        \    ([ +2, +3, +5 ] : List Natural)          \n\
         \    Natural                                  \n\
         \    (λ(x : Natural) → λ(y : Natural) → x + y)\n\
         \    nil                                      \n"
@@ -513,13 +513,13 @@ _List_fold_2 = Test.Tasty.HUnit.testCase "Example #2" (do
         "    λ(list : Type)                                                         \n\
         \→   λ(cons : Natural → list → list)                                        \n\
         \→   λ(nil : list)                                                          \n\
-        \→   ./Prelude/List/fold Natural ([+2, +3, +5] : List Natural) list cons nil\n"
+        \→   ./Prelude/List/fold Natural ([ +2, +3, +5 ] : List Natural) list cons nil\n"
     Util.assertNormalizesTo e "λ(list : Type) → λ(cons : Natural → list → list) → λ(nil : list) → cons +2 (cons +3 (cons +5 nil))" )
 
 _List_generate_0 :: TestTree
 _List_generate_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code "./Prelude/List/generate +5 Bool Natural/even"
-    Util.assertNormalizesTo e "[True, False, True, False, True] : List Bool" )
+    Util.assertNormalizesTo e "[ True, False, True, False, True ] : List Bool" )
 
 _List_generate_1 :: TestTree
 _List_generate_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -528,8 +528,8 @@ _List_generate_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _List_head_0 :: TestTree
 _List_head_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/List/head Integer ([0, 1, 2] : List Integer)"
-    Util.assertNormalizesTo e "[0] : Optional Integer" )
+    e <- Util.code "./Prelude/List/head Integer ([ 0, 1, 2 ] : List Integer)"
+    Util.assertNormalizesTo e "[ 0 ] : Optional Integer" )
 
 _List_head_1 :: TestTree
 _List_head_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -538,8 +538,8 @@ _List_head_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _List_indexed_0 :: TestTree
 _List_indexed_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/List/indexed Bool ([True, False, True] : List Bool)"
-    Util.assertNormalizesTo e "[{ index = +0, value = True }, { index = +1, value = False }, { index = +2, value = True }] : List { index : Natural, value : Bool }" )
+    e <- Util.code "./Prelude/List/indexed Bool ([ True, False, True ] : List Bool)"
+    Util.assertNormalizesTo e "[ { index = +0, value = True }, { index = +1, value = False }, { index = +2, value = True } ] : List { index : Natural, value : Bool }" )
 
 _List_indexed_1 :: TestTree
 _List_indexed_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -549,7 +549,7 @@ _List_indexed_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _List_iterate_0 :: TestTree
 _List_iterate_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code "./Prelude/List/iterate +10 Natural (λ(x : Natural) → x * +2) +1"
-    Util.assertNormalizesTo e "[+1, +2, +4, +8, +16, +32, +64, +128, +256, +512] : List Natural" )
+    Util.assertNormalizesTo e "[ +1, +2, +4, +8, +16, +32, +64, +128, +256, +512 ] : List Natural" )
 
 _List_iterate_1 :: TestTree
 _List_iterate_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -558,8 +558,8 @@ _List_iterate_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _List_last_0 :: TestTree
 _List_last_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/List/last Integer ([0, 1, 2] : List Integer)"
-    Util.assertNormalizesTo e "[2] : Optional Integer" )
+    e <- Util.code "./Prelude/List/last Integer ([ 0, 1, 2 ] : List Integer)"
+    Util.assertNormalizesTo e "[ 2 ] : Optional Integer" )
 
 _List_last_1 :: TestTree
 _List_last_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -568,7 +568,7 @@ _List_last_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _List_length_0 :: TestTree
 _List_length_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/List/length Integer ([0, 1, 2] : List Integer)"
+    e <- Util.code "./Prelude/List/length Integer ([ 0, 1, 2 ] : List Integer)"
     Util.assertNormalizesTo e "+3" )
 
 _List_length_1 :: TestTree
@@ -579,8 +579,8 @@ _List_length_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _List_map_0 :: TestTree
 _List_map_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
-        "./Prelude/List/map Natural Bool Natural/even ([+2, +3, +5] : List Natural)"
-    Util.assertNormalizesTo e "[True, False, False] : List Bool" )
+        "./Prelude/List/map Natural Bool Natural/even ([ +2, +3, +5 ] : List Natural)"
+    Util.assertNormalizesTo e "[ True, False, False ] : List Bool" )
 
 _List_map_1 :: TestTree
 _List_map_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -589,7 +589,7 @@ _List_map_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _List_null_0 :: TestTree
 _List_null_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/List/null Integer ([0, 1, 2] : List Integer)"
+    e <- Util.code "./Prelude/List/null Integer ([ 0, 1, 2 ] : List Integer)"
     Util.assertNormalizesTo e "False" )
 
 _List_null_1 :: TestTree
@@ -600,7 +600,7 @@ _List_null_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _List_replicate_0 :: TestTree
 _List_replicate_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code "./Prelude/List/replicate +9 Integer 1"
-    Util.assertNormalizesTo e "[1, 1, 1, 1, 1, 1, 1, 1, 1] : List Integer" )
+    Util.assertNormalizesTo e "[ 1, 1, 1, 1, 1, 1, 1, 1, 1 ] : List Integer" )
 
 _List_replicate_1 :: TestTree
 _List_replicate_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -610,7 +610,7 @@ _List_replicate_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _List_reverse_0 :: TestTree
 _List_reverse_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code "./Prelude/List/reverse Integer ([0, 1, 2] : List Integer)"
-    Util.assertNormalizesTo e "[2, 1, 0] : List Integer" )
+    Util.assertNormalizesTo e "[ 2, 1, 0 ] : List Integer" )
 
 _List_reverse_1 :: TestTree
 _List_reverse_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -636,7 +636,7 @@ _List_shifted_0 = Test.Tasty.HUnit.testCase "Example #0" (do
         \        ]   : List { index : Natural, value : Bool }   \n\
         \    ]   : List (List { index : Natural, value : Bool })\n\
         \)                                                      \n"
-    Util.assertNormalizesTo e "[{ index = +0, value = True }, { index = +1, value = True }, { index = +2, value = True }, { index = +3, value = False }, { index = +4, value = False }, { index = +5, value = True }, { index = +6, value = True }, { index = +7, value = True }, { index = +8, value = True }] : List { index : Natural, value : Bool }" )
+    Util.assertNormalizesTo e "[ { index = +0, value = True }, { index = +1, value = True }, { index = +2, value = True }, { index = +3, value = False }, { index = +4, value = False }, { index = +5, value = True }, { index = +6, value = True }, { index = +7, value = True }, { index = +8, value = True } ] : List { index : Natural, value : Bool }" )
 
 _List_shifted_1 :: TestTree
 _List_shifted_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -655,7 +655,7 @@ _List_unzip_0 = Test.Tasty.HUnit.testCase "Example #0" (do
         \    ,   { _1 = \"GHI\", _2 = True  }   \n\
         \    ]   : List { _1 : Text, _2 : Bool }\n\
         \)                                      \n"
-    Util.assertNormalizesTo e "{ _1 = [\"ABC\", \"DEF\", \"GHI\"] : List Text, _2 = [True, False, True] : List Bool }" )
+    Util.assertNormalizesTo e "{ _1 = [ \"ABC\", \"DEF\", \"GHI\" ] : List Text, _2 = [ True, False, True ] : List Bool }" )
 
 _List_unzip_1 :: TestTree
 _List_unzip_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -736,7 +736,7 @@ _Natural_build_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _Natural_enumerate_0 :: TestTree
 _Natural_enumerate_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code "./Prelude/Natural/enumerate +10"
-    Util.assertNormalizesTo e "[+0, +1, +2, +3, +4, +5, +6, +7, +8, +9] : List Natural" )
+    Util.assertNormalizesTo e "[ +0, +1, +2, +3, +4, +5, +6, +7, +8, +9 ] : List Natural" )
 
 _Natural_enumerate_1 :: TestTree
 _Natural_enumerate_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -795,7 +795,7 @@ _Natural_odd_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Natural_product_0 :: TestTree
 _Natural_product_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Natural/product ([+2, +3, +5] : List Natural)"
+    e <- Util.code "./Prelude/Natural/product ([ +2, +3, +5 ] : List Natural)"
     Util.assertNormalizesTo e "+30" )
 
 _Natural_product_1 :: TestTree
@@ -815,7 +815,7 @@ _Natural_show_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Natural_sum_0 :: TestTree
 _Natural_sum_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Natural/sum ([+2, +3, +5] : List Natural)"
+    e <- Util.code "./Prelude/Natural/sum ([ +2, +3, +5 ] : List Natural)"
     Util.assertNormalizesTo e "+10" )
 
 _Natural_sum_1 :: TestTree
@@ -835,7 +835,7 @@ _Natural_toInteger_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Optional_all_0 :: TestTree
 _Optional_all_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Optional/all Natural Natural/even ([+3] : Optional Natural)"
+    e <- Util.code "./Prelude/Optional/all Natural Natural/even ([ +3 ] : Optional Natural)"
     Util.assertNormalizesTo e "False" )
 
 _Optional_all_1 :: TestTree
@@ -845,7 +845,7 @@ _Optional_all_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Optional_any_0 :: TestTree
 _Optional_any_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Optional/any Natural Natural/even ([+2] : Optional Natural)"
+    e <- Util.code "./Prelude/Optional/any Natural Natural/even ([ +2 ] : Optional Natural)"
     Util.assertNormalizesTo e "True" )
 
 _Optional_any_1 :: TestTree
@@ -863,7 +863,7 @@ _Optional_build_0 = Test.Tasty.HUnit.testCase "Example #0" (do
         \→   λ(nothing : optional)       \n\
         \→   just 1                      \n\
         \)                               \n"
-    Util.assertNormalizesTo e "[1] : Optional Integer" )
+    Util.assertNormalizesTo e "[ 1 ] : Optional Integer" )
 
 _Optional_build_1 :: TestTree
 _Optional_build_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -880,13 +880,13 @@ _Optional_build_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _Optional_concat_0 :: TestTree
 _Optional_concat_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
-        "./Prelude/Optional/concat Integer ([[1] : Optional Integer] : Optional (Optional Integer))"
-    Util.assertNormalizesTo e "[1] : Optional Integer" )
+        "./Prelude/Optional/concat Integer ([ [ 1 ] : Optional Integer ] : Optional (Optional Integer))"
+    Util.assertNormalizesTo e "[ 1 ] : Optional Integer" )
 
 _Optional_concat_1 :: TestTree
 _Optional_concat_1 = Test.Tasty.HUnit.testCase "Example #1" (do
     e <- Util.code
-        "./Prelude/Optional/concat Integer ([[] : Optional Integer] : Optional (Optional Integer))"
+        "./Prelude/Optional/concat Integer ([ [] : Optional Integer ] : Optional (Optional Integer))"
     Util.assertNormalizesTo e "[] : Optional Integer" )
 
 _Optional_concat_2 :: TestTree
@@ -897,18 +897,18 @@ _Optional_concat_2 = Test.Tasty.HUnit.testCase "Example #2" (do
 _Optional_filter_0 :: TestTree
 _Optional_filter_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
-        "./Prelude/Optional/filter Natural Natural/even ([+2] : Optional Natural)"
-    Util.assertNormalizesTo e "[+2] : Optional Natural" )
+        "./Prelude/Optional/filter Natural Natural/even ([ +2 ] : Optional Natural)"
+    Util.assertNormalizesTo e "[ +2 ] : Optional Natural" )
 
 _Optional_filter_1 :: TestTree
 _Optional_filter_1 = Test.Tasty.HUnit.testCase "Example #1" (do
-    e <- Util.code "./Prelude/Optional/filter Natural Natural/odd ([+2] : Optional Natural)"
+    e <- Util.code "./Prelude/Optional/filter Natural Natural/odd ([ +2 ] : Optional Natural)"
     Util.assertNormalizesTo e "[] : Optional Natural" )
 
 _Optional_fold_0 :: TestTree
 _Optional_fold_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
-        "./Prelude/Optional/fold Integer ([2] : Optional Integer) Integer (λ(x : Integer) → x) 0"
+        "./Prelude/Optional/fold Integer ([ 2 ] : Optional Integer) Integer (λ(x : Integer) → x) 0"
     Util.assertNormalizesTo e "2" )
 
 _Optional_fold_1 :: TestTree
@@ -920,19 +920,21 @@ _Optional_fold_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _Optional_head_0 :: TestTree
 _Optional_head_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
-        "./Prelude/Optional/head                                                    \n\
-        \Integer                                                                    \n\
-        \(   [[] : Optional Integer, [1] : Optional Integer, [2] : Optional Integer]\n\
-        \    : List (Optional Integer)                                              \n\
-        \)                                                                          \n"
-    Util.assertNormalizesTo e "[1] : Optional Integer" )
+        "./Prelude/Optional/head        \n\
+        \Integer                        \n\
+        \(   [ []    : Optional Integer \n\
+        \    , [ 1 ] : Optional Integer \n\
+        \    , [ 2 ] : Optional Integer \n\
+        \    ] : List (Optional Integer)\n\
+        \)                              \n"
+    Util.assertNormalizesTo e "[ 1 ] : Optional Integer" )
 
 _Optional_head_1 :: TestTree
 _Optional_head_1 = Test.Tasty.HUnit.testCase "Example #1" (do
     e <- Util.code
-        "./Prelude/Optional/head                                                   \n\
-        \Integer                                                                   \n\
-        \([[] : Optional Integer, [] : Optional Integer] : List (Optional Integer))\n"
+        "./Prelude/Optional/head                                                     \n\
+        \Integer                                                                     \n\
+        \([ [] : Optional Integer, [] : Optional Integer ] : List (Optional Integer))\n"
     Util.assertNormalizesTo e "[] : Optional Integer" )
 
 _Optional_head_2 :: TestTree
@@ -943,19 +945,21 @@ _Optional_head_2 = Test.Tasty.HUnit.testCase "Example #2" (do
 _Optional_last_0 :: TestTree
 _Optional_last_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
-        "./Prelude/Optional/last                                                    \n\
-        \Integer                                                                    \n\
-        \(   [[] : Optional Integer, [1] : Optional Integer, [2] : Optional Integer]\n\
-        \    : List (Optional Integer)                                              \n\
-        \)                                                                          \n"
-    Util.assertNormalizesTo e "[2] : Optional Integer" )
+        "./Prelude/Optional/last        \n\
+        \Integer                        \n\
+        \(   [ [] : Optional Integer    \n\
+        \    , [1] : Optional Integer   \n\
+        \    , [2] : Optional Integer   \n\
+        \    ] : List (Optional Integer)\n\
+        \)                              \n"
+    Util.assertNormalizesTo e "[ 2 ] : Optional Integer" )
 
 _Optional_last_1 :: TestTree
 _Optional_last_1 = Test.Tasty.HUnit.testCase "Example #1" (do
     e <- Util.code
-        "./Prelude/Optional/last                                                   \n\
-        \Integer                                                                   \n\
-        \([[] : Optional Integer, [] : Optional Integer] : List (Optional Integer))\n"
+        "./Prelude/Optional/last                                                     \n\
+        \Integer                                                                     \n\
+        \([ [] : Optional Integer, [] : Optional Integer ] : List (Optional Integer))\n"
     Util.assertNormalizesTo e "[] : Optional Integer" )
 
 _Optional_last_2 :: TestTree
@@ -966,18 +970,8 @@ _Optional_last_2 = Test.Tasty.HUnit.testCase "Example #2" (do
 _Optional_map_0 :: TestTree
 _Optional_map_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
-        "./Prelude/Optional/map Natural Bool Natural/even ([+3] : Optional Natural)"
-    Util.assertNormalizesTo e "[False] : Optional Bool" )
-
-_Optional_length_0 :: TestTree
-_Optional_length_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Optional/length Integer ([2] : Optional Integer)"
-    Util.assertNormalizesTo e "+1" )
-
-_Optional_length_1 :: TestTree
-_Optional_length_1 = Test.Tasty.HUnit.testCase "Example #1" (do
-    e <- Util.code "./Prelude/Optional/length Integer ([] : Optional Integer)"
-    Util.assertNormalizesTo e "+0" )
+        "./Prelude/Optional/map Natural Bool Natural/even ([ +3 ] : Optional Natural)"
+    Util.assertNormalizesTo e "[ False ] : Optional Bool" )
 
 _Optional_map_1 :: TestTree
 _Optional_map_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -985,9 +979,20 @@ _Optional_map_1 = Test.Tasty.HUnit.testCase "Example #1" (do
         "./Prelude/Optional/map Natural Bool Natural/even ([] : Optional Natural)"
     Util.assertNormalizesTo e "[] : Optional Bool" )
 
+_Optional_length_0 :: TestTree
+_Optional_length_0 = Test.Tasty.HUnit.testCase "Example #0" (do
+    e <- Util.code
+        "./Prelude/Optional/length Integer ([ 2 ] : Optional Integer)"
+    Util.assertNormalizesTo e "+1" )
+
+_Optional_length_1 :: TestTree
+_Optional_length_1 = Test.Tasty.HUnit.testCase "Example #1" (do
+    e <- Util.code "./Prelude/Optional/length Integer ([] : Optional Integer)"
+    Util.assertNormalizesTo e "+0" )
+
 _Optional_null_0 :: TestTree
 _Optional_null_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Optional/null Integer ([2] : Optional Integer)"
+    e <- Util.code "./Prelude/Optional/null Integer ([ 2]  : Optional Integer)"
     Util.assertNormalizesTo e "False" )
 
 _Optional_null_1 :: TestTree
@@ -997,8 +1002,9 @@ _Optional_null_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Optional_toList_0 :: TestTree
 _Optional_toList_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Optional/toList Integer ([1] : Optional Integer)"
-    Util.assertNormalizesTo e "[1]" )
+    e <- Util.code
+        "./Prelude/Optional/toList Integer ([ 1 ] : Optional Integer)"
+    Util.assertNormalizesTo e "[ 1 ]" )
 
 _Optional_toList_1 :: TestTree
 _Optional_toList_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -1008,11 +1014,11 @@ _Optional_toList_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _Optional_unzip_0 :: TestTree
 _Optional_unzip_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
-        "./Prelude/Optional/unzip                                            \n\
-        \Text                                                                \n\
-        \Bool                                                                \n\
-        \([{ _1 = \"ABC\", _2 = True  }] : Optional { _1 : Text, _2 : Bool })\n"
-    Util.assertNormalizesTo e "{ _1 = [\"ABC\"] : Optional Text, _2 = [True] : Optional Bool }" )
+        "./Prelude/Optional/unzip                                              \n\
+        \Text                                                                  \n\
+        \Bool                                                                  \n\
+        \([ { _1 = \"ABC\", _2 = True  } ] : Optional { _1 : Text, _2 : Bool })\n"
+    Util.assertNormalizesTo e "{ _1 = [ \"ABC\" ] : Optional Text, _2 = [ True ] : Optional Bool }" )
 
 _Optional_unzip_1 :: TestTree
 _Optional_unzip_1 = Test.Tasty.HUnit.testCase "Example #1" (do
@@ -1022,7 +1028,7 @@ _Optional_unzip_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Text_concat_0 :: TestTree
 _Text_concat_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Text/concat ([\"ABC\", \"DEF\", \"GHI\"] : List Text)"
+    e <- Util.code "./Prelude/Text/concat ([ \"ABC\", \"DEF\", \"GHI\" ] : List Text)"
     Util.assertNormalizesTo e "\"ABCDEFGHI\"" )
 
 _Text_concat_1 :: TestTree
@@ -1033,7 +1039,7 @@ _Text_concat_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 _Text_concatMap_0 :: TestTree
 _Text_concatMap_0 = Test.Tasty.HUnit.testCase "Example #0" (do
     e <- Util.code
-        "./Prelude/Text/concatMap Integer (λ(n : Integer) → \"${Integer/show n} \") [0, 1, 2]"
+        "./Prelude/Text/concatMap Integer (λ(n : Integer) → \"${Integer/show n} \") [ 0, 1, 2 ]"
     Util.assertNormalizesTo e "\"0 1 2 \"" )
 
 _Text_concatMap_1 :: TestTree
@@ -1044,7 +1050,7 @@ _Text_concatMap_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Text_concatMapSep_0 :: TestTree
 _Text_concatMapSep_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Text/concatMapSep \", \" Integer Integer/show [0, 1, 2]"
+    e <- Util.code "./Prelude/Text/concatMapSep \", \" Integer Integer/show [ 0, 1, 2 ]"
     Util.assertNormalizesTo e "\"0, 1, 2\"" )
 
 _Text_concatMapSep_1 :: TestTree
@@ -1055,7 +1061,7 @@ _Text_concatMapSep_1 = Test.Tasty.HUnit.testCase "Example #1" (do
 
 _Text_concatSep_0 :: TestTree
 _Text_concatSep_0 = Test.Tasty.HUnit.testCase "Example #0" (do
-    e <- Util.code "./Prelude/Text/concatSep \", \" [\"ABC\", \"DEF\", \"GHI\"]"
+    e <- Util.code "./Prelude/Text/concatSep \", \" [ \"ABC\", \"DEF\", \"GHI\" ]"
     Util.assertNormalizesTo e "\"ABC, DEF, GHI\"" )
 
 _Text_concatSep_1 :: TestTree

--- a/tests/Normalization.hs
+++ b/tests/Normalization.hs
@@ -79,12 +79,12 @@ naturalShow = testCase "Natural/show" $ do
 integerShow :: TestTree
 integerShow = testCase "Integer/show" $ do
   e <- code "[Integer/show 1337, Integer/show -42, Integer/show 0]"
-  e `assertNormalizesTo` "[\"1337\", \"-42\", \"0\"]"
+  e `assertNormalizesTo` "[ \"1337\", \"-42\", \"0\" ]"
 
 doubleShow :: TestTree
 doubleShow = testCase "Double/show" $ do
   e <- code "[Double/show -0.42, Double/show 13.37]"
-  e `assertNormalizesTo` "[\"-0.42\", \"13.37\"]"
+  e `assertNormalizesTo` "[ \"-0.42\", \"13.37\" ]"
 
 optionalFold :: TestTree
 optionalFold = testGroup "Optional/fold" [ just, nothing ]
@@ -110,7 +110,7 @@ optionalBuild1 = testCase "reducible" $ do
     \→   λ(nothing : optional)       \n\
     \→   just +1                     \n\
     \)                               \n"
-  e `assertNormalizesTo` "[+1] : Optional Natural"
+  e `assertNormalizesTo` "[ +1 ] : Optional Natural"
 
 optionalBuildShadowing :: TestTree
 optionalBuildShadowing = testCase "handles shadowing" $ do
@@ -122,7 +122,7 @@ optionalBuildShadowing = testCase "handles shadowing" $ do
     \→   λ(x : optional)          \n\
     \→   x@1 1                    \n\
     \)                            \n"
-  e `assertNormalizesTo` "[1] : Optional Integer"
+  e `assertNormalizesTo` "[ 1 ] : Optional Integer"
 
 optionalBuildIrreducible :: TestTree
 optionalBuildIrreducible = testCase "irreducible" $ do
@@ -176,4 +176,4 @@ fuseOptionalFB = testCase "build . fold" $ do
     \    Text                       \n\
     \    ([\"foo\"] : Optional Text)\n\
     \)                              \n"
-  test `assertNormalizesTo` "[\"foo\"] : Optional Text"
+  test `assertNormalizesTo` "[ \"foo\" ] : Optional Text"


### PR DESCRIPTION
This updates the recently added support for integrity checking to hash the
final normalized result instead of hashing the text of the import.  This gives
much stronger guarantees about the safety of the imported value, since the
hash now reflects changes to the expression's semantic value

This also lets you safely refactor imported values without changing the hash so
long as the refactor is behavior-preserving.  The hash provides a quick and
dirty protection against human error when used in this way