### PR TITLE
Fix benchmark test file path

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -153,7 +153,7 @@ Extra-Source-Files:
     tests/typecheck/*.dhall
     tests/typecheck/examples/Monoid/*.dhall
     benchmark/examples/*.dhall
-    benchmark/deep-nested-large/record/*.dhall
+    benchmark/deep-nested-large-record/*.dhall
 
 Source-Repository head
     Type: git


### PR DESCRIPTION
This path was wrong and causes cabal to give out a warning every time one builds