### PR TITLE
Simplify option extraction

### DIFF
--- a/dhall-format/Main.hs
+++ b/dhall-format/Main.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE TypeOperators      #-}
 
 {-| Utility executable for pretty-printing Dhall code
@@ -31,7 +33,7 @@ import Data.Monoid ((<>))
 import Data.Version (showVersion)
 import Dhall.Parser (exprAndHeaderFromText)
 import Dhall.Pretty (annToAnsiStyle, prettyExpr)
-import Options.Generic (Generic, ParseRecord, type (<?>)(..))
+import Options.Generic (Generic, ParseRecord, Wrapped, type (<?>)(..), (:::))
 import System.IO (stderr)
 import System.Exit (exitFailure, exitSuccess)
 import Text.Trifecta.Delta (Delta(..))
@@ -49,12 +51,12 @@ import qualified Options.Generic
 import qualified System.Console.ANSI
 import qualified System.IO
 
-data Options = Options
-    { version :: Bool           <?> "Display version and exit"
-    , inplace :: Maybe FilePath <?> "Modify the specified file in-place"
+data Options w = Options
+    { version :: w ::: Bool           <?> "Display version and exit"
+    , inplace :: w ::: Maybe FilePath <?> "Modify the specified file in-place"
     } deriving (Generic)
 
-instance ParseRecord Options
+instance ParseRecord (Options Wrapped)
 
 opts :: Pretty.LayoutOptions
 opts =
@@ -63,8 +65,8 @@ opts =
 
 main :: IO ()
 main = do
-    options <- Options.Generic.getRecord "Formatter for the Dhall language"
-    when (unHelpful (version options)) $ do
+    Options {..} <- Options.Generic.unwrapRecord "Formatter for the Dhall language"
+    when version $ do
       putStrLn (showVersion Meta.version)
       exitSuccess
 
@@ -75,7 +77,7 @@ main = do
             System.Exit.exitFailure
 
     Control.Exception.handle handler (do
-        case unHelpful (inplace options) of
+        case inplace of
             Just file -> do
                 strictText <- Data.Text.IO.readFile file
                 let lazyText = Data.Text.Lazy.fromStrict strictText

--- a/dhall-hash/Main.hs
+++ b/dhall-hash/Main.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE TypeOperators      #-}
 
 module Main where
@@ -13,7 +15,7 @@ import Dhall.Core (normalize)
 import Dhall.Import (Imported(..), hashExpressionToCode, load)
 import Dhall.Parser (Src, exprFromText)
 import Dhall.TypeCheck (DetailedTypeError(..), TypeError, X)
-import Options.Generic (Generic, ParseRecord, type (<?>)(..))
+import Options.Generic (Generic, ParseRecord, Wrapped, type (<?>)(..), (:::))
 import System.IO (stderr)
 import System.Exit (exitFailure, exitSuccess)
 import Text.Trifecta.Delta (Delta(..))
@@ -26,17 +28,17 @@ import qualified Dhall.TypeCheck
 import qualified Options.Generic
 import qualified System.IO
 
-data Options = Options
-    { explain :: Bool <?> "Explain error messages in more detail"
-    , version :: Bool <?> "Display version and exit"
+data Options w = Options
+    { explain :: w ::: Bool <?> "Explain error messages in more detail"
+    , version :: w ::: Bool <?> "Display version and exit"
     } deriving (Generic)
 
-instance ParseRecord Options
+instance ParseRecord (Options Wrapped)
 
 main :: IO ()
 main = do
-    options <- Options.Generic.getRecord "Compiler for the Dhall language"
-    when (unHelpful (version options)) $ do
+    Options {..} <- Options.Generic.unwrapRecord "Compiler for the Dhall language"
+    when version $ do
       putStrLn (showVersion Meta.version)
       exitSuccess
     let handle =
@@ -47,7 +49,7 @@ main = do
             handler0 e = do
                 let _ = e :: TypeError Src X
                 System.IO.hPutStrLn stderr ""
-                if unHelpful (explain options)
+                if explain
                     then Control.Exception.throwIO (DetailedTypeError e)
                     else do
                         Data.Text.Lazy.IO.hPutStrLn stderr "\ESC[2mUse \"dhall --explain\" for detailed errors\ESC[0m"
@@ -56,7 +58,7 @@ main = do
             handler1 (Imported ps e) = do
                 let _ = e :: TypeError Src X
                 System.IO.hPutStrLn stderr ""
-                if unHelpful (explain options)
+                if explain
                     then Control.Exception.throwIO (Imported ps (DetailedTypeError e))
                     else do
                         Data.Text.Lazy.IO.hPutStrLn stderr "\ESC[2mUse \"dhall --explain\" for detailed errors\ESC[0m"

--- a/dhall/Main.hs
+++ b/dhall/Main.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE TypeOperators      #-}
 
 module Main where
@@ -15,7 +17,7 @@ import Dhall.Import (Imported(..), load)
 import Dhall.Parser (Src, exprAndHeaderFromText)
 import Dhall.Pretty (annToAnsiStyle, prettyExpr)
 import Dhall.TypeCheck (DetailedTypeError(..), TypeError, X)
-import Options.Generic (Generic, ParseRecord, type (<?>)(..))
+import Options.Generic (Generic, ParseRecord, Wrapped, type (<?>)(..), (:::))
 import System.Exit (exitFailure, exitSuccess)
 import Text.Trifecta.Delta (Delta(..))
 
@@ -32,13 +34,13 @@ import qualified Options.Generic
 import qualified System.Console.ANSI
 import qualified System.IO
 
-data Options = Options
-    { explain :: Bool <?> "Explain error messages in more detail"
-    , version :: Bool <?> "Display version and exit"
-    , pretty  :: Bool <?> "Format output"
+data Options w = Options
+    { explain :: w ::: Bool <?> "Explain error messages in more detail"
+    , version :: w ::: Bool <?> "Display version and exit"
+    , pretty  :: w ::: Bool <?> "Format output"
     } deriving (Generic)
 
-instance ParseRecord Options
+instance ParseRecord (Options Wrapped)
 
 opts :: Pretty.LayoutOptions
 opts =
@@ -50,8 +52,8 @@ unbounded = Pretty.LayoutOptions { Pretty.layoutPageWidth = Pretty.Unbounded }
 
 main :: IO ()
 main = do
-    options <- Options.Generic.getRecord "Compiler for the Dhall language"
-    when (unHelpful (version options)) $ do
+    Options {..} <- Options.Generic.unwrapRecord "Compiler for the Dhall language"
+    when version $ do
       putStrLn (showVersion Meta.version)
       exitSuccess
 
@@ -63,7 +65,7 @@ main = do
             handler0 e = do
                 let _ = e :: TypeError Src X
                 System.IO.hPutStrLn System.IO.stderr ""
-                if unHelpful (explain options)
+                if explain
                     then Control.Exception.throwIO (DetailedTypeError e)
                     else do
                         Data.Text.Lazy.IO.hPutStrLn System.IO.stderr "\ESC[2mUse \"dhall --explain\" for detailed errors\ESC[0m"
@@ -72,7 +74,7 @@ main = do
             handler1 (Imported ps e) = do
                 let _ = e :: TypeError Src X
                 System.IO.hPutStrLn System.IO.stderr ""
-                if unHelpful (explain options)
+                if explain
                     then Control.Exception.throwIO (Imported ps (DetailedTypeError e))
                     else do
                         Data.Text.Lazy.IO.hPutStrLn System.IO.stderr "\ESC[2mUse \"dhall --explain\" for detailed errors\ESC[0m"
@@ -99,7 +101,7 @@ main = do
                         then Pretty.Terminal.renderIO handle (fmap annToAnsiStyle doc)
                         else Pretty.Text.renderIO handle (Pretty.unAnnotateS doc)
 
-                if unHelpful (pretty options)
+                if pretty
                     then do
                         let doc = Pretty.pretty header <> prettyExpr e
                         renderIO (Pretty.layoutSmart opts doc)


### PR DESCRIPTION
This takes advantage of two features to simplify accessing options
fields:

* This uses `optparse-generic`'s support for generating option records
  without `Helpful` newtype wrappers
* This also uses `RecordWildCards` to unpack the option record