### PR TITLE
Housekeeping

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -96,12 +96,10 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                        >= 4.9.0.0  && < 5   ,
-        ansi-terminal               >= 0.6.3.1  && < 0.8 ,
         ansi-wl-pprint                           < 0.7 ,
         base16-bytestring                        < 0.2 ,
         bytestring                               < 0.11,
         case-insensitive                         < 1.3 ,
-        charset                                  < 0.4 ,
         containers                  >= 0.5.0.0  && < 0.6 ,
         contravariant                            < 1.5 ,
         cryptohash                               < 0.12,
@@ -157,7 +155,6 @@ Executable dhall-repl
     Build-Depends:
         base             >= 4        && < 5   ,
         dhall                                 ,
-        containers                            ,
         haskeline        >= 0.7.3.0  && < 0.8 ,
         mtl              >= 2.2.1    && < 2.3 ,
         repline          >= 0.1.6.0  && < 0.2 ,
@@ -211,7 +208,6 @@ Test-Suite test
         Util
     Build-Depends:
         base                      >= 4        && < 5   ,
-        containers                >= 0.5.0.0  && < 0.6 ,
         deepseq                   >= 1.2.0.1  && < 1.5 ,
         dhall                                          ,
         insert-ordered-containers                      ,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,3 @@
 resolver: lts-9.6
-
+extra-deps:
+    - prettyprinter-1.2.0.1


### PR DESCRIPTION
- LTS-9/10 contain only Prettyprinter 1.1*, the required 1.2 bump will not happen until LTS-11. For this reason, Prettyprinter 1.2 is added explicitly to the stack.yaml file so that `stack build` works once again.
- Remove a couple of redundant dependencies (courtesy of [Weeder](https://hackage.haskell.org/package/weeder))