### PR TITLE
Add template-haskell-2.12.0.0 to lts-6

### DIFF
--- a/src/Dhall/TH.hs
+++ b/src/Dhall/TH.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP             #-}
 
 {-| This module provides `staticDhallExpression` which can be used to resolve
     all of an expression’s imports at compile time, allowing one to reference
@@ -25,6 +26,10 @@ module Dhall.TH where
 
 import Control.Monad
 import Data.Typeable
+#if MIN_VERSION_template_haskell(2,11,0)
+#else
+import Language.Haskell.TH.Quote
+#endif
 import Language.Haskell.TH.Syntax
 
 import qualified Data.Text as Text


### PR DESCRIPTION
Cause picking 2.10 (default version in lts 6) makes dhall not compile: in that version [dataToExpQ](https://github.com/dhall-lang/dhall-haskell/blob/master/src/Dhall/TH.hs#L37) is in `Language.Haskell.TH.Quote` and not in `Language.Haskell.TH.Syntax`