### PR TITLE
Version 1.11.1 → 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+1.12.0
+
+* Additional changes to support GHC 8.4
+    * See: https://github.com/dhall-lang/dhall-haskell/pull/331
+* BREAKING CHANGE TO API: Replace dependency on `text-format` with `formatting`
+    * This replace the `Data.Text.Buildable.Buildable` instances with
+      `Formatting.Buildable.Buildable` instances, which is why this is a
+       breaking change
+    * `text-format` is no longer maintained and blocking GHC 8.4 support
+    * See: https://github.com/dhall-lang/dhall-haskell/pull/330
+
 1.11.1
 
 * Support GHC 8.4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `dhall 1.11.1`
+# `dhall 1.12.0`
 
 `dhall` is a total programming language specialized to configuration files
 

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@
 }:
 mkDerivation {
   pname = "dhall";
-  version = "1.11.1";
+  version = "1.12.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;
@@ -21,7 +21,6 @@ mkDerivation {
     lens-family-core memory parsers prettyprinter
     prettyprinter-ansi-terminal scientific text transformers trifecta
     unordered-containers vector
-
   ];
   executableHaskellDepends = [
     ansi-terminal base haskeline mtl optparse-generic prettyprinter

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -1,5 +1,5 @@
 Name: dhall
-Version: 1.11.1
+Version: 1.12.0
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 Tested-With: GHC == 8.0.1


### PR DESCRIPTION
The main motivation for this release is to build on GHC 8.4 (necessary for Stackage nightly)