### PR TITLE
Fix Nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,12 +55,21 @@ let
   };
 
   overlayDynamic = pkgsNew: pkgsOld: {
-    haskellPackages = pkgsOld.haskellPackages.override {
-      overrides = haskellPackagesNew: haskellPackagesOld: {
-        hpack =
-          haskellPackagesOld.hpack_0_29_6;
-      };
-    };
+    haskellPackages = pkgsOld.haskellPackages.override (old: {
+        overrides =
+          let
+            extension =
+              haskellPackagesNew: haskellPackagesOld: {
+                hpack =
+                  haskellPackagesOld.hpack_0_29_6;
+              };
+
+          in
+            pkgsNew.lib.composeExtensions
+              (old.overrides or (_: _: {}))
+              extension;
+      }
+    );
   };
 
   nixpkgs = fetchNixpkgs {


### PR DESCRIPTION
The haskell package overrides section of `overlayDynamic` was shadowing
the corresponding overrides in `overlayShared`.  This change fixes that
so that they correctly stack.