### PR TITLE
Test that formatting preserves projection order

### DIFF
--- a/dhall/tests/Format.hs
+++ b/dhall/tests/Format.hs
@@ -34,6 +34,10 @@ formatTests =
             "fieldOrder"
         , should
             Unicode
+            "preserve the original order of projections"
+            "projectionOrder"
+        , should
+            Unicode
             "escape numeric labels correctly"
             "escapeNumericLabel"
         , should

--- a/dhall/tests/format/projectionOrderA.dhall
+++ b/dhall/tests/format/projectionOrderA.dhall
@@ -1,0 +1,1 @@
+e.{ foo, bar, baz }

--- a/dhall/tests/format/projectionOrderB.dhall
+++ b/dhall/tests/format/projectionOrderB.dhall
@@ -1,0 +1,1 @@
+e.{ foo, bar, baz }


### PR DESCRIPTION
Tested that these fail on a commit prior to merging #670 like so:

```bash
git checkout dc5493d87f7f98b71b457c0163edab043a704b91
stack test
```

The result, as formerly expected, was that the projected fields were coming out in sorted order:

```
    preserve the original order of projections:                                     FAIL
      tests/Format.hs:102:
      The formatted expression did not match the expected output
      expected: "e.{ foo, bar, baz }"
       but got: "e.{ bar, baz, foo }"
```

The tests pass when run against the latest master commit.