### PR TITLE
Cache imports that contain imports.

### DIFF
--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -762,42 +762,40 @@ loadStaticWith from_import ctx import_ = do
         then throwM (Imported imports (ReferentiallyOpaque import_))
         else return ()
 
-    (expr, cached) <- if here `elem` canonicalizeAll imports
+    expr <- if here `elem` canonicalizeAll imports
         then throwM (Imported imports (Cycle import_))
         else do
             m <- zoom cache State.get
             case Map.lookup here m of
-                Just expr -> return (expr, True)
+                Just expr -> return expr
                 Nothing   -> do
-                    expr'  <- loadDynamic from_import import_
+                    expr'  <- loadDynamic from_import here
                     expr'' <- case traverse (\_ -> Nothing) expr' of
                         -- No imports left
-                        Just expr -> do
-                            zoom cache (State.put $! Map.insert here expr m)
-                            return expr
+                        Just expr -> return expr
                         -- Some imports left, so recurse
                         Nothing   -> do
-                            let imports' = import_:imports
+                            let imports' = here:imports
                             zoom stack (State.put imports')
                             expr'' <- fmap join (traverse (loadStaticWith from_import ctx)
                                                            expr')
                             zoom stack (State.put imports)
                             return expr''
-                    return (expr'', False)
-
-    -- Type-check expressions here for three separate reasons:
-    --
-    --  * to verify that they are closed
-    --  * to catch type errors as early in the import process as possible
-    --  * to avoid normalizing ill-typed expressions that need to be hashed
-    --
-    -- There is no need to check expressions that have been cached, since they
-    -- have already been checked
-    if cached
-        then return ()
-        else case Dhall.TypeCheck.typeWith ctx expr of
-            Left  err -> throwM (Imported (import_:imports) err)
-            Right _   -> return ()
+                    -- Type-check expressions here for three separate reasons:
+                    --
+                    --  * to verify that they are closed
+                    --  * to catch type errors as early in the import process
+                    --    as possible
+                    --  * to avoid normalizing ill-typed expressions that need
+                    --    to be hashed
+                    --
+                    -- There is no need to check expressions that have been
+                    -- cached, since they have already been checked
+                    case Dhall.TypeCheck.typeWith ctx expr'' of
+                        Left  err -> throwM (Imported (here:imports) err)
+                        Right _   -> return ()
+                    zoom cache (State.put $! Map.insert here expr'' m)
+                    return expr''
 
     case hash (importHashed import_) of
         Nothing -> do


### PR DESCRIPTION
Relevant to #362.

Previously, if an import contained additional imports, it wouldn’t get
cached. This fixes that, with a couple related changes:
- type checking happens in the failed-lookup branch, rather than having to
return a `cached` boolean,
- the normalized form of the import is used more consistently (although this
doesn’t fix the related normalization problem around `../`).