### PR TITLE
Support for ghc-7.10.3 / lts-6.27

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -213,20 +213,20 @@ Executable dhall
     Other-Modules:
         Paths_dhall
 
--- Executable dhall-repl
---     Hs-Source-Dirs: dhall-repl
---     Main-Is: Main.hs
---     Build-Depends:
---         base             >= 4        && < 5   ,
---         ansi-terminal                         ,
---         dhall                                 ,
---         haskeline        >= 0.7.3.0  && < 0.8 ,
---         mtl              >= 2.2.1    && < 2.3 ,
---         repline          >= 0.1.6.0  && < 0.2 ,
---         prettyprinter                         ,
---         prettyprinter-ansi-terminal           ,
---         text
---     GHC-Options: -Wall -Wcompat
+Executable dhall-repl
+    Hs-Source-Dirs: dhall-repl
+    Main-Is: Main.hs
+    Build-Depends:
+        base             >= 4        && < 5   ,
+        ansi-terminal                         ,
+        dhall                                 ,
+        haskeline        >= 0.7.3.0  && < 0.8 ,
+        mtl              >= 2.2.1    && < 2.3 ,
+        repline          >= 0.1.6.0  && < 0.2 ,
+        prettyprinter                         ,
+        prettyprinter-ansi-terminal           ,
+        text
+    GHC-Options: -Wall
 
 Executable dhall-format
     Hs-Source-Dirs: dhall-format

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -155,8 +155,8 @@ Source-Repository head
 Library
     Hs-Source-Dirs: src
     Build-Depends:
-        base                        >= 4.9.0.0  && < 5   ,
-        ansi-terminal               >= 0.6.3.1  && < 0.8 ,
+        base                        >= 4.8.2.0  && < 5   ,
+        ansi-terminal               >= 0.6.3.1  && < 0.8 ,          
         base16-bytestring                        < 0.2 ,
         bytestring                               < 0.11,
         case-insensitive                         < 1.3 ,
@@ -180,7 +180,9 @@ Library
         text                        >= 0.11.1.0 && < 1.3 ,
         transformers                >= 0.2.0.0  && < 0.6 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
-        vector                      >= 0.11.0.0 && < 0.13
+        vector                      >= 0.11.0.0 && < 0.13,
+        semigroups                  >= 0.8.3.1  && < 1 
+                   
     Exposed-Modules:
         Dhall,
         Dhall.Context,
@@ -193,7 +195,7 @@ Library
         Dhall.TypeCheck
     Other-Modules:
         Dhall.Pretty.Internal
-    GHC-Options: -Wall -Wcompat
+    GHC-Options: -Wall
 
 Executable dhall
     Hs-Source-Dirs: dhall
@@ -207,24 +209,24 @@ Executable dhall
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
         megaparsec                  >= 6.4.0    && < 6.5 ,
         text                        >= 0.11.1.0 && < 1.3
-    GHC-Options: -Wall -Wcompat
+    GHC-Options: -Wall
     Other-Modules:
         Paths_dhall
 
-Executable dhall-repl
-    Hs-Source-Dirs: dhall-repl
-    Main-Is: Main.hs
-    Build-Depends:
-        base             >= 4        && < 5   ,
-        ansi-terminal                         ,
-        dhall                                 ,
-        haskeline        >= 0.7.3.0  && < 0.8 ,
-        mtl              >= 2.2.1    && < 2.3 ,
-        repline          >= 0.1.6.0  && < 0.2 ,
-        prettyprinter                         ,
-        prettyprinter-ansi-terminal           ,
-        text
-    GHC-Options: -Wall -Wcompat
+-- Executable dhall-repl
+--     Hs-Source-Dirs: dhall-repl
+--     Main-Is: Main.hs
+--     Build-Depends:
+--         base             >= 4        && < 5   ,
+--         ansi-terminal                         ,
+--         dhall                                 ,
+--         haskeline        >= 0.7.3.0  && < 0.8 ,
+--         mtl              >= 2.2.1    && < 2.3 ,
+--         repline          >= 0.1.6.0  && < 0.2 ,
+--         prettyprinter                         ,
+--         prettyprinter-ansi-terminal           ,
+--         text
+--     GHC-Options: -Wall -Wcompat
 
 Executable dhall-format
     Hs-Source-Dirs: dhall-format
@@ -238,7 +240,7 @@ Executable dhall-format
         prettyprinter               >= 1.2.0.1  && < 1.3 ,
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
         text                        >= 0.11.1.0 && < 1.3
-    GHC-Options: -Wall -Wcompat
+    GHC-Options: -Wall
     Other-Modules:
         Paths_dhall
 
@@ -258,7 +260,7 @@ Test-Suite test
     Type: exitcode-stdio-1.0
     Hs-Source-Dirs: tests
     Main-Is: Tests.hs
-    GHC-Options: -Wall -Wcompat
+    GHC-Options: -Wall
     Other-Modules:
         Format
         Normalization

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -156,7 +156,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                        >= 4.8.2.0  && < 5   ,
-        ansi-terminal               >= 0.6.3.1  && < 0.8 ,          
+        ansi-terminal               >= 0.6.3.1  && < 0.8 ,
         base16-bytestring                        < 0.2 ,
         bytestring                               < 0.11,
         case-insensitive                         < 1.3 ,
