### PR TITLE
Add `$` as an allowed character in quoted labels

### DIFF
--- a/src/Dhall/Parser/Token.hs
+++ b/src/Dhall/Parser/Token.hs
@@ -173,7 +173,7 @@ backtickLabel = do
     _ <- Text.Parser.Char.char '`'
     return (Data.Text.pack t)
   where
-    predicate c = alpha c || digit c || elem c ("-/_:." :: String)
+    predicate c = alpha c || digit c || elem c ("$-/_:." :: String)
 
 labels :: Parser (Set Text)
 labels = do

--- a/tests/parser/quotedLabel.dhall
+++ b/tests/parser/quotedLabel.dhall
@@ -1,1 +1,4 @@
-{ example1 = let `let` = 1 in `let`, example2 = let `:.` = 1 in `:.` }
+{ example1 = let `let` = 1 in `let`
+, example2 = let `:.` = 1 in `:.`
+, example3 = let `$ref` = 1 in `$ref`
+}


### PR DESCRIPTION
Implements https://github.com/dhall-lang/dhall-lang/pull/184