### PR TITLE
RFC: Fold/build fusion for Natural

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -1265,6 +1265,7 @@ normalizeWith ctx e0 = loop (denote e0)
       where
         _A' = loop _A
         _B' = loop _B
+    App NaturalFold (App NaturalBuild g) -> loop g -- fold/build fusion for `Natural'
     App f a -> case loop f of
         Lam x _A b -> loop b''  -- Beta reduce
           where

--- a/tests/Normalization.hs
+++ b/tests/Normalization.hs
@@ -30,6 +30,7 @@ normalizationTests =
         , constantFolding
         , conversions
         , shouldNormalize "Optional build/fold fusion" "optionalBuildFold"
+        , shouldNormalize "Natural fold/build fusion" "naturalFoldBuild"
         , customization
         , shouldNormalize "a remote-systems.conf builder" "remoteSystems"
         ]

--- a/tests/normalization/naturalFoldBuildA.dhall
+++ b/tests/normalization/naturalFoldBuildA.dhall
@@ -1,0 +1,33 @@
+{ example0 =
+    Natural/fold
+    ( Natural/build
+      (   λ(natural : Type)
+        → λ(succ : natural → natural)
+        → λ(zero : natural)
+        → succ zero
+      )
+    )
+, example1 =
+    Natural/fold
+    ( Natural/build
+      (   λ(natural : Type)
+        → λ(succ : natural → natural)
+        → λ(zero : natural)
+        → succ zero
+      )
+    )
+    Text
+    (λ(t : Text) → t ++ "!")
+, example2 =
+    Natural/fold
+    ( Natural/build
+      (   λ(natural : Type)
+        → λ(succ : natural → natural)
+        → λ(zero : natural)
+        → succ zero
+      )
+    )
+    Text
+    (λ(t : Text) → t ++ "!")
+    "You're welcome"
+}

--- a/tests/normalization/naturalFoldBuildA.dhall
+++ b/tests/normalization/naturalFoldBuildA.dhall
@@ -30,4 +30,16 @@
     Text
     (λ(t : Text) → t ++ "!")
     "You're welcome"
+, example3 =
+    Natural/fold
+    (     let one =
+                Natural/build
+                (   λ(natural : Type)
+                  → λ(succ : natural → natural)
+                  → λ(zero : natural)
+                  → succ zero
+                )
+      
+      in  one
+    )
 }

--- a/tests/normalization/naturalFoldBuildB.dhall
+++ b/tests/normalization/naturalFoldBuildB.dhall
@@ -7,4 +7,9 @@
     λ(zero : Text) → zero ++ "!"
 , example2 =
     "You're welcome!"
+, example3 =
+      λ(natural : Type)
+    → λ(succ : natural → natural)
+    → λ(zero : natural)
+    → succ zero
 }

--- a/tests/normalization/naturalFoldBuildB.dhall
+++ b/tests/normalization/naturalFoldBuildB.dhall
@@ -1,0 +1,10 @@
+{ example0 =
+      λ(natural : Type)
+    → λ(succ : natural → natural)
+    → λ(zero : natural)
+    → succ zero
+, example1 =
+    λ(zero : Text) → zero ++ "!"
+, example2 =
+    "You're welcome!"
+}


### PR DESCRIPTION
This is a first attempt at implementing fold/build fusion for `Natural` as part of #365.

2d8d0e6 demonstrates that this implementation isn't confluent yet: unlike example0, example3 normalizes to `Natural/fold +1`.

Here's a sketch of what I think might get us confluence. Normalization could be split into the following 3 steps:

1. Normalize everything except applications of `List/build`, `List/append`,  `Natural/build` and `Optional/build`.

2. Apply the fusion rules. 

If there were any changes in step 2, go back to step 1, else

3. Normalize everything including what was skipped in step 1.