### PR TITLE
Improve `dhall freeze` to cache as it goes

### DIFF
--- a/src/Dhall/Freeze.hs
+++ b/src/Dhall/Freeze.hs
@@ -52,7 +52,11 @@ hashImport _protocolVersion import_ = do
 
     let newImportHashed = (importHashed import_) { hash = expressionHash }
 
-    return $ import_ { importHashed = newImportHashed }
+    let newImport = import_ { importHashed = newImportHashed }
+
+    State.evalStateT (Dhall.Import.exprToImport newImport normalizedExpression) status
+
+    return newImport
 
 parseExpr :: String -> Text -> IO (Text, Expr Src Import)
 parseExpr src txt =


### PR DESCRIPTION
Previously `dhall freeze` would tag imports with their hash but not actually
cache the hashed expressions until a subsequent run of the interpreter.  This
adds an explicit step to cache each frozen import using the newly added
`exprToImport` function