### PR TITLE
fix sha256 missing space in pretty print output 

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -204,7 +204,7 @@ instance Pretty ImportHashed where
     pretty (ImportHashed  Nothing p) =
       Pretty.pretty p
     pretty (ImportHashed (Just h) p) =
-      Pretty.pretty p <> "sha256:" <> Pretty.pretty (show h) <> " "
+      Pretty.pretty p <> " sha256:" <> Pretty.pretty (show h)
 
 -- | Reference to an external resource
 data Import = Import

--- a/tests/Format.hs
+++ b/tests/Format.hs
@@ -48,6 +48,9 @@ formatTests =
         , should
             "not remove parentheses when accessing a field of a record"
             "importAccess"
+        , should
+            "handle formatting sha256 imports correctly"
+            "sha256Printing"
         ]
 
 opts :: Data.Text.Prettyprint.Doc.LayoutOptions

--- a/tests/format/sha256PrintingA.dhall
+++ b/tests/format/sha256PrintingA.dhall
@@ -1,0 +1,2 @@
+let replicate =
+    https://raw.githubusercontent.com/dhall-lang/Prelude/c79c2bc3c46f129cc5b6d594ce298a381bcae92c/List/replicate sha256:b0e3ec1797b32c80c0bcb7e8254b08c7e9e35e75e6b410c7ac21477ab90167ad in  replicate 5

--- a/tests/format/sha256PrintingB.dhall
+++ b/tests/format/sha256PrintingB.dhall
@@ -1,0 +1,4 @@
+    let replicate =
+          https://raw.githubusercontent.com/dhall-lang/Prelude/c79c2bc3c46f129cc5b6d594ce298a381bcae92c/List/replicate sha256:b0e3ec1797b32c80c0bcb7e8254b08c7e9e35e75e6b410c7ac21477ab90167ad
+
+in  replicate 5


### PR DESCRIPTION
Looks like some SHA256 formatting got moved about or something.