### PR TITLE
GHC 8.6 stuff

### DIFF
--- a/dhall.cabal
+++ b/dhall.cabal
@@ -319,7 +319,7 @@ Benchmark deep-nested-large-record
     Main-Is: Main.hs
     Build-Depends:
         base                      >= 4        && < 5  ,
-        containers                >= 0.5.0.0  && < 0.6,
+        containers                >= 0.5.0.0  && < 0.7,
         criterion                 >= 1.1      && < 1.6,
         dhall
     Default-Language: Haskell2010

--- a/dhall.cabal
+++ b/dhall.cabal
@@ -193,7 +193,7 @@ Library
         parsers                     >= 0.12.4   && < 0.13,
         prettyprinter               >= 1.2.0.1  && < 1.3 ,
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
-        repline                     >= 0.1.6.0  && < 0.2 ,
+        repline                     >= 0.2.0.0  && < 0.3 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
         template-haskell                           < 2.15,

--- a/nix/repline.nix
+++ b/nix/repline.nix
@@ -1,0 +1,11 @@
+{ mkDerivation, base, containers, haskeline, mtl, process, stdenv
+}:
+mkDerivation {
+  pname = "repline";
+  version = "0.2.0.0";
+  sha256 = "ecc72092d0340b896ee6bf96bf6645694dbcd33361725a2cd28c5ab5d60c02de";
+  libraryHaskellDepends = [ base containers haskeline mtl process ];
+  homepage = "https://github.com/sdiehl/repline";
+  description = "Haskeline wrapper for GHCi-like REPL interfaces";
+  license = stdenv.lib.licenses.mit;
+}

--- a/src/Dhall/Repl.hs
+++ b/src/Dhall/Repl.hs
@@ -45,10 +45,11 @@ repl characterSet explain _protocolVersion =
     io =
       evalStateT
         ( Repline.evalRepl
-            "⊢ "
+            ( pure "⊢ " )
             ( dontCrash . eval )
             options
-        ( Repline.Word completer )
+            Nothing
+            ( Repline.Word completer )
             greeter
         )
         (emptyEnv { characterSet, explain, _protocolVersion })

--- a/stack-lts-11.yaml
+++ b/stack-lts-11.yaml
@@ -4,6 +4,7 @@ extra-deps:
   - serialise-0.2.0.0
   - megaparsec-7.0.0
   - parser-combinators-1.0.0
+  - repline-0.2.0.0
 nix:
   packages:
     - ncurses

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - directory-1.2.7.1
 - foundation-0.0.19
 - process-1.6.2.0
-- repline-0.1.7.0
+- repline-0.2.0.0
 - haskeline-0.7.4.2
 - aeson-1.2.3.0
 - th-abstraction-0.2.6.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,7 @@
 resolver: lts-12.4
 extra-deps:
   - megaparsec-7.0.0@rev:0
+  - repline-0.2.0.0@rev:0
   # Version 0.2.0.0 of cborg, the latest on Hackage, is broken on i386.
   - github: well-typed/cborg
     commit: master


### PR DESCRIPTION
Compatibility with `repline` 0.2.0.0 and a bounds bump on `containers`.

I *think* I did the necessary Nix stuff; let's see what CI thinks.

When this is merged, the only blockers of full GHC 8.6 support are releases of `cborg` and `serialise` (well-typed/cborg#171).