### PR TITLE
Doc should be Prefer

### DIFF
--- a/src/Dhall/Core.hs
+++ b/src/Dhall/Core.hs
@@ -436,7 +436,7 @@ data Expr s a
     | Combine (Expr s a) (Expr s a)
     -- | > CombineTypes x y                         ~  x ⩓ y
     | CombineTypes (Expr s a) (Expr s a)
-    -- | > CombineRight x y                         ~  x ⫽ y
+    -- | > Prefer x y                               ~  x ⫽ y
     | Prefer (Expr s a) (Expr s a)
     -- | > Merge x y (Just t )                      ~  merge x y : t
     --   > Merge x y  Nothing                       ~  merge x y


### PR DESCRIPTION
The doc said `CombineRight`. I'm guessing a name change was made but the doc wasn't updated.