### PR TITLE
Use UVector Char for parsing

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -233,6 +233,7 @@ Library
         Dhall.Parser.Expression,
         Dhall.Parser.Combinators,
         Dhall.Parser.Token,
+        Dhall.Parser.Vector,
         Dhall.Import.Types,
         Dhall.Util,
         Paths_dhall

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -196,7 +196,7 @@ Library
         repline                     >= 0.1.6.0  && < 0.2 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
-        template-haskell                           < 2.14,
+        template-haskell                           < 2.15,
         text                        >= 0.11.1.0 && < 1.3 ,
         transformers                >= 0.2.0.0  && < 0.6 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -175,7 +175,7 @@ Library
         bytestring                                 < 0.11,
         case-insensitive                           < 1.3 ,
         cborg                       >= 0.2.0.0  && < 0.3 ,
-        containers                  >= 0.5.0.0  && < 0.6 ,
+        containers                  >= 0.5.0.0  && < 0.7 ,
         contravariant                              < 1.6 ,
         cryptonite                  >= 0.23     && < 1.0 ,
         Diff                        >= 0.2      && < 0.4 ,
@@ -303,7 +303,7 @@ Benchmark dhall-parser
     Build-Depends:
         base                      >= 4        && < 5  ,
         bytestring                                    ,
-        containers                >= 0.5.0.0  && < 0.6,
+        containers                >= 0.5.0.0  && < 0.7,
         criterion                 >= 1.1      && < 1.6,
         dhall                                         ,
         directory                 >= 1.2.7.1  && < 1.4,

--- a/src/Dhall/Import.hs
+++ b/src/Dhall/Import.hs
@@ -196,6 +196,8 @@ import qualified Text.Megaparsec
 import qualified Text.Parser.Combinators
 import qualified Text.Parser.Token
 
