### PR TITLE
Improve parsing of string literals

### DIFF
--- a/benchmark/parser/Main.hs
+++ b/benchmark/parser/Main.hs
@@ -63,11 +63,13 @@ main = do
     issue108Text  <- TIO.readFile "benchmark/examples/issue108.dhall"
     issue108Bytes <- Data.ByteString.Lazy.readFile "benchmark/examples/issue108.dhall.bin"
     defaultMain
-        [ bgroup "Issue #108"
+        [ benchExprFromText "Long single-quoted strings" ("''" <> T.replicate 1000000 "x" <> "''")
+        , bgroup "Issue #108"
             [ benchExprFromText  "Text"   issue108Text
             , benchExprFromBytes "Binary" issue108Bytes
             ]
         , benchExprFromText "Long variable names" (T.replicate 1000000 "x")
         , benchExprFromText "Large number of function arguments" (T.replicate 10000 "x ")
+        , benchExprFromText "Long double-quoted strings" ("\"" <> T.replicate 1000000 "x" <> "\"")
         , benchParser prelude
         ]

--- a/benchmark/parser/Main.hs
+++ b/benchmark/parser/Main.hs
@@ -63,13 +63,13 @@ main = do
     issue108Text  <- TIO.readFile "benchmark/examples/issue108.dhall"
     issue108Bytes <- Data.ByteString.Lazy.readFile "benchmark/examples/issue108.dhall.bin"
     defaultMain
-        [ benchExprFromText "Long single-quoted strings" ("''" <> T.replicate 1000000 "x" <> "''")
-        , bgroup "Issue #108"
+        [ bgroup "Issue #108"
             [ benchExprFromText  "Text"   issue108Text
             , benchExprFromBytes "Binary" issue108Bytes
             ]
         , benchExprFromText "Long variable names" (T.replicate 1000000 "x")
         , benchExprFromText "Large number of function arguments" (T.replicate 10000 "x ")
         , benchExprFromText "Long double-quoted strings" ("\"" <> T.replicate 1000000 "x" <> "\"")
+        , benchExprFromText "Long single-quoted strings" ("''" <> T.replicate 1000000 "x" <> "''")
         , benchParser prelude
         ]

--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -469,7 +469,8 @@ doubleQuotedChunk :: Parser a -> Parser (Chunks Src a)
 doubleQuotedChunk embedded =
     choice
         [ interpolation
-        , unescapedCharacter
+        , unescapedCharacterFast
+        , unescapedCharacterSlow
         , escapedCharacter
         ]
   where
@@ -479,14 +480,19 @@ doubleQuotedChunk embedded =
         _ <- Text.Parser.Char.char '}'
         return (Chunks [(mempty, e)] mempty)
 
-    unescapedCharacter = do
-        c <- Text.Parser.Char.satisfy predicate
-        return (Chunks [] (Data.Text.singleton c))
+    unescapedCharacterFast = do
+        t <- Text.Megaparsec.takeWhile1P Nothing predicate
+        return (Chunks [] t)
       where
         predicate c =
-                ('\x20' <= c && c <= '\x21'    )
+            (   ('\x20' <= c && c <= '\x21'    )
             ||  ('\x23' <= c && c <= '\x5B'    )
             ||  ('\x5D' <= c && c <= '\x10FFFF')
+            ) && c /= '$'
+
+    unescapedCharacterSlow = do
+        _ <- Text.Megaparsec.single '$'
+        return (Chunks [] "$")
 
     escapedCharacter = do
         _ <- Text.Parser.Char.char '\\'
@@ -545,7 +551,8 @@ singleQuoteContinue embedded =
         , interpolation
         , escapeInterpolation
         , endLiteral
-        , unescapedCharacter
+        , unescapedCharacterFast
+        , unescapedCharacterSlow
         , tab
         , endOfLine
         ]
@@ -571,12 +578,20 @@ singleQuoteContinue embedded =
             _ <- Text.Parser.Char.text "''"
             return mempty
 
-        unescapedCharacter = do
+        unescapedCharacterFast = do
+            a <- Text.Megaparsec.takeWhile1P Nothing predicate
+            b <- singleQuoteContinue embedded
+            return (Chunks [] a <> b)
+          where
+            predicate c =
+                ('\x20' <= c && c <= '\x10FFFF') && c /= '$' && c /= '\''
+
+        unescapedCharacterSlow = do
             a <- satisfy predicate
             b <- singleQuoteContinue embedded
             return (Chunks [] a <> b)
           where
-            predicate c = '\x20' <= c && c <= '\x10FFFF'
+            predicate c = c == '$' || c == '\''
 
         endOfLine = do
             a <- "\n" <|> "\r\n"


### PR DESCRIPTION
This adds a fast path for bulk parsing of both double-quoted and
single-quoted string literals, which improves performance ~10x on
double-quoted string literals and ~100x on single-quoted string
literals.