### PR TITLE
remove space in end of imports when formatting

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -180,19 +180,18 @@ instance Semigroup ImportType where
 
 instance Buildable ImportType where
     build (Local prefix file) =
-        build prefix <> build file <> " "
+        build prefix <> build file
 
     build (URL prefix file suffix headers) =
             build prefix
         <>  build file
         <>  build suffix
         <>  foldMap buildHeaders headers
-        <>  " "
       where
         buildHeaders h = " using " <> build h
 
     build (Env env) =
-        "env:" <> build env <> " "
+        "env:" <> build env
 
 -- | How to interpret the import's contents (i.e. as Dhall code or raw text)
 data ImportMode = Code | RawText deriving (Eq, Ord, Show)

--- a/tests/Format.hs
+++ b/tests/Format.hs
@@ -39,6 +39,12 @@ formatTests =
         , should
             "indent then/else to the same column"
             "ifThenElse"
+        , should
+            "handle indenting long imports correctly without trailing space per line"
+            "importLines"
+        , should
+            "handle indenting small imports correctly without trailing space inline"
+            "importLines2"
         ]
 
 opts :: Data.Text.Prettyprint.Doc.LayoutOptions

--- a/tests/format/importLines2A.dhall
+++ b/tests/format/importLines2A.dhall
@@ -1,0 +1,2 @@
+let _ = ./emptyRecordA.dhall
+in let _ = ./emptyRecordA.dhall in 123

--- a/tests/format/importLines2B.dhall
+++ b/tests/format/importLines2B.dhall
@@ -1,0 +1,1 @@
+let _ = ./emptyRecordA.dhall in let _ = ./emptyRecordA.dhall in 123

--- a/tests/format/importLinesA.dhall
+++ b/tests/format/importLinesA.dhall
@@ -1,0 +1,7 @@
+let _ = ./emptyRecordA.dhall
+in  let _ = ./emptyRecordA.dhall
+in  let _ = ./emptyRecordA.dhall
+in  let _ = ./emptyRecordA.dhall
+in  let _ = ./emptyRecordA.dhall
+in  let _ = ./emptyRecordA.dhall
+in  123

--- a/tests/format/importLinesB.dhall
+++ b/tests/format/importLinesB.dhall
@@ -1,0 +1,13 @@
+    let _ = ./emptyRecordA.dhall
+
+in  let _ = ./emptyRecordA.dhall
+
+in  let _ = ./emptyRecordA.dhall
+
+in  let _ = ./emptyRecordA.dhall
+
+in  let _ = ./emptyRecordA.dhall
+
+in  let _ = ./emptyRecordA.dhall
+
+in  123


### PR DESCRIPTION
If the spaces are actually required, I'd like to help fix it correctly, but I think I first need an actual example of when this goes wrong.