### PR TITLE
Remove `ansi-terminal` dependency

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -170,7 +170,6 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                        >= 4.8.2.0  && < 5   ,
-        ansi-terminal               >= 0.6.3.1  && < 0.9 ,
         bytestring                                 < 0.11,
         case-insensitive                           < 1.3 ,
         cborg                       >= 0.2.0.0  && < 0.3 ,

--- a/nix/dhall.nix
+++ b/nix/dhall.nix
@@ -1,9 +1,9 @@
-{ mkDerivation, ansi-terminal, base, bytestring, case-insensitive
-, cborg, containers, contravariant, criterion, cryptonite, deepseq
-, Diff, directory, doctest, exceptions, filepath, hashable
-, haskeline, http-client, http-client-tls
-, insert-ordered-containers, lens-family-core, megaparsec, memory
-, mockery, mtl, optparse-applicative, parsers, prettyprinter
+{ mkDerivation, base, bytestring, case-insensitive, cborg
+, containers, contravariant, criterion, cryptonite, deepseq, Diff
+, directory, doctest, exceptions, filepath, hashable, haskeline
+, http-client, http-client-tls, insert-ordered-containers
+, lens-family-core, megaparsec, memory, mockery, mtl
+, optparse-applicative, parsers, prettyprinter
 , prettyprinter-ansi-terminal, QuickCheck, quickcheck-instances
 , repline, scientific, serialise, stdenv, tasty, tasty-hunit
 , tasty-quickcheck, template-haskell, text, transformers
@@ -16,23 +16,22 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-terminal base bytestring case-insensitive cborg containers
-    contravariant cryptonite Diff directory exceptions filepath
-    haskeline http-client http-client-tls insert-ordered-containers
-    lens-family-core megaparsec memory mtl optparse-applicative parsers
-    prettyprinter prettyprinter-ansi-terminal repline scientific
-    serialise template-haskell text transformers unordered-containers
-    vector
+    base bytestring case-insensitive cborg containers contravariant
+    cryptonite Diff directory exceptions filepath haskeline http-client
+    http-client-tls insert-ordered-containers lens-family-core
+    megaparsec memory mtl optparse-applicative parsers prettyprinter
+    prettyprinter-ansi-terminal repline scientific serialise
+    template-haskell text transformers unordered-containers vector
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
     base containers deepseq directory doctest filepath hashable
     insert-ordered-containers mockery prettyprinter QuickCheck
     quickcheck-instances serialise tasty tasty-hunit tasty-quickcheck
-    text vector
+    text transformers vector
   ];
   benchmarkHaskellDepends = [
-    base containers criterion directory text
+    base bytestring containers criterion directory serialise text
   ];
   description = "A configuration language guaranteed to terminate";
   license = stdenv.lib.licenses.bsd3;

--- a/src/Dhall/Format.hs
+++ b/src/Dhall/Format.hs
@@ -12,11 +12,11 @@ import Dhall.Pretty (annToAnsiStyle, prettyExpr, layoutOpts)
 
 import Data.Monoid ((<>))
 
-import qualified Data.Text.Prettyprint.Doc                 as Pretty
-import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty
 import qualified Control.Exception
 import qualified Data.Text.IO
-import qualified System.Console.ANSI
+import qualified Data.Text.Prettyprint.Doc                 as Pretty
+import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty
+import qualified Dhall.Pretty.Internal
 import qualified System.IO
 
 -- | Implementation of the @dhall format@ subcommand
@@ -46,7 +46,7 @@ format inplace = do
 
                 let doc = Pretty.pretty header <> prettyExpr expr
 
-                supportsANSI <- System.Console.ANSI.hSupportsANSI System.IO.stdout
+                supportsANSI <- Dhall.Pretty.Internal.hSupportsANSI System.IO.stdout
 
                 if supportsANSI
                   then

--- a/src/Dhall/Freeze.hs
+++ b/src/Dhall/Freeze.hs
@@ -17,7 +17,6 @@ import Dhall.Import (hashExpression, protocolVersion)
 import Dhall.Parser (exprAndHeaderFromText, Src)
 import Dhall.Pretty (annToAnsiStyle, layoutOpts)
 import Lens.Family (set)
-import System.Console.ANSI (hSupportsANSI)
 
 import qualified Control.Exception
 import qualified Control.Monad.Trans.State.Strict          as State
@@ -25,6 +24,7 @@ import qualified Data.Text.Prettyprint.Doc                 as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty
 import qualified Data.Text.IO
 import qualified Dhall.Import
+import qualified Dhall.Pretty.Internal
 import qualified System.IO
 
 readInput :: Maybe FilePath -> IO Text
@@ -62,7 +62,7 @@ writeExpr inplace (header, expr) = do
                 Pretty.renderIO h (annToAnsiStyle <$> stream))
 
         Nothing -> do
