### PR TITLE
Serialization support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,9 @@ let
 
                  prettyprinter =
                    pkgs.haskell.lib.dontCheck haskellPackagesOld.prettyprinter;
+
+                 serialise =
+                   pkgs.haskell.lib.dontCheck haskellPackagesOld.serialise;
               };
 
           in

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -172,6 +172,7 @@ Library
         ansi-terminal               >= 0.6.3.1  && < 0.9 ,
         bytestring                                 < 0.11,
         case-insensitive                           < 1.3 ,
+        cborg                       >= 0.2.0.0  && < 0.3 ,
         containers                  >= 0.5.0.0  && < 0.6 ,
         contravariant                              < 1.6 ,
         cryptonite                  >= 0.23     && < 1.0 ,
@@ -190,6 +191,7 @@ Library
         prettyprinter               >= 1.2.0.1  && < 1.3 ,
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
         repline                     >= 0.1.6.0  && < 0.2 ,
+        serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
         template-haskell                           < 2.14,
         text                        >= 0.11.1.0 && < 1.3 ,
@@ -252,18 +254,25 @@ Test-Suite tasty
         Import
         Normalization
         Parser
+        QuickCheck
         Regression
         Tutorial
         TypeCheck
         Util
     Build-Depends:
         base                      >= 4        && < 5   ,
+        containers                                     ,
         deepseq                   >= 1.2.0.1  && < 1.5 ,
         dhall                                          ,
+        hashable                                 < 1.3 ,
         insert-ordered-containers                      ,
         prettyprinter                                  ,
+        QuickCheck                >= 2.10     && < 2.12,
+        quickcheck-instances      >= 0.3.12   && < 0.4 ,
+        serialise                                      ,
         tasty                     >= 0.11.2   && < 1.2 ,
         tasty-hunit               >= 0.9.2    && < 0.11,
+        tasty-quickcheck          >= 0.9.2    && < 0.11,
         text                      >= 0.11.1.0 && < 1.3 ,
         vector                    >= 0.11.0.0 && < 0.13
     Default-Language: Haskell2010

--- a/nix/dhall.nix
+++ b/nix/dhall.nix
@@ -1,10 +1,12 @@
 { mkDerivation, ansi-terminal, base, bytestring, case-insensitive
-, containers, contravariant, criterion, cryptonite, deepseq, Diff
-, directory, doctest, exceptions, filepath, haskeline, http-client
-, http-client-tls, insert-ordered-containers, lens-family-core
-, megaparsec, memory, mockery, mtl, optparse-applicative, parsers
-, prettyprinter, prettyprinter-ansi-terminal, repline, scientific
-, stdenv, tasty, tasty-hunit, template-haskell, text, transformers
+, cborg, containers, contravariant, criterion, cryptonite, deepseq
+, Diff, directory, doctest, exceptions, filepath, hashable
+, haskeline, http-client, http-client-tls
+, insert-ordered-containers, lens-family-core, megaparsec, memory
+, mockery, mtl, optparse-applicative, parsers, prettyprinter
+, prettyprinter-ansi-terminal, QuickCheck, quickcheck-instances
+, repline, scientific, serialise, stdenv, tasty, tasty-hunit
+, tasty-quickcheck, template-haskell, text, transformers
 , unordered-containers, vector
 }:
 mkDerivation {
@@ -14,17 +16,20 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-terminal base bytestring case-insensitive containers
+    ansi-terminal base bytestring case-insensitive cborg containers
     contravariant cryptonite Diff directory exceptions filepath
     haskeline http-client http-client-tls insert-ordered-containers
     lens-family-core megaparsec memory mtl optparse-applicative parsers
     prettyprinter prettyprinter-ansi-terminal repline scientific
-    template-haskell text transformers unordered-containers vector
+    serialise template-haskell text transformers unordered-containers
+    vector
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    base deepseq directory doctest filepath insert-ordered-containers
-    mockery prettyprinter tasty tasty-hunit text vector
+    base containers deepseq directory doctest filepath hashable
+    insert-ordered-containers mockery prettyprinter QuickCheck
+    quickcheck-instances serialise tasty tasty-hunit tasty-quickcheck
+    text vector
   ];
   benchmarkHaskellDepends = [
     base containers criterion directory text

--- a/nix/tasty-quickcheck.nix
+++ b/nix/tasty-quickcheck.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, pcre-light, QuickCheck, random, stdenv
+, tagged, tasty, tasty-hunit
+}:
+mkDerivation {
+  pname = "tasty-quickcheck";
+  version = "0.9.2";
+  sha256 = "c5920adeab6e283d5e3ab45f3c80a1b011bedfbe4a3246a52606da2e1da95873";
+  libraryHaskellDepends = [ base QuickCheck random tagged tasty ];
+  testHaskellDepends = [ base pcre-light tasty tasty-hunit ];
+  homepage = "https://github.com/feuerbach/tasty";
+  description = "QuickCheck support for the Tasty test framework";
+  license = stdenv.lib.licenses.mit;
+}

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveFoldable     #-}
-{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DeriveTraversable  #-}
+{-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE RecordWildCards    #-}
@@ -27,6 +27,7 @@ module Dhall.Core (
     , ImportMode(..)
     , ImportType(..)
     , Path
+    , Scheme(..)
     , Var(..)
     , Chunks(..)
     , Expr(..)
@@ -54,6 +55,8 @@ module Dhall.Core (
     , escapeText
     ) where
 
+import Codec.CBOR.Term (Term(..))
+import Codec.Serialise (Serialise(..))
 #if MIN_VERSION_base(4,8,0)
 #else
 import Control.Applicative (Applicative(..), (<$>))
@@ -74,13 +77,15 @@ import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Pretty)
 import Data.Traversable
 import {-# SOURCE #-} Dhall.Pretty.Internal
+import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
-import Prelude hiding (succ)
+import Prelude hiding (exponent, succ)
 
 import qualified Control.Monad
 import qualified Crypto.Hash
 import qualified Data.HashMap.Strict.InsOrd
 import qualified Data.HashSet
+import qualified Data.Scientific
 import qualified Data.Sequence
 import qualified Data.Set
 import qualified Data.Text
@@ -103,7 +108,7 @@ import qualified Data.Text.Prettyprint.Doc  as Pretty
     Note that Dhall does not support functions from terms to types and therefore
     Dhall is not a dependently typed language
 -}
-data Const = Type | Kind deriving (Show, Eq, Data, Bounded, Enum)
+data Const = Type | Kind deriving (Show, Eq, Data, Bounded, Enum, Generic)
 
 instance Pretty Const where
     pretty = Pretty.unAnnotate . prettyConst
@@ -115,7 +120,7 @@ instance Pretty Const where
     @Directory { components = [ "baz", "bar", "foo" ] }@
 -}
 newtype Directory = Directory { components :: [Text] }
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Generic, Ord, Show)
 
 instance Semigroup Directory where
     Directory components₀ <> Directory components₁ =
