### PR TITLE
Allow whitespace before interpolated expression

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -321,7 +321,7 @@ doubleQuotedChunk embedded =
   where
     interpolation = do
         _ <- Text.Parser.Char.text "${"
-        e <- expression embedded
+        e <- completeExpression embedded
         _ <- Text.Parser.Char.char '}'
         return (Chunks [(mempty, e)] mempty)
 
@@ -469,7 +469,7 @@ singleQuoteContinue embedded =
 
         interpolation = do
             _ <- Text.Parser.Char.text "${"
-            a <- expression embedded
+            a <- completeExpression embedded
             _ <- Text.Parser.Char.char '}'
             b <- singleQuoteContinue embedded
             return (Chunks [(mempty, a)] mempty <> b)

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -130,6 +130,9 @@ parserTests =
             , shouldParse
                 "names that begin with reserved identifiers"
                 "./tests/parser/reservedPrefix.dhall"
+            , shouldParse
+                "interpolated expressions with leading whitespace"
+                "./tests/parser/template.dhall"
             ]
         ]
 

--- a/tests/parser/template.dhall
+++ b/tests/parser/template.dhall
@@ -1,0 +1,13 @@
+    \(record : { name        : Text
+               , value       : Double
+               , taxed_value : Double
+               , in_ca       : Bool
+               }
+     ) ->  ''
+Hello ${record.name}
+You have just won ${Double/show record.value} dollars!
+${ if record.in_ca
+   then "Well, ${Double/show record.taxed_value} dollars, after taxes"
+   else ""
+ }
+''


### PR DESCRIPTION
As standardized in https://github.com/dhall-lang/dhall-lang/pull/132