### PR TITLE
Refactor `Dhall.Main`

### DIFF
--- a/src/Dhall/Diff.hs
+++ b/src/Dhall/Diff.hs
@@ -161,7 +161,7 @@ diffNormalized l0 r0 = Dhall.Diff.diff l1 r1
 diff :: (Eq a, Pretty a) => Expr s a -> Expr s a -> Doc Ann
 diff l0 r0 = doc
   where
-    Diff {..} = diffExpression l0 r0 <> hardline
+    Diff {..} = diffExpression l0 r0
 
 diffPrimitive :: Eq a => (a -> Diff) -> a -> a -> Diff
 diffPrimitive f l r


### PR DESCRIPTION
This reorganizes the code to use `subcommand` and `render` consistently

This includes a change to `Dhall.Diff.diff` to drop the trailing
newline.  This is consistent with other utilities which don't include
the trailing newline and is motivated by the desire to reuse `render`
which already appends a trailing newline

This also includes a change to use "syntax" instead of "characters" in the
`--help` description for the `--ascii` option as requested by @basile-henry 