### PR TITLE
Build on older versions of GHC

### DIFF
--- a/src/Dhall/Util.hs
+++ b/src/Dhall/Util.hs
@@ -7,6 +7,7 @@ module Dhall.Util
     , snipDoc
     ) where
 
+import Data.Monoid ((<>))
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc)
 import Dhall.Pretty (Ann)


### PR DESCRIPTION
CI only tests GHC 8.4, so it missed the fact that `Dhall.Util` does not build
on GHC 8.0 or GHC 8.2 due to missing a `Data.Monoid` import, which this fixes.

I also plan to separately fix CI to test building on GHC 8.0 to prevent this from
recurring