### PR TITLE
Rename `Path{,Mode,Hashed,Type}` to `Import{,Mode,Hashed,Type}`

### DIFF
--- a/dhall/Main.hs
+++ b/dhall/Main.hs
@@ -11,7 +11,7 @@ import Data.Monoid (mempty, (<>))
 import Data.Text.Prettyprint.Doc (Pretty)
 import Data.Typeable (Typeable)
 import Data.Version (showVersion)
-import Dhall.Core (Expr, Path)
+import Dhall.Core (Expr, Import)
 import Dhall.Import (Imported(..), load)
 import Dhall.Parser (Src)
 import Dhall.Pretty (annToAnsiStyle, prettyExpr)
@@ -94,13 +94,13 @@ throws :: Exception e => Either e a -> IO a
 throws (Left  e) = Control.Exception.throwIO e
 throws (Right a) = return a
 
-getExpression :: IO (Expr Src Path)
+getExpression :: IO (Expr Src Import)
 getExpression = do
     inText <- Data.Text.Lazy.IO.getContents
 
     throws (Dhall.Parser.exprFromText "(stdin)" inText)
 
-assertNoImports :: Expr Src Path -> IO (Expr Src X)
+assertNoImports :: Expr Src Import -> IO (Expr Src X)
 assertNoImports expression =
     throws (traverse (\_ -> Left ImportResolutionDisabled) expression)
 


### PR DESCRIPTION
This updates the data types to match the terminology used in the
standard.  Specifically, "path" specifically refers to a directory or
file, whereas "import" is a broader term encapsulating URLs and
environment variables.

See: https://github.com/dhall-lang/dhall-lang/pull/127

This is a breaking change but an easy one to adapt to.  Most downstream
consumers of the API just use the `Path` type, and this change includes
a `Path` type synonym for backwards compatibility.