### PR TITLE
Simplify formatting of multi-line records/unions

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -1055,55 +1055,34 @@ prettyExprF a =
 
     short = "(" <> prettyExprA a <> ")"
 
-prettyKeyValue
-    :: Pretty a
-    => Doc ann
-    -> Int
-    -> (Text, Expr s a)
-    -> (Doc ann, Doc ann)
-prettyKeyValue separator keyLength (key, value) =
+prettyKeyValue :: Pretty a => Doc ann -> (Text, Expr s a) -> (Doc ann, Doc ann)
+prettyKeyValue separator (key, value) =
     (   prettyLabel key <> " " <> separator <> " " <> prettyExprA value
-    ,       Pretty.fill keyLength (prettyLabel key)
+    ,       prettyLabel key
         <>  " "
         <>  separator
-        <>  Pretty.group (Pretty.flatAlt long short)
+        <>  long
     )
   where
     long = Pretty.hardline <> "    " <> prettyExprA value
 
-    short = " " <> prettyExprA value
-
 prettyRecord :: Pretty a => Map Text (Expr s a) -> Doc ann
-prettyRecord a = braces (map adapt (Data.Map.toList a))
-  where
-    keyLength = fromIntegral (maximum (map Text.length (Data.Map.keys a)))
-
-    adapt = prettyKeyValue ":" keyLength 
+prettyRecord = braces . map (prettyKeyValue ":") . Data.Map.toList
 
 prettyRecordLit :: Pretty a => Map Text (Expr s a) -> Doc ann
 prettyRecordLit a
     | Data.Map.null a = "{=}"
-    | otherwise       = braces (map adapt (Data.Map.toList a))
-  where
-    keyLength = fromIntegral (maximum (map Text.length (Data.Map.keys a)))
-
-    adapt = prettyKeyValue "=" keyLength
+    | otherwise       = braces (map (prettyKeyValue "=") (Data.Map.toList a))
 
 prettyUnion :: Pretty a => Map Text (Expr s a) -> Doc ann
-prettyUnion a = angles (map adapt (Data.Map.toList a))
-  where
-    keyLength = fromIntegral (maximum (map Text.length (Data.Map.keys a)))
-
-    adapt = prettyKeyValue ":" keyLength
+prettyUnion = angles . map (prettyKeyValue ":") . Data.Map.toList
 
 prettyUnionLit :: Pretty a => Text -> Expr s a -> Map Text (Expr s a) -> Doc ann
 prettyUnionLit a b c = angles (front : map adapt (Data.Map.toList c))
   where
-    keyLength = fromIntegral (maximum (map Text.length (a : Data.Map.keys c)))
+    front = prettyKeyValue "=" (a, b)
 
-    front = prettyKeyValue "=" keyLength (a, b)
-
-    adapt = prettyKeyValue ":" keyLength
+    adapt = prettyKeyValue ":"
 
 -- | Pretty-print a value
 pretty :: Pretty a => a -> Text


### PR DESCRIPTION
Related to #244

Now, a multi-line record/union will always format the field values on a new
line instead of making the formatting decision on a field-by-field basis.

As an example, this now formats https://raw.githubusercontent.com/ocharles/dhall-to-cabal/d7ad78df7f98ba5a74bf001f3f826eb62af01a27/dhall-to-cabal.dhall like this:

