### PR TITLE
Fix performance issues leading to #412

### DIFF
--- a/src/Dhall/TypeCheck.hs
+++ b/src/Dhall/TypeCheck.hs
@@ -79,6 +79,9 @@ rule Kind Type = return Type
     `typeWith` does not necessarily normalize the type since full normalization
     is not necessary for just type-checking.  If you actually care about the
     returned type then you may want to `Dhall.Core.normalize` it afterwards.
+
+    The supplied `Context` records the types of the names in scope. If
+    these are ill-typed, the return value may be ill-typed.
 -}
 typeWith :: Context (Expr s X) -> Expr s X -> Either (TypeError s X) (Expr s X)
 typeWith ctx expr = do
@@ -107,7 +110,8 @@ typeWithA tpa = loop
         case Dhall.Context.lookup x n ctx of
             Nothing -> Left (TypeError ctx e (UnboundVariable x))
             Just a  -> do
-                _ <- loop ctx a
+                -- Note: no need to typecheck the value we're
+                -- returning; that is done at insertion time.
                 return a
     loop ctx   (Lam x _A  b     ) = do
         _ <- loop ctx _A


### PR DESCRIPTION
Before, on the benchmark from #412:

```
	   dhall-hash +RTS -p -RTS

	total time  =       47.01 secs   (47007 ticks @ 1000 us, 1 processor)
	total alloc = 28,577,665,440 bytes  (excludes profiling overheads)

COST CENTRE     MODULE                     SRC                                                 %time %alloc

toList          Data.HashMap.Strict.InsOrd src/Data/HashMap/Strict/InsOrd.hs:(580,1)-(584,22)   76.3   84.5
traverseWithKey Data.HashMap.Strict.InsOrd src/Data/HashMap/Strict/InsOrd.hs:(420,1)-(421,78)    8.6    1.3
normalizeWith   Dhall.Core                 src/Dhall/Core.hs:(1338,1)-(1688,22)                  4.8    5.2
denote          Dhall.Core                 src/Dhall/Core.hs:(1260,1)-(1320,39)                  2.7    2.7
normalize       Dhall.Core                 src/Dhall/Core.hs:1234:1-41                           2.7    4.1
typeWithA       Dhall.TypeCheck            src/Dhall/TypeCheck.hs:(97,1)-(724,49)                2.1    0.0
shift           Dhall.Core                 src/Dhall/Core.hs:(660,1)-(813,29)                    1.2    1.5
```

After:

```
	   dhall-hash +RTS -p -RTS

	total time  =        4.96 secs   (4962 ticks @ 1000 us, 1 processor)
	total alloc = 3,026,587,104 bytes  (excludes profiling overheads)

COST CENTRE     MODULE                     SRC                                                 %time %alloc

typeWithA       Dhall.TypeCheck            src/Dhall/TypeCheck.hs:(98,1)-(737,49)               25.9   11.6
normalizeWith   Dhall.Core                 src/Dhall/Core.hs:(1326,1)-(1676,22)                 19.4   30.0
denote          Dhall.Core                 src/Dhall/Core.hs:(1248,1)-(1308,39)                 19.1   24.9
toHashMap       Data.HashMap.Strict.InsOrd src/Data/HashMap/Strict/InsOrd.hs:599:1-44           13.3   13.9
getInput        Text.Megaparsec            Text/Megaparsec.hs:404:1-40                           6.8    2.8
traverseWithKey Data.HashMap.Strict.InsOrd src/Data/HashMap/Strict/InsOrd.hs:(420,1)-(421,78)    4.9    2.9
normalize       Dhall.Core                 src/Dhall/Core.hs:1222:1-41                           4.1    7.1
new_            Data.HashMap.Array         Data/HashMap/Array.hs:177:1-28                        3.7    5.7
toList          Data.HashMap.Strict.InsOrd src/Data/HashMap/Strict/InsOrd.hs:(580,1)-(584,22)    2.2    0.4
```

The first commit, changing how `Let` is typechecked, is a factor of ~5 improvement; the second one, changing `toList`, is a factor of ~2.