### PR TITLE
Improve performance heap utilization of parser

### DIFF
--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -758,7 +758,13 @@ missing = do
   return Missing
 
 importType_ :: Parser ImportType
-importType_ = choice [ local, http, env, missing ]
+importType_ = do
+    let predicate c =
+            c == '~' || c == '.' || c == '/' || c == 'h' || c == 'e' || c == 'm'
+
+    _ <- Text.Megaparsec.lookAhead (Text.Megaparsec.satisfy predicate)
+
+    choice [ local, http, env, missing ]
 
 importHashed_ :: Parser ImportHashed
 importHashed_ = do

--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -758,13 +758,7 @@ missing = do
   return Missing
 
 importType_ :: Parser ImportType
-importType_ = do
-    let predicate c =
-            c == '~' || c == '.' || c == '/' || c == 'h' || c == 'e' || c == 'm'
-
-    _ <- Text.Megaparsec.lookAhead (Text.Megaparsec.satisfy predicate)
-
-    choice [ local, http, env, missing ]
+importType_ = choice [ local, http, env, missing ]
 
 importHashed_ :: Parser ImportHashed
 importHashed_ = do


### PR DESCRIPTION
This decreases the heap utilization of the parser by over 10x (~5.5 MB to
350 KB) and improves performance by about 18% on the example benchmark
program from #108

Before:

    time                 289.9 ms   (274.6 ms .. 297.9 ms)
                         0.999 R²   (0.998 R² .. 1.000 R²)
    mean                 309.3 ms   (301.0 ms .. 318.3 ms)
    std dev              11.08 ms   (8.083 ms .. 14.31 ms)

After:

    time                 245.6 ms   (243.0 ms .. 247.1 ms)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 247.5 ms   (246.5 ms .. 248.6 ms)
    std dev              1.338 ms   (1.022 ms .. 1.636 ms)