### PR TITLE
Add missing Diff dependency to doctests' build-depends

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -255,6 +255,7 @@ Test-Suite doctest
     GHC-Options: -Wall
     Build-Depends:
         base                      ,
+        Diff    >= 0.2   && < 0.4 ,
         doctest >= 0.7.0 && < 0.16
     Default-Language: Haskell2010
 


### PR DESCRIPTION
They were breaking without this for me when running with `new-test`.