### PR TITLE
Fix `.cabal` file error

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -163,6 +163,8 @@ Executable dhall-hash
         optparse-generic >= 1.1.1    && < 1.3,
         trifecta         >= 1.6      && < 1.8,
         text             >= 0.11.1.0 && < 1.3
+    Other-Modules:
+        Paths_dhall
 
 Test-Suite test
     Type: exitcode-stdio-1.0


### PR DESCRIPTION
This adds `Paths_dhall` to the `Other-modules` section for
`dhall-hash` to match the other executables