@@ -133,7 +138,7 @@ instance Pretty Directory where
 data File = File
     { directory :: Directory
     , file      :: Text
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Generic, Ord, Show)
 
 instance Pretty File where
     pretty (File {..}) = Pretty.pretty directory <> "/" <> Pretty.pretty file
@@ -149,29 +154,31 @@ data FilePrefix
     -- ^ Path relative to @.@
     | Home
     -- ^ Path relative to @~@
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Generic, Ord, Show)
 
 instance Pretty FilePrefix where
     pretty Absolute = ""
     pretty Here     = "."
     pretty Home     = "~"
 
+data Scheme = HTTP | HTTPS deriving (Eq, Generic, Ord, Show)
+
 -- | The type of import (i.e. local vs. remote vs. environment)
 data ImportType
     = Local FilePrefix File
     -- ^ Local path
-    | URL Text File Text (Maybe ImportHashed)
+    | URL Scheme Text File (Maybe Text) (Maybe Text) (Maybe ImportHashed)
     -- ^ URL of remote resource and optional headers stored in an import
     | Env  Text
     -- ^ Environment variable
     | Missing
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Generic, Ord, Show)
 
 instance Semigroup ImportType where
     Local prefix file₀ <> Local Here file₁ = Local prefix (file₀ <> file₁)
 
-    URL prefix file₀ suffix headers <> Local Here file₁ =
-        URL prefix (file₀ <> file₁) suffix headers
+    URL scheme authority file₀ query fragment headers <> Local Here file₁ =
+        URL scheme authority (file₀ <> file₁) query fragment headers
 
     _ <> import₁ =
         import₁
@@ -180,26 +187,41 @@ instance Pretty ImportType where
     pretty (Local prefix file) =
         Pretty.pretty prefix <> Pretty.pretty file
 
-    pretty (URL prefix file suffix headers) =
-            Pretty.pretty prefix
+    pretty (URL scheme authority file query fragment headers) =
+            schemeDoc
+        <>  "://"
+        <>  Pretty.pretty authority
         <>  Pretty.pretty file
-        <>  Pretty.pretty suffix
+        <>  queryDoc
+        <>  fragmentDoc
         <>  foldMap prettyHeaders headers
       where
         prettyHeaders h = " using " <> Pretty.pretty h
+
+        schemeDoc = case scheme of
+            HTTP  -> "http"
+            HTTPS -> "https"
+
+        queryDoc = case query of
+            Nothing -> ""
+            Just q  -> "?" <> Pretty.pretty q
+
+        fragmentDoc = case fragment of
+            Nothing -> ""
+            Just f  -> "#" <> Pretty.pretty f
 
     pretty (Env env) = "env:" <> Pretty.pretty env
 
     pretty Missing = "missing"
 
 -- | How to interpret the import's contents (i.e. as Dhall code or raw text)
-data ImportMode = Code | RawText deriving (Eq, Ord, Show)
+data ImportMode = Code | RawText deriving (Eq, Generic, Ord, Show)
 
 -- | A `ImportType` extended with an optional hash for semantic integrity checks
 data ImportHashed = ImportHashed
     { hash       :: Maybe (Crypto.Hash.Digest SHA256)
     , importType :: ImportType
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Generic, Ord, Show)
 
 instance Semigroup ImportHashed where
     ImportHashed _ importType₀ <> ImportHashed hash importType₁ =
@@ -215,7 +237,7 @@ instance Pretty ImportHashed where
 data Import = Import
     { importHashed :: ImportHashed
     , importMode   :: ImportMode
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Generic, Ord, Show)
 
 instance Semigroup Import where
     Import importHashed₀ _ <> Import importHashed₁ code =
@@ -267,7 +289,7 @@ type Path = Import
     appear as a numeric suffix.
 -}
 data Var = V Text !Integer
-    deriving (Data, Eq, Show)
+    deriving (Data, Generic, Eq, Show)
 
 instance IsString Var where
     fromString str = V (fromString str) 0
@@ -409,7 +431,7 @@ data Expr s a
     | ImportAlt (Expr s a) (Expr s a)
     -- | > Embed import                             ~  import
     | Embed a
-    deriving (Functor, Foldable, Traversable, Show, Eq, Data)
+    deriving (Functor, Foldable, Generic, Traversable, Show, Eq, Data)
 
 instance Applicative (Expr s) where
     pure = Embed
@@ -553,9 +575,29 @@ instance Bifunctor Expr where
 instance IsString (Expr s a) where
     fromString str = Var (fromString str)
 
+instance Serialise (Expr s Import) where
+    encode expression =
+        encode (TList [ TString "1.0.0", expressionToTerm expression ])
+
+    decode = do
+        term <- decode
+        subTerm <- case term of
+            TList [ TString version, subTerm ]
+                | Data.Text.isPrefixOf "1.0." version -> do
+                    return subTerm
+                | otherwise -> do
+                    fail ("This decoded version is not supported: " <> Data.Text.unpack version)
+            _ -> do
+                fail ("Cannot decode the version from this decoded CBOR expression: " <> show term)
+        case termToExpression subTerm of
+            Nothing ->
+                fail ("This decoded CBOR expression does not represent a valid Dhall expression: " <> show subTerm)
+            Just expression ->
+                return expression
+
 -- | The body of an interpolated @Text@ literal
 data Chunks s a = Chunks [(Text, Expr s a)] Text
