### PR TITLE
Update import logic to more closely match standard

### DIFF
--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -121,8 +122,9 @@ import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.State.Strict (StateT)
 import Crypto.Hash (SHA256)
 import Data.CaseInsensitive (CI)
+import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map (Map)
-import Data.Monoid ((<>))
+import Data.Semigroup (sconcat, (<>))
 import Data.Text.Lazy (Text)
 import Data.Text.Lazy.Builder (Builder)
 #if MIN_VERSION_base(4,8,0)
@@ -135,7 +137,9 @@ import System.FilePath ((</>))
 import Dhall.Core
     ( Expr(..)
     , Chunks(..)
-    , HasHome(..)
+    , Directory(..)
+    , File(..)
+    , FilePrefix(..)
     , ImportHashed(..)
     , ImportType(..)
     , ImportMode(..)
@@ -161,7 +165,6 @@ import qualified Data.List                        as List
 import qualified Data.HashMap.Strict.InsOrd
 import qualified Data.Map.Strict                  as Map
 import qualified Data.Text.Encoding
-import qualified Data.Text.IO
 import qualified Data.Text.Lazy                   as Text
 import qualified Data.Text.Lazy.Builder           as Builder
 import qualified Data.Text.Lazy.Encoding
@@ -365,93 +368,62 @@ needManager = do
             zoom manager (State.put (Just m))
             return m
 
-{-| This function computes the current import by taking the last absolute import
-    (either an absolute `FilePath` or `URL`) and combining it with all following
-    relative imports
-
-    For example, if the file `./foo/bar` imports `./baz`, that will resolve to
-    `./foo/baz`.  Relative imports are relative to a file's parent directory.
-    This also works for URLs, too.
-
-    This code is full of all sorts of edge cases so it wouldn't surprise me at
-    all if you find something broken in here.  Most of the ugliness is due to
-    removing spurious @.@s and @..@s from the import.
-
-    Also, there are way too many `reverse`s in the URL-handling code For now I
-    don't mind, but if were to really do this correctly we'd store the URLs as
-    `Text` for O(1) access to the end of the string.  The only reason we use
-    `String` at all is for consistency with the @http-client@ library.
+{-|
+> canonicalize (canonicalize x) = canonicalize x
 -}
-canonicalize :: [ImportType] -> ImportType
-canonicalize  []                          = File Homeless "."
-canonicalize (File hasHome0 file0:imports0) =
-    if FilePath.isRelative file0 && hasHome0 == Homeless
-    then go file0 imports0
-    else File hasHome0 (FilePath.normalise file0)
-  where
-    go currImport  []                       = File Homeless (FilePath.normalise currImport)
-    go currImport (Env  _           :_    ) = File Homeless (FilePath.normalise currImport)
-    go currImport (URL  url0 headers:rest ) = combine prefix suffix
+class Canonicalize path where
+    canonicalize :: path -> path
+
+instance Canonicalize Directory where
+    canonicalize (Directory []) = Directory []
+
+    canonicalize (Directory ("." : components₀)) =
+        canonicalize (Directory components₀)
+
+    canonicalize (Directory (".." : components₀)) =
+        case canonicalize (Directory components₀) of
+            Directory      []           -> Directory [ ".." ]
+            Directory (_ : components₁) -> Directory components₁
+
+    canonicalize (Directory (component : components₀)) =
+        Directory (component : components₁)
       where
-        headers' = fmap (onImportType (\h -> canonicalize (h:rest))) headers
+        Directory components₁ = canonicalize (Directory components₀)
 
-        prefix = parentURL url0
+instance Canonicalize File where
+    canonicalize (File { directory, .. }) =
+        File { directory = canonicalize directory, .. }
 
-        suffix = FilePath.normalise currImport
+instance Canonicalize ImportType where
+    canonicalize (Local prefix file) =
+        Local prefix (canonicalize file)
 
-        -- `clean` will resolve internal @.@/@..@'s in @currImport@, but we
-        -- still need to manually handle @.@/@..@'s at the beginning of the path
-        combine url path = case List.stripPrefix "../" path of
-            Just path' -> combine url' path'
-              where
-                url' = parentURL url
-            Nothing    -> case List.stripPrefix "./" path of
-                Just path' -> combine url path'
-                Nothing    ->
-                    -- This `last` is safe because the lexer constrains all
-                    -- URLs to be non-empty.  I couldn't find a simple and safe
-                    -- equivalent in the `text` API
-                    case Text.last url of
-                        '/' -> URL (url <>        path') headers'
-                        _   -> URL (url <> "/" <> path') headers'
-                  where
-                    path' = Text.pack path
-    go currImport (File hasHome file:imports) =
-        if FilePath.isRelative file && hasHome == Homeless
-        then go file' imports
-        else File hasHome (FilePath.normalise file')
-      where
-        file' =
-            FilePath.takeDirectory file </> currImport
-canonicalize (URL path headers:rest) = URL path headers'
-  where
-    headers' = fmap (onImportType (\h -> canonicalize (h:rest))) headers
-canonicalize (Env env         :_   ) = Env env
+    canonicalize (URL prefix file suffix header) =
+        URL prefix (canonicalize file) suffix header
 
-onImportType :: (ImportType -> ImportType) -> ImportHashed -> ImportHashed
-onImportType f (ImportHashed a b) = ImportHashed a (f b)
+    canonicalize (Env name) =
+        Env name
+
+instance Canonicalize ImportHashed where
+    canonicalize (ImportHashed hash importType) =
+        ImportHashed hash (canonicalize importType)
+
+instance Canonicalize Import where
+    canonicalize (Import importHashed importMode) =
+        Import (canonicalize importHashed) importMode
 
 canonicalizeImport :: [Import] -> Import
-canonicalizeImport [] =
-    Import
-        { importMode   = Code
-        , importHashed = ImportHashed
-            { hash       = Nothing
-            , importType = canonicalize []
+canonicalizeImport imports =
+    canonicalize (sconcat (defaultImport :| reverse imports))
+  where
+    defaultImport =
+        Import
+            { importMode   = Code
+            , importHashed = ImportHashed
+                { hash       = Nothing
+                , importType = Local Here (File (Directory []) ".")
+                }
             }
-        }
-canonicalizeImport (import_:imports) =
-    Import
-        { importMode   = importMode import_
-        , importHashed = (importHashed import_)
-             { hash       = hash (importHashed import_)
-             , importType =
-                 canonicalize (map (importType . importHashed) (import_:imports))
-             }
-        }
-
-parentURL :: Text -> Text
-parentURL = Text.dropWhileEnd (/= '/')
 
 toHeaders
   :: Expr s a
@@ -532,108 +504,123 @@ instance Show HashMismatch where
 
 -- | Parse an expression from a `Import` containing a Dhall program
 exprFromImport :: Import -> StateT Status IO (Expr Src Import)
-exprFromImport (Import {..}) = case importType of
-    File hasHome file -> liftIO (do
-        path <- case hasHome of
-            Home -> do
-                home <- System.Directory.getHomeDirectory
-                return (home </> file)
-            Homeless -> do
-                return file
+exprFromImport (Import {..}) = do
+    let ImportHashed {..} = importHashed
 
-        case importMode of
-            Code -> do
-                exists <- System.Directory.doesFileExist path
-                if exists
-                    then return ()
-                    else throwIO (MissingFile path)
+    (path, text) <- case importType of
+        Local prefix (File {..}) -> liftIO $ do
+            let Directory {..} = directory
 
-                text <- Data.Text.Lazy.IO.readFile path
-                case Text.Megaparsec.parse parser path text of
-                    Left errInfo -> do
-                        throwIO (ParseError errInfo text)
-                    Right expr -> do
-                        return expr
-            RawText -> do
-                text <- Data.Text.IO.readFile path
-                return (TextLit (Chunks [] (build text))) )
-    URL url headerImport -> do
-        m       <- needManager
-        request <- liftIO (HTTP.parseUrlThrow (Text.unpack url))
+            prefixPath <- case prefix of
+                Home -> do
+                    System.Directory.getHomeDirectory
 
-        requestWithHeaders <- case headerImport of
-            Nothing           -> return request
-            Just importHashed_ -> do
-                expr <- loadStaticIO Dhall.Context.empty (Import importHashed_ Code)
-                let expected :: Expr Src X
-                    expected =
-                        App List
-                            ( Record
-                                ( Data.HashMap.Strict.InsOrd.fromList
-                                    [("header", Text), ("value", Text)]
+                Absolute -> do
+                    return "/"
+
+                Parent -> do
+                    pwd <- System.Directory.getCurrentDirectory
+                    return (FilePath.takeDirectory pwd)
+
+                Here -> do
+                    System.Directory.getCurrentDirectory
+
+            let cs = map Text.unpack (file : components)
+
+            let cons component dir = dir </> component
+
+            let path = foldr cons prefixPath cs
+
+            exists <- System.Directory.doesFileExist path
+
+            if exists
+                then return ()
+                else throwIO (MissingFile path)
+
+            text <- Data.Text.Lazy.IO.readFile path
+
+            return (path, text)
+
+        URL prefix file suffix maybeHeaders -> do
+            m <- needManager
+
+            let fileText = Builder.toLazyText (build file)
+            let url      = Text.unpack (prefix <> fileText <> suffix)
+
+            request <- liftIO (HTTP.parseUrlThrow url)
+
+            requestWithHeaders <- case maybeHeaders of
+                Nothing           -> return request
+                Just importHashed_ -> do
+                    expr <- loadStaticIO Dhall.Context.empty (Import importHashed_ Code)
+                    let expected :: Expr Src X
+                        expected =
+                            App List
+                                ( Record
+                                    ( Data.HashMap.Strict.InsOrd.fromList
+                                        [("header", Text), ("value", Text)]
+                                    )
                                 )
-                            )
-                let suffix =
-                        ( Builder.toLazyText
-                        . build
-                        ) expected
-                let annot = case expr of
-                        Note (Src begin end bytes) _ ->
-                            Note (Src begin end bytes') (Annot expr expected)
-                          where
-                            bytes' = bytes <> " : " <> suffix
-                        _ ->
-                            Annot expr expected
-                case Dhall.TypeCheck.typeOf annot of
-                    Left err -> liftIO (throwIO err)
-                    Right _  -> return ()
-                let expr' = Dhall.Core.normalize expr
-                headers <- case toHeaders expr' of
-                    Just headers -> do
-                        return headers
-                    Nothing      -> do
-                        liftIO (throwIO InternalError)
-                let requestWithHeaders = request
-                        { HTTP.requestHeaders = headers
-                        }
-                return requestWithHeaders
-        response <- liftIO (HTTP.httpLbs requestWithHeaders m)
+                    let suffix_ =
+                            ( Builder.toLazyText
+                            . build
+                            ) expected
+                    let annot = case expr of
+                            Note (Src begin end bytes) _ ->
+                                Note (Src begin end bytes') (Annot expr expected)
+                              where
+                                bytes' = bytes <> " : " <> suffix_
+                            _ ->
+                                Annot expr expected
 
-        let bytes = HTTP.responseBody response
+                    case Dhall.TypeCheck.typeOf annot of
+                        Left err -> liftIO (throwIO err)
+                        Right _  -> return ()
 
-        text <- case Data.Text.Lazy.Encoding.decodeUtf8' bytes of
-            Left  err  -> liftIO (throwIO err)
-            Right text -> return text
+                    let expr' = Dhall.Core.normalize expr
 
-        case importMode of
-            Code ->
-                case Text.Megaparsec.parse parser (Text.unpack url) text of
-                    Left  err  -> liftIO (throwIO err)
-                    Right expr -> return expr
-            RawText -> do
-                return (TextLit (Chunks [] (build text)))
-    Env env -> liftIO (do
-        x <- System.Environment.lookupEnv (Text.unpack env)
-        case x of
-            Just str -> do
-                let text = Text.pack str
-                case importMode of
-                    Code ->
-                        case Text.Megaparsec.parse parser (Text.unpack env) text of
-                            Left errInfo -> do
-                                throwIO (ParseError errInfo text)
-                            Right expr   -> do
-                                return expr
-                    RawText -> return (TextLit (Chunks [] (build str)))
-            Nothing  -> throwIO (MissingEnvironmentVariable env) )
-  where
-    ImportHashed {..} = importHashed
+                    headers <- case toHeaders expr' of
+                        Just headers -> do
+                            return headers
+                        Nothing      -> do
+                            liftIO (throwIO InternalError)
 
-    parser = unParser (do
-        Text.Parser.Token.whiteSpace
-        r <- Dhall.Parser.expr
-        Text.Parser.Combinators.eof
-        return r )
+                    let requestWithHeaders = request
+                            { HTTP.requestHeaders = headers
+                            }
+
+                    return requestWithHeaders
+
+            response <- liftIO (HTTP.httpLbs requestWithHeaders m)
+
+            let bytes = HTTP.responseBody response
+
+            case Data.Text.Lazy.Encoding.decodeUtf8' bytes of
+                Left  err  -> liftIO (throwIO err)
+                Right text -> return (url, text)
+
+        Env env -> liftIO $ do
+            x <- System.Environment.lookupEnv (Text.unpack env)
+            case x of
+                Just string -> return (Text.unpack env, Text.pack string)
+                Nothing     -> throwIO (MissingEnvironmentVariable env)
+
+    case importMode of
+        Code -> do
+            let parser = unParser $ do
+                    Text.Parser.Token.whiteSpace
+                    r <- Dhall.Parser.expr
+                    Text.Parser.Combinators.eof
+                    return r
+
+            case Text.Megaparsec.parse parser path text of
+                Left errInfo -> do
+                    liftIO (throwIO (ParseError errInfo text))
+                Right expr -> do
+                    return expr
+
+        RawText -> do
+            return (TextLit (Chunks [] (build text)))
 
 {-| Load an `Import` as a \"dynamic\" expression (without resolving any imports)
 -}
@@ -684,9 +671,9 @@ loadStaticWith
 loadStaticWith from_import ctx import_ = do
     imports <- zoom stack State.get
 
-    let local (Import (ImportHashed _ (URL _ _ )) _) = False
-        local (Import (ImportHashed _ (File _ _)) _) = True
-        local (Import (ImportHashed _ (Env  _  )) _) = True
+    let local (Import (ImportHashed _ (URL   {})) _) = False
+        local (Import (ImportHashed _ (Local {})) _) = True
+        local (Import (ImportHashed _ (Env   {})) _) = True
 
     let parent = canonicalizeImport imports
     let here   = canonicalizeImport (import_:imports)

--- a/tests/parser/urls.dhall
+++ b/tests/parser/urls.dhall
@@ -1,11 +1,11 @@
-[ http://example.com
+[ http://example.com/someFile.dhall
 , https://john:doe@example.com:8080/foo/bar?qux=0#xyzzy
-, http://prelude.dhall-lang.org/
+, http://prelude.dhall-lang.org/package.dhall
 , https://ipfs.io/ipfs/QmQ8w5PLcsNz56dMvRtq54vbuPe9cNnCCUXAQp6xLc6Ccx/Prelude
-, https://127.0.0.1
-, https://[::]
-, https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]
+, https://127.0.0.1/index.dhall
+, https://[::]/index.dhall
+, https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/tutorial.dhall
 
   -- Yes, this is legal
-, https://-._~%2C!$&'()*+,;=:@-._~%2C!$&'()*+,;=:/-._~%2C!$&'()*+,;=:@?/-._~%2C!$&'()*+,;=:@/?#/-._~%2C!$&'()*+,;=:@/?
+, https://-._~%2C!$&'()*+,;=:@-._~%2C!$&'()*+,;=:/foo?/-._~%2C!$&'()*+,;=:@/?#/-._~%2C!$&'()*+,;=:@/?
 ]


### PR DESCRIPTION
This is one step in a series of commits to update the Haskell
implementation to match the import semantics standardized in:

https://github.com/dhall-lang/dhall-lang/pull/127

This is a BREAKING CHANGE mostly due to restricting the grammar for
valid file paths and URLs.  However, in practice most existing code
should still work after these changes.

Specifically, this change:

* Updates the grammar for file paths and URLs
* Simplifies and cleans up the semantics for canonicalizing paths (and
  chains of paths)

The main difference in the grammar is that file paths and URL paths are
unified to have the same syntax and they are both more restricted than
before.

For example, the following URLs are no longer valid:

* `http://example.com` (missing a path to a file)
* `http://example.com/()` (invalid path characters)

... and the following paths are no longer valid:

* `/?#` (invalid path characters)

Note that this actually deviates from the standard in one way: file
paths no longer permit `?` and `#` characters (whereas the standard
allows them).  However, in the course of testing these changes I
realized that if file paths permit `?` and `#` characters and you unify
URLs to also permit them then you get an ambiguous grammar where a `?`
or `#` in a URL could be interpreted as either part of a path component
or part of a query parameter or fragment.

The semantics for canonicalizing paths is a straightforward translation
of the standard to Haskell code.