### PR TITLE
Optionally optimize for speed by replacing slow construct with native function

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -210,7 +210,8 @@ Library
         Dhall.Repl
         Dhall.TH,
         Dhall.Tutorial,
-        Dhall.TypeCheck
+        Dhall.TypeCheck,
+        Dhall.Optimizer
     Other-Modules:
         Dhall.Pretty.Internal,
         Dhall.Parser.Expression,
@@ -240,6 +241,7 @@ Test-Suite tasty
         Tutorial
         TypeCheck
         Util
+        Optimization
     Build-Depends:
         base                      >= 4        && < 5   ,
         deepseq                   >= 1.2.0.1  && < 1.5 ,

--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -215,7 +215,7 @@ inputFromWith filename (Type {..}) ctx n txt = do
             _ ->
                 Annot expr' expected
     _ <- throws (Dhall.TypeCheck.typeWith ctx annot)
-    case extract (Dhall.Core.normalizeWith n expr') of
+    case extract (Dhall.Core.normalizeWith Nothing n expr') of
         Just x  -> return x
         Nothing -> Control.Exception.throwIO InvalidType
 
@@ -243,7 +243,7 @@ inputExprWith ctx n txt = do
     expr  <- throws (Dhall.Parser.exprFromText "(input)" txt)
     expr' <- Dhall.Import.loadWithContext ctx n expr
     _ <- throws (Dhall.TypeCheck.typeWith ctx expr')
-    pure (Dhall.Core.normalizeWith n expr')
+    pure (Dhall.Core.normalizeWith Nothing n expr')
 
 -- | Use this function to extract Haskell values directly from Dhall AST.
 --   The intended use case is to allow easy extraction of Dhall values for

--- a/src/Dhall/Diff.hs
+++ b/src/Dhall/Diff.hs
@@ -345,7 +345,7 @@ diffChunks cL cR
 
     diffTextSkeleton = difference textSkeleton textSkeleton
 
-    chunks = zipWith chunkDiff (toEitherList cL) (toEitherList cR) 
+    chunks = zipWith chunkDiff (toEitherList cL) (toEitherList cR)
 
     chunkDiff a b =
       case (a, b) of

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -704,7 +704,7 @@ loadStaticWith from_import ctx n (Embed import_) = do
                     -- cached, since they have already been checked
                     expr''' <- case Dhall.TypeCheck.typeWith ctx expr'' of
                         Left  err -> throwM (Imported (import_:imports) err)
-                        Right _   -> return (Dhall.Core.normalizeWith n expr'')
+                        Right _   -> return (Dhall.Core.normalizeWith Nothing n expr'')
                     zoom cache (State.put $! Map.insert here expr''' m)
                     return expr'''
 

--- a/src/Dhall/Optimizer.hs
+++ b/src/Dhall/Optimizer.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TemplateHaskell    #-}
+
+module Dhall.Optimizer (
+  Optimizer,
+  optimizer,
+  ) where
+
+import Dhall.Core
+import Dhall.TH
+
+type Optimizer s a = Expr s a -> Expr s a
+
+optNaturalMonus :: (Eq s, Eq a) => Optimizer s a
+optNaturalMonus e =
+  case e of
+    App (App f (NaturalLit a)) (NaturalLit b) | f `cmp` ast -> NaturalLit (if a > b then a - b else 0)
+    _ -> e
+  where
+    ast = $(staticDhallExpression "./src/Dhall/Optimizer/NaturalMonus")
+    cmp el er = alphaNormalize el == alphaNormalize er
+
+optimizations :: (Eq s, Eq a) => [Expr s a -> Expr s a]
+optimizations = optNaturalMonus : []
+
+optimizer :: (Eq s, Eq a) => Optimizer s a
+optimizer e = foldr id e optimizations

--- a/src/Dhall/Optimizer/NaturalMonus
+++ b/src/Dhall/Optimizer/NaturalMonus
@@ -1,0 +1,4 @@
+-- This function is of type: Natural → Natual → Natural
+-- When applied to x and y, it returns x-y if x>=y and 0 in all other cases
+
+λ(x : Natural) → λ(y : Natural) → Natural/fold y Natural (λ(n : Natural) → (Natural/fold n { prev : Natural, next : Natural } (λ(p : { prev : Natural, next : Natural }) → { prev = p.next, next = p.next + 1}) { prev = 0, next = 0 }).prev) x

--- a/tests/Optimization.hs
+++ b/tests/Optimization.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Optimization (optimizationTests) where
+
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import Numeric.Natural
+import Dhall.Core (Expr)
+import Dhall.TypeCheck (X)
+
+import qualified Control.Exception
+import qualified Data.Text
+import qualified Dhall.Core
+import qualified Dhall.Import
+import qualified Dhall.Parser
+import qualified Dhall.TypeCheck
+import qualified Dhall.Optimizer
+
+--import Dhall.Core
+import Test.Tasty
+import Test.Tasty.HUnit
+
+optimizationTests :: TestTree
+optimizationTests =
+    testGroup "optimization"
+        [ shouldNormalize "NaturalMonus positive value" "NaturalMonus" (9999, 8888, 1111),
+          shouldNormalize "NaturalMonus equal value" "NaturalMonus" (55, 55, 0),
+          shouldNormalize "NaturalMonus zero value" "NaturalMonus" (0, 0, 0),
+          shouldNormalize "NaturalMonus negative value" "NaturalMonus" (6666, 7777, 0)
+        ]
+
+should :: Text -> Text -> (Natural, Natural, Natural) -> TestTree
+should name basename (x, y, r) =
+    Test.Tasty.HUnit.testCase (Data.Text.unpack name) $ do
+        let functionCode   = "./tests/optimization/" <> basename <> ".dhall"
+
+        functionExpr <- case Dhall.Parser.exprFromText mempty functionCode of
+            Left  err  -> Control.Exception.throwIO err
+            Right expr -> return expr
+        functionResolved <- Dhall.Import.load functionExpr
+        case Dhall.TypeCheck.typeOf functionResolved of
+            Left  err -> Control.Exception.throwIO err
+            Right _   -> return ()
+        let fullExpression = Dhall.Core.App (Dhall.Core.App functionResolved (Dhall.Core.NaturalLit x)) (Dhall.Core.NaturalLit y)
+        let actualNormalized = Dhall.Core.normalizeOpt (Just Dhall.Optimizer.optimizer) fullExpression :: Expr X X
+        let expectedNormalized = Dhall.Core.NaturalLit r
+
+        let message =
+                "The normalized expression did not match the expected output"
+        Test.Tasty.HUnit.assertEqual message expectedNormalized actualNormalized
+
+shouldNormalize :: Text -> Text -> (Natural, Natural, Natural) -> TestTree
+shouldNormalize name = should ("optimize " <> name <> " correctly")

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Normalization (normalizationTests)
+import Optimization (optimizationTests)
 import Parser (parserTests)
 import Regression (regressionTests)
 import Tutorial (tutorialTests)
@@ -12,6 +13,7 @@ allTests :: TestTree
 allTests =
     testGroup "Dhall Tests"
         [ normalizationTests
+        , optimizationTests
         , parserTests
         , regressionTests
         , tutorialTests

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -31,7 +31,7 @@ normalize' :: Expr Src X -> Text
 normalize' = Dhall.Core.pretty . Dhall.Core.normalize
 
 normalizeWith' :: Normalizer X -> Expr Src X -> Text
-normalizeWith' ctx = Dhall.Core.pretty . Dhall.Core.normalizeWith ctx
+normalizeWith' ctx = Dhall.Core.pretty . Dhall.Core.normalizeWith Nothing ctx
 
 code :: Text -> IO (Expr Src X)
 code = codeWith Dhall.Context.empty

--- a/tests/optimization/NaturalMonus.dhall
+++ b/tests/optimization/NaturalMonus.dhall
@@ -1,0 +1,9 @@
+λ(x : Natural) →
+λ(y : Natural) →
+  Natural/fold y Natural (
+    λ(n : Natural) → (
+      Natural/fold n
+                   { prev : Natural, next : Natural }
+                   (λ(p : { prev : Natural, next : Natural }) → { prev = p.next, next = p.next + 1})
+                   { prev = 0, next = 0 }).prev
+  ) x


### PR DESCRIPTION
The aim of this PR is not to be merged. I think `dhall-haskell` should be the reference implementation in Haskell and be kept as simple as possible. 

However, I'm wondering if it would be possible to add hooks in the implementation that could be used by packages built on top of this one to optimize the normalization of some construct. I'm using Dhall as an intermediate representation and my application ended up generating a function similar to the one below. It was applied to large natural numbers:
```
λ(x : Natural) → λ(y : Natural) →
  Natural/fold y Natural (
    λ(n : Natural) → (
      Natural/fold n
                   { prev : Natural, next : Natural }
                   (λ(p : { prev : Natural, next : Natural }) → { prev = p.next, next = p.next + 1})
                   { prev = 0, next = 0 }).prev
  ) x 
```

When applied to (for instance) `9999` and `8888`, normalization takes forever as seen below. The optimized version is necessary to get acceptable performance. Of course I could try to change the code generated in the first place, but being able to speed up normalization would be great -- well implemented native functions are as safe as running the Dhall interpreter. 
```
Gilless-MacBook-Pro:dhall-haskell gilles$ time stack exec dhall normalize < ./t_9999_8888.dhall
1111

real	2m28.098s
user	2m25.813s
sys	0m1.425s
Gilless-MacBook-Pro:dhall-haskell gilles$ time stack exec dhall normalizeOpt < ./t_9999_8888.dhall
1111

real	0m0.269s
user	0m0.163s
sys	0m0.096s
```


