### PR TITLE
WIP: Implement `as Location` import syntax

### DIFF
--- a/src/Dhall/Diff.hs
+++ b/src/Dhall/Diff.hs
@@ -32,6 +32,7 @@ import Numeric.Natural (Natural)
 import qualified Data.HashMap.Strict.InsOrd as HashMap
 import qualified Data.List.NonEmpty
 import qualified Data.Set
+import qualified Data.Text                  as Text
 import qualified Data.Text.Prettyprint.Doc  as Pretty
 import qualified Dhall.Core
 import qualified Dhall.Pretty.Internal      as Internal
@@ -687,6 +688,9 @@ diffBoolOr l r@(BoolOr {}) =
 diffBoolOr l r =
     diffTextAppend l r
 
+diffText :: Text -> Text -> Diff
+diffText = diffPrimitive (token . Internal.prettyText)
+
 diffTextAppend :: Pretty a => Expr s a -> Expr s a -> Diff
 diffTextAppend l@(TextAppend {}) r@(TextAppend {}) =
     enclosed' "    " (operator "++" <> "  ") (docs l r)
@@ -991,6 +995,18 @@ diffExprF l@Text r =
     mismatch l r
 diffExprF l r@Text =
     mismatch l r
+diffExprF FilePath FilePath =
+    "…"
+diffExprF l@FilePath r =
+    mismatch l r
+diffExprF l r@FilePath =
+    mismatch l r
+diffExprF Url Url =
+    "…"
+diffExprF l@Url r =
+    mismatch l r
+diffExprF l r@Url =
+    mismatch l r
 diffExprF List List =
     "…"
 diffExprF l@List r =
@@ -1087,6 +1103,19 @@ diffExprF l@(TextLit {}) r@(TextLit {}) =
 diffExprF l@(TextLit {}) r =
     mismatch l r
 diffExprF l r@(TextLit {}) =
+    mismatch l r
+diffExprF (FilePathLit aL) (FilePathLit aR) =
+    diffText (Text.pack aL) (Text.pack aR)
+diffExprF l@(FilePathLit _) r =
+    mismatch l r
+diffExprF l r@(FilePathLit _) =
+    mismatch l r
+-- TODO: Diff maybeHeaders?
+diffExprF (UrlLit aL) (UrlLit aR) =
+    diffText aL aR
+diffExprF l@(UrlLit _) r =
+    mismatch l r
+diffExprF l r@(UrlLit _) =
     mismatch l r
 diffExprF (Record aL) (Record aR) =
     diffRecord aL aR

--- a/src/Dhall/Diff.hs
+++ b/src/Dhall/Diff.hs
@@ -1110,7 +1110,6 @@ diffExprF l@(FilePathLit _) r =
     mismatch l r
 diffExprF l r@(FilePathLit _) =
     mismatch l r
--- TODO: Diff maybeHeaders?
 diffExprF (UrlLit aL) (UrlLit aR) =
     diffText aL aR
 diffExprF l@(UrlLit _) r =

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -530,9 +530,15 @@ data IllegalImportType
 instance Exception IllegalImportType
 
 instance Show IllegalImportType where
-    show EnvAsLocation          = _ERROR <> ": env cannot be imported as a location"
-    show LocationWithHash       = _ERROR <> ": location literal cannot have a hash"
-    show LocationUrlWithHeaders = _ERROR <> ": url literal cannot have headers"
+    show EnvAsLocation =
+        _ERROR
+      <> ": an environment variable cannot be used ❰as Location❱"
+    show LocationWithHash =
+        _ERROR
+      <> ": location literal cannot have a hash"
+    show LocationUrlWithHeaders =
+        _ERROR
+      <> ": url literal cannot have headers"
 
 -- | Parse an expression from a `Import` containing a Dhall program
 exprFromImport :: Import -> StateT Status IO (Expr Src Import)

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -25,7 +25,7 @@ import Control.Exception (Exception)
 import Control.Monad (MonadPlus)
 import Data.ByteArray.Encoding (Base(..))
 import Data.Data (Data)
-import Data.Functor (void)
+import Data.Functor (void, ($>))
 import Data.HashMap.Strict.InsOrd (InsOrdHashMap)
 import Data.Scientific (Scientific)
 import Data.Semigroup (Semigroup(..))
@@ -619,6 +619,9 @@ _Double = reserved "Double"
 
 _Text :: Parser ()
 _Text = reserved "Text"
+
+_Location :: Parser ()
+_Location = reserved "Location"
 
 _List :: Parser ()
 _List = reserved "List"
@@ -1584,13 +1587,11 @@ importHashed_ = do
 import_ :: Parser Import
 import_ = (do
     importHashed <- importHashed_
-    importMode   <- alternative <|> pure Code
+    importMode   <- _as *> mode <|> pure Code
     return (Import {..}) ) <?> "import"
   where
-    alternative = do
-        _as
-        _Text
-        return RawText
+    mode =  _Text $> RawText
+        <|> _Location $> RawLocation
 
 -- | A parsing error
 data ParseError = ParseError

