### PR TITLE
Fix a typo in the docs for Union constructors

### DIFF
--- a/src/Dhall/Tutorial.hs
+++ b/src/Dhall/Tutorial.hs
@@ -1115,7 +1115,7 @@ import Dhall
 -- common pattern:
 --
 -- >     let MyType = constructors < Empty : {} | Person : { name : Text, age : Natural } >
--- > in  [   MyType.Empty {}
+-- > in  [   MyType.Empty {=}
 -- >     ,   MyType.Person { name = "John", age = +23 }
 -- >     ,   MyType.Person { name = "Amy" , age = +25 }
 -- >     ]


### PR DESCRIPTION
Just a simple typo fix for the Tutorial documentation. If I follow the example for Union constructors I get an error:
```
$ dhall
    let MyType = constructors < Empty : {} | Person : { name : Text, age : Natural } >
in  [   MyType.Empty {}
    ,   MyType.Person { name = "John", age = +23 }
    ,   MyType.Person { name = "Amy" , age = +25 }
    ]
^D
Use "dhall --explain" for detailed errors

Error: Wrong type of function argument

MyType.Empty {}
```
The argument to `MyType.Empty` should be the value `{=}` (I think).