### PR TITLE
Try parens as first primitive

### DIFF
--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -235,6 +235,7 @@ completeExpression embedded = completeExpression_
             return (foldl (\e k -> k e) a b) )
 
     primitiveExpression =
+            parensExpression <|>
             noted
                 ( choice
                     [ alternative00
@@ -281,7 +282,6 @@ completeExpression embedded = completeExpression_
                         ] <?> "built-in expression"
                     ]
                 )
-            <|> alternative38
           where
             alternative00 = do
                 a <- try doubleLiteral
@@ -439,11 +439,11 @@ completeExpression embedded = completeExpression_
                 a <- identifier
                 return (Var a)
 
-            alternative38 = do
-                _openParens
-                a <- expression
-                _closeParens
-                return a
+    parensExpression = do
+        _openParens
+        a <- expression
+        _closeParens
+        return a
 
     doubleQuotedChunk =
             choice


### PR DESCRIPTION
`((((((((((((((x))))))))))))))` is still slow, but now less  (from 2.0s -> 1.6s) on my machine