--- a/src/Dhall/Pretty/Internal.hs
+++ b/src/Dhall/Pretty/Internal.hs
@@ -25,6 +25,7 @@ module Dhall.Pretty.Internal (
     , prettyNatural
     , prettyNumber
     , prettyScientific
+    , prettyText
 
     , builtin
     , keyword
@@ -327,7 +328,8 @@ prettyChunks (Chunks a b) =
 
     prettyChunk (c, d) = prettyText c <> syntax "${" <> prettyExprA d <> syntax rbrace
 
-    prettyText t = literal (Pretty.pretty (escapeText t))
+prettyText :: Text -> Doc Ann
+prettyText t = literal (Pretty.pretty (escapeText t))
 
 prettyConst :: Const -> Doc Ann
 prettyConst Type = builtin "Type"
@@ -729,6 +731,10 @@ prettyExprF DoubleShow =
     builtin "Double/show"
 prettyExprF Text =
     builtin "Text"
+prettyExprF FilePath =
+    builtin "FilePath"
+prettyExprF Url =
+    builtin "Url"
 prettyExprF List =
     builtin "List"
 prettyExprF ListBuild =
@@ -764,6 +770,10 @@ prettyExprF (DoubleLit a) =
     prettyScientific a
 prettyExprF (TextLit a) =
     prettyChunks a
+prettyExprF (FilePathLit a) =
+    prettyText (Text.pack a)
+prettyExprF (UrlLit a) =
+    prettyText a
 prettyExprF (Record a) =
     prettyRecord a
 prettyExprF (RecordLit a) =
@@ -1084,6 +1094,10 @@ buildExprF DoubleShow =
     "Double/show"
 buildExprF Text =
     "Text"
+buildExprF FilePath =
+    "FilePath"
+buildExprF Url =
+    "Url"
 buildExprF List =
     "List"
 buildExprF ListBuild =
@@ -1119,6 +1133,10 @@ buildExprF (DoubleLit a) =
     buildScientific a
 buildExprF (TextLit a) =
     buildChunks a
+buildExprF (FilePathLit a) =
+    Text.pack a
+buildExprF (UrlLit a) =
+    a
 buildExprF (Record a) =
     buildRecord a
 buildExprF (RecordLit a) =

--- a/src/Dhall/Tutorial.hs
+++ b/src/Dhall/Tutorial.hs
@@ -56,6 +56,9 @@ module Dhall.Tutorial (
     -- * Raw text
     -- $rawText
 
+    -- * File paths and URLs
+    -- $locations
+
     -- * Formatting code
     -- $format
 
@@ -1596,6 +1599,50 @@ import Dhall
 -- > ...
 -- > (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 -- > SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-- $locations
+--
+-- Configuration files often contain paths to other files (for example, a database
+-- or some resource), and it is often convenient to specify those paths
+-- relative to the configuration file itself.
+--
+-- > $ pwd
+-- > /tmp
+-- > $ cat start.dhall
+-- > ./sub/foo.dhall
+--
+-- Suppose that you would like to have a relative path in @foo.dhall@. It cannot
+-- be a simple string, because it would not contain any information about
+-- the directory, relative to which this path should be resolved.
+-- The following does not work as expected:
+--
+-- > $ cat sub/foo.dhall
+-- > "./bar"
+--
+-- > $ dhall <<< './start.dhall'
+-- > Text
+-- > 
+-- > "./bar"  # There is no 'bar' in current directory
+--
+-- When the Dhall file is evaluated you end up with a simple string and no
+-- way to know which file it came from. Instead, you should use the same syntax
+-- as for imports (without quotation marks) but add `as Location`:
+--
+-- > $ cat sub/foo.dhall
+-- > ./bar as Location
+--
+-- > $ dhall <<< './start.dhall'
+-- > FilePath
+-- > 
+-- > /tmp/sub/bar  # The path was resolved relative to the file that contains it
+--
+-- A Dhall file can also contain URLs and just like file paths they are given by
+-- the include syntax with `as Location`:
+-- 
+-- > $ dhall <<< 'https://github.com/dhall-lang/dhall-lang as Location'
+-- > Url
+-- > 
+-- > https://github.com/dhall-lang/dhall-lang
 
 -- $format
 --

--- a/src/Dhall/TypeCheck.hs
+++ b/src/Dhall/TypeCheck.hs
@@ -358,6 +358,14 @@ typeWithA tpa = loop
             Text -> return ()
             _    -> Left (TypeError ctx e (CantTextAppend r tr))
         return Text
+    loop _      FilePath          = do
+        return (Const Type)
+    loop _     (FilePathLit _   ) = do
+        return FilePath
+    loop _      Url               = do
+        return (Const Type)
+    loop _     (UrlLit _        ) = do
+        return Url
     loop _      List              = do
         return (Pi "_" (Const Type) (Const Type))
     loop ctx e@(ListLit  Nothing  xs) = do


### PR DESCRIPTION
A fix for dhall-lang/dhall-lang#71.

This PR adds two new types:

* `FilePath`
* `Url`

and literals for them. The syntax is

* `./some/path as Location` and
* `https://example.com/url as Location` respectively.

Trying to use an `env:` import with `as Location` is an error.

TODO:

- [ ] Update the language spec :).
- [x] ~Take headers which come from hashes (?) into account in diff.~
- [ ] Use a real `Uri` type for `Url` literals instead of current `Text`?