### PR TITLE
Improve parsing performance

### DIFF
--- a/benchmark/parser/Main.hs
+++ b/benchmark/parser/Main.hs
@@ -47,7 +47,7 @@ main = do
     prelude <- loadPreludeFiles
     issue108 <- TIO.readFile "benchmark/examples/issue108.dhall"
     defaultMain
-        [ benchParser prelude
-        , bgroup "Issue #108" $
-            [ benchExprFromText "108" issue108 ]
+        [ benchExprFromText "Issue #108" issue108
+        , benchExprFromText "Long variable names" (T.replicate 1000000 "x")
+        , benchParser prelude
         ]

--- a/benchmark/parser/Main.hs
+++ b/benchmark/parser/Main.hs
@@ -49,5 +49,6 @@ main = do
     defaultMain
         [ benchExprFromText "Issue #108" issue108
         , benchExprFromText "Long variable names" (T.replicate 1000000 "x")
+        , benchExprFromText "Large number of function arguments" (T.replicate 10000 "x ")
         , benchParser prelude
         ]

--- a/src/Dhall/Parser/Combinators.hs
+++ b/src/Dhall/Parser/Combinators.hs
@@ -131,6 +131,12 @@ plus p = mappend <$> p <*> star p
 satisfy :: (Char -> Bool) -> Parser Text
 satisfy = fmap Data.Text.singleton . Text.Parser.Char.satisfy
 
+takeWhile :: (Char -> Bool) -> Parser Text
+takeWhile predicate = Parser (Text.Megaparsec.takeWhileP Nothing predicate)
+
+takeWhile1 :: (Char -> Bool) -> Parser Text
+takeWhile1 predicate = Parser (Text.Megaparsec.takeWhile1P Nothing predicate)
+
 noDuplicates :: Ord a => [a] -> Parser (Set a)
 noDuplicates = go Data.Set.empty
   where

--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -168,7 +168,7 @@ makeOperatorExpression
 makeOperatorExpression subExpression operatorParser operator embedded =
     noted (do
         a <- subExpression embedded
-        b <- many (do operatorParser; subExpression embedded)
+        b <- Text.Megaparsec.many (do operatorParser; subExpression embedded)
         return (foldr1 operator (a:b)) )
 
 importAltExpression :: Parser a -> Parser (Expr Src a)
@@ -223,7 +223,7 @@ applicationExpression :: Parser a -> Parser (Expr Src a)
 applicationExpression embedded = do
     f <- (do _constructors; return Constructors) <|> return id
     a <- noted (importExpression embedded)
-    b <- many (noted (importExpression embedded))
+    b <- Text.Megaparsec.many (noted (importExpression embedded))
     return (foldl app (f a) b)
   where
     app nL@(Note (Src before _ bytesL) _) nR@(Note (Src _ after bytesR) _) =
@@ -246,7 +246,7 @@ selectorExpression embedded = noted (do
 
     let left  x  e = Field   e x
     let right xs e = Project e xs
-    b <- many (try (do _dot; fmap left label <|> fmap right labels))
+    b <- Text.Megaparsec.many (try (do _dot; fmap left label <|> fmap right labels))
     return (foldl (\e k -> k e) a b) )
 
 primitiveExpression :: Parser a -> Parser (Expr Src a)
@@ -526,7 +526,7 @@ doubleQuotedChunk embedded =
 doubleQuotedLiteral :: Parser a -> Parser (Chunks Src a)
 doubleQuotedLiteral embedded = do
     _      <- Text.Parser.Char.char '"'
-    chunks <- many (doubleQuotedChunk embedded)
+    chunks <- Text.Megaparsec.many (doubleQuotedChunk embedded)
     _      <- Text.Parser.Char.char '"'
     return (mconcat chunks)
 
@@ -626,7 +626,7 @@ nonEmptyRecordTypeOrLiteral embedded = do
     let nonEmptyRecordType = do
             _colon
             b <- expression embedded
-            e <- many (do
+            e <- Text.Megaparsec.many (do
                 _comma
                 c <- label
                 _colon
@@ -638,7 +638,7 @@ nonEmptyRecordTypeOrLiteral embedded = do
     let nonEmptyRecordLiteral = do
             _equal
             b <- expression embedded
-            e <- many (do
+            e <- Text.Megaparsec.many (do
                 _comma
                 c <- label
                 _equal
@@ -666,7 +666,7 @@ nonEmptyUnionTypeOrLiteral embedded = do
         let alternative0 = do
                 _equal
                 b <- expression embedded
-                kvs <- many (do
+                kvs <- Text.Megaparsec.many (do
                     _bar
                     c <- label
                     _colon
@@ -693,7 +693,7 @@ nonEmptyListLiteral :: Parser a -> Parser (Expr Src a)
 nonEmptyListLiteral embedded = (do
     _openBracket
     a <- expression embedded
-    b <- many (do _comma; expression embedded)
+    b <- Text.Megaparsec.many (do _comma; expression embedded)
     _closeBracket
     return (ListLit Nothing (Data.Sequence.fromList (a:b))) ) <?> "list literal"
 

--- a/src/Dhall/Parser/Token.hs
+++ b/src/Dhall/Parser/Token.hs
@@ -155,10 +155,9 @@ blockCommentContinue = endOfComment <|> continue
 
 simpleLabel :: Parser Text
 simpleLabel = try (do
-    c  <- Text.Parser.Char.satisfy headCharacter
-    cs <- many (Text.Parser.Char.satisfy tailCharacter)
-    let string = c:cs
-    let text = Data.Text.pack string
+    c    <- Text.Parser.Char.satisfy headCharacter
+    rest <- Dhall.Parser.Combinators.takeWhile tailCharacter
+    let text = Data.Text.cons c rest
     Control.Monad.guard (not (Data.HashSet.member text reservedIdentifiers))
     return text )
   where
@@ -169,9 +168,9 @@ simpleLabel = try (do
 backtickLabel :: Parser Text
 backtickLabel = do
     _ <- Text.Parser.Char.char '`'
-    t <- some (Text.Parser.Char.satisfy predicate)
+    t <- takeWhile1 predicate
     _ <- Text.Parser.Char.char '`'
-    return (Data.Text.pack t)
+    return t
   where
     predicate c = alpha c || digit c || elem c ("$-/_:." :: String)
 


### PR DESCRIPTION
This uses `takeWhile{,1}P` as a faster alternative to `many . satisfy` to
speed up parsing large labels

This also uses the `many` re-exported by `megaparsec` which is more efficient
for types that implement `MonadPlus`