### PR TITLE
Improve haddock coverage

### DIFF
--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -658,9 +658,9 @@ list = fmap Data.Foldable.toList . sequence
 vector :: Type a -> Type (Vector a)
 vector = fmap Data.Vector.fromList . list
 
-{-| Decode `()` from an empty record.
+{-| Decode @()@ from an empty record.
 
->>> input unit "{=}"  -- GHC doesn't print the result if it is @()@
+>>> input unit "{=}"  -- GHC doesn't print the result if it is ()
 
 -}
 unit :: Type ()
@@ -677,7 +677,7 @@ unit = Type extractOut expectedOut
 >>> input string "\"ABC\""
 "ABC"
 
-"-}
+-}
 string :: Type String
 string = Data.Text.Lazy.unpack <$> lazyText
 

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -142,6 +142,7 @@ instance Semigroup File where
     File directory₀ _ <> File directory₁ file =
         File (directory₀ <> directory₁) file
 
+-- | The beginning of a file path which anchors subsequent path components
 data FilePrefix
     = Absolute
     -- ^ Absolute path

--- a/src/Dhall/Format.hs
+++ b/src/Dhall/Format.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Dhall.Format ( format ) where
+-- | This module contains the implementation of the @dhall format@ subcommand
+
+module Dhall.Format
+    ( -- * Format
+      format
+    ) where
 
 import Dhall.Parser (exprAndHeaderFromText)
 import Dhall.Pretty (annToAnsiStyle, prettyExpr, layoutOpts)
@@ -14,7 +19,12 @@ import qualified Data.Text.IO
 import qualified System.Console.ANSI
 import qualified System.IO
 
-format :: Maybe FilePath -> IO ()
+-- | Implementation of the @dhall format@ subcommand
+format
+    :: Maybe FilePath
+    -- ^ Modify file in-place if present, otherwise read from @stdin@ and write
+    --   to @stdout@
+    -> IO ()
 format inplace = do
         case inplace of
             Just file -> do

