### PR TITLE
Changes to syntax highlighting

### DIFF
--- a/src/Dhall/Pretty/Internal.hs
+++ b/src/Dhall/Pretty/Internal.hs
@@ -50,13 +50,15 @@ data Ann
   | Label       -- ^ Record labels
   | Literal     -- ^ Literals such as integers and strings
   | Builtin     -- ^ Builtin types and values
+  | Operator    -- ^ Operators
 
 annToAnsiStyle :: Ann -> Terminal.AnsiStyle
-annToAnsiStyle Keyword  = Terminal.bold
-annToAnsiStyle Syntax   = mempty
-annToAnsiStyle Label    = Terminal.color Terminal.Green
-annToAnsiStyle Literal  = Terminal.color Terminal.Magenta
-annToAnsiStyle Builtin  = Terminal.color Terminal.Red
+annToAnsiStyle Keyword  = Terminal.colorDull Terminal.Green
+annToAnsiStyle Syntax   = Terminal.colorDull Terminal.Green
+annToAnsiStyle Label    = mempty
+annToAnsiStyle Literal  = Terminal.colorDull Terminal.Magenta
+annToAnsiStyle Builtin  = Terminal.underlined
+annToAnsiStyle Operator = Terminal.colorDull Terminal.Green
 
 prettyExpr :: Pretty a => Expr s a -> Doc Ann
 prettyExpr = prettyExprA
@@ -70,12 +72,13 @@ duplicate :: a -> (a, a)
 duplicate x = (x, x)
 
 -- Annotation helpers
-keyword, syntax, label, literal, builtin :: Doc Ann -> Doc Ann
+keyword, syntax, label, literal, builtin, operator :: Doc Ann -> Doc Ann
 keyword  = Pretty.annotate Keyword
 syntax   = Pretty.annotate Syntax
 label    = Pretty.annotate Label
 literal  = Pretty.annotate Literal
 builtin  = Pretty.annotate Builtin
+operator = Pretty.annotate Operator
 
 comma, lbracket, rbracket, langle, rangle, lbrace, rbrace, lparen, rparen, pipe, rarrow, backtick, dollar, colon, lambda, forall, equals, dot :: Doc Ann
 comma    = syntax Pretty.comma
@@ -475,7 +478,7 @@ prettyExprC = prettyExprC0
 
 prettyExprC0 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC0 a0@(BoolOr _ _) =
-    enclose' "" "    " (space <> builtin "||" <> space) (builtin "||" <> "  ") (fmap duplicate (docs a0))
+    enclose' "" "    " (space <> operator "||" <> space) (operator "||" <> "  ") (fmap duplicate (docs a0))
   where
     docs (BoolOr a b) = prettyExprC1 a : docs b
     docs (Note   _ b) = docs b
@@ -487,7 +490,7 @@ prettyExprC0 a0 =
 
 prettyExprC1 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC1 a0@(TextAppend _ _) =
-    enclose' "" "    " (" " <> builtin "++" <> " ") (builtin "++" <> "  ") (fmap duplicate (docs a0))
+    enclose' "" "    " (" " <> operator "++" <> " ") (operator "++" <> "  ") (fmap duplicate (docs a0))
   where
     docs (TextAppend a b) = prettyExprC2 a : docs b
     docs (Note       _ b) = docs b
@@ -499,7 +502,7 @@ prettyExprC1 a0 =
 
 prettyExprC2 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC2 a0@(NaturalPlus _ _) =
-    enclose' "" "  " (" " <> builtin "+" <> " ") (builtin "+" <> " ") (fmap duplicate (docs a0))
+    enclose' "" "  " (" " <> operator "+" <> " ") (operator "+" <> " ") (fmap duplicate (docs a0))
   where
     docs (NaturalPlus a b) = prettyExprC3 a : docs b
     docs (Note        _ b) = docs b
@@ -511,7 +514,7 @@ prettyExprC2 a0 =
 
 prettyExprC3 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC3 a0@(ListAppend _ _) =
