### PR TITLE
Add non-Haskell dependencies to stack.yaml.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,10 @@
 resolver: lts-9.6
+
+nix:
+  packages:
+    - ncurses
+    - zlib
+
 extra-deps:
 - prettyprinter-1.2.0.1
 - formatting-6.3.1


### PR DESCRIPTION
Not sure if this is a change you’re interested in. IMO, it’s nice for stack
users even if they don’t use Nix, since it makes the dependencies explicit.