### PR TITLE
Stack support

### DIFF
--- a/src/Dhall/Binary.hs
+++ b/src/Dhall/Binary.hs
@@ -34,6 +34,7 @@ import Dhall.Core
     , URL(..)
     , Var(..)
     )
+import Data.Monoid ((<>))
 import Data.Text (Text)
 import Options.Applicative (Parser)
 import Prelude hiding (exponent)

--- a/stack-lts-11.yaml
+++ b/stack-lts-11.yaml
@@ -1,0 +1,8 @@
+resolver: lts-11.12
+extra-deps:
+  - cborg-0.2.0.0
+  - serialise-0.2.0.0
+nix:
+  packages:
+    - ncurses
+    - zlib

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -21,3 +21,5 @@ extra-deps:
 - insert-ordered-containers-0.2.1.0
 - aeson-1.2.3.0
 - th-abstraction-0.2.6.0
+- cborg-0.2.0.0
+- serialise-0.2.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
-resolver: lts-11.12
-
+resolver: lts-12.4
+extra-deps:
+  - serialise-0.2.0.0
 nix:
   packages:
     - ncurses


### PR DESCRIPTION
* Use lts-12.4 in the default yaml file
* Keep lts-11 in it own config file `stack-lts-11.yaml`, adding the needed extra-deps
* Add them to `stack-lts-6.yaml` too
* Add an import to Data.Monoid.(<>) in `Dhall.Binary` to make it compilable with base < 4.11 (and lts-11)