-    enclose' "" "  " (" " <> builtin "#" <> " ") (builtin "#" <> " ") (fmap duplicate (docs a0))
+    enclose' "" "  " (" " <> operator "#" <> " ") (operator "#" <> " ") (fmap duplicate (docs a0))
   where
     docs (ListAppend a b) = prettyExprC4 a : docs b
     docs (Note       _ b) = docs b
@@ -523,7 +526,7 @@ prettyExprC3 a0 =
 
 prettyExprC4 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC4 a0@(BoolAnd _ _) =
-    enclose' "" "    " (" " <> builtin "&&" <> " ") (builtin "&&" <> "  ") (fmap duplicate (docs a0))
+    enclose' "" "    " (" " <> operator "&&" <> " ") (operator "&&" <> "  ") (fmap duplicate (docs a0))
   where
     docs (BoolAnd a b) = prettyExprC5 a : docs b
     docs (Note    _ b) = docs b
@@ -535,7 +538,7 @@ prettyExprC4 a0 =
 
 prettyExprC5 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC5 a0@(Combine _ _) =
-    enclose' "" "  " (" " <> builtin "∧" <> " ") (builtin "∧" <> " ") (fmap duplicate (docs a0))
+    enclose' "" "  " (" " <> operator "∧" <> " ") (operator "∧" <> " ") (fmap duplicate (docs a0))
   where
     docs (Combine a b) = prettyExprC6 a : docs b
     docs (Note    _ b) = docs b
@@ -547,7 +550,7 @@ prettyExprC5 a0 =
 
 prettyExprC6 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC6 a0@(Prefer _ _) =
-    enclose' "" "  " (" " <> builtin "⫽" <> " ") (builtin "⫽" <> " ") (fmap duplicate (docs a0))
+    enclose' "" "  " (" " <> operator "⫽" <> " ") (operator "⫽" <> " ") (fmap duplicate (docs a0))
   where
     docs (Prefer a b) = prettyExprC7 a : docs b
     docs (Note   _ b) = docs b
@@ -559,7 +562,7 @@ prettyExprC6 a0 =
 
 prettyExprC7 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC7 a0@(NaturalTimes _ _) =
-    enclose' "" "  " (" " <> builtin "*" <> " ") (builtin "*" <> " ") (fmap duplicate (docs a0))
+    enclose' "" "  " (" " <> operator "*" <> " ") (operator "*" <> " ") (fmap duplicate (docs a0))
   where
     docs (NaturalTimes a b) = prettyExprC8 a : docs b
     docs (Note         _ b) = docs b
@@ -571,7 +574,7 @@ prettyExprC7 a0 =
 
 prettyExprC8 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC8 a0@(BoolEQ _ _) =
-    enclose' "" "    " (" " <> builtin "==" <> " ") (builtin "==" <> "  ") (fmap duplicate (docs a0))
+    enclose' "" "    " (" " <> operator "==" <> " ") (operator "==" <> "  ") (fmap duplicate (docs a0))
   where
     docs (BoolEQ a b) = prettyExprC9 a : docs b
     docs (Note   _ b) = docs b
@@ -583,7 +586,7 @@ prettyExprC8 a0 =
 
 prettyExprC9 :: Pretty a => Expr s a -> Doc Ann
 prettyExprC9 a0@(BoolNE _ _) =
-    enclose' "" "    " (" " <> builtin "!=" <> " ") (builtin "!=" <> "  ") (fmap duplicate (docs a0))
+    enclose' "" "    " (" " <> operator "!=" <> " ") (operator "!=" <> "  ") (fmap duplicate (docs a0))
   where
     docs (BoolNE a b) = prettyExprD a : docs b
     docs (Note   _ b) = docs b
@@ -668,13 +671,13 @@ prettyExprF OptionalFold =
 prettyExprF OptionalBuild =
     builtin "Optional/build"
 prettyExprF (BoolLit True) =
-    literal "True"
+    builtin "True"
 prettyExprF (BoolLit False) =
-    literal "False"
+    builtin "False"
 prettyExprF (IntegerLit a) =
     prettyNumber a
 prettyExprF (NaturalLit a) =
