### PR TITLE
Fix equivalence check to match standard semantics

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -28,6 +28,7 @@ module Dhall.Core (
     , Expr(..)
 
     -- * Normalization
+    , alphaNormalize
     , normalize
     , normalizeWith
     , Normalizer
@@ -849,6 +850,258 @@ subst x e (Note a b) = Note a b'
 -- The Dhall compiler enforces that all embedded values are closed expressions
 -- and `subst` does nothing to a closed expression
 subst _ _ (Embed p) = Embed p
+
+{-| α-normalize an expression by renaming all variables to @\"_\"@ and using
+    De Bruijn indices to distinguish them
+-}
+alphaNormalize :: Expr s a -> Expr s a
+alphaNormalize (Const c) =
+    Const c
+alphaNormalize (Var v) =
+    Var v
+alphaNormalize (Lam x _A₀ b₀) =
+    Lam "_" _A₁ b₃
+  where
+    _A₁ = alphaNormalize _A₀
+
+    v₀ = Var (V "_" 0)
+    v₁ = shift 1 (V x 0) v₀
+    b₁ = subst (V x 0) v₁ b₀
+    b₂ = shift (-1) (V x 0) b₁
+    b₃ = alphaNormalize b₂
+alphaNormalize (Pi x _A₀ _B₀) =
+    Pi "_" _A₁ _B₃
+  where
+    _A₁ = alphaNormalize _A₀
+
+    v₀  = Var (V "_" 0)
+    v₁  = shift 1 (V x 0) v₀
+    _B₁ = subst (V x 0) v₁ _B₀
+    _B₂ = shift (-1) (V x 0) _B₁
+    _B₃ = alphaNormalize _B₂
+alphaNormalize (App f₀ a₀) =
+    App f₁ a₁
+  where
+    f₁ = alphaNormalize f₀
+
+    a₁ = alphaNormalize a₀
+alphaNormalize (Let x (Just _A₀) a₀ b₀) =
+    Let x (Just _A₁) a₁ b₃
+  where
+    _A₁ = alphaNormalize _A₀
+
+    a₁ = alphaNormalize a₀
+
+    v₀ = Var (V "_" 0)
+    v₁ = shift 1 (V x 0) v₀
+    b₁ = subst (V x 0) v₁ b₀
+    b₂ = shift (-1) (V x 0) b₁
+    b₃ = alphaNormalize b₂
+alphaNormalize (Let x Nothing a₀ b₀) =
+    Let x Nothing a₁ b₃
+  where
+    a₁ = alphaNormalize a₀
+
+    v₀ = Var (V "_" 0)
+    v₁ = shift 1 (V x 0) v₀
+    b₁ = subst (V x 0) v₁ b₀
+    b₂ = shift (-1) (V x 0) b₁
+    b₃ = alphaNormalize b₂
+alphaNormalize (Annot t₀ _T₀) =
+    Annot t₁ _T₁
+  where
+    t₁ = alphaNormalize t₀
+
+    _T₁ = alphaNormalize _T₀
+alphaNormalize Bool =
+    Bool
+alphaNormalize (BoolLit b) =
+    BoolLit b
+alphaNormalize (BoolAnd l₀ r₀) =
+    BoolAnd l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize (BoolOr l₀ r₀) =
+    BoolOr l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize (BoolEQ l₀ r₀) =
+    BoolEQ l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize (BoolNE l₀ r₀) =
+    BoolNE l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize (BoolIf t₀ l₀ r₀) =
+    BoolIf t₁ l₁ r₁
+  where
+    t₁ = alphaNormalize t₀
+
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize Natural =
+    Natural
+alphaNormalize (NaturalLit n) =
+    NaturalLit n
+alphaNormalize NaturalFold =
+    NaturalFold
+alphaNormalize NaturalBuild =
+    NaturalBuild
+alphaNormalize NaturalIsZero =
+    NaturalIsZero
+alphaNormalize NaturalEven =
+    NaturalEven
+alphaNormalize NaturalOdd =
+    NaturalOdd
+alphaNormalize NaturalToInteger =
+    NaturalToInteger
+alphaNormalize NaturalShow =
+    NaturalShow
+alphaNormalize (NaturalPlus l₀ r₀) =
+    NaturalPlus l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize (NaturalTimes l₀ r₀) =
+    NaturalTimes l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize Integer =
+    Integer
+alphaNormalize (IntegerLit n) =
+    IntegerLit n
+alphaNormalize IntegerShow =
+    IntegerShow
+alphaNormalize Double =
+    Double
+alphaNormalize (DoubleLit n) =
+    DoubleLit n
+alphaNormalize DoubleShow =
+    DoubleShow
+alphaNormalize Text =
+    Text
+alphaNormalize (TextLit (Chunks xys₀ z)) =
+    TextLit (Chunks xys₁ z)
+  where
+    xys₁ = do
+        (x, y₀) <- xys₀
+        let y₁ = alphaNormalize y₀
+        return (x, y₁)
+alphaNormalize (TextAppend l₀ r₀) =
+    TextAppend l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize List =
+    List
+alphaNormalize (ListLit (Just _T₀) ts₀) =
+    ListLit (Just _T₁) ts₁
+  where
+    _T₁ = alphaNormalize _T₀
+
+    ts₁ = fmap alphaNormalize ts₀
+alphaNormalize (ListLit Nothing ts₀) =
+    ListLit Nothing ts₁
+  where
+    ts₁ = fmap alphaNormalize ts₀
+alphaNormalize (ListAppend l₀ r₀) =
+    ListAppend l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize ListBuild =
+    ListBuild
+alphaNormalize ListFold =
+    ListFold
+alphaNormalize ListLength =
+    ListLength
+alphaNormalize ListHead =
+    ListHead
+alphaNormalize ListLast =
+    ListLast
+alphaNormalize ListIndexed =
+    ListIndexed
+alphaNormalize ListReverse =
+    ListReverse
+alphaNormalize Optional =
+    Optional
+alphaNormalize (OptionalLit _T₀ ts₀) =
+    OptionalLit _T₁ ts₁
+  where
+    _T₁ = alphaNormalize _T₀
+
+    ts₁ = fmap alphaNormalize ts₀
+alphaNormalize OptionalFold =
+    OptionalFold
+alphaNormalize OptionalBuild =
+    OptionalBuild
+alphaNormalize (Record kts₀) =
+    Record kts₁
+  where
+    kts₁ = fmap alphaNormalize kts₀
+alphaNormalize (RecordLit kvs₀) =
+    RecordLit kvs₁
+  where
+    kvs₁ = fmap alphaNormalize kvs₀
+alphaNormalize (Union kts₀) =
+    Union kts₁
+  where
+    kts₁ = fmap alphaNormalize kts₀
+alphaNormalize (UnionLit k v₀ kts₀) =
+    UnionLit k v₁ kts₁
+  where
+    v₁ = alphaNormalize v₀
+
+    kts₁ = fmap alphaNormalize kts₀
+alphaNormalize (Combine l₀ r₀) =
+    Combine l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize (Prefer l₀ r₀) =
+    Prefer l₁ r₁
+  where
+    l₁ = alphaNormalize l₀
+
+    r₁ = alphaNormalize r₀
+alphaNormalize (Merge t₀ u₀ _T₀) =
+    Merge t₁ u₁ _T₁
+  where
+    t₁ = alphaNormalize t₀
+
+    u₁ = alphaNormalize u₀
+
+    _T₁ = fmap alphaNormalize _T₀
+alphaNormalize (Constructors u₀) =
+    Constructors u₁
+  where
+    u₁ = alphaNormalize u₀
+alphaNormalize (Field e₀ a) =
+    Field e₁ a
+  where
+    e₁ = alphaNormalize e₀
+alphaNormalize (Note s e₀) =
+    Note s e₁
+  where
+    e₁ = alphaNormalize e₀
+alphaNormalize (Embed a) =
+    Embed a
 
 {-| Reduce an expression to its normal form, performing beta reduction
 

--- a/tests/TypeCheck.hs
+++ b/tests/TypeCheck.hs
@@ -26,6 +26,9 @@ typecheckTests =
         , should
             "allow type-valued alternatives in a union"
             "alternativesAreTypes"
+        , should
+            "allow anonymous functions in types to be judgmentally equal"
+            "anonymousFunctionsInTypes"
         ]
 
 should :: Text -> Text -> TestTree

--- a/tests/typecheck/anonymousFunctionsInTypesA.dhall
+++ b/tests/typecheck/anonymousFunctionsInTypesA.dhall
@@ -1,0 +1,5 @@
+    let anonymousFunction = λ(a : Type) → List a
+
+in    λ(HigherOrderType : (Type → Type) → Type)
+    → λ(x : HigherOrderType anonymousFunction)
+    → (x : HigherOrderType anonymousFunction)

--- a/tests/typecheck/anonymousFunctionsInTypesB.dhall
+++ b/tests/typecheck/anonymousFunctionsInTypesB.dhall
@@ -1,0 +1,4 @@
+  ∀(HigherOrderType : (Type → Type) → Type)
+→ ∀(x : HigherOrderType (λ(a : Type) → List a))
+→ HigherOrderType (λ(a : Type) → List a)
+


### PR DESCRIPTION
Fixes #299

The standard mandates that two terms that are α-equivalent and
β-equivalent should be equal for type-checking purposes, but the
implementation was not matching the standard.  Specifically, a
type with an anonymous function would never compare as equal to
itself.

The newly added regression test shows an example of where the previous
implementation was misbehaving, where `λ(x : Type) → List x` would
not compare as equal to itself before.  After this change it correctly
matches itself since it is (obviously) the exact same type.

This also adds a new `alphaNormalize` function which was implemented
along the way, which converts an expression to α-normal form using
De Bruijn indices.