### PR TITLE
Fix canonicalization bug

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -187,7 +187,7 @@ Library
         Dhall,
         Dhall.Context,
         Dhall.Core,
-        Dhall.Diff
+        Dhall.Diff,
         Dhall.Import,
         Dhall.Parser,
         Dhall.Pretty,

--- a/doctest/Main.hs
+++ b/doctest/Main.hs
@@ -3,4 +3,4 @@ module Main where
 import qualified Test.DocTest
 
 main :: IO ()
-main = Test.DocTest.doctest [ "-isrc", "src/Dhall.hs" ]
+main = Test.DocTest.doctest [ "-isrc", "src/Dhall.hs", "src/Dhall/Import.hs" ]

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -375,6 +375,9 @@ needManager = do
 class Canonicalize path where
     canonicalize :: path -> path
 
+-- |
+-- >>> canonicalize (Directory {components = ["..",".."]})
+-- Directory {components = ["..",".."]}
 instance Canonicalize Directory where
     canonicalize (Directory []) = Directory []
 
@@ -383,8 +386,12 @@ instance Canonicalize Directory where
 
     canonicalize (Directory (".." : components₀)) =
         case canonicalize (Directory components₀) of
-            Directory      []           -> Directory [ ".." ]
-            Directory (_ : components₁) -> Directory components₁
+            Directory [] ->
+                Directory [ ".." ]
+            Directory (".." : components₁) ->
+                Directory (".." : ".." : components₁)
+            Directory (_    : components₁) ->
+                Directory components₁
 
     canonicalize (Directory (component : components₀)) =
         Directory (component : components₁)


### PR DESCRIPTION
Fixes #402

The simplest way to summarize this bug is the following incorrect behavior
before this change:

```
>>> Dhall.Import.canonicalize (Directory {components = ["..",".."]})
Directory {components = []}
```

After this change the behavior is correct

```
>>> Dhall.Import.canonicalize (Directory {components = ["..",".."]})
Directory {components = ["..",".."]}
```