### PR TITLE
Increase weight of highlighted syntax

### DIFF
--- a/src/Dhall/Pretty/Internal.hs
+++ b/src/Dhall/Pretty/Internal.hs
@@ -62,12 +62,12 @@ data Ann
     purposes
 -}
 annToAnsiStyle :: Ann -> Terminal.AnsiStyle
-annToAnsiStyle Keyword  = Terminal.colorDull Terminal.Green
-annToAnsiStyle Syntax   = Terminal.colorDull Terminal.Green
+annToAnsiStyle Keyword  = Terminal.bold <> Terminal.colorDull Terminal.Green
+annToAnsiStyle Syntax   = Terminal.bold <> Terminal.colorDull Terminal.Green
 annToAnsiStyle Label    = mempty
 annToAnsiStyle Literal  = Terminal.colorDull Terminal.Magenta
 annToAnsiStyle Builtin  = Terminal.underlined
-annToAnsiStyle Operator = Terminal.colorDull Terminal.Green
+annToAnsiStyle Operator = Terminal.bold <> Terminal.colorDull Terminal.Green
 
 -- | Pretty print an expression
 prettyExpr :: Pretty a => Expr s a -> Doc Ann


### PR DESCRIPTION
This bolds the green highlighted syntax so that it's easier to visually
navigate on white backgrounds