### PR TITLE
Add new `dhall lint` sub-command

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -204,6 +204,7 @@ Library
         Dhall.Format,
         Dhall.Hash,
         Dhall.Import,
+        Dhall.Lint,
         Dhall.Main
         Dhall.Parser,
         Dhall.Pretty,

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -42,6 +42,7 @@ module Dhall.Core (
     , isNormalized
     , isNormalizedWith
     , denote
+    , freeIn
 
     -- * Pretty-printing
     , pretty
@@ -1890,6 +1891,15 @@ isNormalized e = case denote e of
             _ -> True
     Note _ e' -> isNormalized e'
     Embed _ -> True
+
+freeIn :: Eq a => Var -> Expr s a -> Bool
+variable `freeIn` expression =
+    Dhall.Core.shift 1 variable strippedExpression == strippedExpression
+  where
+    denote' :: Expr t b -> Expr () b
+    denote' = denote
+
+    strippedExpression = denote' expression
 
 _ERROR :: String
 _ERROR = "\ESC[1;31mError\ESC[0m"

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -1892,9 +1892,18 @@ isNormalized e = case denote e of
     Note _ e' -> isNormalized e'
     Embed _ -> True
 
+{-| Detect if the given variable is free within the given expression
+
+>>> "x" `freeIn` "x"
+True
+>>> "x" `freeIn` "y"
+False
+>>> "x" `freeIn` Lam "x" (Const Type) "x"
+False
+-}
 freeIn :: Eq a => Var -> Expr s a -> Bool
 variable `freeIn` expression =
-    Dhall.Core.shift 1 variable strippedExpression == strippedExpression
+    Dhall.Core.shift 1 variable strippedExpression /= strippedExpression
   where
     denote' :: Expr t b -> Expr () b
     denote' = denote

--- a/src/Dhall/Import/HTTP.hs
+++ b/src/Dhall/Import/HTTP.hs
@@ -4,7 +4,7 @@
 
 module Dhall.Import.HTTP where
 
-import Control.Exception (Exception, throwIO)
+import Control.Exception (throwIO)
 import Control.Monad (join)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.State.Strict (StateT)
@@ -12,7 +12,6 @@ import Data.ByteString (ByteString)
 import Data.CaseInsensitive (CI)
 import Data.Dynamic (fromDynamic, toDyn)
 import Data.Semigroup ((<>))
-import Data.Typeable (Typeable)
 import Lens.Family.State.Strict (zoom)
 
 import qualified Control.Monad.Trans.State.Strict        as State

--- a/src/Dhall/Lint.hs
+++ b/src/Dhall/Lint.hs
@@ -28,7 +28,7 @@ lint expression = loop (Dhall.Core.denote expression)
         a' = loop a
         b' = loop b
     loop (Let a b c d)
-        | V a 0 `Dhall.Core.freeIn` d =
+        | not (V a 0 `Dhall.Core.freeIn` d) =
             loop d
         | otherwise =
             Let a b' c' d'

--- a/src/Dhall/Lint.hs
+++ b/src/Dhall/Lint.hs
@@ -1,0 +1,217 @@
+module Dhall.Lint
+    ( -- * Lint
+      lint
+    ) where
+
+import Dhall.Core (Chunks(..), Expr(..), Import, Var(..))
+import Dhall.TypeCheck (X(..))
+
+import qualified Dhall.Core
+
+lint :: Expr s Import -> Expr t Import
+lint expression = loop (Dhall.Core.denote expression)
+  where
+    loop (Const a) =
+        Const a
+    loop (Var a) =
+        Var a
+    loop (Lam a b c) = Lam a b' c'
+      where
+        b' = loop b
+        c' = loop c
+    loop (Pi a b c) = Pi a b' c'
+      where
+        b' = loop b
+        c' = loop c
+    loop (App a b) = App a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop (Let a b c d)
+        | V a 0 `Dhall.Core.freeIn` d =
+            loop d
+        | otherwise =
+            Let a b' c' d'
+      where
+        b' = fmap loop b
+        c' =      loop c
+        d' =      loop d
+    loop (Annot a b) =
+        Annot a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop Bool =
+        Bool
+    loop (BoolLit a) =
+        BoolLit a
+    loop (BoolAnd a b) =
+        BoolAnd a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop (BoolOr a b) =
+        BoolOr a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop (BoolEQ a b) =
+        BoolEQ a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop (BoolNE a b) =
+        BoolNE a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop (BoolIf a b c) =
+        BoolIf a' b' c'
+      where
+        a' = loop a
+        b' = loop b
+        c' = loop c
+    loop Natural =
+        Natural
+    loop (NaturalLit a) =
+        NaturalLit a
+    loop NaturalFold =
+        NaturalFold
+    loop NaturalBuild =
+        NaturalBuild
+    loop NaturalIsZero =
+        NaturalIsZero
+    loop NaturalEven =
+        NaturalEven
+    loop NaturalOdd =
+        NaturalOdd
+    loop NaturalToInteger =
+        NaturalToInteger
+    loop NaturalShow =
+        NaturalShow
+    loop (NaturalPlus a b) =
+        NaturalPlus a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop (NaturalTimes a b) =
+        NaturalTimes a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop Integer =
+        Integer
+    loop (IntegerLit a) =
+        IntegerLit a
+    loop IntegerShow =
+        IntegerShow
+    loop IntegerToDouble =
+        IntegerToDouble
+    loop Double =
+        Double
+    loop (DoubleLit a) =
+        DoubleLit a
+    loop DoubleShow =
+        DoubleShow
+    loop Text =
+        Text
+    loop (TextLit (Chunks a b)) =
+        TextLit (Chunks a' b)
+      where
+        a' = fmap (fmap loop) a
+    loop (TextAppend a b) =
+        TextAppend a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop List =
+        List
+    loop (ListLit a b) =
+        ListLit a' b'
+      where
+        a' = fmap loop a
+        b' = fmap loop b
+    loop (ListAppend a b) =
+        ListAppend a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop ListBuild =
+        ListBuild
+    loop ListFold =
+        ListFold
+    loop ListLength =
+        ListLength
+    loop ListHead =
+        ListHead
+    loop ListLast =
+        ListLast
+    loop ListIndexed =
+        ListIndexed
+    loop ListReverse =
+        ListReverse
+    loop Optional =
+        Optional
+    loop (OptionalLit a b) =
+        OptionalLit a' b'
+      where
+        a' =      loop a
+        b' = fmap loop b
+    loop OptionalFold =
+        OptionalFold
+    loop OptionalBuild =
+        OptionalBuild
+    loop (Record a) =
+        Record a'
+      where
+        a' = fmap loop a
+    loop (RecordLit a) =
+        RecordLit a'
+      where
+        a' = fmap loop a
+    loop (Union a) =
+        Union a'
+      where
+        a' = fmap loop a
+    loop (UnionLit a b c) =
+        UnionLit a b' c'
+      where
+        b' =      loop b
+        c' = fmap loop c
+    loop (Combine a b) =
+        Combine a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop (CombineTypes a b) =
+        CombineTypes a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop (Prefer a b) =
+        Prefer a' b'
+      where
+        a' = loop a
+        b' = loop b
+    loop (Merge a b c) =
+        Merge a' b' c'
+      where
+        a' =      loop a
+        b' =      loop b
+        c' = fmap loop c
+    loop (Constructors a) =
+        Constructors a'
+      where
+        a' = loop a
+    loop (Field a b) =
+        Field a' b
+      where
+        a' = loop a
+    loop (Project a b) =
+        Project a' b
+      where
+        a' = loop a
+    loop (Note a _) =
+        absurd a
+    loop (Embed a) =
+        Embed a

--- a/src/Dhall/Main.hs
+++ b/src/Dhall/Main.hs
@@ -35,10 +35,11 @@ import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty
 import qualified Dhall
 import qualified Dhall.Core
 import qualified Dhall.Diff
+import qualified Dhall.Format
+import qualified Dhall.Hash
+import qualified Dhall.Lint
 import qualified Dhall.Parser
 import qualified Dhall.Repl
-import qualified Dhall.Hash
-import qualified Dhall.Format
 import qualified Dhall.TypeCheck
 import qualified Options.Applicative
 import qualified System.Console.ANSI
@@ -50,7 +51,17 @@ data Options = Options
     , plain   :: Bool
     }
 
-data Mode = Default | Version | Resolve | Type | Normalize | Repl | Format (Maybe FilePath) | Hash | Diff Text Text
+data Mode
+    = Default
+    | Version
+    | Resolve
+    | Type
+    | Normalize
+    | Repl
+    | Format (Maybe FilePath)
+    | Hash
+    | Diff Text Text
+    | Lint
 
 parseInplace :: Parser String
 parseInplace =
@@ -85,6 +96,7 @@ parseMode =
     <|> subcommand "repl"      "Interpret expressions in a REPL" (pure Repl)
     <|> subcommand "diff"      "Render the difference between the normal form of two expressions" diffParser
     <|> subcommand "hash"      "Compute semantic hashes for Dhall expressions" (pure Hash)
+    <|> subcommand "lint"      "Improve Dhall code"              (pure Lint)
     <|> formatSubcommand
     <|> pure Default
   where
@@ -266,6 +278,13 @@ command (Options {..}) = do
 
         Hash -> do
             Dhall.Hash.hash 
+
+        Lint -> do
+            expression <- getExpression
+
+            let lintedExpression = Dhall.Lint.lint expression
+
+            render System.IO.stdout lintedExpression
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Fixes #481

Currently this just removes unused `let` bindings