### PR TITLE
Fix `dhall repl` commands

### DIFF
--- a/src/Dhall/Repl.hs
+++ b/src/Dhall/Repl.hs
@@ -48,7 +48,7 @@ repl characterSet explain _standardVersion =
             ( pure "⊢ " )
             ( dontCrash . eval )
             options
-            Nothing
+            (Just ':')
             ( Repline.Word completer )
             greeter
         )


### PR DESCRIPTION
`repline` requires you to specify the leading character for commands now,
otherwise it disables support for commands