### PR TITLE
Fix infinite loop when pretty-printing `constructors` keyword

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -181,6 +181,7 @@ Test-Suite test
     Build-Depends:
         base               >= 4        && < 5   ,
         containers         >= 0.5.0.0  && < 0.6 ,
+        deepseq            >= 1.2.0.1  && < 1.5 ,
         dhall                                   ,
         tasty              >= 0.11.2   && < 0.13,
         tasty-hunit        >= 0.9.2    && < 0.11,

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -901,16 +901,18 @@ prettyExprC9 a0 =
     prettyExprD a0
 
 prettyExprD :: Pretty a => Expr s a -> Doc ann
-prettyExprD a0@(App _ _) =
-    enclose' "" "" " " "" (fmap duplicate (reverse (docs a0)))
+prettyExprD a0 = case a0 of
+    App _ _        -> result
+    Constructors _ -> result
+    Note _ b       -> prettyExprD b
+    _              -> prettyExprE a0
   where
+    result = enclose' "" "" " " "" (fmap duplicate (reverse (docs a0)))
+
     docs (App        a b) = prettyExprE b : docs a
     docs (Constructors b) = [ prettyExprE b , "constructors" ]
     docs (Note       _ b) = docs b
     docs               b  = [ prettyExprE b ]
-prettyExprD (Note _ b) = prettyExprD b
-prettyExprD a0 =
-    prettyExprE a0
 
 prettyExprE :: Pretty a => Expr s a -> Doc ann
 prettyExprE (Field a b) = prettyExprE a <> "." <> prettyLabel b

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -10,10 +10,12 @@ import qualified Data.Map
 import qualified Dhall
 import qualified Dhall.Core
 import qualified Dhall.Parser
+import qualified System.Timeout
 import qualified Test.Tasty
 import qualified Test.Tasty.HUnit
 import qualified Util
 
+import Control.DeepSeq (($!!))
 import Dhall.Import (Imported)
 import Dhall.Parser (Src)
 import Dhall.TypeCheck (TypeError, X)
@@ -120,6 +122,15 @@ issue201 :: TestTree
 issue201 = Test.Tasty.HUnit.testCase "Issue #201" (do
     -- Verify that type synonyms work
     _ <- Util.code "./tests/regression/issue201.dhall"
+    return () )
+
+issue209 :: TestTree
+issue209 = Test.Tasty.HUnit.testCase "Issue #209" (do
+    -- Verify that pretty-printing `constructors` doesn't trigger an infinite
+    -- loop
+    e <- Util.code "./tests/regression/issue209.dhall"
+    let text = Dhall.Core.pretty e
+    Just _ <- System.Timeout.timeout 1000000 (Control.Exception.evaluate $!! text)
     return () )
 
 parsing0 :: TestTree

--- a/tests/regression/issue209.dhall
+++ b/tests/regression/issue209.dhall
@@ -1,0 +1,1 @@
+constructors <>


### PR DESCRIPTION
Fixes #209

The `prettyExprD` function would only transition to the `docs` loop if the
outermost constructor at precedence level "D" was an `App` constructor.  This
meant that the following code would pretty-print correctly:

```haskell
(constructors x) y
```

... but this code would not pretty-print correctly and would instead trigger
an infinite loop:

```haskell
constructors x
```

The reason for the infinite loop is that the pretty-printing logic assumes that
the pretty-printer will make progress for at least one precedence level in order
to terminate.  However, to the above issue the `Constructors` keyword would not
make progress at precedence level "D", which triggered the infinite loop.

The fix is to update `prettyExprD` to transition to the `docs` loops for both
the `App` and `Constructor` constructors.