### PR TITLE
Add kind polymorphism.

### DIFF
--- a/src/Dhall/Binary.hs
+++ b/src/Dhall/Binary.hs
@@ -149,6 +149,8 @@ encode_1_0 (Const Type) =
     TString "Type"
 encode_1_0 (Const Kind) =
     TString "Kind"
+encode_1_0 (Const Sort) =
+    TString "Sort"
 encode_1_0 e@(App _ _) =
     TList ([ TInt 0, f₁ ] ++ map encode_1_0 arguments)
   where
@@ -469,6 +471,8 @@ decode_1_0 (TString "Type") =
     return (Const Type)
 decode_1_0 (TString "Kind") =
     return (Const Kind)
+decode_1_0 (TString "Sort") =
+    return (Const Sort)
 decode_1_0 (TString x) =
     return (Var (V x 0))
 decode_1_0 (TList [ TString x, TInt n ]) =

--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -93,22 +93,25 @@ import qualified Data.Text.Prettyprint.Doc  as Pretty
 
 {-| Constants for a pure type system
 
-    The only axiom is:
+    The axioms are:
 
 > ⊦ Type : Kind
+> ⊦ Kind : Sort
 
     ... and the valid rule pairs are:
 
 > ⊦ Type ↝ Type : Type  -- Functions from terms to terms (ordinary functions)
 > ⊦ Kind ↝ Type : Type  -- Functions from types to terms (polymorphic functions)
 > ⊦ Kind ↝ Kind : Kind  -- Functions from types to types (type constructors)
+> ⊦ Sort ↝ Kind : Kind  -- Functions from kinds to types (polymorphic type constructors)
+> ⊦ Sort ↝ Sort : Sort  -- Functions from kinds to kinds (kind constructors)
 
     These are the same rule pairs as System Fω
 
     Note that Dhall does not support functions from terms to types and therefore
     Dhall is not a dependently typed language
 -}
-data Const = Type | Kind deriving (Show, Eq, Data, Bounded, Enum, Generic)
+data Const = Type | Kind | Sort deriving (Show, Eq, Data, Bounded, Enum, Generic)
 
 instance Pretty Const where
     pretty = Pretty.unAnnotate . prettyConst

--- a/src/Dhall/Pretty/Internal.hs
+++ b/src/Dhall/Pretty/Internal.hs
@@ -334,6 +334,7 @@ prettyChunks (Chunks a b) =
 prettyConst :: Const -> Doc Ann
 prettyConst Type = builtin "Type"
 prettyConst Kind = builtin "Kind"
+prettyConst Sort = builtin "Sort"
 
 prettyVar :: Var -> Doc Ann
 prettyVar (V x 0) = label (Pretty.unAnnotate (prettyLabel x))


### PR DESCRIPTION
I wanted to propose this before I spend too much time on it, so let me know if
it’d be acceptable in some form. (And it would also require a change to the
language spec.)

Here’s an example:

./polyfunctor
```dhall
  λ(j : Kind)
→ λ(k : Kind)
→ λ(c : j → j → Type)
→ λ(d : k → k → Type)
→ λ(f : j → k)
→ { map : ∀(a : j) → ∀(b : j) → c a b → d (f a) (f b) }
```

then
```dhall
./polyfunctor
Type
Type
(λ(a : Type) → λ(b : Type) → a → b)
(λ(a : Type) → λ(b : Type) → a → b)
Optional
```
normalizes to
```dhall
{ map : ∀(a : Type) → ∀(b : Type) → (a → b) → Optional a → Optional b }
```
and
```dhall
./polyfunctor
(Type → Type)
(Type → Type)
(λ(a : Type → Type) → λ(b : Type → Type) → ∀(i : Type) → a i → b i)
(λ(a : Type → Type) → λ(b : Type → Type) → ∀(i : Type) → a i → b i)
```
normalizes to
```dhall
  λ(f : (Type → Type) → Type → Type)
→ { map :
        ∀(a : Type → Type)
      → ∀(b : Type → Type)
      → (∀(i : Type) → a i → b i)
      → ∀(i : Type)
      → f a i
      → f b i
  }
```