@@ -180,9 +180,10 @@ Library
         text                        >= 0.11.1.0 && < 1.3 ,
         transformers                >= 0.2.0.0  && < 0.6 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
-        vector                      >= 0.11.0.0 && < 0.13,
-        semigroups                  >= 0.8.3.1  && < 1 
-                   
+        vector                      >= 0.11.0.0 && < 0.13
+    if !impl(ghc >= 8.0)
+      Build-Depends: semigroups == 0.18.*
+
     Exposed-Modules:
         Dhall,
         Dhall.Context,

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -227,6 +227,8 @@ Executable dhall-repl
         prettyprinter                         ,
         prettyprinter-ansi-terminal           ,
         text
+    if !impl(ghc >= 8.0)
+      Build-Depends: transformers == 0.4.2.*
     GHC-Options: -Wall
 
 Executable dhall-format

--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 {-# LANGUAGE DefaultSignatures          #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}

--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 {-# LANGUAGE DefaultSignatures          #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
@@ -9,7 +10,6 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeOperators              #-}
 
 {-| Please read the "Dhall.Tutorial" module, which contains a tutorial explaining
@@ -884,7 +884,7 @@ instance Inject Scientific where
 
 instance Inject Double where
     injectWith =
-        fmap (contramap (Data.Scientific.fromFloatDigits @Double)) injectWith
+        fmap (contramap (Data.Scientific.fromFloatDigits :: Double -> Scientific)) injectWith
 
 instance Inject () where
     injectWith _ = InputType {..}

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -1,0 +1,20 @@
+resolver: lts-6.27
+extra-deps:
+- ansi-terminal-0.7.1.1
+- ansi-wl-pprint-0.6.8.2
+- cryptonite-0.24
+- formatting-6.3.2
+- megaparsec-6.4.1
+- parser-combinators-0.4.0
+- optparse-generic-1.3.0
+- optparse-applicative-0.14.0.0
+- Only-0.1
+- memory-0.14.14
+- basement-0.0.6
+- prettyprinter-1.2.0.1
+- prettyprinter-ansi-terminal-1.1.1.2
+- directory-1.3.1.0
+- foundation-0.0.19
+- process-1.6.2.0
+- repline-0.1.7.0
+- haskeline-0.7.4.2

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -18,3 +18,6 @@ extra-deps:
 - process-1.6.2.0
 - repline-0.1.7.0
 - haskeline-0.7.4.2
+- insert-ordered-containers-0.2.1.0
+- aeson-1.2.3.0
+- th-abstraction-0.2.6.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,20 +1,4 @@
-resolver: lts-6.27
+resolver: lts-9.6
 extra-deps:
-- ansi-terminal-0.7.1.1
-- ansi-wl-pprint-0.6.8.2
-- cryptonite-0.24
-- formatting-6.3.2
-- megaparsec-6.4.1
-- parser-combinators-0.4.0
-- optparse-generic-1.3.0
-- optparse-applicative-0.14.0.0
-- Only-0.1
-- memory-0.14.14
-- basement-0.0.6
 - prettyprinter-1.2.0.1
-- prettyprinter-ansi-terminal-1.1.1.2
-- directory-1.3.1.0
-- foundation-0.0.19
-- process-1.6.2.0
-- repline-0.1.7.0
-- haskeline-0.7.4.2
+- formatting-6.3.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,5 @@ resolver: lts-9.6
 extra-deps:
 - prettyprinter-1.2.0.1
 - formatting-6.3.1
+- megaparsec-6.4.1
+- parser-combinators-0.4.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,20 @@
-resolver: lts-9.6
+resolver: lts-6.27
 extra-deps:
+- ansi-terminal-0.7.1.1
+- ansi-wl-pprint-0.6.8.2
+- cryptonite-0.24
+- formatting-6.3.2
+- megaparsec-6.4.1
+- parser-combinators-0.4.0
+- optparse-generic-1.3.0
+- optparse-applicative-0.14.0.0
+- Only-0.1
+- memory-0.14.14
+- basement-0.0.6
 - prettyprinter-1.2.0.1
-- formatting-6.3.1
+- prettyprinter-ansi-terminal-1.1.1.2
+- directory-1.3.1.0
+- foundation-0.0.19
+- process-1.6.2.0
+- repline-0.1.7.0
+- haskeline-0.7.4.2


### PR DESCRIPTION
Hi, in the process of integrate [the use of dhall](https://github.com/typelead/eta/issues/704) with [eta](https://github.com/typelead/eta) we have needed to compile dhall with the version of ghc used to compile eta itself. In this way we can use dhall to configure eta and to configure the packages compiled with it.
Maybe a version compilable with ghc-7.10.3 could be useful for other users so we open the pr.
Fortunately all dependencies are in a suitable range and only there is a type application that needs ghc 8.
There is the option to add conditions on ghc version in the cabal file and modules but maybe it supposes too much burden. Another one would be simply create a dedicated branch. Let me know which one do you  think is better.