--- a/src/Dhall/Freeze.hs
+++ b/src/Dhall/Freeze.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Dhall.Freeze (
+-- | This module contains the implementation of the @dhall freeze@ subcommand
+
+module Dhall.Freeze
+    ( -- * Freeze
       freeze
     , hashImport
     ) where
@@ -24,6 +27,7 @@ import qualified System.IO
 readInput :: Maybe FilePath -> IO Text
 readInput = maybe Data.Text.IO.getContents Data.Text.IO.readFile
 
+-- | Retrieve an `Import` and update the hash to match the latest contents
 hashImport :: Import -> IO Import
 hashImport import_ = do
     expression <- Dhall.Import.load (Embed import_)
@@ -60,7 +64,12 @@ writeExpr inplace (header, expr) = do
                else
                  Pretty.renderIO System.IO.stdout (Pretty.layoutSmart layoutOpts (Pretty.unAnnotate doc)) 
 
-freeze :: Maybe FilePath -> IO ()
+-- | Implementation of the @dhall freeze@ subcommand
+freeze
+    :: Maybe FilePath
+    -- ^ Modify file in-place if present, otherwise read from @stdin@ and write
+    --   to @stdout@
+    -> IO ()
 freeze inplace = do
     expr <- readInput inplace
     parseExpr srcInfo expr >>= freezeExpr >>= writeExpr inplace

--- a/src/Dhall/Hash.hs
+++ b/src/Dhall/Hash.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Dhall.Hash ( hash ) where
+-- | This module contains the implementation of the @dhall hash@ subcommand
+
+module Dhall.Hash
+    ( -- * Hash
+      hash
+    ) where
 
 import Dhall.Parser (exprFromText)
 import Dhall.Import (hashExpressionToCode, load)
@@ -9,6 +14,7 @@ import qualified Control.Exception
 import qualified Dhall.TypeCheck
 import qualified Data.Text.IO
 
+-- | Implementation of the @dhall hash@ subcommand
 hash :: IO ()
 hash = do
         inText <- Data.Text.IO.getContents

--- a/src/Dhall/Lint.hs
+++ b/src/Dhall/Lint.hs
@@ -1,3 +1,5 @@
+-- | This module contains the implementation of the @dhall lint@ command
+
 module Dhall.Lint
     ( -- * Lint
       lint
@@ -8,6 +10,10 @@ import Dhall.TypeCheck (X(..))
 
 import qualified Dhall.Core
 
+{-| Automatically improve a Dhall expression
+
+    Currently this only removes unused @let@ bindings
+-}
 lint :: Expr s Import -> Expr t Import
 lint expression = loop (Dhall.Core.denote expression)
   where

--- a/src/Dhall/Main.hs
+++ b/src/Dhall/Main.hs
@@ -1,11 +1,19 @@
+{-| This module contains the top-level entrypoint and options parsing for the
+    @dhall@ executable
+-}
+
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
 module Dhall.Main
-    ( -- Commands
-      parseOptions
+    ( -- * Options
+      Options(..)
+    , Mode(..)
+    , parseOptions
     , parserInfoOptions
+
+      -- * Execution
     , command
     , main
     ) where
@@ -47,12 +55,14 @@ import qualified Options.Applicative
 import qualified System.Console.ANSI
 import qualified System.IO
 
+-- | Top-level program options
 data Options = Options
     { mode    :: Mode
     , explain :: Bool
     , plain   :: Bool
     }
 
+-- | The subcommands for the @dhall@ executable
 data Mode
     = Default
     | Version
@@ -74,6 +84,7 @@ parseInplace =
         <>  Options.Applicative.metavar "FILE"
         )
 
+-- | `Parser` for the `Options` type
 parseOptions :: Parser Options
 parseOptions = Options <$> parseMode <*> parseExplain <*> parsePlain
   where
@@ -166,6 +177,7 @@ assertNoImports :: Expr Src Import -> IO (Expr Src X)
 assertNoImports expression =
     throws (traverse (\_ -> Left ImportResolutionDisabled) expression)
 
+-- | `ParserInfo` for the `Options` type
 parserInfoOptions :: ParserInfo Options
 parserInfoOptions =
     Options.Applicative.info
@@ -174,6 +186,7 @@ parserInfoOptions =
         <>  Options.Applicative.fullDesc
         )
 
+-- | Run the command specified by the `Options` type
 command :: Options -> IO ()
 command (Options {..}) = do
     GHC.IO.Encoding.setLocaleEncoding System.IO.utf8
@@ -320,6 +333,7 @@ command (Options {..}) = do
                           System.IO.stdout
                           (Pretty.layoutSmart layoutOpts (Pretty.unAnnotate doc))
 
+-- | Entry point for the @dhall@ executable
 main :: IO ()
 main = do
     options <- Options.Applicative.execParser parserInfoOptions

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards            #-}
+
 -- | This module contains Dhall's parsing logic
 
 module Dhall.Parser (

--- a/src/Dhall/Pretty.hs
+++ b/src/Dhall/Pretty.hs
@@ -1,11 +1,18 @@
 {-| This module contains logic for pretty-printing expressions, including
     support for syntax highlighting
 -}
-module Dhall.Pretty ( Ann(..), annToAnsiStyle, prettyExpr, layoutOpts ) where
+module Dhall.Pretty
+    ( -- * Pretty
+      Ann(..)
+    , annToAnsiStyle
+    , prettyExpr
+    , layoutOpts
+    ) where
 
 import Dhall.Pretty.Internal
 import qualified Data.Text.Prettyprint.Doc as Pretty
 
+-- | Default layout options
 layoutOpts :: Pretty.LayoutOptions
 layoutOpts =
     Pretty.defaultLayoutOptions

--- a/src/Dhall/Repl.hs
+++ b/src/Dhall/Repl.hs
@@ -1,8 +1,13 @@
+-- | This module contains the implementation of the @dhall repl@ subcommand
+
 {-# language FlexibleContexts #-}
 {-# language NamedFieldPuns #-}
 {-# language OverloadedStrings #-}
 
-module Dhall.Repl ( repl ) where
+module Dhall.Repl
+    ( -- * Repl
+      repl
+    ) where
 
 import Control.Exception ( SomeException(SomeException), displayException, throwIO )
 import Control.Monad.IO.Class ( MonadIO, liftIO )
@@ -26,7 +31,7 @@ import qualified System.Console.Haskeline.MonadException as Haskeline
 import qualified System.Console.Repline as Repline
 import qualified System.IO
 
-
+-- | Implementation of the @dhall repl@ subcommand
 repl :: Bool -> IO ()
 repl explain = if explain then Dhall.detailed io else io
   where

--- a/src/Dhall/TH.hs
+++ b/src/Dhall/TH.hs
@@ -21,7 +21,10 @@
     time with all imports resolved, making it easy to keep your Dhall configs
     and Haskell interpreters in sync.
 -}
-module Dhall.TH where
+module Dhall.TH
+    ( -- * Template Haskell
+      staticDhallExpression
+    ) where
 
 import Data.Typeable
 import Language.Haskell.TH.Quote (dataToExpQ) -- 7.10 compatibility.


### PR DESCRIPTION
This also exposes the `Option` and `Mode` types in `Dhall.Main`, since they
were missing from the API