### PR TITLE
WIP support s3:// url in dhall expressions

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, ansi-terminal, ansi-wl-pprint, base
+{ mkDerivation, amazonka, amazonka-s3, ansi-terminal, ansi-wl-pprint, base
 , base16-bytestring, bytestring, case-insensitive, charset
 , containers, contravariant, cryptohash, deepseq, directory
 , exceptions, filepath, haskeline, http-client, http-client-tls
@@ -15,7 +15,7 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-terminal ansi-wl-pprint base base16-bytestring bytestring
+    amazonka amazonka-s3 ansi-terminal ansi-wl-pprint base base16-bytestring bytestring
     case-insensitive charset containers contravariant cryptohash
     directory exceptions filepath http-client http-client-tls
     insert-ordered-containers lens-family-core parsers prettyprinter

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -95,12 +95,16 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                        >= 4.9.0.0  && < 5   ,
+        amazonka                    >= 1.4      && < 1.6,
+        amazonka-core               >= 1.4      && < 1.6,
+        amazonka-s3                 >= 1.4      && < 1.6,
         ansi-terminal               >= 0.6.3.1  && < 0.8 ,
         ansi-wl-pprint                           < 0.7 ,
         base16-bytestring                        < 0.2 ,
         bytestring                               < 0.11,
         case-insensitive                         < 1.3 ,
         charset                                  < 0.4 ,
+        conduit,
         containers                  >= 0.5.0.0  && < 0.6 ,
         contravariant                            < 1.5 ,
         cryptohash                               < 0.12,

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -80,6 +80,7 @@ import qualified Data.Text.Lazy.Builder                as Builder
 import qualified Data.Text.Prettyprint.Doc             as Pretty
 import qualified Data.Vector
 import qualified Data.Vector.Mutable
+import qualified Network.AWS.S3                        as S3
 
 {-| Constants for a pure type system
 
@@ -111,7 +112,9 @@ data PathType
     = File HasHome FilePath
     -- ^ Local path
     | URL  Text (Maybe PathHashed)
-    -- ^ URL of emote resource and optional headers stored in a path
+    -- ^ URL of remote resource and optional headers stored in a path
+    | S3URL S3.BucketName S3.ObjectKey (Maybe PathHashed)
+    -- ^ s3 URL of remote resource and optional headers stored in a path
     | Env  Text
     -- ^ Environment variable
     deriving (Eq, Ord, Show)
@@ -130,6 +133,8 @@ instance Buildable PathType where
         txt = Text.pack file
     build (URL str  Nothing      ) = build str <> " "
     build (URL str (Just headers)) = build str <> " using " <> build headers <> " "
+    build (S3URL (S3.BucketName bkt) (S3.ObjectKey obj) Nothing)  = "s3://" <> build bkt <> " " <> build obj
+    build (S3URL b o (Just headers)) = build (S3URL b o Nothing) <> " " <> build headers <> " "
     build (Env env) = "env:" <> build env
 
 -- | How to interpret the path's contents (i.e. as Dhall code or raw text)


### PR DESCRIPTION
Addresses #292 

 - [x] Basic parsing of `s3://example/object.dhall` into an `S3URL` constructor of `PathType`
 - [x] Happy-path AWS-credentials discovery, download and parse of file at s3:// URL
 - [ ] Correct `canonicalize` for s3 paths
 - [ ] Better error-handling for malformed s3 paths and download failures
 - [ ] Code clean-up
 - [ ] Documentation
 - [ ] Tests
 - [ ] Possible replacement of `amazonka` (a heavy dependency) with something special-purpose

This simple case, with a `t.dh` dhall file in non-public `dhall-test` s3 bucket, is working:

```
-- local_file.dhall
let x = s3://dhall-test/t.dh
in  if x then 5 else 3
```

```
-- s3://dhall-test/t.dh
True
```

```
[nix-shell:~/code/dhall-haskell]$ dist/build/dhall/dhall <<< ./local_file.dhall
bkt
BucketName "ha2"
obj
ObjectKey "t.dh"
response:
True

Integer

5
```