### PR TITLE
Enforce `-Werror` in CI

### DIFF
--- a/dhall/Main.hs
+++ b/dhall/Main.hs
@@ -26,7 +26,6 @@ import qualified Data.Text.Lazy.IO
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty.Terminal
 import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty.Text
-import qualified Dhall.Core
 import qualified Dhall.TypeCheck
 import qualified Options.Generic
 import qualified System.Console.ANSI
@@ -92,12 +91,12 @@ main = do
             Left  err -> Control.Exception.throwIO err
             Right x   -> return x
 
-        let render handle e = do
-                supportsANSI <- System.Console.ANSI.hSupportsANSI handle
+        let render h e = do
+                supportsANSI <- System.Console.ANSI.hSupportsANSI h
                 let renderIO doc =
                         if supportsANSI
-                        then Pretty.Terminal.renderIO handle (fmap annToAnsiStyle doc)
-                        else Pretty.Text.renderIO handle (Pretty.unAnnotateS doc)
+                        then Pretty.Terminal.renderIO h (fmap annToAnsiStyle doc)
+                        else Pretty.Text.renderIO h (Pretty.unAnnotateS doc)
 
                 if unHelpful (pretty options)
                     then do
@@ -106,7 +105,7 @@ main = do
                     else do
                         let doc = prettyExpr e
                         renderIO (Pretty.layoutPretty unbounded doc)
-                Data.Text.Lazy.IO.hPutStrLn handle ""
+                Data.Text.Lazy.IO.hPutStrLn h ""
 
 
         expr' <- load expr

--- a/release.nix
+++ b/release.nix
@@ -4,9 +4,17 @@ let
       haskellPackages = pkgs.haskellPackages.override {
         overrides = haskellPackagesNew: haskellPackagesOld: {
           dhall =
-            pkgs.haskell.lib.justStaticExecutables
-              (haskellPackagesNew.callPackage ./default.nix { })
-            ;
+            # Remove this once it is available in Nixpkgs 18.03
+            let
+              failOnAllWarnings =
+                drv: pkgs.haskell.lib.appendConfigureFlag drv "--ghc-option=-Wall --ghc-option=-Werror";
+
+
+            in
+              failOnAllWarnings
+                (pkgs.haskell.lib.justStaticExecutables
+                  (haskellPackagesNew.callPackage ./default.nix { })
+                );
         };
       };
     };


### PR DESCRIPTION
This adds the `-Werror` flag to CI so that warnings don't sneak into the
build (and also fixes the current set of warnings)