-    deriving (Functor, Foldable, Traversable, Show, Eq, Data)
+    deriving (Functor, Foldable, Generic, Traversable, Show, Eq, Data)
 
 instance Data.Semigroup.Semigroup (Chunks s a) where
     Chunks xysL zL <> Chunks         []    zR =
@@ -2007,3 +2049,649 @@ reservedIdentifiers =
         , "Optional/build"
         , "Optional/fold"
         ]
+
+{-| Convert a function applied to multiple arguments to the base function and
+    the list of arguments
+-}
+unApply :: Expr s a -> (Expr s a, [Expr s a])
+unApply e = (baseFunction₀, diffArguments₀ [])
+  where
+    ~(baseFunction₀, diffArguments₀) = go e
+
+    go (App f a) = (baseFunction, diffArguments . (a :))
+      where
+        ~(baseFunction, diffArguments) = go f
+    go baseFunction = (baseFunction, id)
+
+expressionToTerm :: Expr s Import -> Term
+expressionToTerm (Var (V "_" n)) =
+    TInteger n
+expressionToTerm (Var (V x 0)) =
+    TString x
+expressionToTerm (Var (V x n)) =
+    TList [ TString x, TInteger n ]
+expressionToTerm NaturalBuild =
+    TString "Natural/build"
+expressionToTerm NaturalFold =
+    TString "Natural/fold"
+expressionToTerm NaturalIsZero =
+    TString "Natural/isZero"
+expressionToTerm NaturalEven =
+    TString "Natural/even"
+expressionToTerm NaturalOdd =
+    TString "Natural/odd"
+expressionToTerm NaturalToInteger =
+    TString "Natural/toInteger"
+expressionToTerm NaturalShow =
+    TString "Natural/show"
+expressionToTerm IntegerToDouble =
+    TString "Integer/toDouble"
+expressionToTerm IntegerShow =
+    TString "Integer/show"
+expressionToTerm DoubleShow =
+    TString "Double/show"
+expressionToTerm ListBuild =
+    TString "List/build"
+expressionToTerm ListFold =
+    TString "List/fold"
+expressionToTerm ListLength =
+    TString "List/length"
+expressionToTerm ListHead =
+    TString "List/head"
+expressionToTerm ListLast =
+    TString "List/last"
+expressionToTerm ListIndexed =
+    TString "List/indexed"
+expressionToTerm ListReverse =
+    TString "List/reverse"
+expressionToTerm OptionalFold =
+    TString "Optional/fold"
+expressionToTerm OptionalBuild =
+    TString "Optional/build"
+expressionToTerm Bool =
+    TString "Bool"
+expressionToTerm Optional =
+    TString "Optional"
+expressionToTerm Natural =
+    TString "Natural"
+expressionToTerm Integer =
+    TString "Integer"
+expressionToTerm Double =
+    TString "Double"
+expressionToTerm Text =
+    TString "Text"
+expressionToTerm List =
+    TString "List"
+expressionToTerm (Const Type) =
+    TString "Type"
+expressionToTerm (Const Kind) =
+    TString "Kind"
+expressionToTerm e@(App _ _) =
+    TList ([ TInt 0, f₁ ] ++ map expressionToTerm arguments)
+  where
+    (f₀, arguments) = unApply e
+
+    f₁ = expressionToTerm f₀
+expressionToTerm (Lam "_" _A₀ b₀) =
+    TList [ TInt 1, _A₁, b₁ ]
+  where
+    _A₁ = expressionToTerm _A₀
+    b₁  = expressionToTerm b₀
+expressionToTerm (Lam x _A₀ b₀) =
+    TList [ TInt 1, TString x, _A₁, b₁ ]
+  where
+    _A₁ = expressionToTerm _A₀
+    b₁  = expressionToTerm b₀
+expressionToTerm (Pi "_" _A₀ _B₀) =
+    TList [ TInt 2, _A₁, _B₁ ]
+  where
+    _A₁ = expressionToTerm _A₀
+    _B₁ = expressionToTerm _B₀
+expressionToTerm (Pi x _A₀ _B₀) =
+    TList [ TInt 2, TString x, _A₁, _B₁ ]
+  where
+    _A₁ = expressionToTerm _A₀
+    _B₁ = expressionToTerm _B₀
+expressionToTerm (BoolOr l₀ r₀) =
+    TList [ TInt 3, TInt 0, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (BoolAnd l₀ r₀) =
+    TList [ TInt 3, TInt 1, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (BoolEQ l₀ r₀) =
+    TList [ TInt 3, TInt 2, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (BoolNE l₀ r₀) =
+    TList [ TInt 3, TInt 3, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (NaturalPlus l₀ r₀) =
+    TList [ TInt 3, TInt 4, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (NaturalTimes l₀ r₀) =
+    TList [ TInt 3, TInt 5, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (TextAppend l₀ r₀) =
+    TList [ TInt 3, TInt 6, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (ListAppend l₀ r₀) =
+    TList [ TInt 3, TInt 7, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (Combine l₀ r₀) =
+    TList [ TInt 3, TInt 8, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (Prefer l₀ r₀) =
+    TList [ TInt 3, TInt 9, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (CombineTypes l₀ r₀) =
+    TList [ TInt 3, TInt 10, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (ImportAlt l₀ r₀) =
+    TList [ TInt 3, TInt 11, l₁, r₁ ]
+  where
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (ListLit _T₀ xs₀)
+    | null xs₀  = TList [ TInt 4, _T₁ ]
+    | otherwise = TList ([ TInt 4, TNull ] ++ xs₁)
+  where
+    _T₁ = case _T₀ of
+        Nothing -> TNull
+        Just t  -> expressionToTerm t
+
+    xs₁ = map expressionToTerm (Data.Foldable.toList xs₀)
+expressionToTerm (OptionalLit _T₀ Nothing) =
+    TList [ TInt 5, _T₁ ]
+  where
+    _T₁ = expressionToTerm _T₀
+expressionToTerm (OptionalLit _T₀ (Just t₀)) =
+    TList [ TInt 5, _T₁, t₁ ]
+  where
+    _T₁ = expressionToTerm _T₀
+    t₁  = expressionToTerm t₀
+expressionToTerm (Merge t₀ u₀ Nothing) =
+    TList [ TInt 6, t₁, u₁ ]
+  where
+    t₁ = expressionToTerm t₀
+    u₁ = expressionToTerm u₀
+expressionToTerm (Merge t₀ u₀ (Just _T₀)) =
+    TList [ TInt 6, t₁, u₁, _T₁ ]
+  where
+    t₁  = expressionToTerm t₀
+    u₁  = expressionToTerm u₀
+    _T₁ = expressionToTerm _T₀
+expressionToTerm (Record xTs₀) =
+    TList [ TInt 7, TMap xTs₁ ]
+  where
+    xTs₁ = do
+        (x₀, _T₀) <- Data.HashMap.Strict.InsOrd.toList xTs₀
+        let x₁  = TString x₀
+        let _T₁ = expressionToTerm _T₀
+        return (x₁, _T₁)
+expressionToTerm (RecordLit xts₀) =
+    TList [ TInt 8, TMap xts₁ ]
+  where
+    xts₁ = do
+        (x₀, t₀) <- Data.HashMap.Strict.InsOrd.toList xts₀
+        let x₁ = TString x₀
+        let t₁ = expressionToTerm t₀
+        return (x₁, t₁)
+expressionToTerm (Field t₀ x) =
+    TList [ TInt 9, t₁, TString x ]
+  where
+    t₁ = expressionToTerm t₀
+expressionToTerm (Project t₀ xs₀) =
+    TList ([ TInt 10, t₁ ] ++ xs₁)
+  where
+    t₁  = expressionToTerm t₀
+    xs₁ = map TString (Data.Foldable.toList xs₀)
+expressionToTerm (Union xTs₀) =
+    TList [ TInt 11, TMap xTs₁ ]
+  where
+    xTs₁ = do
+        (x₀, _T₀) <- Data.HashMap.Strict.InsOrd.toList xTs₀
+        let x₁  = TString x₀
+        let _T₁ = expressionToTerm _T₀
+        return (x₁, _T₁)
+expressionToTerm (UnionLit x t₀ yTs₀) =
+    TList [ TInt 12, TString x, t₁, TMap yTs₁ ]
+  where
+    t₁ = expressionToTerm t₀
+
+    yTs₁ = do
+        (y₀, _T₀) <- Data.HashMap.Strict.InsOrd.toList yTs₀
+        let y₁  = TString y₀
+        let _T₁ = expressionToTerm _T₀
+        return (y₁, _T₁)
+expressionToTerm (Constructors u₀) =
+    TList [ TInt 13, u₁ ]
+  where
+    u₁ = expressionToTerm u₀
+expressionToTerm (BoolLit b) =
+    TBool b
+expressionToTerm (BoolIf t₀ l₀ r₀) =
+    TList [ TInt 14, t₁, l₁, r₁ ]
+  where
+    t₁ = expressionToTerm t₀
+    l₁ = expressionToTerm l₀
+    r₁ = expressionToTerm r₀
+expressionToTerm (NaturalLit n) =
+    TList [ TInt 15, TInteger (fromIntegral n) ]
+expressionToTerm (IntegerLit n) =
+    TList [ TInt 16, TInteger n ]
+expressionToTerm (DoubleLit n) =
+    TList [ TInt 17, TTagged 4 (TList [ TInt exponent, TInteger mantissa ]) ]
+  where
+    normalized = Data.Scientific.normalize n
+
+    exponent = Data.Scientific.base10Exponent normalized
+
+    mantissa = Data.Scientific.coefficient normalized
+expressionToTerm (TextLit (Chunks xys₀ z₀)) =
+    TList ([ TInt 18 ] ++ xys₁ ++ [ z₁ ])
+  where
+    xys₁ = do
+        (x₀, y₀) <- xys₀
+        let x₁ = TString x₀
+        let y₁ = expressionToTerm y₀
+        [ x₁, y₁ ]
+
+    z₁ = TString z₀
+expressionToTerm (Embed x) =
+    importToTerm x
+expressionToTerm (Let x Nothing a₀ b₀) =
+    TList [ TInt 25, TString x, a₁, b₁ ]
+  where
+    a₁ = expressionToTerm a₀
+    b₁ = expressionToTerm b₀
+expressionToTerm (Let x (Just _A₀) a₀ b₀) =
+    TList [ TInt 25, TString x, _A₁, a₁, b₁ ]
+  where
+    a₁  = expressionToTerm a₀
+    _A₁ = expressionToTerm _A₀
+    b₁  = expressionToTerm b₀
+expressionToTerm (Annot t₀ _T₀) =
+    TList [ TInt 26, t₁, _T₁ ]
+  where
+    t₁  = expressionToTerm t₀
+    _T₁ = expressionToTerm _T₀
+expressionToTerm (Note _ e) =
+    expressionToTerm e
+
+importToTerm :: Import -> Term
+importToTerm import_ =
+    case importType of
+        URL scheme₀ authority path query fragment _ ->
+            TList
+                (   [ TInt 24, TInt scheme₁, TString authority ]
+                ++  map TString (reverse components)
+                ++  [ TString file ]
+                ++  (case query    of Nothing -> [ TNull ]; Just q -> [ TString q ])
+                ++  (case fragment of Nothing -> [ TNull ]; Just f -> [ TString f ])
+                )
+          where
+            scheme₁ = case scheme₀ of
+                HTTP  -> 0
+                HTTPS -> 1
+            File {..} = path
+
+            Directory {..} = directory
+
+        Local prefix₀ path ->
+                TList
+                    (   [ TInt 24, TInt prefix₁ ]
+                    ++  map TString components₁
+                    ++  [ TString file ]
+                    )
+          where
+            File {..} = path
+
+            Directory {..} = directory
+
+            (prefix₁, components₁) = case (prefix₀, reverse components) of
+                (Absolute, rest       ) -> (2, rest)
+                (Here    , ".." : rest) -> (4, rest)
+                (Here    , rest       ) -> (3, rest)
+                (Home    , rest       ) -> (5, rest)
+
+        Env x ->
+            TList [ TInt 24, TInt 6, TString x ]
+
+        Missing ->
+            TList [ TInt 24, TInt 7 ]
+  where
+    Import {..} = import_
+
+    ImportHashed {..} = importHashed
+
+termToExpression :: Term -> Maybe (Expr s Import)
+termToExpression (TInt n) =
+    return (Var (V "_" (fromIntegral n)))
+termToExpression (TInteger n) =
+    return (Var (V "_" n))
+termToExpression (TString "Natural/build") =
+    return NaturalBuild
+termToExpression (TString "Natural/fold") =
+    return NaturalFold
+termToExpression (TString "Natural/isZero") =
+    return NaturalIsZero
+termToExpression (TString "Natural/even") =
+    return NaturalEven
+termToExpression (TString "Natural/odd") =
+    return NaturalOdd
+termToExpression (TString "Natural/toInteger") =
+    return NaturalToInteger
+termToExpression (TString "Natural/show") =
+    return NaturalShow
+termToExpression (TString "Integer/toDouble") =
+    return IntegerToDouble
+termToExpression (TString "Integer/show") =
+    return IntegerShow
+termToExpression (TString "Double/show") =
+    return DoubleShow
+termToExpression (TString "List/build") =
+    return ListBuild
+termToExpression (TString "List/fold") =
+    return ListFold
+termToExpression (TString "List/length") =
+    return ListLength
+termToExpression (TString "List/head") =
+    return ListHead
+termToExpression (TString "List/last") =
+    return ListLast
+termToExpression (TString "List/indexed") =
+    return ListIndexed
+termToExpression (TString "List/reverse") =
+    return ListReverse
+termToExpression (TString "Optional/fold") =
+    return OptionalFold
+termToExpression (TString "Optional/build") =
+    return OptionalBuild
+termToExpression (TString "Bool") =
+    return Bool
+termToExpression (TString "Optional") =
+    return Optional
+termToExpression (TString "Natural") =
+    return Natural
+termToExpression (TString "Integer") =
+    return Integer
+termToExpression (TString "Double") =
+    return Double
+termToExpression (TString "Text") =
+    return Text
+termToExpression (TString "List") =
+    return List
+termToExpression (TString "Type") =
+    return (Const Type)
+termToExpression (TString "Kind") =
+    return (Const Kind)
+termToExpression (TString x) =
+    return (Var (V x 0))
+termToExpression (TList [ TString x, TInt n ]) =
+    return (Var (V x (fromIntegral n)))
+termToExpression (TList [ TString x, TInteger n ]) =
+    return (Var (V x n))
+termToExpression (TList (TInt 0 : f₁ : xs₁)) = do
+    f₀  <- termToExpression f₁
+    xs₀ <- traverse termToExpression xs₁
+    return (foldl App f₀ xs₀)
+termToExpression (TList [ TInt 1, _A₁, b₁ ]) = do
+    _A₀ <- termToExpression _A₁
+    b₀  <- termToExpression b₁
+    return (Lam "_" _A₀ b₀)
+termToExpression (TList [ TInt 1, TString x, _A₁, b₁ ]) = do
+    _A₀ <- termToExpression _A₁
+    b₀  <- termToExpression b₁
+    return (Lam x _A₀ b₀)
+termToExpression (TList [ TInt 2, _A₁, _B₁ ]) = do
+    _A₀ <- termToExpression _A₁
+    _B₀ <- termToExpression _B₁
+    return (Pi "_" _A₀ _B₀)
+termToExpression (TList [ TInt 2, TString x, _A₁, _B₁ ]) = do
+    _A₀ <- termToExpression _A₁
+    _B₀ <- termToExpression _B₁
+    return (Pi x _A₀ _B₀)
+termToExpression (TList [ TInt 3, TInt n, l₁, r₁ ]) = do
+    l₀ <- termToExpression l₁
+    r₀ <- termToExpression r₁
+    op <- case n of
+            0  -> return BoolOr
+            1  -> return BoolAnd
+            2  -> return BoolEQ
+            3  -> return BoolNE
+            4  -> return NaturalPlus
+            5  -> return NaturalTimes
+            6  -> return TextAppend
+            7  -> return ListAppend
+            8  -> return Combine
+            9  -> return Prefer
+            10 -> return CombineTypes
+            11 -> return ImportAlt
+            _  -> empty
+    return (op l₀ r₀)
+termToExpression (TList [ TInt 4, _T₁ ]) = do
+    _T₀ <- termToExpression _T₁
+    return (ListLit (Just _T₀) empty)
+termToExpression (TList (TInt 4 : TNull : xs₁ )) = do
+    xs₀ <- traverse termToExpression xs₁
+    return (ListLit Nothing (Data.Sequence.fromList xs₀))
+termToExpression (TList [ TInt 5, _T₁ ]) = do
+    _T₀ <- termToExpression _T₁
+    return (OptionalLit _T₀ Nothing)
+termToExpression (TList [ TInt 5, _T₁, t₁ ]) = do
+    _T₀ <- termToExpression _T₁
+    t₀  <- termToExpression t₁
+    return (OptionalLit _T₀ (Just t₀))
+termToExpression (TList [ TInt 6, t₁, u₁ ]) = do
+    t₀ <- termToExpression t₁
+    u₀ <- termToExpression u₁
+    return (Merge t₀ u₀ Nothing)
+termToExpression (TList [ TInt 6, t₁, u₁, _T₁ ]) = do
+    t₀  <- termToExpression t₁
+    u₀  <- termToExpression u₁
+    _T₀ <- termToExpression _T₁
+    return (Merge t₀ u₀ (Just _T₀))
+termToExpression (TList [ TInt 7, TMap xTs₁ ]) = do
+    let process (TString x, _T₁) = do
+            _T₀ <- termToExpression _T₁
+
+            return (x, _T₀)
+        process _ =
+            empty
+
+    xTs₀ <- traverse process xTs₁
+
+    return (Record (Data.HashMap.Strict.InsOrd.fromList xTs₀))
+termToExpression (TList [ TInt 8, TMap xts₁ ]) = do
+    let process (TString x, t₁) = do
+           t₀ <- termToExpression t₁
+
+           return (x, t₀)
+        process _ =
+            empty
+
+    xts₀ <- traverse process xts₁
+
+    return (RecordLit (Data.HashMap.Strict.InsOrd.fromList xts₀))
+termToExpression (TList [ TInt 9, t₁, TString x ]) = do
+    t₀ <- termToExpression t₁
+
+    return (Field t₀ x)
+termToExpression (TList (TInt 10 : t₁ : xs₁)) = do
+    t₀ <- termToExpression t₁
+
+    let process (TString x) = return x
+        process  _          = empty
+
+    xs₀ <- traverse process xs₁
+
+    return (Project t₀ (Data.Set.fromList xs₀))
+termToExpression (TList [ TInt 11, TMap xTs₁ ]) = do
+    let process (TString x, _T₁) = do
+            _T₀ <- termToExpression _T₁
+
+            return (x, _T₀)
+        process _ =
+            empty
+
+    xTs₀ <- traverse process xTs₁
+
+    return (Union (Data.HashMap.Strict.InsOrd.fromList xTs₀))
+termToExpression (TList [ TInt 12, TString x, t₁, TMap yTs₁ ]) = do
+    t₀ <- termToExpression t₁
+
+    let process (TString y, _T₁) = do
+            _T₀ <- termToExpression _T₁
+
+            return (y, _T₀)
+        process _ =
+            empty
+
+    yTs₀ <- traverse process yTs₁
+
+    return (UnionLit x t₀ (Data.HashMap.Strict.InsOrd.fromList yTs₀))
+termToExpression (TList [ TInt 13, u₁ ]) = do
+    u₀ <- termToExpression u₁
+
+    return (Constructors u₀)
+termToExpression (TBool b) = do
+    return (BoolLit b)
+termToExpression (TList [ TInt 14, t₁, l₁, r₁ ]) = do
+    t₀ <- termToExpression t₁
+    l₀ <- termToExpression l₁
+    r₀ <- termToExpression r₁
+
+    return (BoolIf t₀ l₀ r₀)
+termToExpression (TList [ TInt 15, TInt n ]) = do
+    return (NaturalLit (fromIntegral n))
+termToExpression (TList [ TInt 15, TInteger n ]) = do
+    return (NaturalLit (fromInteger n))
+termToExpression (TList [ TInt 16, TInt n ]) = do
+    return (IntegerLit (fromIntegral n))
+termToExpression (TList [ TInt 16, TInteger n ]) = do
+    return (IntegerLit n)
+termToExpression (TList [ TInt 17, TTagged 4 (TList [ TInt exponent, TInteger mantissa ]) ]) = do
+    return (DoubleLit (Data.Scientific.scientific mantissa exponent))
+termToExpression (TList [ TInt 17, TTagged 4 (TList [ TInt exponent, TInt mantissa ]) ]) = do
+    return (DoubleLit (Data.Scientific.scientific (fromIntegral mantissa) exponent))
+termToExpression (TList (TInt 18 : xs)) = do
+    let process (TString x : y₁ : zs) = do
+            y₀ <- termToExpression y₁
+
+            ~(xys, z) <- process zs
+
+            return ((x, y₀) : xys, z)
+        process [ TString z ] = do
+            return ([], z)
+        process _ = do
+            empty
+
+    (xys, z) <- process xs
+
+    return (TextLit (Chunks xys z))
+termToExpression (TList (TInt 24 : TInt n : xs)) = do
+    let remote scheme = do
+            let process [ TString file, q, f ] = do
+                    query <- case q of
+                        TNull     -> return Nothing
+                        TString x -> return (Just x)
+                        _         -> empty
+                    fragment <- case f of
+                        TNull     -> return Nothing
+                        TString x -> return (Just x)
+                        _         -> empty
+                    return ([], file, query, fragment)
+                process (TString path : ys) = do
+                    (paths, file, query, fragment) <- process ys
+                    return (path : paths, file, query, fragment)
+                process _ = do
+                    empty
+
+            (authority, paths, file, query, fragment) <- case xs of
+                TString authority : ys -> do
+                    (paths, file, query, fragment) <- process ys
+                    return (authority, paths, file, query, fragment)
+                _                      -> empty
+
+            let components   = reverse paths
+            let directory    = Directory {..}
+            return (URL scheme authority (File {..}) query fragment Nothing)
+
+    let local prefix = do
+            let process [ TString file ] = do
+                    return ([], file)
+                process (TString path : ys) = do
+                    (paths, file) <- process ys
+                    return (path : paths, file)
+                process _ =
+                    empty
+
+            (paths, file) <- process xs
+
+            let finalPaths = case n of
+                    4 -> ".." : paths
+                    _ -> paths
+
+            let components = reverse finalPaths
+            let directory  = Directory {..}
+
+            return (Local prefix (File {..}))
+
+    let env = do
+            case xs of
+                [ TString x ] -> return (Env x)
+                _             -> empty
+
+    let missing = return Missing
+
+    importType <- case n of
+        0 -> remote HTTP
+        1 -> remote HTTPS
+        2 -> local Absolute
+        3 -> local Here
+        4 -> local Here
+        5 -> local Home
+        6 -> env
+        7 -> missing
+        _ -> empty
+
+    let hash         = Nothing
+    let importHashed = ImportHashed {..}
+    let importMode   = Code
+    return (Embed (Import {..}))
+termToExpression (TList [ TInt 25, TString x, a₁, b₁ ]) = do
+    a₀ <- termToExpression a₁
+    b₀ <- termToExpression b₁
+    return (Let x Nothing a₀ b₀)
+termToExpression (TList [ TInt 25, TString x, _A₁, a₁, b₁ ]) = do
+    _A₀ <- termToExpression _A₁
+    a₀  <- termToExpression a₁
+    b₀  <- termToExpression b₁
+    return (Let x (Just _A₀) a₀ b₀)
+termToExpression (TList [ TInt 26, t₁, _T₁ ]) = do
+    t₀  <- termToExpression t₁
+    _T₀ <- termToExpression _T₁
+    return (Annot t₀ _T₀)
+termToExpression _ =
+    empty

--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -757,12 +757,12 @@ local = do
 
 http :: Parser ImportType
 http = do
-    (prefix, path, suffix) <- httpRaw
+    (s, a, path, q, f) <- httpRaw
     whitespace
     headers <- optional (do
         _using
         (importHashed_ <|> (_openParens *> importHashed_ <* _closeParens)) )
-    return (URL prefix path suffix headers)
+    return (URL s a path q f headers)
 
 missing :: Parser ImportType
 missing = do

--- a/tests/QuickCheck.hs
+++ b/tests/QuickCheck.hs
@@ -1,0 +1,273 @@
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module QuickCheck where
+
+import Codec.Serialise (DeserialiseFailure(..))
+import Control.Monad (guard)
+import Data.Hashable (Hashable)
+import Data.HashMap.Strict.InsOrd (InsOrdHashMap)
+import Dhall.Core
+    ( Chunks(..)
+    , Const(..)
+    , Directory(..)
+    , Expr(..)
+    , File(..)
+    , FilePrefix(..)
+    , Import(..)
+    , ImportHashed(..)
+    , ImportMode(..)
+    , ImportType(..)
+    , Scheme(..)
+    , Var(..)
+    )
+import Numeric.Natural (Natural)
+import Test.QuickCheck
+    (Arbitrary(..), Gen, Property, genericShrink, (===))
+import Test.QuickCheck.Instances ()
+import Test.Tasty (TestTree)
+
+import qualified Codec.Serialise
+import qualified Data.HashMap.Strict.InsOrd
+import qualified Data.Sequence
+import qualified Test.QuickCheck
+import qualified Test.Tasty.QuickCheck
+
+deriving instance Eq DeserialiseFailure
+
+lift0 :: a -> Gen a
+lift0 = pure
+
+lift1 :: Arbitrary a => (a -> b) -> Gen b
+lift1 f = f <$> arbitrary
+
+lift2 :: (Arbitrary a, Arbitrary b) => (a -> b -> c) -> Gen c
+lift2 f = f <$> arbitrary <*> arbitrary
+
+lift3 :: (Arbitrary a, Arbitrary b, Arbitrary c) => (a -> b -> c -> d) -> Gen d
+lift3 f = f <$> arbitrary <*> arbitrary <*> arbitrary
+
+lift4
+    :: (Arbitrary a, Arbitrary b, Arbitrary c, Arbitrary d)
+    => (a -> b -> c -> d -> e) -> Gen e
+lift4 f = f <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+lift5
+    :: ( Arbitrary a
+       , Arbitrary b
+       , Arbitrary c
+       , Arbitrary d
+       , Arbitrary e
+       )
+    => (a -> b -> c -> d -> e -> f) -> Gen f
+lift5 f =
+      f <$> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+
+instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (InsOrdHashMap k v) where
+    arbitrary = do
+        n   <- Test.QuickCheck.choose (0, 2)
+        kvs <- Test.QuickCheck.vectorOf n ((,) <$> arbitrary <*> arbitrary)
+        return (Data.HashMap.Strict.InsOrd.fromList kvs)
+
+    shrink =
+            map Data.HashMap.Strict.InsOrd.fromList
+        .   shrink
+        .   Data.HashMap.Strict.InsOrd.toList
+
+instance (Arbitrary s, Arbitrary a) => Arbitrary (Chunks s a) where
+    arbitrary = do
+        n <- Test.QuickCheck.choose (0, 2)
+        Chunks <$> Test.QuickCheck.vectorOf n arbitrary <*> arbitrary
+
+    shrink = genericShrink
+
+instance Arbitrary Const where
+    arbitrary = Test.QuickCheck.oneof [ pure Type, pure Kind ]
+
+    shrink = genericShrink
+
+instance Arbitrary Directory where
+    arbitrary = lift1 Directory
+
+    shrink = genericShrink
+
+averageDepth :: Natural
+averageDepth = 3
+
+averageNumberOfSubExpressions :: Double
+averageNumberOfSubExpressions = 1 - 1 / fromIntegral averageDepth
+
+probabilityOfNullaryConstructor :: Double
+probabilityOfNullaryConstructor = 1 / fromIntegral averageDepth
+
+numberOfConstructors :: Natural
+numberOfConstructors = 50
+
+instance (Arbitrary s, Arbitrary a) => Arbitrary (Expr s a) where
+    arbitrary =
+        Test.QuickCheck.suchThat
+            (Test.QuickCheck.frequency
+                [ ( 7, lift1 Const)
+                , ( 7, lift1 Var)
+                , ( 1, lift3 Lam)
+                , ( 1, lift3 Pi)
+                , ( 1, lift2 App)
+                , ( 1, lift4 Let)
+                , ( 1, lift2 Annot)
+                , ( 7, lift0 Bool)
+                , ( 7, lift1 BoolLit)
+                , ( 1, lift2 BoolAnd)
+                , ( 1, lift2 BoolOr)
+                , ( 1, lift2 BoolEQ)
+                , ( 1, lift2 BoolNE)
+                , ( 1, lift3 BoolIf)
+                , ( 7, lift0 Natural)
+                , ( 7, lift1 NaturalLit)
+                , ( 7, lift0 NaturalFold)
+                , ( 7, lift0 NaturalBuild)
+                , ( 7, lift0 NaturalIsZero)
+                , ( 7, lift0 NaturalEven)
+                , ( 7, lift0 NaturalOdd)
+                , ( 7, lift0 NaturalToInteger)
+                , ( 7, lift0 NaturalShow)
+                , ( 1, lift2 NaturalPlus)
+                , ( 1, lift2 NaturalTimes)
+                , ( 7, lift0 Integer)
+                , ( 7, lift1 IntegerLit)
+                , ( 7, lift0 IntegerShow)
+                , ( 7, lift0 Double)
+                , ( 7, lift1 DoubleLit)
+                , ( 7, lift0 DoubleShow)
+                , ( 7, lift0 Text)
+                , ( 1, lift1 TextLit)
+                , ( 1, lift2 TextAppend)
+                , ( 7, lift0 List)
+                , let listLit = do
+                          n  <- Test.QuickCheck.choose (0, 3)
+                          xs <- Test.QuickCheck.vectorOf n arbitrary
+                          let ys = Data.Sequence.fromList xs
+                          ListLit <$> arbitrary <*> pure ys
+
+                  in  ( 1, listLit)
+                , ( 1, lift2 ListAppend)
+                , ( 7, lift0 ListBuild)
+                , ( 7, lift0 ListFold)
+                , ( 7, lift0 ListLength)
+                , ( 7, lift0 ListHead)
+                , ( 7, lift0 ListLast)
+                , ( 7, lift0 ListIndexed)
+                , ( 7, lift0 ListReverse)
+                , ( 7, lift0 Optional)
+                , ( 1, lift2 OptionalLit)
+                , ( 7, lift0 OptionalFold)
+                , ( 7, lift0 OptionalBuild)
+                , ( 1, lift1 Record)
+                , ( 1, lift1 RecordLit)
+                , ( 1, lift1 Union)
+                , ( 1, lift3 UnionLit)
+                , ( 1, lift2 Combine)
+                , ( 1, lift2 CombineTypes)
+                , ( 1, lift2 Prefer)
+                , ( 1, lift3 Merge)
+                , ( 1, lift1 Constructors)
+                , ( 1, lift2 Field)
+                , ( 1, lift2 Project)
+                , ( 7, lift1 Embed)
+                ]
+            )
+            standardizedExpression
+
+    shrink expression = filter standardizedExpression (genericShrink expression)
+
+standardizedExpression :: Expr s a -> Bool
+standardizedExpression (ListLit  Nothing  xs) = not (Data.Sequence.null xs)
+standardizedExpression (ListLit (Just _ ) xs) = Data.Sequence.null xs
+standardizedExpression (Note _ _            ) = False
+standardizedExpression  _                     = True
+
+instance Arbitrary File where
+    arbitrary = lift2 File
+
+    shrink = genericShrink
+
+instance Arbitrary FilePrefix where
+    arbitrary = Test.QuickCheck.oneof [ pure Absolute, pure Here, pure Home ]
+
+    shrink = genericShrink
+
+instance Arbitrary ImportType where
+    arbitrary =
+        Test.QuickCheck.suchThat
+            (Test.QuickCheck.oneof
+                [ lift2 Local
+                , lift5 (\a b c d e -> URL a b c d e Nothing)
+                , lift1 Env
+                , lift0 Missing
+                ]
+            )
+            standardizedImportType
+
+    shrink importType =
+        filter standardizedImportType (genericShrink importType)
+
+standardizedImportType :: ImportType -> Bool
+standardizedImportType (URL _ _ _ _ _ (Just _)) = False
+standardizedImportType  _                       = True
+
+instance Arbitrary ImportHashed where
+    arbitrary =
+        Test.QuickCheck.suchThat
+            (lift1 (ImportHashed Nothing))
+            standardizedImportHashed
+
+    shrink (ImportHashed { importType = oldImportType, .. }) = do
+        newImportType <- shrink oldImportType
+        let importHashed = ImportHashed { importType = newImportType, .. }
+        guard (standardizedImportHashed importHashed)
+        return importHashed
+
+standardizedImportHashed :: ImportHashed -> Bool
+standardizedImportHashed (ImportHashed (Just _) _) = False
+standardizedImportHashed  _                        = True
+
+-- The standard does not yet specify how to encode `as Text`, so don't test it
+-- yet
+instance Arbitrary ImportMode where
+    arbitrary = lift0 Code
+
+    shrink = genericShrink
+
+instance Arbitrary Import where
+    arbitrary = lift2 Import
+
+    shrink = genericShrink
+
+instance Arbitrary Scheme where
+    arbitrary = Test.QuickCheck.oneof [ pure HTTP, pure HTTPS ]
+
+    shrink = genericShrink
+
+instance Arbitrary Var where
+    arbitrary = lift2 V
+
+    shrink = genericShrink
+
+binaryRoundtrip :: Expr () Import -> Property
+binaryRoundtrip expression =
+        Codec.Serialise.deserialiseOrFail (Codec.Serialise.serialise expression)
+    === Right expression
+
+quickcheckTests :: TestTree
+quickcheckTests
+    = Test.Tasty.QuickCheck.testProperties
+        "QuickCheck"
+        [ ( "Binary serialization should round-trip"
+          , Test.QuickCheck.property binaryRoundtrip
+          )
+        ]

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -3,6 +3,7 @@ module Main where
 import Normalization (normalizationTests)
 import Parser (parserTests)
 import Regression (regressionTests)
+import QuickCheck (quickcheckTests)
 import Tutorial (tutorialTests)
 import TypeCheck (typecheckTests)
 import Format (formatTests)
@@ -19,6 +20,7 @@ allTests =
         , formatTests
         , typecheckTests
         , importTests
+        , quickcheckTests
         ]
 
 main :: IO ()


### PR DESCRIPTION
... as standardized in https://github.com/dhall-lang/dhall-lang/pull/194

This also changes the hashing algorithm to use a has of the serialized form
instead of the pretty-printed form

Note that this requires a breaking change to `ImportType` so that it can
store more structured information required for serialization