### PR TITLE
Use `readDirectory` to simplify bumping dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,20 +9,27 @@ let
     outputSha256 = "0ga345hgw6v2kzyhvf5kw96hf60mx5pbd9c4qj5q4nan4lr7nkxn";
   };
 
+  readDirectory = import ./nix/readDirectory.nix;
+
   config = {
     packageOverrides = pkgs: {
       haskellPackages = pkgs.haskellPackages.override {
-        overrides = haskellPackagesNew: haskellPackagesOld: {
-          dhall =
-            pkgs.haskell.lib.failOnAllWarnings
-              (pkgs.haskell.lib.justStaticExecutables
-                (haskellPackagesNew.callPackage ./nix/dhall.nix { })
-              );
+        overrides =
+          let
+            manualOverrides =
+              haskellPackagesNew: haskellPackagesOld: {
+                dhall =
+                  pkgs.haskell.lib.failOnAllWarnings
+                    (pkgs.haskell.lib.justStaticExecutables
+                      haskellPackagesOld.dhall
+                    );
 
-          formatting = haskellPackagesOld.formatting_6_3_0;
+                 prettyprinter =
+                   pkgs.haskell.lib.dontCheck haskellPackagesOld.prettyprinter;
+              };
 
-          prettyprinter = haskellPackagesOld.prettyprinter_1_2_0_1;
-        };
+          in
+            pkgs.lib.composeExtensions (readDirectory ./nix) manualOverrides;
       };
     };
   };

--- a/nix/prettyprinter.nix
+++ b/nix/prettyprinter.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, ansi-wl-pprint, base, bytestring, containers
+, criterion, deepseq, doctest, mtl, pgp-wordlist, QuickCheck
+, random, stdenv, tasty, tasty-hunit, tasty-quickcheck, text
+, transformers
+}:
+mkDerivation {
+  pname = "prettyprinter";
+  version = "1.2.1";
+  sha256 = "e7653e0ba87cc06553a50e4780dde81c5dd156196c0199511d03d972e5517fcf";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [ base text ];
+  testHaskellDepends = [
+    base bytestring doctest pgp-wordlist tasty tasty-hunit
+    tasty-quickcheck text
+  ];
+  benchmarkHaskellDepends = [
+    ansi-wl-pprint base containers criterion deepseq mtl QuickCheck
+    random text transformers
+  ];
+  homepage = "http://github.com/quchen/prettyprinter";
+  description = "A modern, easy to use, well-documented, extensible pretty-printer";
+  license = stdenv.lib.licenses.bsd2;
+}

--- a/nix/readDirectory.nix
+++ b/nix/readDirectory.nix
@@ -1,0 +1,14 @@
+directory:
+
+haskellPackagesNew: haskellPackagesOld:
+  let
+    haskellPaths = builtins.attrNames (builtins.readDir directory);
+
+    toKeyVal = file: {
+      name  = builtins.replaceStrings [ ".nix" ] [ "" ] file;
+
+      value = haskellPackagesNew.callPackage (directory + "/${file}") { };
+    };
+
+  in
+    builtins.listToAttrs (map toKeyVal haskellPaths)


### PR DESCRIPTION
This comes in handy when testing Stackage-related bumps to upper bounds