### PR TITLE
Make fold tests unambiguous wrt associativity

### DIFF
--- a/tests/normalization/examples/List/fold/1B.dhall
+++ b/tests/normalization/examples/List/fold/1B.dhall
@@ -1,1 +1,1 @@
-λ(nil : Natural) → 2 + 3 + 5 + nil
+λ(nil : Natural) → 2 + (3 + (5 + nil))

--- a/tests/normalization/examples/Natural/fold/1B.dhall
+++ b/tests/normalization/examples/Natural/fold/1B.dhall
@@ -1,1 +1,1 @@
-λ(zero : Natural) → 5 * 5 * 5 * zero
+λ(zero : Natural) → 5 * (5 * (5 * zero))


### PR DESCRIPTION
As noted in https://github.com/dhall-lang/dhall-haskell/issues/568#issuecomment-421777944