### PR TITLE
Remove the Parent constructor from FilePrefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.15.0
+
+* BREAKING CHANGE TO THE API: Removed the `Parent` constructor from `FilePrefix`.
+    * Instead, use `Here` with a `".."` prefix.
+
 1.14.0
 
 * BREAKING CHANGE TO THE LANGUAGE: Switch grammar of `Natural` and `Integer`

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -146,8 +146,6 @@ data FilePrefix
     -- ^ Absolute path
     | Here
     -- ^ Path relative to @.@
-    | Parent
-    -- ^ Path relative to @..@
     | Home
     -- ^ Path relative to @~@
     deriving (Eq, Ord, Show)
@@ -155,7 +153,6 @@ data FilePrefix
 instance Buildable FilePrefix where
     build Absolute = ""
     build Here     = "."
-    build Parent   = ".."
     build Home     = "~"
 
 -- | The type of import (i.e. local vs. remote vs. environment)
@@ -168,20 +165,11 @@ data ImportType
     -- ^ Environment variable
     deriving (Eq, Ord, Show)
 
-parent :: File
-parent = File { directory = Directory { components = [ ".." ] }, file = "" }
-
 instance Semigroup ImportType where
     Local prefix file₀ <> Local Here file₁ = Local prefix (file₀ <> file₁)
 
     URL prefix file₀ suffix headers <> Local Here file₁ =
         URL prefix (file₀ <> file₁) suffix headers
-
-    Local prefix file₀ <> Local Parent file₁ =
-        Local prefix (file₀ <> parent <> file₁)
-
-    URL prefix file₀ suffix headers <> Local Parent file₁ =
-        URL prefix (file₀ <> parent <> file₁) suffix headers
 
     _ <> import₁ =
         import₁

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -178,7 +178,6 @@ import qualified Network.HTTP.Client              as HTTP
 import qualified Network.HTTP.Client.TLS          as HTTP
 import qualified System.Environment
 import qualified System.Directory
-import qualified System.FilePath                  as FilePath
 import qualified Text.Megaparsec
 import qualified Text.Parser.Combinators
 import qualified Text.Parser.Token
@@ -525,10 +524,6 @@ exprFromImport (Import {..}) = do
 
                 Absolute -> do
                     return "/"
-
-                Parent -> do
-                    pwd <- System.Directory.getCurrentDirectory
-                    return (FilePath.takeDirectory pwd)
 
                 Here -> do
                     System.Directory.getCurrentDirectory

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -812,9 +812,9 @@ localRaw =
   where
     parentPath = do
         _    <- ".." :: Parser Builder
-        file <- file_
+        File (Directory segments) final <- file_
 
-        return (Local Parent file)
+        return (Local Here (File (Directory (segments ++ [".."])) final))
 
     herePath = do
         _    <- "." :: Parser Builder


### PR DESCRIPTION
The 'Parent' constructor is entirely subsumed by 'Here'; having it
only leads to redundant representations.

Closes #406.