### PR TITLE
Loosen upper bound on exceptions library

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -103,7 +103,7 @@ Library
         containers                  >= 0.5.0.0  && < 0.6 ,
         contravariant                            < 1.5 ,
         cryptohash                               < 0.12,
-        exceptions                  >= 0.8.3    && < 0.9 ,
+        exceptions                  >= 0.8.3    && < 0.10 ,
         directory                   >= 1.3      && < 1.4 ,
         filepath                    >= 1.4      && < 1.5 ,
         http-client                 >= 0.4.30   && < 0.6 ,


### PR DESCRIPTION
This would loosen the upper bound on the `exceptions` library, simplifying things for me downstream :)