### PR TITLE
Fix missing space in import suffix formatting

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -221,7 +221,7 @@ instance Pretty Import where
       where
         suffix :: Text
         suffix = case importMode of
-            RawText -> "as Text"
+            RawText -> " as Text"
             Code    -> ""
 
 -- | Type synonym for `Import`, provided for backwards compatibility

--- a/tests/Format.hs
+++ b/tests/Format.hs
@@ -51,6 +51,9 @@ formatTests =
         , should
             "handle formatting sha256 imports correctly"
             "sha256Printing"
+        , should
+            "handle formatting of Import suffix correctly"
+            "importSuffix"
         ]
 
 opts :: Data.Text.Prettyprint.Doc.LayoutOptions

--- a/tests/format/importSuffixA.dhall
+++ b/tests/format/importSuffixA.dhall
@@ -1,0 +1,1 @@
+let a = env:AAA      as Text in a

--- a/tests/format/importSuffixB.dhall
+++ b/tests/format/importSuffixB.dhall
@@ -1,0 +1,1 @@
+let a = env:AAA as Text in a


### PR DESCRIPTION
Before:

```bash
❯ dhall-format <<< "env:AAA as Text"
env:AAAas Text
```