### PR TITLE
Change `dhall freeze` to refreeze imports

### DIFF
--- a/src/Dhall/Freeze.hs
+++ b/src/Dhall/Freeze.hs
@@ -38,9 +38,16 @@ hashImport
     -> Import
     -> IO Import
 hashImport directory _standardVersion import_ = do
+    let unprotectedImport =
+            import_
+                { importHashed =
+                    (importHashed import_)
+                        { hash = Nothing
+                        }
+                }
     let status = set standardVersion _standardVersion (Dhall.Import.emptyStatus directory)
 
-    expression <- State.evalStateT (Dhall.Import.loadWith (Embed import_)) status
+    expression <- State.evalStateT (Dhall.Import.loadWith (Embed unprotectedImport)) status
 
     case Dhall.TypeCheck.typeOf expression of
         Left  exception -> Control.Exception.throwIO exception


### PR DESCRIPTION
Fixes: https://github.com/dhall-lang/dhall-haskell/issues/630

`dhall freeze` will now ignore the hash on existing imports and attempt to
refreeze them