+import           Dhall.Parser.Vector
+
 -- | An import failed because of a cycle in the import graph
 newtype Cycle = Cycle
     { cyclicImport :: Import  -- ^ The offending cyclic import
@@ -663,7 +665,7 @@ exprFromUncachedImport (Import {..}) = do
                     Text.Parser.Combinators.eof
                     return r
 
-            case Text.Megaparsec.parse parser path text of
+            case Text.Megaparsec.parse parser path (uvectorFromText text) of
                 Left errInfo -> do
                     liftIO (throwIO (ParseError errInfo text))
                 Right expr -> do

--- a/src/Dhall/Parser.hs
+++ b/src/Dhall/Parser.hs
@@ -29,6 +29,7 @@ import qualified Text.Megaparsec
 import Dhall.Parser.Combinators
 import Dhall.Parser.Token
 import Dhall.Parser.Expression
+import Dhall.Parser.Vector
 
 -- | Parser for a top-level Dhall expression
 expr :: Parser (Expr Src Import)
@@ -41,7 +42,7 @@ exprA = completeExpression
 
 -- | A parsing error
 data ParseError = ParseError
-    { unwrap :: Text.Megaparsec.ParseErrorBundle Text Void
+    { unwrap :: Text.Megaparsec.ParseErrorBundle UVectorChar Void
     , input  :: Text
     }
 
@@ -78,7 +79,7 @@ exprAndHeaderFromText
     -> Either ParseError (Text, Expr Src Import)
 exprAndHeaderFromText delta text = case result of
     Left errInfo   -> Left (ParseError { unwrap = errInfo, input = text })
-    Right (txt, r) -> Right (Data.Text.dropWhileEnd (/= '\n') txt, r)
+    Right (txt, r) -> Right (Data.Text.dropWhileEnd (/= '\n') (uvectorToText txt), r)
   where
     parser = do
         (bytes, _) <- Text.Megaparsec.match whitespace
@@ -86,4 +87,4 @@ exprAndHeaderFromText delta text = case result of
         Text.Megaparsec.eof
         return (bytes, r)
 
-    result = Text.Megaparsec.parse (unParser parser) delta text
+    result = Text.Megaparsec.parse (unParser parser) delta (uvectorFromText text)

--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -26,13 +26,14 @@ import qualified Text.Parser.Char
 
 import Dhall.Parser.Combinators
 import Dhall.Parser.Token
+import Dhall.Parser.Vector
 
 noted :: Parser (Expr Src a) -> Parser (Expr Src a)
 noted parser = do
     before      <- Text.Megaparsec.getSourcePos
     (tokens, e) <- Text.Megaparsec.match parser
     after       <- Text.Megaparsec.getSourcePos
-    let src₀ = Src before after tokens
+    let src₀ = Src before after (uvectorToText tokens)
     case e of
         Note src₁ _ | laxSrcEq src₀ src₁ -> return e
         _                                -> return (Note src₀ e)
@@ -481,7 +482,7 @@ doubleQuotedChunk embedded =
         return (Chunks [(mempty, e)] mempty)
 
     unescapedCharacterFast = do
-        t <- Text.Megaparsec.takeWhile1P Nothing predicate
+        t <- takeWhile1 predicate
         return (Chunks [] t)
       where
         predicate c =
@@ -579,7 +580,7 @@ singleQuoteContinue embedded =
             return mempty
 
         unescapedCharacterFast = do
-            a <- Text.Megaparsec.takeWhile1P Nothing predicate
+            a <- takeWhile1 predicate
             b <- singleQuoteContinue embedded
             return (Chunks [] a <> b)
           where

--- a/src/Dhall/Parser/Vector.hs
+++ b/src/Dhall/Parser/Vector.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+-- | Unboxed vector as megaparsec's Stream.
+module Dhall.Parser.Vector (
+    UVectorChar,
+    uvectorToText,
+    uvectorFromText,
+    ) where
+
+import Data.Proxy (Proxy (..))
+import Text.Megaparsec (SourcePos (..), PosState (..), Token, Tokens, pos1, mkPos, unPos, takeWhile_)
+
+import qualified Text.Megaparsec
+import qualified Data.Text
+import qualified Data.Vector.Unboxed as U
+
+type UVectorChar =  U.Vector Char
+
+uvectorToText :: UVectorChar -> Data.Text.Text
+uvectorToText = Data.Text.pack . U.toList
+
+uvectorFromText :: Data.Text.Text -> UVectorChar
+uvectorFromText = U.fromList . Data.Text.unpack
+
+instance c ~ Char => Text.Megaparsec.Stream (U.Vector c) where
+    type Token (U.Vector c) = c
+    type Tokens (U.Vector c) = U.Vector c
+
+    tokenToChunk _  = U.singleton
+    tokensToChunk _ = U.fromList
+    chunkToTokens _ = U.toList
+    chunkLength _   = U.length
+    chunkEmpty _    = U.null
+
+    take1_ xs
+        | U.null xs = Nothing
+        | otherwise = Just (U.unsafeHead xs, U.unsafeTail xs)
+
+    takeN_ n xs
+        | n <= 0           = Just (U.empty, xs)
+        | U.null xs        = Nothing
+        | U.length xs <= n = Just (xs, U.empty)
+        | otherwise        = Just (U.splitAt n xs)
+
+    takeWhile_ = U.span
+    showTokens _ = Text.Megaparsec.showTokens (Proxy :: Proxy Data.Text.Text)
+
+    reachOffset o pst =
+        reachOffset' U.splitAt U.foldl' U.toList id ('\n', '\t') o pst
+    reachOffsetNoLine o pst =
+        reachOffsetNoLine' U.splitAt U.foldl' ('\n', '\t') o pst
+
+----------------------------------------------------------------------------
+-- Helpers from megaparsec
+
+-- | An internal helper state type combining a difference 'String' and an
+-- unboxed 'SourcePos'.
+
+data St = St SourcePos ShowS
+
+-- {-# UNPACK #-} -- TODO do we need to unpack or not?
+
+-- | A helper definition to facilitate defining 'reachOffset' for various
+-- stream types.
+
+reachOffset'
+  :: forall s. Text.Megaparsec.Stream s
+  => (Int -> s -> (Tokens s, s))
+     -- ^ How to split input stream at given offset
+  -> (forall b. (b -> Token s -> b) -> b -> Tokens s -> b)
+     -- ^ How to fold over input stream
+  -> (Tokens s -> String)
+     -- ^ How to convert chunk of input stream into a 'String'
+  -> (Token s -> Char)
+     -- ^ How to convert a token into a 'Char'
+  -> (Token s, Token s)
+     -- ^ Newline token and tab token
+  -> Int
+     -- ^ Offset to reach
+  -> PosState s
+     -- ^ Initial 'PosState' to use
+  -> (SourcePos, String, PosState s)
+     -- ^ Reached 'SourcePos', line at which 'SourcePos' is located, updated
+     -- 'PosState'
+reachOffset' splitAt'
+             foldl''
+             fromToks
+             fromTok
+             (newlineTok, tabTok)
+             o
+             PosState {..} =
+  ( spos
+  , case expandTab pstateTabWidth
+           . addPrefix
+           . f
+           . fromToks
+           . fst
+           $ takeWhile_ (/= newlineTok) post of
+      "" -> "<empty line>"
+      xs -> xs
+  , PosState
+      { pstateInput = post
+      , pstateOffset = max pstateOffset o
+      , pstateSourcePos = spos
+      , pstateTabWidth = pstateTabWidth
+      , pstateLinePrefix =
+          if sameLine
+            -- NOTE We don't use difference lists here because it's
+            -- desirable for 'PosState' to be an instance of 'Eq' and
+            -- 'Show'. So we just do appending here. Fortunately several
+            -- parse errors on the same line should be relatively rare.
+            then pstateLinePrefix ++ f ""
+            else f ""
+      }
+  )
+  where
+    addPrefix xs =
+      if sameLine
+        then pstateLinePrefix ++ xs
+        else xs
+    sameLine = sourceLine spos == sourceLine pstateSourcePos
+    (pre, post) = splitAt' (o - pstateOffset) pstateInput
+    St spos f = foldl'' go (St pstateSourcePos id) pre
+    go (St apos g) ch =
+      let SourcePos n l c = apos
+          c' = unPos c
+          w  = unPos pstateTabWidth
+      in if | ch == newlineTok ->
+                St (SourcePos n (l <> pos1) pos1)
+                   id
+            | ch == tabTok ->
+                St (SourcePos n l (mkPos $ c' + w - ((c' - 1) `rem` w)))
+                   (g . (fromTok ch :))
+            | otherwise ->
+                St (SourcePos n l (c <> pos1))
+                   (g . (fromTok ch :))
+{-# INLINE reachOffset' #-}
+
+-- | Like 'reachOffset'' but for 'reachOffsetNoLine'.
+
+reachOffsetNoLine'
+  :: forall s. Text.Megaparsec.Stream s
+  => (Int -> s -> (Tokens s, s))
+     -- ^ How to split input stream at given offset
+  -> (forall b. (b -> Token s -> b) -> b -> Tokens s -> b)
+     -- ^ How to fold over input stream
+  -> (Token s, Token s)
+     -- ^ Newline token and tab token
+  -> Int
+     -- ^ Offset to reach
+  -> PosState s
+     -- ^ Initial 'PosState' to use
+  -> (SourcePos, PosState s)
+     -- ^ Reached 'SourcePos' and updated 'PosState'
+reachOffsetNoLine' splitAt'
+                   foldl''
+                   (newlineTok, tabTok)
+                   o
+                   PosState {..} =
+  ( spos
+  , PosState
+      { pstateInput = post
+      , pstateOffset = max pstateOffset o
+      , pstateSourcePos = spos
+      , pstateTabWidth = pstateTabWidth
+      , pstateLinePrefix = pstateLinePrefix
+      }
+  )
+  where
+    spos = foldl'' go pstateSourcePos pre
+    (pre, post) = splitAt' (o - pstateOffset) pstateInput
+    go (SourcePos n l c) ch =
+      let c' = unPos c
+          w  = unPos pstateTabWidth
+      in if | ch == newlineTok ->
+                SourcePos n (l <> pos1) pos1
+            | ch == tabTok ->
+                SourcePos n l (mkPos $ c' + w - ((c' - 1) `rem` w))
+            | otherwise ->
+                SourcePos n l (c <> pos1)
+{-# INLINE reachOffsetNoLine' #-}
+
+-- | Replace tab characters with given number of spaces.
+
+expandTab
+  :: Text.Megaparsec.Pos
+  -> String
+  -> String
+expandTab w' = go 0
+  where
+    go 0 []        = []
+    go 0 ('\t':xs) = go w xs
+    go 0 (x:xs)    = x : go 0 xs
+    go n xs        = ' ' : go (n - 1) xs
+    w              = unPos w'


### PR DESCRIPTION
I tested locally, and with this one gets 8.355s -> 7.94s speedup (average of 10 runs).

- [ ] We can save a little more bit by avoiding reading `Text` in between, but directly converting from `ByteString` to `UVectorChar`
- [ ] `UVectorChar` could be renamed into `InputText` and made `newtype` (current code is PoC), we can save few back/forth conversions then too.

Comments more than welcome