### PR TITLE
Run tests in CI

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -38,6 +38,9 @@ in
           shared.tarball-dhall-json
           shared.tarball-dhall-text
 
+          # This is the only `dhall` build that runs the test suite
+          coverage.dhall
+
           shared.pwd
         ];
       };


### PR DESCRIPTION
CI was running tests, but they weren't blocking merge because they weren't a
dependency of the `dhall` attribute (which is what gates the GitHub status).

This fixes that by adding `coverage.dhall` as a dependency (which does include
tests).  The other builds were not running tests since that is what happens
`coverage` defaults to `false`.