-    "+" <> prettyNatural a
+    literal "+" <> prettyNatural a
 prettyExprF (DoubleLit a) =
     prettyScientific a
 prettyExprF (TextLit a) =


### PR DESCRIPTION
The main thing this does is changing the color scheme as follows:

* Use dull green for all punctuation (including operators) and reserved
  keywords
* Use dull magenta for literals (i.e. numbers and strings)
* Use foreground color for all labels and builtin types/functions/values
* Underline builtins

Related changes include:

* Reclassifying `True`/`False` as builtins rather than literals
* Reclassifying operators as a new annotation type: `Operator`
* Including the leading `+` as part of a `Natural` literal for
  highlighting purposes

Here is the rationale for these highlighting choices:

My strongest preference is that variables should use the default foreground color
because:

* The variable names need to be the most legible part of the grammar for safety
  reasons in order to protect against confusing similarly named variables
* I assume user's terminals will be configured so that the default foreground color
  is maximally legible to them

My second preference is that built-in variables render similar to user-defined variables
names but are still distinguishable.

The reasons I believe built-in variables should render similar to user-defined variables are:

* I don't want to give built-in variables a strong syntax highlighting advantage over
  user-defined variables otherwise it might subtly disincentivize users from using
  abstraction in order to preserve coloration
* Builtins obey the grammar for variable names so I think they should render in a
  similar way
* The documentation encourages users to name variables to resemble builtin names (i.e.
  `let List/map = https://... in ...`) and those should render similar to builtins

However, I still underline builtins so that (A) users can still discern which variables are
built-in for educational purposes and discoverability and (B) so that users can quickly
discern if they mistyped a built-in name.

Given that we have no control over the default foreground color of the terminal, that
implies that if we pin built-in variables to a specific color then we can't guarantee that it
will be close to the default foreground color.  So I opted to still use the same foreground
color for built-ins but use an underline to distinguish them.  I also tried italics but that
was visually jarring in code that had even proportions of user-defined and built-in variables.
Bold is another alternative that seemed okay, but underline just seemed a little more
subtle.

I classified `True` and `False` as builtin variables for the same reason: in a pure type
system are conceptually no different from `Text`, `Type`, or `Kind`: they are built-in
variables and the fact that they are on the term-level isn't a significant distinction.
They also follow the same grammar as user-defined variables, just like all the other
built-in variables

My next preference was to use the same color for all punctuation.  It didn't have to be
dull green specifically, but that was one of the few colors that was easily legible for me on both
black and white terminal backgrounds (the other ones being vivid red and dull/vivid magenta;
both dull/vivid blue were difficult on dark backgrounds and vivid green + dull/vivid yellow + dull/vivid cyan were difficult on light backgrounds).

I also ended up using the same color for keywords, too.  My reasoning was that I wanted to
convey through the use of a single consistent color that these were all built-in syntax so that
the user always mentally associates "green" with "built-in syntax".  However, I would be open
to using a different color for keywords: my preference to use the same color for keywords and
punctuation is not that strong, but I was running out of colors to use.

Literals I left almost the same as before: they are still magenta but now dull for improved
contrast on white backgrounds.  Vivid magenta was still pretty legible, but dull magenta was
just a little bit more legible.

The reason I did not use red anywhere was that I wanted to reserve that color for error
messages so that users can tell at a glance that they got an error just by looking for the
presence of red.  That's also another reason I preferred dull magenta over vivid magenta
because it is slightly more differentiated from the vivid red of error messages.

Here are examples of how this looks on both white and dark backgrounds:

<img width="486" alt="screen shot 2018-02-18 at 8 07 15 am" src="https://user-images.githubusercontent.com/1313787/36354007-d7b78934-1482-11e8-8b00-ddcf402fd81f.png">

<img width="487" alt="screen shot 2018-02-18 at 8 07 44 am" src="https://user-images.githubusercontent.com/1313787/36354010-ddee41c6-1482-11e8-9f96-a0ed6bcdc318.png">
