### PR TITLE
set hPrint encodings to use utf8, independent of locale

### DIFF
--- a/dhall-format/Main.hs
+++ b/dhall-format/Main.hs
@@ -71,6 +71,7 @@ main = do
 
     let handler e = do
             let _ = e :: SomeException
+            System.IO.hSetEncoding System.IO.stderr System.IO.utf8
             System.IO.hPrint stderr e
             System.Exit.exitFailure
 

--- a/dhall-format/Main.hs
+++ b/dhall-format/Main.hs
@@ -90,6 +90,7 @@ main = do
                     Pretty.renderIO handle (Pretty.layoutSmart opts doc)
                     Data.Text.IO.hPutStrLn handle "" )
             Nothing -> do
+                System.IO.hSetEncoding System.IO.stdin System.IO.utf8
                 inText <- Data.Text.Lazy.IO.getContents
 
                 (header, expr) <- case exprAndHeaderFromText (Directed "(stdin)" 0 0 0 0) inText of

--- a/dhall-hash/Main.hs
+++ b/dhall-hash/Main.hs
@@ -70,6 +70,7 @@ main = do
                 System.Exit.exitFailure
 
     handle (do
+        System.IO.hSetEncoding System.IO.stdin System.IO.utf8
         inText <- Data.Text.Lazy.IO.getContents
 
         expr <- case exprFromText (Directed "(stdin)" 0 0 0 0) inText of

--- a/dhall-hash/Main.hs
+++ b/dhall-hash/Main.hs
@@ -65,6 +65,7 @@ main = do
 
             handler2 e = do
                 let _ = e :: SomeException
+                System.IO.hSetEncoding System.IO.stderr System.IO.utf8
                 System.IO.hPrint stderr e
                 System.Exit.exitFailure
 

--- a/dhall/Main.hs
+++ b/dhall/Main.hs
@@ -79,6 +79,7 @@ main = do
                 System.Exit.exitFailure
 
     handle (do
+        System.IO.hSetEncoding System.IO.stdin System.IO.utf8
         inText <- Data.Text.Lazy.IO.getContents
 
         (header, expr) <- case exprAndHeaderFromText (Directed "(stdin)" 0 0 0 0) inText of

--- a/dhall/Main.hs
+++ b/dhall/Main.hs
@@ -74,6 +74,7 @@ main = do
 
             handler2 e = do
                 let _ = e :: SomeException
+                System.IO.hSetEncoding System.IO.stderr System.IO.utf8
                 System.IO.hPrint System.IO.stderr e
                 System.Exit.exitFailure
 


### PR DESCRIPTION
On systems with the locale set to non-UTF8 (e.g. `LC_ALL=C`, the default POSIX
locale), handles are opened in that locale, so printing dhall’s error messages
fails on the first non-ASCII character:

```
Error: Not a function

Explanation: Expressions separated by whitespace denote function application,
like this:

    dhall: <stderr>: hPutChar: invalid argument (invalid character)
```

We set the stderr handle accordingly.

For example, in nix builds, dhall outputs:

```
these derivations will be built:
  /nix/store/im88hab49pp2rajjzx50fyvig7i7cbpr-dhall.drv
building path(s) ‘/nix/store/0khp05jvcgim2q48k3jm016acx0545qa-dhall’


Error: Not a function

Explanation: Expressions separated by whitespace denote function application,   
like this:                                                                      
                                                                                
                                                                                
    dhall: <stderr>: hPutChar: invalid argument (invalid character)
builder for ‘/nix/store/im88hab49pp2rajjzx50fyvig7i7cbpr-dhall.drv’ failed with exit code 1
error: build of ‘/nix/store/im88hab49pp2rajjzx50fyvig7i7cbpr-dhall.drv’ failed
```

With this change, the build runs as expected and the correct glyphs are printed.