### PR TITLE
Silence cabal check by setting cabal-version to 1.10

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -1,6 +1,6 @@
 Name: dhall
 Version: 1.14.0
-Cabal-Version: >=1.8.0.2
+Cabal-Version: >=1.10
 Build-Type: Simple
 Tested-With: GHC == 8.0.1
 License: BSD3


### PR DESCRIPTION
Previously, `cabal check` was failing because of `default-language`
fields. They require 1.10, so that's what we'll go with.