### PR TITLE
dhall-format expand --inplace option for directories

### DIFF
--- a/dhall-format/Main.hs
+++ b/dhall-format/Main.hs
@@ -43,19 +43,26 @@ import qualified Data.Text.Prettyprint.Doc                 as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty
 import qualified Options.Applicative
 import qualified System.Console.ANSI
-import qualified System.Directory          as File
-import qualified System.FilePath.Posix     as File
+import qualified System.Directory      as File
+import qualified System.FilePath.Posix as File
 import qualified System.IO
 
+-- | Extinguish an extension from a plain 'String'
 newtype Ext = Ext String deriving Eq
 
+-- | Options for inplace formatting.
+--
+--   'File' applies the formatting to a single specified file.
+--
+--   'Directory' applies the formatting to a directory recursively.
+--   It will only format files with the specified extensions ('Ext').
 data InplaceOption
-    = File      FilePath
-    | Directory FilePath [Ext]
+    = File      FilePath       -- ^ Option to format a file inplace
+    | Directory FilePath [Ext] -- ^ Option to format a directory in place
 
 data Options = Options
-    { version   :: Bool
-    , inplace   :: Maybe InplaceOption
+    { version :: Bool
+    , inplace :: Maybe InplaceOption
     }
 
 parseOptions :: Parser Options

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -237,6 +237,8 @@ Executable dhall-format
         base                        >= 4        && < 5   ,
         ansi-terminal                                    ,
         dhall                                            ,
+        directory                   >= 1.3               ,
+        filepath                    >= 1.4               ,
         megaparsec                                       ,
         optparse-applicative                       < 0.15,
         prettyprinter               >= 1.2.0.1  && < 1.3 ,


### PR DESCRIPTION
The purpose of this PR is so that if you have your config files gathered in a directory you can apply a directory wide format, instead of going to each file individually.

**Changes:**

* Created `InplaceOption` to distinguish between formatting in place for a single `File` or a whole `Directory` with `Ext`ensions the user can target.
* Updated CLI parser
* Moved the file formatting into a function `inplaceFile`
* Created `inplaceDirectory` which is recursive and utilises `inplaceFile`

Hopefully this useful to the toolchain :)