### PR TITLE
Fix precedence of parsing variable names

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -2607,6 +2607,7 @@ reservedIdentifiers =
         , "else"
         , "as"
         , "using"
+        , "constructors"
         , "Natural"
         , "Natural/fold"
         , "Natural/build"
@@ -2629,5 +2630,6 @@ reservedIdentifiers =
         , "List/indexed"
         , "List/reverse"
         , "Optional"
+        , "Optional/build"
         , "Optional/fold"
         ]

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -1173,6 +1173,7 @@ primitiveExpression embedded =
             , alternative05
             , alternative06
             , alternative07
+            , alternative37
 
             , choice
                 [ alternative08
@@ -1205,7 +1206,6 @@ primitiveExpression embedded =
                 , alternative35
                 , alternative36
                 ] <?> "built-in expression"
-            , alternative37
             ]
         )
     <|> alternative38

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -128,6 +128,9 @@ parserTests =
             , shouldPass
                 "large expression"
                 "./tests/parser/largeExpression.dhall"
+            , shouldPass
+                "names that begin with reserved identifiers"
+                "./tests/parser/reservedPrefix.dhall"
             ]
         ]
 

--- a/tests/parser/reservedPrefix.dhall
+++ b/tests/parser/reservedPrefix.dhall
@@ -1,0 +1,1 @@
+let TypeSynonym = Integer in 1 : TypeSynonym


### PR DESCRIPTION
... as standardized in https://github.com/dhall-lang/dhall-lang/pull/83

Fixes #250

This allows identifier names to begin with reserved identifiers.  For
example, previously `TypeSynonym` was not a valid identifier because it
began with `Type` and now it is a valid identifier.