### PR TITLE
Improve parsing performance on happy path

### DIFF
--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -37,7 +37,7 @@ expr = exprA import_
 -- | Parser for a top-level Dhall expression. The expression is parameterized
 -- over any parseable type, allowing the language to be extended as needed.
 exprA :: Parser a -> Parser (Expr Src a)
-exprA = completeExpression
+exprA = parseExpression noted
 
 -- | A parsing error
 data ParseError = ParseError
@@ -76,14 +76,33 @@ exprAndHeaderFromText
               --   used in parsing error messages
     -> Text   -- ^ Input expression to parse
     -> Either ParseError (Text, Expr Src Import)
-exprAndHeaderFromText delta text = case result of
-    Left errInfo   -> Left (ParseError { unwrap = errInfo, input = text })
-    Right (txt, r) -> Right (Data.Text.dropWhileEnd (/= '\n') txt, r)
+exprAndHeaderFromText delta text = do
+    (txt, r) <- case Text.Megaparsec.parse (unParser (parser id)) delta text of
+        Left _ ->
+            case Text.Megaparsec.parse (unParser (parser noted)) delta text of
+                Left errInfo ->
+                    Left (ParseError { unwrap = errInfo, input = text })
+
+                Right x ->
+                    return x
+
+        Right x ->
+            return x
+
+    return (Data.Text.dropWhileEnd (/= '\n') txt, r)
   where
-    parser = do
+    parser n = do
         (bytes, _) <- Text.Megaparsec.match whitespace
-        r <- expr
+        r <- parseExpression n import_
         Text.Megaparsec.eof
         return (bytes, r)
 
-    result = Text.Megaparsec.parse (unParser parser) delta text
+noted :: Parser (Expr Src a) -> Parser (Expr Src a)
+noted parser = do
+    before      <- Text.Megaparsec.getPosition
+    (tokens, e) <- Text.Megaparsec.match parser
+    after       <- Text.Megaparsec.getPosition
+    let src₀ = Src before after tokens
+    case e of
+        Note src₁ _ | src₀ == src₁ -> return e
+        _                          -> return (Note src₀ e)

--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- | Parsing Dhall expressions.
 module Dhall.Parser.Expression where
 
@@ -26,681 +28,678 @@ import qualified Text.Parser.Char
 import Dhall.Parser.Combinators
 import Dhall.Parser.Token
 
-noted :: Parser (Expr Src a) -> Parser (Expr Src a)
-noted parser = do
-    before      <- Text.Megaparsec.getPosition
-    (tokens, e) <- Text.Megaparsec.match parser
-    after       <- Text.Megaparsec.getPosition
-    let src₀ = Src before after tokens
-    case e of
-        Note src₁ _ | src₀ == src₁ -> return e
-        _                          -> return (Note src₀ e)
+parseExpression
+    :: forall a
+    .  (Parser (Expr Src a) -> Parser (Expr Src a))
+    -> Parser a
+    -> Parser (Expr Src a)
+parseExpression noted = completeExpression
+  where
+    expression :: Parser a -> Parser (Expr Src a)
+    expression embedded =
+        (   noted
+            ( choice
+                [ alternative0
+                , alternative1
+                , alternative2
+                , alternative3
+                , alternative4
+                ]
+            )
+        <|> alternative5
+        ) <?> "expression"
+      where
+        alternative0 = do
+            _lambda
+            _openParens
+            a <- label
+            _colon
+            b <- expression embedded
+            _closeParens
+            _arrow
+            c <- expression embedded
+            return (Lam a b c)
 
