### PR TITLE
Proof-of-concept refactoring of the zoo of different input functions

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -36,6 +36,7 @@ module Dhall.Core (
     , normalize
     , normalizeWith
     , Normalizer
+    , ReifiedNormalizer (..)
     , judgmentallyEqual
     , subst
     , shift
@@ -1713,6 +1714,11 @@ judgmentallyEqual eL0 eR0 = alphaBetaNormalize eL0 == alphaBetaNormalize eR0
 -- | Use this to wrap you embedded functions (see `normalizeWith`) to make them
 --   polymorphic enough to be used.
 type Normalizer a = forall s. Expr s a -> Maybe (Expr s a)
+
+-- | A reified 'Normalizer', which can be stored in structures without
+-- running into impredicative polymorphism.
+data ReifiedNormalizer a = ReifiedNormalizer
+  { getReifiedNormalizer :: Normalizer a }
 
 -- | Check if an expression is in a normal form given a context of evaluation.
 --   Unlike `isNormalized`, this will fully normalize and traverse through the expression.


### PR DESCRIPTION
This isn't necessarily meant to be merged as-is, but more as a
suggestion that this API can take. BC breaks aside, there are two
things I would like to bring up:

* Argument order. If `InputSettings` went last, we could use the tight
  precedence of record updates to write this:

  ```
     expr <- inputExprWithSettings txt defaultSettings
       { sourceName = "foobar" }
  ```

  However, we then can't use monad operators so conveniently. I'm not
  sure which is more important.

* A putative `inputFile`, which would do the Right Thing for
  `rootDirectory` and `sourceName` and hence would not take them as
  parameters, but which would still take a context and a normaliser.