### PR TITLE
Make `dhall` `-Wcompat` clean

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -190,7 +190,7 @@ Library
         Dhall.TypeCheck
     Other-Modules:
         Dhall.Pretty.Internal
-    GHC-Options: -Wall
+    GHC-Options: -Wall -Wcompat
 
 Executable dhall
     Hs-Source-Dirs: dhall
@@ -204,7 +204,7 @@ Executable dhall
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
         trifecta                    >= 1.6      && < 1.8 ,
         text                        >= 0.11.1.0 && < 1.3
-    GHC-Options: -Wall
+    GHC-Options: -Wall -Wcompat
     Other-Modules:
         Paths_dhall
 
@@ -222,7 +222,7 @@ Executable dhall-repl
         prettyprinter-ansi-terminal           ,
         text                                  ,
         trifecta
-    GHC-Options: -Wall
+    GHC-Options: -Wall -Wcompat
 
 Executable dhall-format
     Hs-Source-Dirs: dhall-format
@@ -236,7 +236,7 @@ Executable dhall-format
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
         trifecta                    >= 1.6      && < 1.8 ,
         text                        >= 0.11.1.0 && < 1.3
-    GHC-Options: -Wall
+    GHC-Options: -Wall -Wcompat
     Other-Modules:
         Paths_dhall
 
@@ -256,7 +256,7 @@ Test-Suite test
     Type: exitcode-stdio-1.0
     Hs-Source-Dirs: tests
     Main-Is: Tests.hs
-    GHC-Options: -Wall
+    GHC-Options: -Wall -Wcompat
     Other-Modules:
         Format
         Normalization

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -58,10 +58,10 @@ import Data.Bifunctor (Bifunctor(..))
 import Data.Foldable
 import Data.HashMap.Strict.InsOrd (InsOrdHashMap)
 import Data.HashSet (HashSet)
-import Data.Monoid ((<>))
 import Data.String (IsString(..))
 import Data.Scientific (Scientific)
 import Data.Sequence (Seq, ViewL(..), ViewR(..))
+import Data.Semigroup (Semigroup(..))
 import Data.Text.Lazy (Text)
 import Data.Text.Lazy.Builder (Builder)
 import Data.Text.Prettyprint.Doc (Pretty)
@@ -468,20 +468,17 @@ instance IsString (Expr s a) where
 data Chunks s a = Chunks [(Builder, Expr s a)] Builder
     deriving (Functor, Foldable, Traversable, Show, Eq)
 
+instance Data.Semigroup.Semigroup (Chunks s a) where
+    Chunks xysL zL <> Chunks         []    zR =
+        Chunks xysL (zL <> zR)
+    Chunks xysL zL <> Chunks ((x, y):xysR) zR =
+        Chunks (xysL ++ (zL <> x, y):xysR) zR
+
 instance Monoid (Chunks s a) where
     mempty = Chunks [] mempty
 
-#if MIN_VERSION_base(4,11,0)
-instance Semigroup (Chunks s a) where
-    (<>) (Chunks xysL zL) (Chunks         []    zR) =
-        Chunks xysL (zL <> zR)
-    (<>) (Chunks xysL zL) (Chunks ((x, y):xysR) zR) =
-        Chunks (xysL ++ (zL <> x, y):xysR) zR
-#else
-    mappend (Chunks xysL zL) (Chunks         []    zR) =
-        Chunks xysL (zL <> zR)
-    mappend (Chunks xysL zL) (Chunks ((x, y):xysR) zR) =
-        Chunks (xysL ++ (zL <> x, y):xysR) zR
+#if !(MIN_VERSION_base(4,11,0))
+    mappend = (<>)
 #endif
 
 instance IsString (Chunks s a) where


### PR DESCRIPTION
This fixes Dhall to exactly match the guidance given in
https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid for
compatibility with GHC 8.4