### PR TITLE
Adds support for `as Template`.

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -135,7 +135,7 @@ instance Buildable PathType where
     build (Env env) = "env:" <> build env
 
 -- | How to interpret the path's contents (i.e. as Dhall code or raw text)
-data PathMode = Code | RawText deriving (Eq, Ord, Show)
+data PathMode = Code | RawText | Template deriving (Eq, Ord, Show)
 
 data PathHashed = PathHashed
     { hash     :: Maybe Data.ByteString.ByteString
@@ -161,6 +161,7 @@ instance Buildable Path where
       where
         suffix = case pathMode of
             RawText -> "as Text"
+            Template -> "as Template"
             Code    -> ""
 
 instance Pretty Path where
@@ -2472,6 +2473,7 @@ reservedIdentifiers =
         , "Double"
         , "Double/show"
         , "Text"
+        , "Template"
         , "List"
         , "List/build"
         , "List/fold"

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -97,6 +97,15 @@
     > ocuments. You may use this\n    domain in examples without prior coordination or
     >  asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/exampl
     > e\">More information...</a></p>\n</div>\n</body>\n</html>\n"
+
+    If you wish to just interpolate the contents of a path with the current scope as
+    @Text@ then add @as Template@ to the end of the import:
+
+    > $ echo 'value of var is \${var}'
+    > $ dhall <<< 'let var = "val" in ./template as Template'
+    > Text
+    > 
+    > "value of var is val\n"
 -}
 
 module Dhall.Import (
@@ -143,7 +152,7 @@ import Dhall.Core
     , PathType(..)
     , Path(..)
     )
-import Dhall.Parser (Parser(..), ParseError(..), Src(..))
+import Dhall.Parser (Parser(..), ParseError(..), Src(..), exprFromText)
 import Dhall.TypeCheck (X(..))
 #if MIN_VERSION_http_client(0,5,0)
 import Network.HTTP.Client
@@ -621,7 +630,23 @@ exprFromPath (Path {..}) = case pathType of
             RawText -> do
                 let pathString = Filesystem.Path.CurrentOS.encodeString path
                 text <- Data.Text.IO.readFile pathString
-                return (TextLit (build text)) )
+                return (TextLit (build text))
+            Template -> do
+                let pathString = Filesystem.Path.CurrentOS.encodeString path
+                template <- Data.Text.IO.readFile pathString
+
+                let textPath = case Filesystem.Path.CurrentOS.toText path of
+                      Left  text -> text
+                      Right text -> text
+                    bytesPath = Data.Text.Encoding.encodeUtf8 textPath
+                let delta =
+                        Directed bytesPath 0 0 0 0
+                case exprFromText delta (Text.fromStrict $ "''" <> template <> "''") of
+                    Left parserError -> do
+                        throwIO parserError
+                    Right expr -> do
+                        return expr )
+
     URL url headerPath -> do
         m       <- needManager
         request <- liftIO (HTTP.parseUrlThrow (Text.unpack url))
@@ -715,6 +740,17 @@ exprFromPath (Path {..}) = case pathType of
                     Success expr -> return expr
             RawText -> do
                 return (TextLit (build text))
+            Template -> do
+                let urlBytes = Data.Text.Lazy.Encoding.encodeUtf8 url
+                let delta =
+                        Directed (Data.ByteString.Lazy.toStrict urlBytes) 0 0 0 0
+                case exprFromText delta ("''" <> text <> "''") of
+                    Left parserError -> do
+                        liftIO (throwIO parserError)
+                    Right expr -> do
+                        return expr
+
+
     Env env -> liftIO (do
         x <- System.Environment.lookupEnv (Text.unpack env)
         case x of
@@ -730,6 +766,16 @@ exprFromPath (Path {..}) = case pathType of
                             Success expr    -> do
                                 return expr
                     RawText -> return (TextLit (build str))
+                    Template -> do
+                        let envBytes = Data.Text.Lazy.Encoding.encodeUtf8 env
+                        let delta =
+                                Directed (Data.ByteString.Lazy.toStrict envBytes) 0 0 0 0
+                        case exprFromText delta (Text.pack $ "''" <> str <> "''") of
+                            Left parserError -> do
+                                throwIO parserError
+                            Right expr -> do
+                                return expr
+
             Nothing  -> throwIO (MissingEnvironmentVariable env) )
   where
     PathHashed {..} = pathHashed
@@ -825,7 +871,9 @@ loadStaticWith from_path ctx path = do
     --
     -- There is no need to check expressions that have been cached, since they
     -- have already been checked
-    if cached
+    --
+    -- Also do not type check templates on their own; they are not closed.
+    if cached || (pathMode path == Template)
         then return ()
         else case Dhall.TypeCheck.typeWith ctx expr of
             Left  err -> throwM (Imported (path:paths) err)

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -586,6 +586,9 @@ _Double = reserved "Double"
 _Text :: Parser ()
 _Text = reserved "Text"
 
+_Template :: Parser ()
+_Template = reserved "Template"
+
 _List :: Parser ()
 _List = reserved "List"
 
@@ -1519,13 +1522,17 @@ pathHashed_ = do
 import_ :: Parser Path
 import_ = (do
     pathHashed <- pathHashed_
-    pathMode   <- alternative <|> pure Code
+    pathMode   <- choice [ asTemplate, asText, pure Code ]
     return (Path {..}) ) <?> "import"
   where
-    alternative = do
+    asText = do
         _as
         _Text
         return RawText
+    asTemplate = do
+        _as
+        _Template
+        return Template
 
 -- | A parsing error
 newtype ParseError = ParseError Doc deriving (Typeable)


### PR DESCRIPTION
This would resolve the issue I ran into in dhall-lang/dhall-lang#67.

This will basically allow to inject open templates into dhall expressions,
and decouple dhall logic from the pure templating logic for interpolation.

Example:
```bash
cat << EOF > index.html                                                                                                                                                                   ~/Projects/zw3rk/dhall-haskell
<html>
  <head><title>\${page.title}</title></head>
  <body><h1>\${page.header}</h1>
        <p>dhall is \${page.value}!</p>
  </body>
</html>
EOF
```
with
```bash
$ dhall <<< 'let page = { title = "dhall templates"
                        , header = "Templates"
                        , value = "a great templating language" }
             in (./index.html as Template)' 
```

will result in
```
<html>
  <head><title>dhall templates</title></head>
  <body><h1>Templates</h1>
        <p>dhall is a great templating language!</p>
  </body>
</html>
```