### PR TITLE
Add options and command-line support for protocol versions

### DIFF
--- a/benchmark/deep-nested-large-record/Main.hs
+++ b/benchmark/deep-nested-large-record/Main.hs
@@ -2,7 +2,6 @@
 module Main (main) where
 
 import Criterion.Main (defaultMain)
-import Dhall.Binary (ProtocolVersion(..))
 
 import qualified Criterion as Criterion
 import qualified Data.Sequence as Seq

--- a/benchmark/deep-nested-large-record/Main.hs
+++ b/benchmark/deep-nested-large-record/Main.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import qualified Criterion as Criterion
 import Criterion.Main (defaultMain)
+import Dhall.Binary (ProtocolVersion(..))
+
+import qualified Criterion as Criterion
 import qualified Data.Sequence as Seq
 import qualified Dhall.Core as Core
 import qualified Dhall.Import as Import

--- a/benchmark/parser/Main.hs
+++ b/benchmark/parser/Main.hs
@@ -5,6 +5,7 @@ module Main where
 import Control.Monad (forM)
 import Criterion.Main (defaultMain, bgroup, bench, whnf, nfIO)
 import Data.Map (Map, foldrWithKey, singleton, unions)
+import Dhall.Binary (ProtocolVersion(..))
 
 import System.Directory
 
@@ -53,7 +54,7 @@ benchExprFromBytes name bytes = bench name (whnf f bytes)
         term <- case Codec.Serialise.deserialiseOrFail bytes of
             Left  _    -> Nothing
             Right term -> return term
-        Dhall.Binary.decodeWithVersion_1_0 term
+        Dhall.Binary.decode V_1_0 term
 
 main :: IO ()
 main = do

--- a/benchmark/parser/Main.hs
+++ b/benchmark/parser/Main.hs
@@ -54,7 +54,7 @@ benchExprFromBytes name bytes = bench name (whnf f bytes)
         term <- case Codec.Serialise.deserialiseOrFail bytes of
             Left  _    -> Nothing
             Right term -> return term
-        Dhall.Binary.decode V_1_0 term
+        Dhall.Binary.decode term
 
 main :: IO ()
 main = do

--- a/benchmark/parser/Main.hs
+++ b/benchmark/parser/Main.hs
@@ -5,7 +5,6 @@ module Main where
 import Control.Monad (forM)
 import Criterion.Main (defaultMain, bgroup, bench, whnf, nfIO)
 import Data.Map (Map, foldrWithKey, singleton, unions)
-import Dhall.Binary (ProtocolVersion(..))
 
 import System.Directory
 

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -276,6 +276,7 @@ Test-Suite tasty
         tasty-hunit               >= 0.9.2    && < 0.11,
         tasty-quickcheck          >= 0.9.2    && < 0.11,
         text                      >= 0.11.1.0 && < 1.3 ,
+        transformers                                   ,
         vector                    >= 0.11.0.0 && < 0.13
     Default-Language: Haskell2010
 

--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -307,7 +307,6 @@ inputWithSettings settings (Type {..}) txt = do
                set Dhall.Import.protocolVersion _protocolVersion
             .  set Dhall.Import.normalizer      _normalizer
             .  set Dhall.Import.startingContext _startingContext
-            .  set Dhall.Import.rootDirectory   _rootDirectory
 
     let status = transform (Dhall.Import.emptyStatus ".")
 
@@ -401,7 +400,6 @@ inputExprWithSettings settings txt = do
                set Dhall.Import.protocolVersion _protocolVersion
             .  set Dhall.Import.normalizer      _normalizer
             .  set Dhall.Import.startingContext _startingContext
-            .  set Dhall.Import.rootDirectory   _rootDirectory
 
     let status = transform (Dhall.Import.emptyStatus ".")
 

--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -309,7 +309,7 @@ inputWithSettings settings (Type {..}) txt = do
             .  set Dhall.Import.normalizer      _normalizer
             .  set Dhall.Import.startingContext _startingContext
 
