### PR TITLE
Add a `pwd` derivation force status updates by Hydra

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -30,6 +30,12 @@ let
   pkgs =
     import nixpkgs { inherit config; };
 
+  # Derivation that trivially depends on the current directory so that Hydra's
+  # pull request builder always posts a GitHub status on each revision
+  pwd = pkgs.runCommand "pwd" { here = ./.; } "touch $out";
+
 in
-  { inherit (pkgs.haskellPackages) dhall;
+  { inherit pwd;
+
+    inherit (pkgs.haskellPackages) dhall;
   }


### PR DESCRIPTION
Hydra doesn't update a pull request if the derivation hasn't changed
since the last revision (i.e. a cache hit).  This change adds a `pwd`
derivation which depends trivially on the current directory to force a
cache miss and status update