-expression :: Parser a -> Parser (Expr Src a)
-expression embedded =
-    (   noted
-        ( choice
+        alternative1 = do
+            _if
+            a <- expression embedded
+            _then
+            b <- expression embedded
+            _else
+            c <- expression embedded
+            return (BoolIf a b c)
+
+        alternative2 = do
+            _let
+            a <- label
+            b <- optional (do
+                _colon
+                expression embedded )
+            _equal
+            c <- expression embedded
+            _in
+            d <- expression embedded
+            return (Let a b c d)
+
+        alternative3 = do
+            _forall
+            _openParens
+            a <- label
+            _colon
+            b <- expression embedded
+            _closeParens
+            _arrow
+            c <- expression embedded
+            return (Pi a b c)
+
+        alternative4 = do
+            a <- try (do a <- operatorExpression embedded; _arrow; return a)
+            b <- expression embedded
+            return (Pi "_" a b)
+
+        alternative5 = annotatedExpression embedded
+
+    annotatedExpression :: Parser a -> Parser (Expr Src a)
+    annotatedExpression embedded =
+        noted
+            ( choice
+                [ alternative0
+                , try alternative1
+                , alternative2
+                ]
+            )
+      where
+        alternative0 = do
+            _merge
+            a <- importExpression embedded
+            b <- importExpression embedded
+            c <- optional (do
+                _colon
+                applicationExpression embedded )
+            return (Merge a b c)
+
+        alternative1 = (do
+            _openBracket
+            (emptyCollection embedded <|> nonEmptyOptional embedded) )
+            <?> "list literal"
+
+        alternative2 = do
+            a <- operatorExpression embedded
+            b <- optional (do _colon; expression embedded)
+            case b of
+                Nothing -> return a
+                Just c  -> return (Annot a c)
+
+    emptyCollection :: Parser a -> Parser (Expr Src a)
+    emptyCollection embedded = do
+        _closeBracket
+        _colon
+        a <- alternative0 <|> alternative1
+        b <- importExpression embedded
+        return (a b)
+      where
+        alternative0 = do
+            _List
+            return (\a -> ListLit (Just a) empty)
+
+        alternative1 = do
+            _Optional
+            return (\a -> OptionalLit a empty)
+
+    nonEmptyOptional :: Parser a -> Parser (Expr Src a)
+    nonEmptyOptional embedded = do
+        a <- expression embedded
+        _closeBracket
+        _colon
+        _Optional
+        b <- importExpression embedded
+        return (OptionalLit b (pure a))
+
+    operatorExpression :: Parser a -> Parser (Expr Src a)
+    operatorExpression = importAltExpression
+
+    makeOperatorExpression
+        :: (Parser a -> Parser (Expr Src a))
+        -> Parser ()
+        -> (Expr Src a -> Expr Src a -> Expr Src a)
+        -> Parser a
+        -> Parser (Expr Src a)
+    makeOperatorExpression subExpression operatorParser operator embedded =
+        noted (do
+            a <- subExpression embedded
+            b <- Text.Megaparsec.many (do operatorParser; subExpression embedded)
+            return (foldr1 operator (a:b)) )
+
+    importAltExpression :: Parser a -> Parser (Expr Src a)
+    importAltExpression =
+        makeOperatorExpression orExpression _importAlt ImportAlt
+
+    orExpression :: Parser a -> Parser (Expr Src a)
+    orExpression =
+        makeOperatorExpression plusExpression _or BoolOr
+
+    plusExpression :: Parser a -> Parser (Expr Src a)
+    plusExpression =
+        makeOperatorExpression textAppendExpression _plus NaturalPlus
+
+    textAppendExpression :: Parser a -> Parser (Expr Src a)
+    textAppendExpression =
+        makeOperatorExpression listAppendExpression _textAppend TextAppend
+
+    listAppendExpression :: Parser a -> Parser (Expr Src a)
+    listAppendExpression =
+        makeOperatorExpression andExpression _listAppend ListAppend
+
+    andExpression :: Parser a -> Parser (Expr Src a)
+    andExpression =
+        makeOperatorExpression combineExpression _and BoolAnd
+
+    combineExpression :: Parser a -> Parser (Expr Src a)
+    combineExpression =
+        makeOperatorExpression preferExpression _combine Combine
+
+    preferExpression :: Parser a -> Parser (Expr Src a)
+    preferExpression =
+        makeOperatorExpression combineTypesExpression _prefer Prefer
+
+    combineTypesExpression :: Parser a -> Parser (Expr Src a)
+    combineTypesExpression =
+        makeOperatorExpression timesExpression _combineTypes CombineTypes
+
+    timesExpression :: Parser a -> Parser (Expr Src a)
+    timesExpression =
+        makeOperatorExpression equalExpression _times NaturalTimes
+
+    equalExpression :: Parser a -> Parser (Expr Src a)
+    equalExpression =
+        makeOperatorExpression notEqualExpression _doubleEqual BoolEQ
+
+    notEqualExpression :: Parser a -> Parser (Expr Src a)
+    notEqualExpression =
+        makeOperatorExpression applicationExpression _notEqual BoolNE
+
+    applicationExpression :: Parser a -> Parser (Expr Src a)
+    applicationExpression embedded = do
+        f <- (do _constructors; return Constructors) <|> return id
+        a <- noted (importExpression embedded)
+        b <- Text.Megaparsec.many (noted (importExpression embedded))
+        return (foldl app (f a) b)
+      where
+        app nL@(Note (Src before _ bytesL) _) nR@(Note (Src _ after bytesR) _) =
+            Note (Src before after (bytesL <> bytesR)) (App nL nR)
+        app nL nR =
+            App nL nR
+
+    importExpression :: Parser a -> Parser (Expr Src a)
+    importExpression embedded = noted (choice [ alternative0, alternative1 ])
+      where
+        alternative0 = do
+            a <- embedded
+            return (Embed a)
+
+        alternative1 = selectorExpression embedded
+
+    selectorExpression :: Parser a -> Parser (Expr Src a)
+    selectorExpression embedded = noted (do
+        a <- primitiveExpression embedded
+
+        let left  x  e = Field   e x
+        let right xs e = Project e xs
+        b <- Text.Megaparsec.many (try (do _dot; fmap left label <|> fmap right labels))
+        return (foldl (\e k -> k e) a b) )
+
+    primitiveExpression :: Parser a -> Parser (Expr Src a)
+    primitiveExpression embedded =
+        noted
+            ( choice
+                [ alternative00
+                , alternative01
+                , alternative02
+                , alternative03
+                , alternative04
+                , alternative05
+                , alternative06
+                , alternative37
+
+                , choice
+                    [ alternative08
+                    , alternative09
+                    , alternative10
+                    , alternative11
+                    , alternative12
+                    , alternative13
+                    , alternative14
+                    , alternative15
+                    , alternativeIntegerToDouble
+                    , alternative16
+                    , alternative17
+                    , alternative18
+                    , alternative19
+                    , alternative20
+                    , alternative21
+                    , alternative22
+                    , alternative23
+                    , alternative24
+                    , alternative25
+                    , alternative26
+                    , alternative27
+                    , alternative28
+                    , alternative29
+                    , alternative30
+                    , alternative31
+                    , alternative32
+                    , alternative33
+                    , alternative34
+                    , alternative35
+                    , alternative36
+                    ] <?> "built-in expression"
+                ]
+            )
+        <|> alternative38
+      where
+        alternative00 = do
+            a <- try doubleLiteral
+            return (DoubleLit a)
+
+        alternative01 = do
+            a <- try naturalLiteral
+            return (NaturalLit a)
+
+        alternative02 = do
+            a <- try integerLiteral
+            return (IntegerLit a)
+
+        alternative03 = textLiteral embedded
+
+        alternative04 = (do
+            _openBrace
+            a <- recordTypeOrLiteral embedded
+            _closeBrace
+            return a ) <?> "record type or literal"
+
+        alternative05 = (do
+            _openAngle
+            a <- unionTypeOrLiteral embedded
+            _closeAngle
+            return a ) <?> "union type or literal"
+
+        alternative06 = nonEmptyListLiteral embedded
+
+        alternative08 = do
+            _NaturalFold
+            return NaturalFold
+
+        alternative09 = do
+            _NaturalBuild
+            return NaturalBuild
+
+        alternative10 = do
+            _NaturalIsZero
+            return NaturalIsZero
+
+        alternative11 = do
+            _NaturalEven
+            return NaturalEven
+
+        alternative12 = do
+            _NaturalOdd
+            return NaturalOdd
+
+        alternative13 = do
+            _NaturalToInteger
+            return NaturalToInteger
+
+        alternative14 = do
+            _NaturalShow
+            return NaturalShow
+
+        alternative15 = do
+            _IntegerShow
+            return IntegerShow
+
+        alternativeIntegerToDouble = do
+            _IntegerToDouble
+            return IntegerToDouble
+
+        alternative16 = do
+            _DoubleShow
+            return DoubleShow
+
+        alternative17 = do
+            _ListBuild
+            return ListBuild
+
+        alternative18 = do
+            _ListFold
+            return ListFold
+
+        alternative19 = do
+            _ListLength
+            return ListLength
+
+        alternative20 = do
+            _ListHead
+            return ListHead
+
+        alternative21 = do
+            _ListLast
+            return ListLast
+
+        alternative22 = do
+            _ListIndexed
+            return ListIndexed
+
+        alternative23 = do
+            _ListReverse
+            return ListReverse
+
+        alternative24 = do
+            _OptionalFold
+            return OptionalFold
+
+        alternative25 = do
+            _OptionalBuild
+            return OptionalBuild
+
+        alternative26 = do
+            _Bool
+            return Bool
+
+        alternative27 = do
+            _Optional
+            return Optional
+
+        alternative28 = do
+            _Natural
+            return Natural
+
+        alternative29 = do
+            _Integer
+            return Integer
+
+        alternative30 = do
+            _Double
+            return Double
+
+        alternative31 = do
+            _Text
+            return Text
+
+        alternative32 = do
+            _List
+            return List
+
+        alternative33 = do
+            _True
+            return (BoolLit True)
+
+        alternative34 = do
+            _False
+            return (BoolLit False)
+
+        alternative35 = do
+            _Type
+            return (Const Type)
+
+        alternative36 = do
+            _Kind
+            return (Const Kind)
+
+        alternative37 = do
+            a <- identifier
+            return (Var a)
+
+        alternative38 = do
+            _openParens
+            a <- expression embedded
+            _closeParens
+            return a
+
+
+    doubleQuotedChunk :: Parser a -> Parser (Chunks Src a)
+    doubleQuotedChunk embedded =
+        choice
+            [ interpolation
+            , unescapedCharacter
+            , escapedCharacter
+            ]
+      where
+        interpolation = do
+            _ <- Text.Parser.Char.text "${"
+            e <- completeExpression embedded
+            _ <- Text.Parser.Char.char '}'
+            return (Chunks [(mempty, e)] mempty)
+
+        unescapedCharacter = do
+            c <- Text.Parser.Char.satisfy predicate
+            return (Chunks [] (Data.Text.singleton c))
+          where
+            predicate c =
+                    ('\x20' <= c && c <= '\x21'    )
+                ||  ('\x23' <= c && c <= '\x5B'    )
+                ||  ('\x5D' <= c && c <= '\x10FFFF')
+
+        escapedCharacter = do
+            _ <- Text.Parser.Char.char '\\'
+            c <- choice
+                [ quotationMark
+                , dollarSign
+                , backSlash
+                , forwardSlash
+                , backSpace
+                , formFeed
+                , lineFeed
+                , carriageReturn
+                , tab
+                , unicode
+                ]
+            return (Chunks [] (Data.Text.singleton c))
+          where
+            quotationMark = Text.Parser.Char.char '"'
+
+            dollarSign = Text.Parser.Char.char '$'
+
+            backSlash = Text.Parser.Char.char '\\'
+
+            forwardSlash = Text.Parser.Char.char '/'
+
+            backSpace = do _ <- Text.Parser.Char.char 'b'; return '\b'
+
+            formFeed = do _ <- Text.Parser.Char.char 'f'; return '\f'
+
+            lineFeed = do _ <- Text.Parser.Char.char 'n'; return '\n'
+
+            carriageReturn = do _ <- Text.Parser.Char.char 'r'; return '\r'
+
+            tab = do _ <- Text.Parser.Char.char 't'; return '\t'
+
+            unicode = do
+                _  <- Text.Parser.Char.char 'u';
+                n0 <- hexNumber
+                n1 <- hexNumber
+                n2 <- hexNumber
+                n3 <- hexNumber
+                let n = ((n0 * 16 + n1) * 16 + n2) * 16 + n3
+                return (Data.Char.chr n)
+
+    doubleQuotedLiteral :: Parser a -> Parser (Chunks Src a)
+    doubleQuotedLiteral embedded = do
+        _      <- Text.Parser.Char.char '"'
+        chunks <- Text.Megaparsec.many (doubleQuotedChunk embedded)
+        _      <- Text.Parser.Char.char '"'
+        return (mconcat chunks)
+
+    singleQuoteContinue :: Parser a -> Parser (Chunks Src a)
+    singleQuoteContinue embedded =
+        choice
+            [ escapeSingleQuotes
+            , interpolation
+            , escapeInterpolation
+            , endLiteral
+            , unescapedCharacter
+            , tab
+            , endOfLine
+            ]
+      where
+            escapeSingleQuotes = do
+                _ <- "'''" :: Parser Text
+                b <- singleQuoteContinue embedded
+                return ("''" <> b)
+
+            interpolation = do
+                _ <- Text.Parser.Char.text "${"
+                a <- completeExpression embedded
+                _ <- Text.Parser.Char.char '}'
+                b <- singleQuoteContinue embedded
+                return (Chunks [(mempty, a)] mempty <> b)
+
+            escapeInterpolation = do
+                _ <- Text.Parser.Char.text "''${"
+                b <- singleQuoteContinue embedded
+                return ("${" <> b)
+
+            endLiteral = do
+                _ <- Text.Parser.Char.text "''"
+                return mempty
+
+            unescapedCharacter = do
+                a <- satisfy predicate
+                b <- singleQuoteContinue embedded
+                return (Chunks [] a <> b)
+              where
+                predicate c = '\x20' <= c && c <= '\x10FFFF'
+
+            endOfLine = do
+                a <- "\n" <|> "\r\n"
+                b <- singleQuoteContinue embedded
+                return (Chunks [] a <> b)
+
+            tab = do
+                _ <- Text.Parser.Char.char '\t'
+                b <- singleQuoteContinue embedded
+                return ("\t" <> b)
+
+    singleQuoteLiteral :: Parser a -> Parser (Chunks Src a)
+    singleQuoteLiteral embedded = do
+        _ <- Text.Parser.Char.text "''"
+
+        -- This is technically not in the grammar, but it's still equivalent to the
+        -- original grammar and an easy way to discard the first character if it's
+        -- a newline
+        _ <- optional endOfLine
+
+        a <- singleQuoteContinue embedded
+
+        return (dedent a)
+      where
+        endOfLine =
+                void (Text.Parser.Char.char '\n'  )
+            <|> void (Text.Parser.Char.text "\r\n")
+
+    textLiteral :: Parser a -> Parser (Expr Src a)
+    textLiteral embedded = (do
+        literal <- doubleQuotedLiteral embedded <|> singleQuoteLiteral embedded
+        whitespace
+        return (TextLit literal) ) <?> "text literal"
+
+    recordTypeOrLiteral :: Parser a -> Parser (Expr Src a)
+    recordTypeOrLiteral embedded =
+        choice
             [ alternative0
             , alternative1
             , alternative2
-            , alternative3
-            , alternative4
             ]
-        )
-    <|> alternative5
-    ) <?> "expression"
-  where
-    alternative0 = do
-        _lambda
-        _openParens
-        a <- label
-        _colon
-        b <- expression embedded
-        _closeParens
-        _arrow
-        c <- expression embedded
-        return (Lam a b c)
-
-    alternative1 = do
-        _if
-        a <- expression embedded
-        _then
-        b <- expression embedded
-        _else
-        c <- expression embedded
-        return (BoolIf a b c)
-
-    alternative2 = do
-        _let
-        a <- label
-        b <- optional (do
-            _colon
-            expression embedded )
-        _equal
-        c <- expression embedded
-        _in
-        d <- expression embedded
-        return (Let a b c d)
-
-    alternative3 = do
-        _forall
-        _openParens
-        a <- label
-        _colon
-        b <- expression embedded
-        _closeParens
-        _arrow
-        c <- expression embedded
-        return (Pi a b c)
-
-    alternative4 = do
-        a <- try (do a <- operatorExpression embedded; _arrow; return a)
-        b <- expression embedded
-        return (Pi "_" a b)
-
-    alternative5 = annotatedExpression embedded
-
-annotatedExpression :: Parser a -> Parser (Expr Src a)
-annotatedExpression embedded =
-    noted
-        ( choice
-            [ alternative0
-            , try alternative1
-            , alternative2
-            ]
-        )
-  where
-    alternative0 = do
-        _merge
-        a <- importExpression embedded
-        b <- importExpression embedded
-        c <- optional (do
-            _colon
-            applicationExpression embedded )
-        return (Merge a b c)
-
-    alternative1 = (do
-        _openBracket
-        (emptyCollection embedded <|> nonEmptyOptional embedded) )
-        <?> "list literal"
-
-    alternative2 = do
-        a <- operatorExpression embedded
-        b <- optional (do _colon; expression embedded)
-        case b of
-            Nothing -> return a
-            Just c  -> return (Annot a c)
-
-emptyCollection :: Parser a -> Parser (Expr Src a)
-emptyCollection embedded = do
-    _closeBracket
-    _colon
-    a <- alternative0 <|> alternative1
-    b <- importExpression embedded
-    return (a b)
-  where
-    alternative0 = do
-        _List
-        return (\a -> ListLit (Just a) empty)
-
-    alternative1 = do
-        _Optional
-        return (\a -> OptionalLit a empty)
-
-nonEmptyOptional :: Parser a -> Parser (Expr Src a)
-nonEmptyOptional embedded = do
-    a <- expression embedded
-    _closeBracket
-    _colon
-    _Optional
-    b <- importExpression embedded
-    return (OptionalLit b (pure a))
-
-operatorExpression :: Parser a -> Parser (Expr Src a)
-operatorExpression = importAltExpression
-
-makeOperatorExpression
-    :: (Parser a -> Parser (Expr Src a))
-    -> Parser ()
-    -> (Expr Src a -> Expr Src a -> Expr Src a)
-    -> Parser a
-    -> Parser (Expr Src a)
-makeOperatorExpression subExpression operatorParser operator embedded =
-    noted (do
-        a <- subExpression embedded
-        b <- Text.Megaparsec.many (do operatorParser; subExpression embedded)
-        return (foldr1 operator (a:b)) )
-
-importAltExpression :: Parser a -> Parser (Expr Src a)
-importAltExpression =
-    makeOperatorExpression orExpression _importAlt ImportAlt
-
-orExpression :: Parser a -> Parser (Expr Src a)
-orExpression =
-    makeOperatorExpression plusExpression _or BoolOr
-
-plusExpression :: Parser a -> Parser (Expr Src a)
-plusExpression =
-    makeOperatorExpression textAppendExpression _plus NaturalPlus
-
-textAppendExpression :: Parser a -> Parser (Expr Src a)
-textAppendExpression =
-    makeOperatorExpression listAppendExpression _textAppend TextAppend
-
-listAppendExpression :: Parser a -> Parser (Expr Src a)
-listAppendExpression =
-    makeOperatorExpression andExpression _listAppend ListAppend
-
-andExpression :: Parser a -> Parser (Expr Src a)
-andExpression =
-    makeOperatorExpression combineExpression _and BoolAnd
-
-combineExpression :: Parser a -> Parser (Expr Src a)
-combineExpression =
-    makeOperatorExpression preferExpression _combine Combine
-
-preferExpression :: Parser a -> Parser (Expr Src a)
-preferExpression =
-    makeOperatorExpression combineTypesExpression _prefer Prefer
-
-combineTypesExpression :: Parser a -> Parser (Expr Src a)
-combineTypesExpression =
-    makeOperatorExpression timesExpression _combineTypes CombineTypes
-
-timesExpression :: Parser a -> Parser (Expr Src a)
-timesExpression =
-    makeOperatorExpression equalExpression _times NaturalTimes
-
-equalExpression :: Parser a -> Parser (Expr Src a)
-equalExpression =
-    makeOperatorExpression notEqualExpression _doubleEqual BoolEQ
-
-notEqualExpression :: Parser a -> Parser (Expr Src a)
-notEqualExpression =
-    makeOperatorExpression applicationExpression _notEqual BoolNE
-
-applicationExpression :: Parser a -> Parser (Expr Src a)
-applicationExpression embedded = do
-    f <- (do _constructors; return Constructors) <|> return id
-    a <- noted (importExpression embedded)
-    b <- Text.Megaparsec.many (noted (importExpression embedded))
-    return (foldl app (f a) b)
-  where
-    app nL@(Note (Src before _ bytesL) _) nR@(Note (Src _ after bytesR) _) =
-        Note (Src before after (bytesL <> bytesR)) (App nL nR)
-    app nL nR =
-        App nL nR
-
-importExpression :: Parser a -> Parser (Expr Src a)
-importExpression embedded = noted (choice [ alternative0, alternative1 ])
-  where
-    alternative0 = do
-        a <- embedded
-        return (Embed a)
-
-    alternative1 = selectorExpression embedded
-
-selectorExpression :: Parser a -> Parser (Expr Src a)
-selectorExpression embedded = noted (do
-    a <- primitiveExpression embedded
-
-    let left  x  e = Field   e x
-    let right xs e = Project e xs
-    b <- Text.Megaparsec.many (try (do _dot; fmap left label <|> fmap right labels))
-    return (foldl (\e k -> k e) a b) )
-
-primitiveExpression :: Parser a -> Parser (Expr Src a)
-primitiveExpression embedded =
-    noted
-        ( choice
-            [ alternative00
-            , alternative01
-            , alternative02
-            , alternative03
-            , alternative04
-            , alternative05
-            , alternative06
-            , alternative37
-
-            , choice
-                [ alternative08
-                , alternative09
-                , alternative10
-                , alternative11
-                , alternative12
-                , alternative13
-                , alternative14
-                , alternative15
-                , alternativeIntegerToDouble
-                , alternative16
-                , alternative17
-                , alternative18
-                , alternative19
-                , alternative20
-                , alternative21
-                , alternative22
-                , alternative23
-                , alternative24
-                , alternative25
-                , alternative26
-                , alternative27
-                , alternative28
-                , alternative29
-                , alternative30
-                , alternative31
-                , alternative32
-                , alternative33
-                , alternative34
-                , alternative35
-                , alternative36
-                ] <?> "built-in expression"
-            ]
-        )
-    <|> alternative38
-  where
-    alternative00 = do
-        a <- try doubleLiteral
-        return (DoubleLit a)
-
-    alternative01 = do
-        a <- try naturalLiteral
-        return (NaturalLit a)
-
-    alternative02 = do
-        a <- try integerLiteral
-        return (IntegerLit a)
-
-    alternative03 = textLiteral embedded
-
-    alternative04 = (do
-        _openBrace
-        a <- recordTypeOrLiteral embedded
-        _closeBrace
-        return a ) <?> "record type or literal"
-
-    alternative05 = (do
-        _openAngle
-        a <- unionTypeOrLiteral embedded
-        _closeAngle
-        return a ) <?> "union type or literal"
-
-    alternative06 = nonEmptyListLiteral embedded
-
-    alternative08 = do
-        _NaturalFold
-        return NaturalFold
-
-    alternative09 = do
-        _NaturalBuild
-        return NaturalBuild
-
-    alternative10 = do
-        _NaturalIsZero
-        return NaturalIsZero
-
-    alternative11 = do
-        _NaturalEven
-        return NaturalEven
-
-    alternative12 = do
-        _NaturalOdd
-        return NaturalOdd
-
-    alternative13 = do
-        _NaturalToInteger
-        return NaturalToInteger
-
-    alternative14 = do
-        _NaturalShow
-        return NaturalShow
-
-    alternative15 = do
-        _IntegerShow
-        return IntegerShow
-
-    alternativeIntegerToDouble = do
-        _IntegerToDouble
-        return IntegerToDouble
-
-    alternative16 = do
-        _DoubleShow
-        return DoubleShow
-
-    alternative17 = do
-        _ListBuild
-        return ListBuild
-
-    alternative18 = do
-        _ListFold
-        return ListFold
-
-    alternative19 = do
-        _ListLength
-        return ListLength
-
-    alternative20 = do
-        _ListHead
-        return ListHead
-
-    alternative21 = do
-        _ListLast
-        return ListLast
-
-    alternative22 = do
-        _ListIndexed
-        return ListIndexed
-
-    alternative23 = do
-        _ListReverse
-        return ListReverse
-
-    alternative24 = do
-        _OptionalFold
-        return OptionalFold
-
-    alternative25 = do
-        _OptionalBuild
-        return OptionalBuild
-
-    alternative26 = do
-        _Bool
-        return Bool
-
-    alternative27 = do
-        _Optional
-        return Optional
-
-    alternative28 = do
-        _Natural
-        return Natural
-
-    alternative29 = do
-        _Integer
-        return Integer
-
-    alternative30 = do
-        _Double
-        return Double
-
-    alternative31 = do
-        _Text
-        return Text
-
-    alternative32 = do
-        _List
-        return List
-
-    alternative33 = do
-        _True
-        return (BoolLit True)
-
-    alternative34 = do
-        _False
-        return (BoolLit False)
-
-    alternative35 = do
-        _Type
-        return (Const Type)
-
-    alternative36 = do
-        _Kind
-        return (Const Kind)
-
-    alternative37 = do
-        a <- identifier
-        return (Var a)
-
-    alternative38 = do
-        _openParens
-        a <- expression embedded
-        _closeParens
-        return a
-
-
-doubleQuotedChunk :: Parser a -> Parser (Chunks Src a)
-doubleQuotedChunk embedded =
-    choice
-        [ interpolation
-        , unescapedCharacter
-        , escapedCharacter
-        ]
-  where
-    interpolation = do
-        _ <- Text.Parser.Char.text "${"
-        e <- completeExpression embedded
-        _ <- Text.Parser.Char.char '}'
-        return (Chunks [(mempty, e)] mempty)
-
-    unescapedCharacter = do
-        c <- Text.Parser.Char.satisfy predicate
-        return (Chunks [] (Data.Text.singleton c))
       where
