### PR TITLE
Fix newlines in error messages

### DIFF
--- a/src/Dhall/Diff.hs
+++ b/src/Dhall/Diff.hs
@@ -161,7 +161,7 @@ diffNormalized l0 r0 = Dhall.Diff.diff l1 r1
 diff :: (Eq a, Pretty a) => Expr s a -> Expr s a -> Doc Ann
 diff l0 r0 = doc
   where
-    Diff {..} = diffExpression l0 r0 <> hardline
+    Diff {..} = diffExpression l0 r0
 
 diffPrimitive :: Eq a => (a -> Diff) -> a -> a -> Diff
 diffPrimitive f l r

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -250,6 +250,7 @@ instance Exception e => Exception (Imported e)
 instance Show e => Show (Imported e) where
     show (Imported imports e) =
            concat (zipWith indent [0..] toDisplay)
+        ++ "\n"
         ++ show e
       where
         indent n import_ =

--- a/src/Dhall/Parser/Combinators.hs
+++ b/src/Dhall/Parser/Combinators.hs
@@ -42,7 +42,6 @@ instance Pretty Src where
             pretty text <> "\n"
         <>  "\n"
         <>  pretty (Text.Megaparsec.sourcePosPretty begin)
-        <>  "\n"
 
 {-| A `Parser` that is almost identical to
     @"Text.Megaparsec".`Text.Megaparsec.Parsec`@ except treating Haskell-style

--- a/src/Dhall/TypeCheck.hs
+++ b/src/Dhall/TypeCheck.hs
@@ -3637,10 +3637,10 @@ instance (Eq a, Pretty s, Pretty a, Typeable s, Typeable a) => Exception (TypeEr
 instance (Eq a, Pretty s, Pretty a) => Pretty (TypeError s a) where
     pretty (TypeError ctx expr msg)
         = Pretty.unAnnotate
-            ("\n"
+            (   "\n"
             <>  (   if null (Dhall.Context.toList ctx)
                     then ""
-                    else prettyContext ctx <> "\n"
+                    else prettyContext ctx <> "\n\n"
                 )
             <>  shortTypeMessage msg <> "\n"
             <>  source
@@ -3673,9 +3673,9 @@ instance (Eq a, Pretty s, Pretty a) => Pretty (DetailedTypeError s a) where
     pretty (DetailedTypeError (TypeError ctx expr msg))
         = Pretty.unAnnotate
             (   "\n"
-            <>  (   if  null (Dhall.Context.toList ctx)
+            <>  (   if null (Dhall.Context.toList ctx)
                     then ""
-                    else prettyContext ctx <> "\n"
+                    else prettyContext ctx <> "\n\n"
                 )
             <>  longTypeMessage msg <> "\n"
             <>  "────────────────────────────────────────────────────────────────────────────────\n"


### PR DESCRIPTION
There are a several places where the error message either has too many
or too few newlines, which this change fixes.