### PR TITLE
Move pretty layout options to Dhall.Pretty

### DIFF
--- a/src/Dhall/Format.hs
+++ b/src/Dhall/Format.hs
@@ -3,7 +3,7 @@
 module Dhall.Format ( format ) where
 
 import Dhall.Parser (exprAndHeaderFromText)
-import Dhall.Pretty (annToAnsiStyle, prettyExpr)
+import Dhall.Pretty (annToAnsiStyle, prettyExpr, layoutOpts)
 
 import Data.Monoid ((<>))
 
@@ -13,11 +13,6 @@ import qualified Control.Exception
 import qualified Data.Text.IO
 import qualified System.Console.ANSI
 import qualified System.IO
-
-opts :: Pretty.LayoutOptions
-opts =
-    Pretty.defaultLayoutOptions
-        { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
 
 format :: Maybe FilePath -> IO ()
 format inplace = do
@@ -30,7 +25,7 @@ format inplace = do
 
                 let doc = Pretty.pretty header <> Pretty.pretty expr
                 System.IO.withFile file System.IO.WriteMode (\handle -> do
-                    Pretty.renderIO handle (Pretty.layoutSmart opts doc)
+                    Pretty.renderIO handle (Pretty.layoutSmart layoutOpts doc)
                     Data.Text.IO.hPutStrLn handle "" )
             Nothing -> do
                 System.IO.hSetEncoding System.IO.stdin System.IO.utf8
@@ -48,8 +43,8 @@ format inplace = do
                   then
                     Pretty.renderIO
                       System.IO.stdout
-                      (fmap annToAnsiStyle (Pretty.layoutSmart opts doc))
+                      (fmap annToAnsiStyle (Pretty.layoutSmart layoutOpts doc))
                   else
                     Pretty.renderIO
                       System.IO.stdout
-                      (Pretty.layoutSmart opts (Pretty.unAnnotate doc))
+                      (Pretty.layoutSmart layoutOpts (Pretty.unAnnotate doc))

--- a/src/Dhall/Freeze.hs
+++ b/src/Dhall/Freeze.hs
@@ -8,7 +8,7 @@ module Dhall.Freeze (
 import Dhall.Core
 import Dhall.Import (load, hashExpression)
 import Dhall.Parser (exprAndHeaderFromText, Src)
-import Dhall.Pretty (annToAnsiStyle)
+import Dhall.Pretty (annToAnsiStyle, layoutOpts)
 
 import System.Console.ANSI (hSupportsANSI)
 import Data.Monoid ((<>))
@@ -20,11 +20,6 @@ import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty
 import qualified Control.Exception
 import qualified Data.Text.IO
 import qualified System.IO
-
-opts :: Pretty.LayoutOptions
-opts =
-    Pretty.defaultLayoutOptions
-        { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
 
 readInput :: Maybe FilePath -> IO Text
 readInput = maybe fromStdin Data.Text.IO.readFile
@@ -52,8 +47,7 @@ freezeExpr (t, e) = do
 writeExpr :: Maybe FilePath -> (Text, Expr s Import) -> IO ()
 writeExpr inplace (header, expr) = do
     let doc = Pretty.pretty header <> Pretty.pretty expr
-    let layoutOptions = opts
-    let stream = Pretty.layoutSmart layoutOptions doc
+    let stream = Pretty.layoutSmart layoutOpts doc
 
     case inplace of
         Just f ->
@@ -64,9 +58,9 @@ writeExpr inplace (header, expr) = do
             supportsANSI <- System.Console.ANSI.hSupportsANSI System.IO.stdout
             if supportsANSI 
                then 
-                 Pretty.renderIO System.IO.stdout (annToAnsiStyle <$> Pretty.layoutSmart opts doc)
+                 Pretty.renderIO System.IO.stdout (annToAnsiStyle <$> Pretty.layoutSmart layoutOpts doc)
                else
-                 Pretty.renderIO System.IO.stdout (Pretty.layoutSmart opts (Pretty.unAnnotate doc)) 
+                 Pretty.renderIO System.IO.stdout (Pretty.layoutSmart layoutOpts (Pretty.unAnnotate doc)) 
 
 freeze :: Maybe FilePath -> IO ()
 freeze inplace = do

--- a/src/Dhall/Main.hs
+++ b/src/Dhall/Main.hs
@@ -19,7 +19,7 @@ import Data.Version (showVersion)
 import Dhall.Core (Expr, Import)
 import Dhall.Import (Imported(..), load)
 import Dhall.Parser (Src)
-import Dhall.Pretty (annToAnsiStyle, prettyExpr)
+import Dhall.Pretty (annToAnsiStyle, prettyExpr, layoutOpts)
 import Dhall.TypeCheck (DetailedTypeError(..), TypeError, X)
 import Options.Applicative (Parser, ParserInfo)
 import System.Exit (exitFailure)
@@ -146,11 +146,6 @@ parseMode =
         where
             parseFreeze = Freeze <$> optional parseInplace
 
-opts :: Pretty.LayoutOptions
-opts =
-    Pretty.defaultLayoutOptions
-        { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
-
 data ImportResolutionDisabled = ImportResolutionDisabled deriving (Exception)
 
 instance Show ImportResolutionDisabled where
@@ -215,9 +210,7 @@ command (Options {..}) = do
         render h e = do
             let doc = prettyExpr e
 
-            let layoutOptions = opts
-
-            let stream = Pretty.layoutSmart layoutOptions doc
+            let stream = Pretty.layoutSmart layoutOpts doc
 
             supportsANSI <- System.Console.ANSI.hSupportsANSI h
             let ansiStream =
@@ -304,7 +297,7 @@ command (Options {..}) = do
                     let doc = Pretty.pretty header <> Pretty.pretty lintedExpression
 
                     System.IO.withFile file System.IO.WriteMode (\h -> do
-                        Pretty.renderIO h (Pretty.layoutSmart opts doc)
+                        Pretty.renderIO h (Pretty.layoutSmart layoutOpts doc)
                         Data.Text.IO.hPutStrLn h "" )
                 Nothing -> do
                     System.IO.hSetEncoding System.IO.stdin System.IO.utf8
@@ -322,11 +315,11 @@ command (Options {..}) = do
                       then
                         Pretty.renderIO
                           System.IO.stdout
-                          (fmap annToAnsiStyle (Pretty.layoutSmart opts doc))
+                          (fmap annToAnsiStyle (Pretty.layoutSmart layoutOpts doc))
                       else
                         Pretty.renderIO
                           System.IO.stdout
-                          (Pretty.layoutSmart opts (Pretty.unAnnotate doc))
+                          (Pretty.layoutSmart layoutOpts (Pretty.unAnnotate doc))
 
 main :: IO ()
 main = do

--- a/src/Dhall/Pretty.hs
+++ b/src/Dhall/Pretty.hs
@@ -1,6 +1,13 @@
 {-| This module contains logic for pretty-printing expressions, including
     support for syntax highlighting
 -}
-module Dhall.Pretty ( Ann(..), annToAnsiStyle, prettyExpr ) where
+module Dhall.Pretty ( Ann(..), annToAnsiStyle, prettyExpr, layoutOpts ) where
 
 import Dhall.Pretty.Internal
+import qualified Data.Text.Prettyprint.Doc as Pretty
+
+layoutOpts :: Pretty.LayoutOptions
+layoutOpts =
+    Pretty.defaultLayoutOptions
+        { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
+

--- a/src/Dhall/Repl.hs
+++ b/src/Dhall/Repl.hs
@@ -241,11 +241,7 @@ output
 output handle expr = do
   liftIO (System.IO.hPutStrLn handle "")  -- Visual spacing
 
-  let opts =
-          Pretty.defaultLayoutOptions
-              { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
-
-  let stream = Pretty.layoutSmart opts (Dhall.Pretty.prettyExpr expr)
+  let stream = Pretty.layoutSmart Dhall.Pretty.layoutOpts (Dhall.Pretty.prettyExpr expr)
   supportsANSI <- liftIO (System.Console.ANSI.hSupportsANSI handle)
   let ansiStream =
           if supportsANSI

--- a/src/Dhall/TypeCheck.hs
+++ b/src/Dhall/TypeCheck.hs
@@ -33,7 +33,7 @@ import Data.Traversable (forM)
 import Data.Typeable (Typeable)
 import Dhall.Core (Const(..), Chunks(..), Expr(..), Var(..))
 import Dhall.Context (Context)
-import Dhall.Pretty (Ann)
+import Dhall.Pretty (Ann, layoutOpts)
 
 import qualified Data.Foldable
 import qualified Data.HashMap.Strict
@@ -3494,11 +3494,7 @@ data TypeError s a = TypeError
     }
 
 instance (Eq a, Pretty s, Pretty a) => Show (TypeError s a) where
-    show = Pretty.renderString . Pretty.layoutPretty options . Pretty.pretty
-      where
-        options =
-            Pretty.LayoutOptions
-                { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
+    show = Pretty.renderString . Pretty.layoutPretty layoutOpts . Pretty.pretty
 
 instance (Eq a, Pretty s, Pretty a, Typeable s, Typeable a) => Exception (TypeError s a)
 
@@ -3533,11 +3529,7 @@ newtype DetailedTypeError s a = DetailedTypeError (TypeError s a)
     deriving (Typeable)
 
 instance (Eq a, Pretty s, Pretty a) => Show (DetailedTypeError s a) where
-    show = Pretty.renderString . Pretty.layoutPretty options . Pretty.pretty
-      where
-        options =
-            Pretty.LayoutOptions
-                { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
+    show = Pretty.renderString . Pretty.layoutPretty layoutOpts . Pretty.pretty
 
 instance (Eq a, Pretty s, Pretty a, Typeable s, Typeable a) => Exception (DetailedTypeError s a)
 

--- a/tests/Format.hs
+++ b/tests/Format.hs
@@ -12,6 +12,7 @@ import qualified Data.Text.IO
 import qualified Data.Text.Prettyprint.Doc
 import qualified Data.Text.Prettyprint.Doc.Render.Text
 import qualified Dhall.Parser
+import qualified Dhall.Pretty
 import qualified Test.Tasty
 import qualified Test.Tasty.HUnit
 
@@ -56,13 +57,6 @@ formatTests =
             "importSuffix"
         ]
 
-opts :: Data.Text.Prettyprint.Doc.LayoutOptions
-opts =
-    Data.Text.Prettyprint.Doc.defaultLayoutOptions
-        { Data.Text.Prettyprint.Doc.layoutPageWidth =
-            Data.Text.Prettyprint.Doc.AvailablePerLine 80 1.0
-        }
-
 should :: Text -> Text -> TestTree
 should name basename =
     Test.Tasty.HUnit.testCase (Data.Text.unpack name) $ do
@@ -77,7 +71,7 @@ should name basename =
             Right expr -> return expr
 
         let doc        = Data.Text.Prettyprint.Doc.pretty expr
-        let docStream  = Data.Text.Prettyprint.Doc.layoutSmart opts doc
+        let docStream  = Data.Text.Prettyprint.Doc.layoutSmart Dhall.Pretty.layoutOpts doc
         let actualText = Data.Text.Prettyprint.Doc.Render.Text.renderStrict docStream
 
         expectedText <- Data.Text.IO.readFile outputFile

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -14,6 +14,7 @@ import qualified Dhall
 import qualified Dhall.Context
 import qualified Dhall.Core
 import qualified Dhall.Parser
+import qualified Dhall.Pretty
 import qualified Dhall.TypeCheck
 import qualified System.Timeout
 import qualified Test.Tasty
@@ -141,19 +142,12 @@ issue209 = Test.Tasty.HUnit.testCase "Issue #209" (do
     Just _ <- System.Timeout.timeout 1000000 (Control.Exception.evaluate $!! text)
     return () )
 
-opts :: Data.Text.Prettyprint.Doc.LayoutOptions
-opts =
-    Data.Text.Prettyprint.Doc.defaultLayoutOptions
-        { Data.Text.Prettyprint.Doc.layoutPageWidth =
-            Data.Text.Prettyprint.Doc.AvailablePerLine 80 1.0
-        }
-
 issue216 :: TestTree
 issue216 = Test.Tasty.HUnit.testCase "Issue #216" (do
     -- Verify that pretty-printing preserves string interpolation
     e <- Util.code "./tests/regression/issue216a.dhall"
     let doc       = Data.Text.Prettyprint.Doc.pretty e
-    let docStream = Data.Text.Prettyprint.Doc.layoutSmart opts doc
+    let docStream = Data.Text.Prettyprint.Doc.layoutSmart Dhall.Pretty.layoutOpts doc
     let text0 = Data.Text.Prettyprint.Doc.Render.Text.renderLazy docStream
 
     text1 <- Data.Text.Lazy.IO.readFile "./tests/regression/issue216b.dhall"


### PR DESCRIPTION

```haskell
    Pretty.defaultLayoutOptions
        { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
```

I noticed these were being redefined multiple times so I thought it would make sense to just move them to `Dhall.Pretty` :nail_care: 