-    let status = transform (Dhall.Import.emptyStatus ".")
+    let status = transform (Dhall.Import.emptyStatus _rootDirectory)
 
     expr' <- State.evalStateT (Dhall.Import.loadWith expr) status
 
@@ -402,7 +402,7 @@ inputExprWithSettings settings txt = do
             .  set Dhall.Import.normalizer      _normalizer
             .  set Dhall.Import.startingContext _startingContext
 
-    let status = transform (Dhall.Import.emptyStatus ".")
+    let status = transform (Dhall.Import.emptyStatus _rootDirectory)
 
     expr' <- State.evalStateT (Dhall.Import.loadWith expr) status
 

--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -115,6 +115,7 @@ import qualified Data.Text
 import qualified Data.Text.IO
 import qualified Data.Text.Lazy
 import qualified Data.Vector
+import qualified Dhall.Binary
 import qualified Dhall.Context
 import qualified Dhall.Core
 import qualified Dhall.Import
@@ -204,7 +205,7 @@ defaultEvaluateSettings :: EvaluateSettings
 defaultEvaluateSettings = EvaluateSettings
   { _startingContext = Dhall.Context.empty
   , _normalizer      = Dhall.Core.ReifiedNormalizer (const Nothing)
-  , _protocolVersion = V_1_0
+  , _protocolVersion = Dhall.Binary.defaultProtocolVersion
   }
 
 -- | Access the starting context used for evaluation and type-checking.

--- a/src/Dhall/Binary.hs
+++ b/src/Dhall/Binary.hs
@@ -9,6 +9,7 @@
 module Dhall.Binary
     ( -- * Protocol versions
       ProtocolVersion(..)
+    , defaultProtocolVersion
     , parseProtocolVersion
 
     -- * Encoding and decoding
@@ -50,12 +51,15 @@ data ProtocolVersion
     = V_1_0
     -- ^ Protocol version string "1.0"
 
+defaultProtocolVersion :: ProtocolVersion
+defaultProtocolVersion = V_1_0
+
 parseProtocolVersion :: Parser ProtocolVersion
 parseProtocolVersion =
     Options.Applicative.option readProtocolVersion
         (   Options.Applicative.long "protocol-version"
         <>  Options.Applicative.metavar "X.Y"
-        <>  Options.Applicative.value V_1_0
+        <>  Options.Applicative.value defaultProtocolVersion
         )
   where
     readProtocolVersion = do

--- a/src/Dhall/Hash.hs
+++ b/src/Dhall/Hash.hs
@@ -7,26 +7,33 @@ module Dhall.Hash
       hash
     ) where
 
+import Dhall.Binary (ProtocolVersion)
 import Dhall.Parser (exprFromText)
-import Dhall.Import (hashExpressionToCode, load)
+import Dhall.Import (hashExpressionToCode, protocolVersion)
+import Lens.Family (set)
 
+import qualified Control.Monad.Trans.State.Strict as State
 import qualified Control.Exception
+import qualified Dhall.Import
 import qualified Dhall.TypeCheck
 import qualified Data.Text.IO
 
 -- | Implementation of the @dhall hash@ subcommand
-hash :: IO ()
-hash = do
-        inText <- Data.Text.IO.getContents
+hash :: ProtocolVersion -> IO ()
+hash _protocolVersion = do
+    inText <- Data.Text.IO.getContents
 
-        expr <- case exprFromText "(stdin)" inText of
-            Left  err  -> Control.Exception.throwIO err
-            Right expr -> return expr
+    expr <- case exprFromText "(stdin)" inText of
+        Left  err  -> Control.Exception.throwIO err
+        Right expr -> return expr
 
-        expr' <- load expr
+    let status =
+            set protocolVersion _protocolVersion (Dhall.Import.emptyStatus ".")
 
-        _ <- case Dhall.TypeCheck.typeOf expr' of
-            Left  err -> Control.Exception.throwIO err
-            Right _   -> return ()
+    expr' <- State.evalStateT (Dhall.Import.loadWith expr) status
 
