### PR TITLE
Align `then`/`else` when formatting `if` expressions

### DIFF
--- a/tests/Format.hs
+++ b/tests/Format.hs
@@ -36,6 +36,9 @@ formatTests =
         , should
             "correctly format the empty record literal"
             "emptyRecord"
+        , should
+            "indent then/else to the same column"
+            "ifThenElse"
         ]
 
 opts :: Data.Text.Prettyprint.Doc.LayoutOptions

--- a/tests/format/ifThenElseA.dhall
+++ b/tests/format/ifThenElseA.dhall
@@ -1,0 +1,2 @@
+if True then if True then if True then 1 else 2 else if True then 3 else 4
+else if True then if True then 5 else 6 else if True then 7 else 8

--- a/tests/format/ifThenElseB.dhall
+++ b/tests/format/ifThenElseB.dhall
@@ -1,0 +1,13 @@
+      if True
+
+then  if True then if True then 1 else 2 else if True then 3 else 4
+
+else  if True
+
+then  if True then 5 else 6
+
+else  if True
+
+then  7
+
+else  8


### PR DESCRIPTION
Fixes #397