### PR TITLE
Add inputFrom and inputFromWith, to allow setting the filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * BREAKING CHANGE TO THE API: Removed the `Parent` constructor from `FilePrefix`.
     * Instead, use `Here` with a `".."` prefix.
 
+* Added `inputFrom` and `inputFromWith`, which allow naming the file
+  that the expression is coming from. This improves error messages but
+  has no change to the semantics.
+
 1.14.0
 
 * BREAKING CHANGE TO THE LANGUAGE: Switch grammar of `Natural` and `Integer`


### PR DESCRIPTION
I discovered we have a variant of `input` in `dhall-to-cabal` whose
main innovation is being able to set the filename in error messages to
something other than `(input)`. It makes sense to piggyback off
`dhall-haskell`'s code here and just thread that through as a
parameter.