### PR TITLE
Fix pretty-printing of source positions

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -66,7 +66,7 @@ instance Buildable Src where
     build (Src begin _ text) =
             build text <> "\n"
         <>  "\n"
-        <>  build (show begin)
+        <>  build (Text.Megaparsec.sourcePosPretty begin)
         <>  "\n"
 
 {-| A `Parser` that is almost identical to


### PR DESCRIPTION
This fixes the `Buildable` instance for `Src` to use
`Text.Megaparsec.sourcePosPretty` instead of `Show` to give a
nicer-looking file/line/column position for error messages