### PR TITLE
Cache imports protected by a semantic integrity check

### DIFF
--- a/benchmark/parser/Main.hs
+++ b/benchmark/parser/Main.hs
@@ -53,7 +53,9 @@ benchExprFromBytes name bytes = bench name (whnf f bytes)
         term <- case Codec.Serialise.deserialiseOrFail bytes of
             Left  _    -> Nothing
             Right term -> return term
-        Dhall.Binary.decode term
+        case Dhall.Binary.decode term of
+            Left  _          -> Nothing
+            Right expression -> return expression
 
 main :: IO ()
 main = do

--- a/src/Dhall/Binary.hs
+++ b/src/Dhall/Binary.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -15,10 +16,14 @@ module Dhall.Binary
     -- * Encoding and decoding
     , encode
     , decode
+
+    -- * Exceptions
+    , DecodingFailure(..)
     ) where
 
 import Codec.CBOR.Term (Term(..))
 import Control.Applicative (empty)
+import Control.Exception (Exception)
 import Dhall.Core
     ( Chunks(..)
     , Const(..)
@@ -727,7 +732,7 @@ encodeWithVersion_1_0 expression =
     This auto-detects whiich protocol version to decode based on the included
     protocol version string in the decoded expression
 -}
-decode :: Term -> Maybe (Expr s Import)
+decode :: Term -> Either DecodingFailure (Expr s Import)
 decode term = do
     (version, subTerm) <- case term of
         TList [ TString version, subTerm ] ->
@@ -750,3 +755,39 @@ decode term = do
 -- | Encode a Dhall expression using the specified `ProtocolVersion`
 encode :: ProtocolVersion -> Expr s Import -> Term
 encode V_1_0 = encodeWithVersion_1_0
+
+data DecodingFailure
+    = CannotDecodeProtocolVersionString Term
+    | UnsupportedProtocolVersionString Text
+    | CBORIsNotDhall Term
+    deriving (Eq, Exception)
+
+_ERROR :: String
+_ERROR = "\ESC[1;31mError\ESC[0m"
+
+instance Show DecodingFailure where
+    show (CannotDecodeProtocolVersionString term) =
+            _ERROR <> ": Cannot decode version string\n"
+        <>  "\n"
+        <>  "This CBOR expression does not contain a protocol version string in any\n"
+        <>  "recognizable format\n"
+        <>  "\n"
+        <>  "↳ " <> show term <> "\n"
+    show (UnsupportedProtocolVersionString version) =
+            _ERROR <> ": Unsupported version string\n"
+        <>  "\n"
+        <>  "The encoded Dhall expression was tagged with a protocol version string of:\n"
+        <>  "\n"
+        <>  "↳ " <> show version <> "\n"
+        <>  "\n"
+        <>  "... but this implementation cannot decode that protocol version\n"
+        <>  "\n"
+        <>  "Some common reasons why you might get this error:\n"
+        <>  "\n"
+        <>  "● You are using an old version of the interpreter and need to upgrade\n"
+    show (CBORIsNotDhall term) =
+            _ERROR <> ": Cannot decode CBOR to Dhall\n"
+        <>  "\n"
+        <>  "The following CBOR expression does not encode a valid Dhall expression\n"
+        <>  "\n"
+        <>  "↳ " <> show term <> "\n"

--- a/tests/QuickCheck.hs
+++ b/tests/QuickCheck.hs
@@ -321,7 +321,7 @@ binaryRoundtrip expression =
                   )
                 )
             )
-    === wrap (Right (Just expression))
+    === wrap (Right (Right expression))
   where
     wrap
         :: Either DeserialiseFailure       a


### PR DESCRIPTION
... as standardized in https://github.com/dhall-lang/dhall-lang/pull/208

For example, given this file:

```haskell
http://prelude.dhall-lang.org/package.dhall sha256:2a84d3c5a420e2549f1dfb145fa2a6956481d99f022a77bc31152c29a008dbfa
```

The first time you interpret the file it is retrieved, parsed, and normalized
like normal:

```bash
$ time dist/build/dhall/dhall <<< './test.dhall'
{ `Bool` :
    { and :
…
    }
}

real    0m6.524s
user    0m0.720s
sys     0m0.158s
```

... and the second time you get a significant speedup by hitting the
local cache:

```bash
$ time dist/build/dhall/dhall <<< './test.dhall'
{ `Bool` :
    { and :
…
    }
}

real    0m0.162s
user    0m0.063s
sys     0m0.070s
```

The main contributors to the speed up are:

* Retrieving a single local file is faster than retrieving multiple
  remote files
* Decoding binary is faster than parsing text
* The expression is cached in normal form, so there is no need to
  re-normalize