### PR TITLE
Introduce InputText

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -233,6 +233,7 @@ Library
         Dhall.Parser.Expression,
         Dhall.Parser.Combinators,
         Dhall.Parser.Token,
+        Dhall.Parser.InputText,
         Dhall.Import.Types,
         Dhall.Util,
         Paths_dhall

--- a/src/Dhall.hs
+++ b/src/Dhall.hs
@@ -325,7 +325,7 @@ inputWithSettings settings (Type {..}) txt = do
             Note (Src begin end bytes) _ ->
                 Note (Src begin end bytes') (Annot expr' expected)
               where
-                bytes' = bytes <> " : " <> suffix
+                bytes' = bytes <> " : " <> Dhall.Parser.inputChunkFromText suffix
             _ ->
                 Annot expr' expected
     _ <- throws (Dhall.TypeCheck.typeWith (view startingContext settings) annot)

--- a/src/Dhall/Parser/Combinators.hs
+++ b/src/Dhall/Parser/Combinators.hs
@@ -34,8 +34,10 @@ import qualified Text.Parser.Char
 import qualified Text.Parser.Combinators
 import qualified Text.Parser.Token.Style
 
+import Dhall.Parser.InputText
+
 -- | Source code extract
-data Src = Src !Text.Megaparsec.SourcePos !Text.Megaparsec.SourcePos Text
+data Src = Src !Text.Megaparsec.SourcePos !Text.Megaparsec.SourcePos InputChunk
   -- Text field is intentionally lazy
   deriving (Data, Eq, Show)
 
@@ -51,7 +53,7 @@ laxSrcEq (Src p q _) (Src p' q' _) = eq p  p' && eq q q'
 
 instance Pretty Src where
     pretty (Src begin _ text) =
-            pretty (Dhall.Util.snip (prefix <> text))
+            pretty (Dhall.Util.snip (prefix <> inputChunkToText text))
         <>  "\n"
         <>  pretty (Text.Megaparsec.sourcePosPretty begin)
       where
@@ -63,7 +65,7 @@ instance Pretty Src where
     @"Text.Megaparsec".`Text.Megaparsec.Parsec`@ except treating Haskell-style
     comments as whitespace
 -}
-newtype Parser a = Parser { unParser :: Text.Megaparsec.Parsec Void Text a }
+newtype Parser a = Parser { unParser :: Text.Megaparsec.Parsec Void InputText a }
 
 instance Functor Parser where
     fmap f (Parser x) = Parser (fmap f x)
