### PR TITLE
Fix pretty-printing of multi-line strings

### DIFF
--- a/src/Dhall/Pretty/Internal.hs
+++ b/src/Dhall/Pretty/Internal.hs
@@ -247,15 +247,20 @@ prettyScientific = literal . Pretty.pretty . show
 prettyChunks :: Pretty a => Chunks s a -> Doc Ann
 prettyChunks (Chunks a b) =
     if any (\(builder, _) -> hasNewLine builder) a || hasNewLine b
-    then
+    then Pretty.flatAlt long short
+    else short
+  where
+    long =
         Pretty.align
         (   literal ("''" <> Pretty.hardline)
         <>  Pretty.align
             (foldMap prettyMultilineChunk a <> prettyMultilineBuilder b)
         <>  literal "''"
         )
-    else literal "\"" <> foldMap prettyChunk a <> literal (prettyText b <> "\"")
-  where
+
+    short =
+        literal "\"" <> foldMap prettyChunk a <> literal (prettyText b <> "\"")
+
     hasNewLine builder = Text.any (== '\n') lazyText
       where
         lazyText = Builder.toLazyText builder


### PR DESCRIPTION
Before this change the `dhall` executable would fail on the following input:

```bash
$ dhall <<< 'λ(x : Text) → "\n" ++ x'
∀(x : Text) → Text

»SFail« must not appear in a rendered »SimpleDocStream«. This is a bug in the layout algorithm! Please report this as a bug
CallStack (from HasCallStack):
  error, called at src/Data/Text/Prettyprint/Doc/Render/Util/Panic.hs:13:21 in prettyprinter-1.1.1-1CDqnG9d6HQ5GZzz2F5LpU:Data.Text.Prettyprint.Doc.Render.Util.Panic
λ(x : Text) → ''
```

This is because the `prettyprinter` library requires that any `hardline`
is guarded (using a `flatAlt`) by a `hardline`-free alternative.
However, the pretty-printing code for multi-line strings was forcing a
hardline without any fallback, triggering the above panic.

The solution is to fall back to a double-quoted string, which is free of
hard lines.