### PR TITLE
Show `Optional` and `List` in diffs

### DIFF
--- a/src/Dhall/Diff.hs
+++ b/src/Dhall/Diff.hs
@@ -465,6 +465,12 @@ skeleton (Pi {}) =
     <>  rarrow
     <>  " "
     <>  ignore
+skeleton (App Optional _) =
+        "Optional "
+    <>  ignore
+skeleton (App List _) =
+        "List "
+    <>  ignore
 skeleton (App {}) =
         ignore
     <>  " "


### PR DESCRIPTION
Part of #424

This special-cases the logic for displaying type mismatches to display
`Optional` and `List` when the skeletons of the two types mismatch

For example:

```
$ dhall diff '{ foo : Integer }' '(Optional { foo : Integer })'
- { … : … }
+ Optional …
```