### PR TITLE
Support identifiers beginning with keywords

### DIFF
--- a/src/Dhall/Parser/Token.hs
+++ b/src/Dhall/Parser/Token.hs
@@ -34,6 +34,9 @@ import qualified Text.Parser.Token
 whitespace :: Parser ()
 whitespace = Text.Parser.Combinators.skipMany whitespaceChunk
 
+nonemptyWhitespace :: Parser ()
+nonemptyWhitespace = Text.Parser.Combinators.skipSome whitespaceChunk
+
 alpha :: Char -> Bool
 alpha c = ('\x41' <= c && c <= '\x5A') || ('\x61' <= c && c <= '\x7A')
 
@@ -399,7 +402,7 @@ reserved :: Data.Text.Text -> Parser ()
 reserved x = do _ <- Text.Parser.Char.text x; whitespace
 
 keyword :: Data.Text.Text -> Parser ()
-keyword x = try (do _ <- Text.Parser.Char.text x; whitespaceChunk)
+keyword x = try (do _ <- Text.Parser.Char.text x; nonemptyWhitespace)
 
 _if :: Parser ()
 _if = keyword "if"

--- a/src/Dhall/Parser/Token.hs
+++ b/src/Dhall/Parser/Token.hs
@@ -398,32 +398,35 @@ unreserved c =
 reserved :: Data.Text.Text -> Parser ()
 reserved x = do _ <- Text.Parser.Char.text x; whitespace
 
+keyword :: Data.Text.Text -> Parser ()
+keyword x = try (do _ <- Text.Parser.Char.text x; whitespaceChunk)
+
 _if :: Parser ()
-_if = reserved "if"
+_if = keyword "if"
 
 _then :: Parser ()
-_then = reserved "then"
+_then = keyword "then"
 
 _else :: Parser ()
-_else = reserved "else"
+_else = keyword "else"
 
 _let :: Parser ()
-_let = reserved "let"
+_let = keyword "let"
 
 _in :: Parser ()
-_in = reserved "in"
+_in = keyword "in"
 
 _as :: Parser ()
-_as = reserved "as"
+_as = keyword "as"
 
 _using :: Parser ()
-_using = reserved "using"
+_using = keyword "using"
 
 _merge :: Parser ()
-_merge = reserved "merge"
+_merge = keyword "merge"
 
 _constructors :: Parser ()
-_constructors = reserved "constructors"
+_constructors = keyword "constructors"
 
 _NaturalFold :: Parser ()
 _NaturalFold = reserved "Natural/fold"


### PR DESCRIPTION
... as standardized in https://github.com/dhall-lang/dhall-lang/pull/222

Fixes #547

This allows code like this to work:

```haskell
$ dhall <<< "let mergedRec = { a = 1 } // { b = 2 } in mergedRec"
```

... by requiring non-empty whitespace after keywords that are not built-ins