### PR TITLE
Fix `dhall format --inplace`

### DIFF
--- a/src/Dhall/Format.hs
+++ b/src/Dhall/Format.hs
@@ -36,7 +36,7 @@ format characterSet inplace = do
                     Right x   -> return x
 
                 let doc =   Pretty.pretty header
-                        <>  fmap annToAnsiStyle (Dhall.Pretty.prettyCharacterSet characterSet expr)
+                        <>  Pretty.unAnnotate (Dhall.Pretty.prettyCharacterSet characterSet expr)
                 System.IO.withFile file System.IO.WriteMode (\handle -> do
                     Pretty.renderIO handle (Pretty.layoutSmart layoutOpts doc)
                     Data.Text.IO.hPutStrLn handle "" )


### PR DESCRIPTION
07f873244038fcf1fd48db80584b5d577a05fe20 caused `dhall format` to start saving
escape codes to formatted files, which this change fixes