@@ -122,7 +124,7 @@ instance MonadPlus Parser where
     mplus = (<|>)
     -- {-# INLINE mplus #-}
 
-instance Text.Megaparsec.MonadParsec Void Text Parser where
+instance Text.Megaparsec.MonadParsec Void InputText Parser where
     failure u e    = Parser (Text.Megaparsec.failure u e)
 
     fancyFailure e = Parser (Text.Megaparsec.fancyFailure e)
@@ -169,7 +171,7 @@ instance (Data.Semigroup.Semigroup a, Monoid a) => Monoid (Parser a) where
 #endif
 
 instance IsString a => IsString (Parser a) where
-    fromString x = fromString x <$ Text.Megaparsec.Char.string (fromString x)
+    fromString x = fromString x <$ Text.Megaparsec.Char.string (inputChunkFromString x)
 
 instance Text.Parser.Combinators.Parsing Parser where
   try = Text.Megaparsec.try
@@ -195,9 +197,9 @@ instance Text.Parser.Char.CharParsing Parser where
 
   anyChar = Text.Megaparsec.anySingle
 
-  string = fmap Data.Text.unpack . Text.Megaparsec.Char.string . fromString
+  string = fmap inputChunkToString . Text.Megaparsec.Char.string . inputChunkFromString
 
-  text = Text.Megaparsec.Char.string
+  text = fmap inputChunkToText . Text.Megaparsec.Char.string . inputChunkFromText
 
 instance TokenParsing Parser where
     someSpace =
@@ -232,10 +234,10 @@ satisfy :: (Char -> Bool) -> Parser Text
 satisfy = fmap Data.Text.singleton . Text.Parser.Char.satisfy
 
 takeWhile :: (Char -> Bool) -> Parser Text
-takeWhile predicate = Parser (Text.Megaparsec.takeWhileP Nothing predicate)
+takeWhile predicate = Parser (inputChunkToText <$> Text.Megaparsec.takeWhileP Nothing predicate)
 
 takeWhile1 :: (Char -> Bool) -> Parser Text
-takeWhile1 predicate = Parser (Text.Megaparsec.takeWhile1P Nothing predicate)
+takeWhile1 predicate = Parser (inputChunkToText <$> Text.Megaparsec.takeWhile1P Nothing predicate)
 
 noDuplicates :: Ord a => [a] -> Parser (Set a)
 noDuplicates = go Data.Set.empty

--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -481,7 +481,7 @@ doubleQuotedChunk embedded =
         return (Chunks [(mempty, e)] mempty)
 
     unescapedCharacterFast = do
-        t <- Text.Megaparsec.takeWhile1P Nothing predicate
+        t <- takeWhile1 predicate
         return (Chunks [] t)
       where
         predicate c =
@@ -579,7 +579,7 @@ singleQuoteContinue embedded =
             return mempty
 
         unescapedCharacterFast = do
-            a <- Text.Megaparsec.takeWhile1P Nothing predicate
+            a <- takeWhile1 predicate
             b <- singleQuoteContinue embedded
             return (Chunks [] a <> b)
           where

--- a/src/Dhall/Parser/InputText.hs
+++ b/src/Dhall/Parser/InputText.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+module Dhall.Parser.InputText (
+    -- * Input text
+      InputText
+    , inputTextFromString
+    , inputTextFromText
+    , inputTextToText
+    , inputTextFromByteString
+    , inputTextFromByteStringIO
+    , inputTextFromLazyByteString
+    , inputTextFromLazyByteStringIO
+    , readInputText
+    -- * Input chunk
+    , InputChunk
+    , inputChunkToText
+    , inputChunkFromText
+    , inputChunkToString
+    , inputChunkFromString
+    ) where
+
+import           Control.Exception          (throwIO)
+import           Data.Coerce                (coerce)
+import           Data.Data                  (Data)
+import           Data.Proxy                 (Proxy (..))
+import           Data.Semigroup             (Semigroup (..))
+import           Data.String                (IsString (..))
+import           Data.Text                  (Text)
+
+import qualified Data.Text
+import qualified Data.Text.Encoding
+import qualified Data.Text.Encoding.Error
+import qualified Data.ByteString
+import qualified Data.ByteString.Lazy
+import qualified Text.Megaparsec
+
+-- | Input text. This type deliberately doesn't have almost any instances.
+newtype InputText = InputText Text
+
+instance IsString InputText where
+    fromString = inputTextFromString
+
+inputTextFromString :: String -> InputText
+inputTextFromString = coerce Data.Text.pack
+
+inputTextFromText :: Text -> InputText
+inputTextFromText = InputText -- coerce -- to use data constructor at least once
+
+inputTextToText :: InputText -> Text
+inputTextToText = coerce
+
+inputTextFromByteString
+    :: Data.ByteString.ByteString
+    -> Either Data.Text.Encoding.Error.UnicodeException InputText
+inputTextFromByteString = coerce Data.Text.Encoding.decodeUtf8'
+
+inputTextFromByteStringIO
+    :: Data.ByteString.ByteString
+    -> IO InputText
+inputTextFromByteStringIO = either throwIO return . inputTextFromByteString
+
+inputTextFromLazyByteString
+    :: Data.ByteString.Lazy.ByteString
+    -> Either Data.Text.Encoding.Error.UnicodeException InputText
+inputTextFromLazyByteString =
+    coerce Data.Text.Encoding.decodeUtf8' . Data.ByteString.Lazy.toStrict
+
+inputTextFromLazyByteStringIO
+    :: Data.ByteString.Lazy.ByteString
+    -> IO InputText
+inputTextFromLazyByteStringIO = either throwIO return . inputTextFromLazyByteString
+
+readInputText :: FilePath -> IO InputText
+readInputText path = Data.ByteString.readFile path >>= inputTextFromByteStringIO
+
+instance Text.Megaparsec.Stream InputText where
+    type Token  InputText = Char
+    type Tokens InputText = InputChunk
+
+    take1_            = coerce (Text.Megaparsec.take1_ :: Text -> Maybe (Char, Text))
+    takeN_            = coerce (Text.Megaparsec.takeN_ :: Int -> Text -> Maybe (Text, Text))
+    tokensToChunk _   = coerce (Text.Megaparsec.tokensToChunk (Proxy :: Proxy Text))
+    chunkToTokens _   = coerce (Text.Megaparsec.chunkToTokens (Proxy :: Proxy Text))
+    chunkLength _     = coerce (Text.Megaparsec.chunkLength (Proxy :: Proxy Text))
+    chunkEmpty _      = coerce (Text.Megaparsec.chunkEmpty (Proxy :: Proxy Text))
+    takeWhile_        = coerce (Text.Megaparsec.takeWhile_ :: (Char -> Bool) -> Text -> (Text,  Text))
+    showTokens _      = coerce (Text.Megaparsec.showTokens (Proxy :: Proxy Text))
+    reachOffset       = coerce (Text.Megaparsec.reachOffset :: Int -> Text.Megaparsec.PosState Text -> (Text.Megaparsec.SourcePos, String, Text.Megaparsec.PosState Text))
+    reachOffsetNoLine = coerce (Text.Megaparsec.reachOffsetNoLine :: Int -> Text.Megaparsec.PosState Text -> (Text.Megaparsec.SourcePos, Text.Megaparsec.PosState Text))
+
+newtype InputChunk = InputChunk Text
+  deriving (Eq, Ord, Show, Data)
+
+instance IsString InputChunk where
+    fromString = inputChunkFromString 
+
+instance Semigroup InputChunk where
+    (<>) = coerce ((<>) :: Text -> Text -> Text)
+
+inputChunkToText :: InputChunk -> Text
+inputChunkToText = coerce
+
+inputChunkFromText :: Text -> InputChunk
+inputChunkFromText = coerce
+
+inputChunkToString :: InputChunk -> String
+inputChunkToString = coerce Data.Text.unpack
+
+inputChunkFromString :: String -> InputChunk
+inputChunkFromString = coerce Data.Text.pack

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.4
+resolver: lts-12.10
 extra-deps:
   - megaparsec-7.0.0@rev:0
   # Version 0.2.0.0 of cborg, the latest on Hackage, is broken on i386.


### PR DESCRIPTION
InputText (something to be parsed) and InputChunk (something parsed)
help to differentiate from all other Text we have

As a bonus this allows to experiment with different underlying
representations.

Operationally there shouldn't be any differences, but one:
`readInputText` doesn't care about users' LOCALE settings,
and assumes input to be UTF8 _always_.
That's different from `Data.Text.readTextIO`

Otherwise, this patches adds a lot differently named `coerce`,
so performance shouldn't be affected, given GHC does good job.