### PR TITLE
Fix derived `Inject` instance for sum types

### DIFF
--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -939,10 +939,10 @@ instance (Constructor c1, Constructor c2, GenericInject f1, GenericInject f2) =>
     genericInjectWith options@(InterpretOptions {..}) = pure (InputType {..})
       where
         embed (L1 (M1 l)) =
-            UnionLit keyL (embedL l) Data.HashMap.Strict.InsOrd.empty
+            UnionLit keyL (embedL l) (Data.HashMap.Strict.InsOrd.singleton keyR declaredR)
 
         embed (R1 (M1 r)) =
-            UnionLit keyR (embedR r) Data.HashMap.Strict.InsOrd.empty
+            UnionLit keyR (embedR r) (Data.HashMap.Strict.InsOrd.singleton keyL declaredL)
 
         declared =
             Union (Data.HashMap.Strict.InsOrd.fromList [(keyL, declaredL), (keyR, declaredR)])


### PR DESCRIPTION
Related to #346

This fixes the `GenericInject` instance for a sum type with two
constructors to include the type of the alternative constructor.  For
example, before this change you would get the following incorrect
conversion:

```
$ cabal repl lib:dhall
>>> :set -XDeriveGeneric
>>> :set -XDeriveAnyClass
>>> data Amount = Debit Scientific | Credit Scientific deriving (Show, Generic, Inject, Interpret)
>>> Dhall.Core.pretty (embed inject (Debit 5.45))
"< Debit = { _1 = 5.45 } >"
```

... which is missing the `Credit` alternative.

After this change you get the correct result:

```
< Debit = { _1 = 5.45 } | Credit : { _1 : Double } >
```