-        predicate c =
-                ('\x20' <= c && c <= '\x21'    )
-            ||  ('\x23' <= c && c <= '\x5B'    )
-            ||  ('\x5D' <= c && c <= '\x10FFFF')
-
-    escapedCharacter = do
-        _ <- Text.Parser.Char.char '\\'
-        c <- choice
-            [ quotationMark
-            , dollarSign
-            , backSlash
-            , forwardSlash
-            , backSpace
-            , formFeed
-            , lineFeed
-            , carriageReturn
-            , tab
-            , unicode
-            ]
-        return (Chunks [] (Data.Text.singleton c))
-      where
-        quotationMark = Text.Parser.Char.char '"'
-
-        dollarSign = Text.Parser.Char.char '$'
-
-        backSlash = Text.Parser.Char.char '\\'
-
-        forwardSlash = Text.Parser.Char.char '/'
-
-        backSpace = do _ <- Text.Parser.Char.char 'b'; return '\b'
-
-        formFeed = do _ <- Text.Parser.Char.char 'f'; return '\f'
-
-        lineFeed = do _ <- Text.Parser.Char.char 'n'; return '\n'
-
-        carriageReturn = do _ <- Text.Parser.Char.char 'r'; return '\r'
-
-        tab = do _ <- Text.Parser.Char.char 't'; return '\t'
-
-        unicode = do
-            _  <- Text.Parser.Char.char 'u';
-            n0 <- hexNumber
-            n1 <- hexNumber
-            n2 <- hexNumber
-            n3 <- hexNumber
-            let n = ((n0 * 16 + n1) * 16 + n2) * 16 + n3
-            return (Data.Char.chr n)
-
-doubleQuotedLiteral :: Parser a -> Parser (Chunks Src a)
-doubleQuotedLiteral embedded = do
-    _      <- Text.Parser.Char.char '"'
-    chunks <- Text.Megaparsec.many (doubleQuotedChunk embedded)
-    _      <- Text.Parser.Char.char '"'
-    return (mconcat chunks)
-
-singleQuoteContinue :: Parser a -> Parser (Chunks Src a)
-singleQuoteContinue embedded =
-    choice
-        [ escapeSingleQuotes
-        , interpolation
-        , escapeInterpolation
-        , endLiteral
-        , unescapedCharacter
-        , tab
-        , endOfLine
-        ]
-  where
-        escapeSingleQuotes = do
-            _ <- "'''" :: Parser Text
-            b <- singleQuoteContinue embedded
-            return ("''" <> b)
-
-        interpolation = do
-            _ <- Text.Parser.Char.text "${"
-            a <- completeExpression embedded
-            _ <- Text.Parser.Char.char '}'
-            b <- singleQuoteContinue embedded
-            return (Chunks [(mempty, a)] mempty <> b)
-
-        escapeInterpolation = do
-            _ <- Text.Parser.Char.text "''${"
-            b <- singleQuoteContinue embedded
-            return ("${" <> b)
-
-        endLiteral = do
-            _ <- Text.Parser.Char.text "''"
-            return mempty
-
-        unescapedCharacter = do
-            a <- satisfy predicate
-            b <- singleQuoteContinue embedded
-            return (Chunks [] a <> b)
-          where
-            predicate c = '\x20' <= c && c <= '\x10FFFF'
-
-        endOfLine = do
-            a <- "\n" <|> "\r\n"
-            b <- singleQuoteContinue embedded
-            return (Chunks [] a <> b)
-
-        tab = do
-            _ <- Text.Parser.Char.char '\t'
-            b <- singleQuoteContinue embedded
-            return ("\t" <> b)
-
-singleQuoteLiteral :: Parser a -> Parser (Chunks Src a)
-singleQuoteLiteral embedded = do
-    _ <- Text.Parser.Char.text "''"
-
-    -- This is technically not in the grammar, but it's still equivalent to the
-    -- original grammar and an easy way to discard the first character if it's
-    -- a newline
-    _ <- optional endOfLine
-
-    a <- singleQuoteContinue embedded
-
-    return (dedent a)
-  where
-    endOfLine =
-            void (Text.Parser.Char.char '\n'  )
-        <|> void (Text.Parser.Char.text "\r\n")
-
-textLiteral :: Parser a -> Parser (Expr Src a)
-textLiteral embedded = (do
-    literal <- doubleQuotedLiteral embedded <|> singleQuoteLiteral embedded
-    whitespace
-    return (TextLit literal) ) <?> "text literal"
-
-recordTypeOrLiteral :: Parser a -> Parser (Expr Src a)
-recordTypeOrLiteral embedded =
-    choice
-        [ alternative0
-        , alternative1
-        , alternative2
-        ]
-  where
-    alternative0 = do
-        _equal
-        return (RecordLit Data.HashMap.Strict.InsOrd.empty)
-
-    alternative1 = nonEmptyRecordTypeOrLiteral embedded
-
-    alternative2 = return (Record Data.HashMap.Strict.InsOrd.empty)
-
-nonEmptyRecordTypeOrLiteral :: Parser a -> Parser (Expr Src a)
-nonEmptyRecordTypeOrLiteral embedded = do
-    a <- label
-
-    let nonEmptyRecordType = do
-            _colon
-            b <- expression embedded
-            e <- Text.Megaparsec.many (do
-                _comma
-                c <- label
-                _colon
-                d <- expression embedded
-                return (c, d) )
-            m <- toMap ((a, b) : e)
-            return (Record m)
-
-    let nonEmptyRecordLiteral = do
+        alternative0 = do
             _equal