-        Data.Text.IO.putStrLn (hashExpressionToCode expr')
+    _ <- case Dhall.TypeCheck.typeOf expr' of
+        Left  err -> Control.Exception.throwIO err
+        Right _   -> return ()
+
+    Data.Text.IO.putStrLn (hashExpressionToCode _protocolVersion expr')

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -113,7 +113,6 @@ module Dhall.Import (
     , normalizer
     , startingContext
     , resolver
-    , rootDirectory
     , Cycle(..)
     , ReferentiallyOpaque(..)
     , Imported(..)

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -548,7 +548,11 @@ exprFromImport (Import {..}) = do
 emptyStatus :: FilePath -> Status IO
 emptyStatus = emptyStatusWith exprFromImport
 
--- | This loads a \"static\" expression (i.e. an expression free of imports)
+{-| Generalized version of `load`
+
+    You can configure the desired behavior through the initial `Status` that you
+    supply
+-}
 loadWith :: MonadCatch m => Expr Src Import -> StateT (Status m) m (Expr Src X)
 loadWith expr₀ = case expr₀ of
   Embed import_ -> do

--- a/src/Dhall/Import/HTTP.hs
+++ b/src/Dhall/Import/HTTP.hs
@@ -75,7 +75,7 @@ renderPrettyHttpException e = case e of
         <> show e'
 #endif
 
-needManager :: StateT Status IO Manager
+needManager :: StateT (Status m) IO Manager
 needManager = do
     x <- zoom manager State.get
     case join (fmap fromDynamic x) of
@@ -97,7 +97,7 @@ needManager = do
 fetchFromHttpUrl
     :: String
     -> Maybe [(CI ByteString, ByteString)]
-    -> StateT Status IO (String, Text.Text)
+    -> StateT (Status m) IO (String, Text.Text)
 fetchFromHttpUrl url mheaders = do
     m <- needManager
 

--- a/src/Dhall/Import/Types.hs
+++ b/src/Dhall/Import/Types.hs
@@ -52,8 +52,6 @@ data Status m = Status
     , _startingContext :: Context (Expr Src X)
 
     , _resolver :: Import -> StateT (Status m) m (Expr Src Import)
-
-    , _rootDirectory :: FilePath
     }
 
 -- | Default starting `Status` that is polymorphic in the base `Monad`
@@ -61,7 +59,7 @@ emptyStatusWith
     :: (Import -> StateT (Status m) m (Expr Src Import))
     -> FilePath
     -> Status m
-emptyStatusWith _resolver _rootDirectory = Status {..}
+emptyStatusWith _resolver rootDirectory = Status {..}
   where
     _stack = pure rootImport
 
@@ -75,11 +73,11 @@ emptyStatusWith _resolver _rootDirectory = Status {..}
 
     _startingContext = Dhall.Context.empty
 
-    prefix = if isRelative _rootDirectory
+    prefix = if isRelative rootDirectory
       then Here
       else Absolute
     pathComponents =
-        fmap Data.Text.pack (reverse (splitDirectories _rootDirectory))
+        fmap Data.Text.pack (reverse (splitDirectories rootDirectory))
 
     dirAsFile = File (Directory pathComponents) "."
 
@@ -116,9 +114,6 @@ resolver
     :: Functor f
     => LensLike' f (Status m) (Import -> StateT (Status m) m (Expr Src Import))
 resolver k s = fmap (\x -> s { _resolver = x }) (k (_resolver s))
-
-rootDirectory :: Functor f => LensLike' f (Status m) FilePath
-rootDirectory k s = fmap (\x -> s { _rootDirectory = x }) (k (_rootDirectory s))
 
 {-| This exception indicates that there was an internal error in Dhall's
     import-related logic

--- a/src/Dhall/Import/Types.hs
+++ b/src/Dhall/Import/Types.hs
@@ -28,6 +28,7 @@ import Dhall.TypeCheck (X)
 import Lens.Family (LensLike')
 import System.FilePath (isRelative, splitDirectories)
 
+import qualified Dhall.Binary
 import qualified Dhall.Context
 import qualified Data.Map      as Map
 import qualified Data.Text
@@ -67,7 +68,7 @@ emptyStatusWith _resolver rootDirectory = Status {..}
 
     _manager = Nothing
 
-    _protocolVersion = V_1_0
+    _protocolVersion = Dhall.Binary.defaultProtocolVersion
 
     _normalizer = ReifiedNormalizer (const Nothing)
 

--- a/src/Dhall/Repl.hs
+++ b/src/Dhall/Repl.hs
@@ -14,7 +14,11 @@ import Control.Monad.IO.Class ( MonadIO, liftIO )
 import Control.Monad.State.Class ( MonadState, get, modify )
 import Control.Monad.State.Strict ( evalStateT )
 import Data.List ( foldl' )
+import Dhall.Binary (ProtocolVersion(..))
+import Dhall.Import (protocolVersion)
+import Lens.Family (set)
 
+import qualified Control.Monad.Trans.State.Strict as State
 import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty ( renderIO )
@@ -32,8 +36,8 @@ import qualified System.Console.Repline as Repline
 import qualified System.IO
 
 -- | Implementation of the @dhall repl@ subcommand
-repl :: Bool -> IO ()
-repl explain = if explain then Dhall.detailed io else io
+repl :: Bool -> ProtocolVersion -> IO ()
+repl explain _protocolVersion = if explain then Dhall.detailed io else io
   where
     io =
       evalStateT
@@ -44,13 +48,14 @@ repl explain = if explain then Dhall.detailed io else io
         ( Repline.Word completer )
             greeter
         )
-        (emptyEnv { explain })
+        (emptyEnv { explain, _protocolVersion })
 
 
 data Env = Env
-  { envBindings :: Dhall.Context.Context Binding
-  , envIt :: Maybe Binding
-  , explain :: Bool
+  { envBindings      :: Dhall.Context.Context Binding
+  , envIt            :: Maybe Binding
+  , explain          :: Bool
+  , _protocolVersion :: ProtocolVersion
   }
 
 
@@ -60,6 +65,7 @@ emptyEnv =
     { envBindings = Dhall.Context.empty
     , envIt = Nothing
     , explain = False
+    , _protocolVersion = V_1_0
     }
 
 
@@ -83,6 +89,9 @@ parseAndLoad
   :: ( MonadIO m, MonadState Env m )
   => String -> m ( Dhall.Expr Dhall.Src Dhall.X )
 parseAndLoad src = do
+  env <-
+    get
+
   parsed <-
     case Dhall.exprFromText "(stdin)" ( Text.pack src ) of
       Left e ->
@@ -91,7 +100,10 @@ parseAndLoad src = do
       Right a ->
         return a
 
-  liftIO ( Dhall.load parsed )
+  let status =
+        set protocolVersion (_protocolVersion env) (Dhall.emptyStatus ".")
+
+  liftIO ( State.evalStateT (Dhall.loadWith parsed) status )
 
 
 eval :: ( MonadIO m, MonadState Env m ) => String -> m ()

--- a/src/Dhall/Repl.hs
+++ b/src/Dhall/Repl.hs
@@ -23,6 +23,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty ( renderIO )
 import qualified Dhall
+import qualified Dhall.Binary
 import qualified Dhall.Context
 import qualified Dhall.Core as Dhall ( Var(V), Expr, normalize )
 import qualified Dhall.Pretty
@@ -65,7 +66,7 @@ emptyEnv =
     { envBindings = Dhall.Context.empty
     , envIt = Nothing
     , explain = False
-    , _protocolVersion = V_1_0
+    , _protocolVersion = Dhall.Binary.defaultProtocolVersion
     }
 
 

--- a/tests/Import.hs
+++ b/tests/Import.hs
@@ -8,9 +8,9 @@ import Dhall.Import (MissingImports(..))
 import Control.Exception (catch, throwIO)
 import Data.Monoid ((<>))
 
+import qualified Control.Monad.Trans.State.Strict as State
 import qualified Data.Text
 import qualified Data.Text.IO
-import qualified Dhall.Context
 import qualified Dhall.Parser
 import qualified Dhall.Import
 import qualified Test.Tasty
@@ -65,7 +65,9 @@ shouldNotFailRelative name dir path = Test.Tasty.HUnit.testCase (Data.Text.unpac
     expr <- case Dhall.Parser.exprFromText mempty text of
                      Left  err  -> throwIO err
                      Right expr -> return expr
-    _ <- Dhall.Import.loadDirWith dir Dhall.Import.exprFromImport Dhall.Context.empty (const Nothing) expr
+
+    _ <- State.evalStateT (Dhall.Import.loadWith expr) (Dhall.Import.emptyStatus dir)
+
     return ())
 
 shouldFail :: Int -> Text -> FilePath -> TestTree

--- a/tests/QuickCheck.hs
+++ b/tests/QuickCheck.hs
@@ -315,7 +315,7 @@ binaryRoundtrip :: Expr () Import -> Property
 binaryRoundtrip expression =
         wrap
             (fmap
-                (Dhall.Binary.decode V_1_0)
+                Dhall.Binary.decode
                 (Codec.Serialise.deserialiseOrFail
                   (Codec.Serialise.serialise
                     (Dhall.Binary.encode V_1_0 expression)

--- a/tests/QuickCheck.hs
+++ b/tests/QuickCheck.hs
@@ -10,6 +10,7 @@ import Codec.Serialise (DeserialiseFailure(..))
 import Control.Monad (guard)
 import Data.Hashable (Hashable)
 import Data.HashMap.Strict.InsOrd (InsOrdHashMap)
+import Dhall.Binary (ProtocolVersion(..))
 import Dhall.Core
     ( Chunks(..)
     , Const(..)
@@ -314,10 +315,10 @@ binaryRoundtrip :: Expr () Import -> Property
 binaryRoundtrip expression =
         wrap
             (fmap
-                Dhall.Binary.decodeWithVersion_1_0
+                (Dhall.Binary.decode V_1_0)
                 (Codec.Serialise.deserialiseOrFail
                   (Codec.Serialise.serialise
-                    (Dhall.Binary.encodeWithVersion_1_0 expression)
+                    (Dhall.Binary.encode V_1_0 expression)
                   )
                 )
             )

--- a/tests/QuickCheck.hs
+++ b/tests/QuickCheck.hs
@@ -10,7 +10,6 @@ import Codec.Serialise (DeserialiseFailure(..))
 import Control.Monad (guard)
 import Data.Hashable (Hashable)
 import Data.HashMap.Strict.InsOrd (InsOrdHashMap)
-import Dhall.Binary (ProtocolVersion(..))
 import Dhall.Core
     ( Chunks(..)
     , Const(..)
@@ -318,7 +317,7 @@ binaryRoundtrip expression =
                 Dhall.Binary.decode
                 (Codec.Serialise.deserialiseOrFail
                   (Codec.Serialise.serialise
-                    (Dhall.Binary.encode defaultProtocolVersion expression)
+                    (Dhall.Binary.encode Dhall.Binary.defaultProtocolVersion expression)
                   )
                 )
             )

--- a/tests/QuickCheck.hs
+++ b/tests/QuickCheck.hs
@@ -318,7 +318,7 @@ binaryRoundtrip expression =
                 Dhall.Binary.decode
                 (Codec.Serialise.deserialiseOrFail
                   (Codec.Serialise.serialise
-                    (Dhall.Binary.encode V_1_0 expression)
+                    (Dhall.Binary.encode defaultProtocolVersion expression)
                   )
                 )
             )


### PR DESCRIPTION
The immediate goal of this pull request was to add command-line support
for a `--protocol-version` flag so that users could pin to a specific
binary protocol versions tring to avoid a forced upgrade when they
install a newer version of the Dhall interpreter.

However, in the process I ended up cleaning up the `Dhall.Import`
`load*` family of functions by consolidating everything into two
functions:

* `load` - Exact same type signature and semantics as before for the
  happy path with sensible defaults

* `loadWith` - The ultra-customizable version where all the options are
  stuffed into the existing `Status` record for ease of extension later

I also fixed a bug along the way where `decodeWithVersion_1_0` and
`encodeWithVersion_1_0` were serializing and deserializing the wrong
version string.