### PR TITLE
Fix parse error for IPv4-mapped IPv6 addresses

### DIFF
--- a/src/Dhall/Parser/Token.hs
+++ b/src/Dhall/Parser/Token.hs
@@ -430,7 +430,7 @@ h16 :: Parser Text
 h16 = range 1 3 (satisfy hexdig)
 
 ls32 :: Parser Text
-ls32 = (h16 <> ":" <> h16) <|> ipV4Address
+ls32 = try (h16 <> ":" <> h16) <|> ipV4Address
 
 ipV4Address :: Parser Text
 ipV4Address = decOctet <> "." <> decOctet <> "." <> decOctet <> "." <> decOctet


### PR DESCRIPTION
This is a simple fix for a parse error which isn't compliant with the [specification](https://github.com/dhall-lang/dhall-lang/blob/a4d201c78639da6f95aea5c583fe6bf0b8c70f17/standard/dhall.abnf#L451). The issue is that h16 partially matches an IPv4 address but cannot backtrack when it fails.

```
> dhall format <<< 'https://[::192.168.0.1]/file'

Error: Invalid input

(stdin):1:14:
  |
1 | https://[::192.168.0.1]/file
  |              ^
unexpected '.'
expecting ']'
```