-            b <- expression embedded
-            e <- Text.Megaparsec.many (do
-                _comma
-                c <- label
-                _equal
-                d <- expression embedded
-                return (c, d) )
-            m <- toMap ((a, b) : e)
-            return (RecordLit m)
+            return (RecordLit Data.HashMap.Strict.InsOrd.empty)
 
-    nonEmptyRecordType <|> nonEmptyRecordLiteral
+        alternative1 = nonEmptyRecordTypeOrLiteral embedded
 
-unionTypeOrLiteral :: Parser a -> Parser (Expr Src a)
-unionTypeOrLiteral embedded =
-        nonEmptyUnionTypeOrLiteral embedded
-    <|> return (Union Data.HashMap.Strict.InsOrd.empty)
+        alternative2 = return (Record Data.HashMap.Strict.InsOrd.empty)
 
-nonEmptyUnionTypeOrLiteral :: Parser a -> Parser (Expr Src a)
-nonEmptyUnionTypeOrLiteral embedded = do
-    (f, kvs) <- loop
-    m <- toMap kvs
-    return (f m)
-  where
-    loop = do
+    nonEmptyRecordTypeOrLiteral :: Parser a -> Parser (Expr Src a)
+    nonEmptyRecordTypeOrLiteral embedded = do
         a <- label
 
