### PR TITLE
Expose `MissingEnvironmentVariable` exception type

### DIFF
--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -111,6 +111,7 @@ module Dhall.Import (
     , Imported(..)
     , PrettyHttpException(..)
     , MissingFile(..)
+    , MissingEnvironmentVariable(..)
     ) where
 
 import Control.Applicative (empty)


### PR DESCRIPTION
This allows people to selectively catch that exception