### PR TITLE
Make Lint handle some transitive cases.

### DIFF
--- a/src/Dhall/Lint.hs
+++ b/src/Dhall/Lint.hs
@@ -34,8 +34,8 @@ lint expression = loop (Dhall.Core.denote expression)
         a' = loop a
         b' = loop b
     loop (Let a b c d)
-        | not (V a 0 `Dhall.Core.freeIn` d) =
-            loop d
+        | not (V a 0 `Dhall.Core.freeIn` d') =
+            d'
         | otherwise =
             Let a b' c' d'
       where


### PR DESCRIPTION
As it stands, the linter doesn't completely solve

```
$ cat Lint.dhall 
   let a = 5
in let b = a + 4
in 5
```

because it doesn't eliminate the a:

```
$ stack exec dhall lint < Lint.dhall 
let a = 5 in 5
```

After this fix, it does:

```
$ stack exec dhall lint < Lint.dhall 
5
```