-            supportsANSI <- System.Console.ANSI.hSupportsANSI System.IO.stdout
+            supportsANSI <- Dhall.Pretty.Internal.hSupportsANSI System.IO.stdout
             if supportsANSI 
                then 
                  Pretty.renderIO System.IO.stdout (annToAnsiStyle <$> Pretty.layoutSmart layoutOpts doc)

--- a/src/Dhall/Main.hs
+++ b/src/Dhall/Main.hs
@@ -53,11 +53,11 @@ import qualified Dhall.Hash
 import qualified Dhall.Import
 import qualified Dhall.Lint
 import qualified Dhall.Parser
+import qualified Dhall.Pretty.Internal
 import qualified Dhall.Repl
 import qualified Dhall.TypeCheck
 import qualified GHC.IO.Encoding
 import qualified Options.Applicative
-import qualified System.Console.ANSI
 import qualified System.IO
 
 -- | Top-level program options
@@ -240,7 +240,7 @@ command (Options {..}) = do
 
             let stream = Pretty.layoutSmart layoutOpts doc
 
-            supportsANSI <- System.Console.ANSI.hSupportsANSI h
+            supportsANSI <- Dhall.Pretty.Internal.hSupportsANSI h
             let ansiStream =
                     if supportsANSI && not plain
                     then fmap annToAnsiStyle stream
@@ -336,7 +336,7 @@ command (Options {..}) = do
 
                     let doc = Pretty.pretty header <> prettyExpr lintedExpression
 
-                    supportsANSI <- System.Console.ANSI.hSupportsANSI System.IO.stdout
+                    supportsANSI <- Dhall.Pretty.Internal.hSupportsANSI System.IO.stdout
 
                     if supportsANSI
                       then

--- a/src/Dhall/Pretty/Internal.hs
+++ b/src/Dhall/Pretty/Internal.hs
@@ -47,6 +47,8 @@ module Dhall.Pretty.Internal (
     , rbrace
     , rbracket
     , rparen
+
+    , hSupportsANSI
     ) where
 
 import {-# SOURCE #-} Dhall.Core
@@ -64,17 +66,20 @@ import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty, space)
 import Numeric.Natural (Natural)
 import Prelude hiding (succ)
-import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Terminal
+import System.IO (Handle)
 
 import qualified Data.Char
 import qualified Data.HashMap.Strict.InsOrd
 import qualified Data.HashSet
 import qualified Data.List
 import qualified Data.Set
-import qualified Data.Text                               as Text
-import qualified Data.Text.Prettyprint.Doc               as Pretty
-import qualified Data.Text.Prettyprint.Doc.Render.Text   as Pretty
-import qualified Data.Text.Prettyprint.Doc.Render.String as Pretty
+import qualified Data.Text                                 as Text
+import qualified Data.Text.Prettyprint.Doc                 as Pretty
+import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Terminal
+import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty
+import qualified Data.Text.Prettyprint.Doc.Render.String   as Pretty
+import qualified System.Environment
+import qualified System.IO
 
 {-| Annotation type used to tag elements in a pretty-printed document for
     syntax highlighting purposes
@@ -910,3 +915,11 @@ docToStrictText = Pretty.renderStrict . Pretty.layoutPretty options
 
 prettyToStrictText :: Pretty a => a -> Text.Text
 prettyToStrictText = docToStrictText . Pretty.pretty
+
+-- | Copied from @ansi-terminal@ to eliminate a dependency
+hSupportsANSI :: Handle -> IO Bool
+hSupportsANSI handle = do
+    isTerminalDevice <- System.IO.hIsTerminalDevice handle
+    maybeTerm        <- System.Environment.lookupEnv "TERM"
+
+    return (isTerminalDevice && maybeTerm /= Just "dumb")

--- a/src/Dhall/Repl.hs
+++ b/src/Dhall/Repl.hs
@@ -30,8 +30,8 @@ import qualified Dhall.Pretty
 import qualified Dhall.Core as Expr ( Expr(..) )
 import qualified Dhall.Import as Dhall
 import qualified Dhall.Parser as Dhall
+import qualified Dhall.Pretty.Internal
 import qualified Dhall.TypeCheck as Dhall
-import qualified System.Console.ANSI
 import qualified System.Console.Haskeline.MonadException as Haskeline
 import qualified System.Console.Repline as Repline
 import qualified System.IO
@@ -260,7 +260,7 @@ output handle expr = do
   liftIO (System.IO.hPutStrLn handle "")  -- Visual spacing
 
   let stream = Pretty.layoutSmart Dhall.Pretty.layoutOpts (Dhall.Pretty.prettyExpr expr)
-  supportsANSI <- liftIO (System.Console.ANSI.hSupportsANSI handle)
+  supportsANSI <- liftIO (Dhall.Pretty.Internal.hSupportsANSI handle)
   let ansiStream =
           if supportsANSI
           then fmap Dhall.Pretty.annToAnsiStyle stream


### PR DESCRIPTION
We were only using `ansi-terminal` for a single function, so this change
internally vendors that function to remove the dependency on
`ansi-terminal`