-        let alternative0 = do
-                _equal
+        let nonEmptyRecordType = do
+                _colon
                 b <- expression embedded
-                kvs <- Text.Megaparsec.many (do
-                    _bar
+                e <- Text.Megaparsec.many (do
+                    _comma
                     c <- label
                     _colon
                     d <- expression embedded
                     return (c, d) )
-                return (UnionLit a b, kvs)
+                m <- toMap ((a, b) : e)
+                return (Record m)
 
-        let alternative1 = do
-                _colon
+        let nonEmptyRecordLiteral = do
+                _equal
                 b <- expression embedded
+                e <- Text.Megaparsec.many (do
+                    _comma
+                    c <- label
+                    _equal
+                    d <- expression embedded
+                    return (c, d) )
+                m <- toMap ((a, b) : e)
+                return (RecordLit m)
 
-                let alternative2 = do
+        nonEmptyRecordType <|> nonEmptyRecordLiteral
+
+    unionTypeOrLiteral :: Parser a -> Parser (Expr Src a)
+    unionTypeOrLiteral embedded =
+            nonEmptyUnionTypeOrLiteral embedded
+        <|> return (Union Data.HashMap.Strict.InsOrd.empty)
+
+    nonEmptyUnionTypeOrLiteral :: Parser a -> Parser (Expr Src a)
+    nonEmptyUnionTypeOrLiteral embedded = do
+        (f, kvs) <- loop
+        m <- toMap kvs
+        return (f m)
+      where
+        loop = do
+            a <- label
+
+            let alternative0 = do
+                    _equal
+                    b <- expression embedded
+                    kvs <- Text.Megaparsec.many (do
                         _bar
-                        (f, kvs) <- loop
-                        return (f, (a, b):kvs)
+                        c <- label
+                        _colon
+                        d <- expression embedded
+                        return (c, d) )
+                    return (UnionLit a b, kvs)
 
-                let alternative3 = return (Union, [(a, b)])
+            let alternative1 = do
+                    _colon
+                    b <- expression embedded
 
-                alternative2 <|> alternative3
+                    let alternative2 = do
+                            _bar
+                            (f, kvs) <- loop
+                            return (f, (a, b):kvs)
 
-        alternative0 <|> alternative1
+                    let alternative3 = return (Union, [(a, b)])
 
-nonEmptyListLiteral :: Parser a -> Parser (Expr Src a)
-nonEmptyListLiteral embedded = (do
-    _openBracket
-    a <- expression embedded
-    b <- Text.Megaparsec.many (do _comma; expression embedded)
-    _closeBracket
-    return (ListLit Nothing (Data.Sequence.fromList (a:b))) ) <?> "list literal"
+                    alternative2 <|> alternative3
 
-completeExpression :: Parser a -> Parser (Expr Src a)
-completeExpression embedded = do
-    whitespace
-    expression embedded
+            alternative0 <|> alternative1
+
+    nonEmptyListLiteral :: Parser a -> Parser (Expr Src a)
+    nonEmptyListLiteral embedded = (do
+        _openBracket
+        a <- expression embedded
+        b <- Text.Megaparsec.many (do _comma; expression embedded)
+        _closeBracket
+        return (ListLit Nothing (Data.Sequence.fromList (a:b))) ) <?> "list literal"
+
+    completeExpression embedded = do
+        whitespace
+        expression embedded
+
 
 env :: Parser ImportType
 env = do


### PR DESCRIPTION
This uses `noted = id` on the first attempt to parse an expression and then
uses the real `noted` if parsing fails to provide better error messages