### PR TITLE
Allow omitting 'in' in chained bindings

### DIFF
--- a/src/Dhall/Parser/Expression.hs
+++ b/src/Dhall/Parser/Expression.hs
@@ -89,8 +89,7 @@ completeExpression embedded = completeExpression_
                 expression )
             _equal
             c <- expression
-            _in
-            d <- expression
+            d <- (_in >> expression) <|> alternative2
             return (Let a b c d)
 
         alternative3 = do


### PR DESCRIPTION
Hi,

I want to make the language change as described below.
I am not sure whether I should propose this with [dhall-lang](https://github.com/dhall-lang/dhall-lang) or here.
Any help getting this through the proper channels is greatly appreciated.

Apologies if this has been brought up before, the GitHub search makes it awefully hard to search for `let` and `in`. 

---

In my head this is a purely cosmetic change.
It should not change the validity of programs that are currently valid.

What was previously written as 

```
   let l = λ(n : Natural) → λ(m : Natural) → λ(x : Natural) → n + m * x
in let f = l 2 3
in f 445
```

can now be written like

```
let l = λ(n : Natural) → λ(m : Natural) → λ(x : Natural) → n + m * x
let f = l 2 3
in
    f 445
```

This effectively makes `in` terminate a `let`-chain.