### PR TITLE
Fix layout when not using `--pretty`

### DIFF
--- a/dhall/Main.hs
+++ b/dhall/Main.hs
@@ -114,7 +114,7 @@ makeRender options header = do
                 let doc = Pretty.pretty header <> prettyExpr e
                 render h (Pretty.layoutSmart opts doc)
             else do
-                render h (Pretty.layoutSmart unbounded (prettyExpr e))
+                render h (Pretty.layoutPretty unbounded (prettyExpr e))
         Data.Text.Lazy.IO.hPutStrLn h ""
 
     where


### PR DESCRIPTION
The `layoutSmart` option appears to not behave correctly when specifying an
`Unbounded` number of columns:

https://github.com/quchen/prettyprinter/issues/49

... and the symptom of this problem is that the `dhall` executable by
default (i.e. without `--pretty`) renders all expressions in the long
format (i.e. multiline with indentation), regardless of the number of available
columns.

However, the `layoutPretty` function behaves correctly with the
`Unbounded` directive, so this change switches to using that when
rendering output without `--pretty`.