### PR TITLE
Use `lens-family-core` instead of `lens`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,9 @@
 { mkDerivation, ansi-wl-pprint, base, base16-bytestring, bytestring
 , case-insensitive, charset, containers, contravariant, cryptohash
-, deepseq, exceptions, http-client, http-client-tls, lens
-, optparse-generic, parsers, prettyprinter, stdenv, system-fileio
-, system-filepath, tasty, tasty-hunit, text, text-format
-, transformers, trifecta, unordered-containers, vector
+, deepseq, exceptions, http-client, http-client-tls
+, lens-family-core, optparse-generic, parsers, prettyprinter
+, stdenv, system-fileio, system-filepath, tasty, tasty-hunit, text
+, text-format, transformers, trifecta, unordered-containers, vector
 }:
 mkDerivation {
   pname = "dhall";
@@ -14,9 +14,9 @@ mkDerivation {
   libraryHaskellDepends = [
     ansi-wl-pprint base base16-bytestring bytestring case-insensitive
     charset containers contravariant cryptohash exceptions http-client
-    http-client-tls lens parsers prettyprinter system-fileio
-    system-filepath text text-format transformers trifecta
-    unordered-containers vector
+    http-client-tls lens-family-core parsers prettyprinter
+    system-fileio system-filepath text text-format transformers
+    trifecta unordered-containers vector
   ];
   executableHaskellDepends = [
     base optparse-generic prettyprinter system-filepath text trifecta

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -104,7 +104,7 @@ Library
         exceptions           >= 0.8.3    && < 0.9 ,
         http-client          >= 0.4.30   && < 0.6 ,
         http-client-tls      >= 0.2.0    && < 0.4 ,
-        lens                 >= 2.4      && < 4.16,
+        lens-family-core     >= 1.0.0    && < 1.3 ,
         parsers              >= 0.12.4   && < 0.13,
         prettyprinter        >= 1.1.1    && < 1.2 ,
         system-filepath      >= 0.3.1    && < 0.5 ,

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -118,7 +118,6 @@ module Dhall.Import (
 import Control.Applicative (empty)
 import Control.Exception
     (Exception, IOException, SomeException, onException, throwIO)
-import Control.Lens (Lens', zoom)
 import Control.Monad (join)
 import Control.Monad.Catch (throwM, MonadCatch(catch))
 import Control.Monad.IO.Class (MonadIO(..))
@@ -147,6 +146,8 @@ import Dhall.Core
     )
 import Dhall.Parser (Parser(..), ParseError(..), Src(..))
 import Dhall.TypeCheck (X(..))
+import Lens.Family (LensLike')
+import Lens.Family.State.Strict (zoom)
 #if MIN_VERSION_http_client(0,5,0)
 import Network.HTTP.Client
     (HttpException(..), HttpExceptionContent(..), Manager)
@@ -346,13 +347,13 @@ emptyStatus = Status [] Map.empty Nothing
 canonicalizeAll :: [Path] -> [Path]
 canonicalizeAll = map canonicalizePath . List.tails
 
-stack :: Lens' Status [Path]
+stack :: Functor f => LensLike' f Status [Path]
 stack k s = fmap (\x -> s { _stack = x }) (k (_stack s))
 
-cache :: Lens' Status (Map Path (Expr Src X))
+cache :: Functor f => LensLike' f Status (Map Path (Expr Src X))
 cache k s = fmap (\x -> s { _cache = x }) (k (_cache s))
 
-manager :: Lens' Status (Maybe Manager)
+manager :: Functor f => LensLike' f Status (Maybe Manager)
 manager k s = fmap (\x -> s { _manager = x }) (k (_manager s))
 
 needManager :: StateT Status IO Manager


### PR DESCRIPTION
Related to https://github.com/fpco/stackage/issues/3238

The immediate motivation of this change is to fix the upper bound issue
linked above.  However, since we don't need the full `lens` dependency
this uses the much smaller and more stable `lens-family-core` library.  Besides
reducing the footprint of the `dhall` executable this should hopefully also
reduce the number times we need to update the upper bound.