### PR TITLE
Avoid instance derivation error with stack-lts-6

### DIFF
--- a/src/Dhall/Binary.hs
+++ b/src/Dhall/Binary.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
@@ -764,7 +762,7 @@ data DecodingFailure
     | CBORIsNotDhall Term
     deriving (Eq)
 
-deriving instance Exception DecodingFailure
+instance Exception DecodingFailure
 
 _ERROR :: String
 _ERROR = "\ESC[1;31mError\ESC[0m"

--- a/src/Dhall/Binary.hs
+++ b/src/Dhall/Binary.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE OverloadedStrings  #-}
 
 {-| This module contains logic for converting Dhall expressions to and from
     CBOR expressions which can in turn be converted to and from a binary
@@ -761,7 +762,9 @@ data DecodingFailure
     = CannotDecodeProtocolVersionString Term
     | UnsupportedProtocolVersionString Text
     | CBORIsNotDhall Term
-    deriving (Eq, Exception)
+    deriving (Eq)
+
+deriving instance Exception DecodingFailure
 
 _ERROR :: String
 _ERROR = "\ESC[1;31mError\ESC[0m"


### PR DESCRIPTION
Hi, when trying to build master with stack-lts-6.yaml i've got an error:
```
C:\ws\eta\dhall\dhall-haskell\src\Dhall\Binary.hs:765:19:
    No instance for (Exception Text) 
      arising from the first field of ‘UnsupportedProtocolVersionString’
        (type ‘Text’)
    Possible fix: 
      use a standalone 'deriving instance' declaration,
        so you can specify the instance context yourself
    When deriving the instance for (Exception DecodingFailure)
```
I guess this is a bug resolved for ghc > 7.10: https://stackoverflow.com/questions/39379006/what-is-the-difference-between-deriveanyclass-and-an-empty-instance