### PR TITLE
Set locale to UTF-8

### DIFF
--- a/src/Dhall/Format.hs
+++ b/src/Dhall/Format.hs
@@ -33,7 +33,6 @@ format inplace = do
                     Pretty.renderIO handle (Pretty.layoutSmart opts doc)
                     Data.Text.IO.hPutStrLn handle "" )
             Nothing -> do
-                System.IO.hSetEncoding System.IO.stdin System.IO.utf8
                 inText <- Data.Text.IO.getContents
 
                 (header, expr) <- case exprAndHeaderFromText "(stdin)" inText of

--- a/src/Dhall/Freeze.hs
+++ b/src/Dhall/Freeze.hs
@@ -27,9 +27,7 @@ opts =
         { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
 
 readInput :: Maybe FilePath -> IO Text
-readInput = maybe fromStdin Data.Text.IO.readFile
-    where 
-        fromStdin = System.IO.hSetEncoding System.IO.stdin System.IO.utf8 >> Data.Text.IO.getContents
+readInput = maybe Data.Text.IO.getContents Data.Text.IO.readFile
 
 hashImport :: Import -> IO Import
 hashImport import_ = do

--- a/src/Dhall/Hash.hs
+++ b/src/Dhall/Hash.hs
@@ -8,11 +8,9 @@ import Dhall.Import (hashExpressionToCode, load)
 import qualified Control.Exception
 import qualified Dhall.TypeCheck
 import qualified Data.Text.IO
-import qualified System.IO
 
 hash :: IO ()
 hash = do
-        System.IO.hSetEncoding System.IO.stdin System.IO.utf8
         inText <- Data.Text.IO.getContents
 
         expr <- case exprFromText "(stdin)" inText of

--- a/src/Dhall/Main.hs
+++ b/src/Dhall/Main.hs
@@ -42,6 +42,7 @@ import qualified Dhall.Lint
 import qualified Dhall.Parser
 import qualified Dhall.Repl
 import qualified Dhall.TypeCheck
+import qualified GHC.IO.Encoding
 import qualified Options.Applicative
 import qualified System.Console.ANSI
 import qualified System.IO
@@ -180,7 +181,7 @@ parserInfoOptions =
 
 command :: Options -> IO ()
 command (Options {..}) = do
-    System.IO.hSetEncoding System.IO.stdin System.IO.utf8
+    GHC.IO.Encoding.setLocaleEncoding System.IO.utf8
 
     let handle =
                 Control.Exception.handle handler2
@@ -207,7 +208,6 @@ command (Options {..}) = do
 
             handler2 e = do
                 let _ = e :: SomeException
-                System.IO.hSetEncoding System.IO.stderr System.IO.utf8
                 System.IO.hPrint System.IO.stderr e
                 System.Exit.exitFailure
 
@@ -307,7 +307,6 @@ command (Options {..}) = do
                         Pretty.renderIO h (Pretty.layoutSmart opts doc)
                         Data.Text.IO.hPutStrLn h "" )
                 Nothing -> do
-                    System.IO.hSetEncoding System.IO.stdin System.IO.utf8
                     text <- Data.Text.IO.getContents
 
                     (header, expression) <- throws (Dhall.Parser.exprAndHeaderFromText "(stdin)" text)


### PR DESCRIPTION
Fixes #504

This ensures that all handles use the UTF-8 locale by default so that we don't
have to keep setting the locale for each individual handle