### PR TITLE
Set lower bound of directory to 1.2.7.1 to make it compatible with cabal-1.22

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -178,7 +178,7 @@ Library
         contravariant                              < 1.6 ,
         cryptonite                  >= 0.23     && < 1.0 ,
         Diff                        >= 0.2      && < 0.4 ,
-        directory                   >= 1.3      && < 1.4 ,
+        directory                   >= 1.2.7.1  && < 1.4 ,
         exceptions                  >= 0.8.3    && < 0.11,
         filepath                    >= 1.4      && < 1.5 ,
         haskeline                   >= 0.7.3.0  && < 0.8 ,
@@ -302,7 +302,7 @@ Benchmark dhall-parser
         containers                >= 0.5.0.0  && < 0.6,
         criterion                 >= 1.1      && < 1.6,
         dhall                                         ,
-        directory                 >= 1.3      && < 1.4,
+        directory                 >= 1.2.7.1  && < 1.4,
         serialise                                     ,
         text                      >= 0.11.1.0 && < 1.3
     Default-Language: Haskell2010

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -13,7 +13,7 @@ extra-deps:
 - basement-0.0.6
 - prettyprinter-1.2.0.1
 - prettyprinter-ansi-terminal-1.1.1.2
-- directory-1.3.1.0
+- directory-1.2.7.1
 - foundation-0.0.19
 - process-1.6.2.0
 - repline-0.1.7.0


### PR DESCRIPTION
Hi, in the proccess of set dhall as the default config for etlas we had a clash between the upper bound of directory (< 1.3 trough the etlas dep on cabal 1.22 ) and the lower bound of dhall (>= 1.3) so we had to force `allow-newer:true` in the `stack yaml` for etlas. That flag in stack is global and could cause problems in the resolution later.
I've built dhall with lts-6, lts-12 and cabal and i've not seen any problem with this bound but i wonder if the lower bound 1.3 (although is 1.2.2.0 for doctest) was deliberate.