### PR TITLE
Fix pretty-printing example

### DIFF
--- a/src/Dhall/Tutorial.hs
+++ b/src/Dhall/Tutorial.hs
@@ -1611,49 +1611,43 @@ import Dhall
 -- > <Ctrl-D>
 -- > List (List (List Integer))
 -- > 
--- > (   [ (   [ ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           ]
--- >         : List (List Integer)
--- >       )
--- >     , (   [ ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           ]
--- >         : List (List Integer)
--- >       )
--- >     , (   [ ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           ]
--- >         : List (List Integer)
--- >       )
--- >     , (   [ ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           ]
--- >         : List (List Integer)
--- >       )
--- >     , (   [ ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           , ([ 1, 1, 1, 1, 1 ] : List Integer)
--- >           ]
--- >         : List (List Integer)
--- >       )
--- >     ]
--- >   : List (List (List Integer))
--- > )
+-- >   [   [ [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       ]
+-- >     : List (List Integer)
+-- >   ,   [ [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       ]
+-- >     : List (List Integer)
+-- >   ,   [ [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       ]
+-- >     : List (List Integer)
+-- >   ,   [ [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       ]
+-- >     : List (List Integer)
+-- >   ,   [ [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       , [ 1, 1, 1, 1, 1 ] : List Integer
+-- >       ]
+-- >     : List (List Integer)
+-- >   ]
+-- > : List (List (List Integer))
 --
 -- You can also use the formatter to modify files in place using the
 -- @--inplace@ flag:


### PR DESCRIPTION
This updates the `dhall-format` tutorial example to reflect the improvements
introduced in 8d27f8cb56a55d016de848ca243a143f3f5f2c5e