### PR TITLE
Fix parsing of //\\

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -28,6 +28,7 @@ Extra-Source-Files:
     Prelude/Monoid
     tests/format/*.dhall
     tests/normalization/tutorial/combineTypes/*.dhall
+    tests/normalization/tutorial/prefer/*.dhall
     tests/normalization/tutorial/projection/*.dhall
     tests/normalization/tutorial/access/*.dhall
     tests/normalization/*.dhall

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -158,8 +158,8 @@ completeExpression embedded = completeExpression_
             <|> Combine     <$ _combine
 
     precedence2Operator =
-                Prefer       <$ _prefer
-            <|> CombineTypes <$ _combineTypes
+                CombineTypes <$ _combineTypes
+            <|> Prefer       <$ _prefer
             <|> NaturalTimes <$ _times
             <|> BoolNE       <$ _notEqual
 

--- a/dhall/tests/Normalization.hs
+++ b/dhall/tests/Normalization.hs
@@ -40,6 +40,7 @@ tutorialExamples :: TestTree
 tutorialExamples =
     testGroup "Tutorial examples"
         [ shouldNormalize "⩓" "./tutorial/combineTypes/0"
+        , shouldNormalize "//\\\\" "./tutorial/combineTypes/1"
         , shouldNormalize "projection" "./tutorial/projection/0"
         , shouldNormalize "access record" "./tutorial/access/0"
         , shouldNormalize "access union" "./tutorial/access/1"

--- a/dhall/tests/Normalization.hs
+++ b/dhall/tests/Normalization.hs
@@ -41,6 +41,7 @@ tutorialExamples =
     testGroup "Tutorial examples"
         [ shouldNormalize "⩓" "./tutorial/combineTypes/0"
         , shouldNormalize "//\\\\" "./tutorial/combineTypes/1"
+        , shouldNormalize "//" "./tutorial/prefer/0"
         , shouldNormalize "projection" "./tutorial/projection/0"
         , shouldNormalize "access record" "./tutorial/access/0"
         , shouldNormalize "access union" "./tutorial/access/1"

--- a/dhall/tests/normalization/tutorial/combineTypes/1A.dhall
+++ b/dhall/tests/normalization/tutorial/combineTypes/1A.dhall
@@ -1,0 +1,1 @@
+{ foo : { bar : Text } } //\\ { foo : { baz : Bool }, qux : Integer }

--- a/dhall/tests/normalization/tutorial/combineTypes/1B.dhall
+++ b/dhall/tests/normalization/tutorial/combineTypes/1B.dhall
@@ -1,0 +1,1 @@
+{ foo : { bar : Text, baz : Bool }, qux : Integer }

--- a/dhall/tests/normalization/tutorial/prefer/0A.dhall
+++ b/dhall/tests/normalization/tutorial/prefer/0A.dhall
@@ -1,0 +1,1 @@
+{ foo = 1, bar = "ABC" } // { baz = True }

--- a/dhall/tests/normalization/tutorial/prefer/0B.dhall
+++ b/dhall/tests/normalization/tutorial/prefer/0B.dhall
@@ -1,0 +1,1 @@
+{ bar = "ABC", baz = True, foo = 1 }


### PR DESCRIPTION
Hello, I'm a long time user, first time contributor :) I noticed this issue today and thought I'd submit a PR.

The original error (after I added the test):

```
 FAIL
        Exception: 
        ↳ ./tests/normalization/tutorial/combineTypes/1A.dhall
        
        Error: Invalid input
        
        ./tests/normalization/tutorial/combineTypes/1A.dhall:1:28:
          |
        1 | { foo : { bar : Text } } //\\ { foo : { baz : Bool }, qux : Integer }
          |                            ^^^^^
        unexpected "\\ { "
        expecting "Some", "constructors", "merge", '(', built-in expression, double literal, import, integer literal, label, list literal, natural literal, record type or literal, text literal, union type or literal, or whitespace
```