### PR TITLE
Fix build of `benchmark:dhall-command` on OS X

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -299,7 +299,8 @@ Test-Suite doctest
 
 Benchmark dhall-parser
     Type: exitcode-stdio-1.0
-    Main-Is: benchmark/parser/Main.hs
+    Hs-Source-Dirs: benchmark/parser
+    Main-Is: Main.hs
     Build-Depends:
         base                      >= 4        && < 5  ,
         bytestring                                    ,
@@ -314,7 +315,8 @@ Benchmark dhall-parser
 
 Benchmark deep-nested-large-record
     Type: exitcode-stdio-1.0
-    Main-Is: benchmark/deep-nested-large-record/Main.hs
+    Hs-Source-Dirs: benchmark/deep-nested-large-record
+    Main-Is: Main.hs
     Build-Depends:
         base                      >= 4        && < 5  ,
         containers                >= 0.5.0.0  && < 0.6,
@@ -325,7 +327,8 @@ Benchmark deep-nested-large-record
 
 Benchmark dhall-command
     Type: exitcode-stdio-1.0
-    Main-Is: benchmark/dhall-command/Main.hs
+    Main-Is: Main.hs
+    Hs-Source-Dirs: benchmark/dhall-command
     Build-Depends:
         base                      >= 4        && < 5  ,
         dhall


### PR DESCRIPTION
Due to OS X's case-insensitive filesystem the build fails due to it
accidentally resolving the `Dhall.Main` import to `src/Dhall/Main.hs`.
The fix is to just narrow the source directory to that one benchmark
so that it doesn't pick up that file by mistake.  I also made the same
change to other benchmarks as a precaution.