```haskell
    let empty-package = ./dhall/empty-package.dhall 

in  let licenses = constructors ./dhall/types/License 

in  let extensions = constructors ./dhall/types/Extension 

in  let package =
            λ(package : Text)
          → λ(version-range : VersionRange)
          → { bounds = version-range, package = package }

in  let common-deps =
          { Cabal =
              package "Cabal" (majorBoundVersion [ +2, +0 ])
          , base =
              package "base" (majorBoundVersion [ +4, +10 ])
          , bytestring =
              package "bytestring" (majorBoundVersion [ +0, +10 ])
          , dhall =
              package "dhall" (majorBoundVersion [ +1, +9 ])
          , dhall-to-cabal =
              package "dhall-to-cabal" anyVersion
          , text =
              package "text" (majorBoundVersion [ +1, +2 ])
          }

in  let gitHub-project = ./dhall/gitHubProject.dhall 

in  let always = λ(os : < Linux : {} >) → True

in    gitHub-project { owner = "ocharles", repo = "dhall-to-cabal" }
    ⫽ { executables =
          [ { executable =
                [ { body =
                        ./dhall/defaults/Executable.dhall 
                      ⫽ { build-dependencies =
                            [ common-deps.base
                            , common-deps.dhall-to-cabal
                            , package
                              "optparse-applicative"
                              ( unionVersionRanges
                                (majorBoundVersion [ +0, +13, +2 ])
                                (majorBoundVersion [ +0, +14 ])
                              )
                            , common-deps.text
                            , common-deps.dhall
                            , common-deps.Cabal
                            ]
                        , hs-source-dirs =
                            [ "exe" ]
                        , main-is =
                            "Main.hs"
                        , other-extensions =
                            [ extensions.NamedFieldPuns {=} ]
                        }
                  , guard =
                      always
                  }
                ]
            , name =
                "dhall-to-cabal"
            }
          ]
      , library =
          [ [ { body =
                    ./dhall/defaults/Library.dhall 
                  ⫽ { build-dependencies =
                        [ common-deps.base
                        , common-deps.Cabal
                        , common-deps.dhall
                        , common-deps.text
                        , common-deps.bytestring
                        , package "containers" (majorBoundVersion [ +0, +5 ])
                        , package "vector" (majorBoundVersion [ +0, +12 ])
                        , package "trifecta" (majorBoundVersion [ +1, +7 ])
                        , package "text-format" (majorBoundVersion [ +0, +3 ])
                        , package
                          "transformers"
                          (majorBoundVersion [ +0, +5, +2 ])
                        ]
                    , compiler-options =
                          ./dhall/defaults/CompilerOptions 
                        ⫽ { GHC =
                              { build-options =
                                  [ "-Wall", "-fno-warn-name-shadowing" ]
                              }
                          }
                    , exposed-modules =
                        [ "Distribution.Package.Dhall" ]
                    , hs-source-dirs =
                        [ "lib" ]
                    , other-extensions =
                        [ extensions.ApplicativeDo {=}
                        , extensions.GADTs {=}
                        , extensions.GeneralizedNewtypeDeriving {=}
                        , extensions.LambdaCase {=}
                        , extensions.OverloadedStrings {=}
                        , extensions.RecordWildCards {=}
                        , extensions.TypeApplications {=}
                        ]
                    , other-modules =
                        [ "Dhall.Extra" ]
                    }
              , guard =
                  always
              }
            ]
          ] : Optional (./dhall/types/Guarded  ./dhall/types/Library )
      , license =
          licenses.MIT {=}
      , package =
          { name = "dhall-to-cabal", version = [ +0, +1, +0 ] }
      , test-suites =
          [ { name =
                "golden-tests"
            , test-suite =
                [ { body =
                        ./dhall/defaults/TestSuite.dhall 
                      ⫽ { build-dependencies =
                            [ common-deps.bytestring
                            , common-deps.base
                            , common-deps.Cabal
                            , common-deps.text
                            , package "tasty" (majorBoundVersion [ +0, +11 ])
                            , package "filepath" (majorBoundVersion [ +1, +4 ])
                            , common-deps.dhall-to-cabal
                            , package
                              "tasty-golden"
                              (majorBoundVersion [ +2, +3 ])
                            , package "Diff" (majorBoundVersion [ +0, +3, +4 ])
                            ]
                        , hs-source-dirs =
                            [ "golden-tests" ]
                        , main-is =
                            "GoldenTests.hs"
                        }
                  , guard =
                      always
                  }
                ]
            }
          ]
      }
```