### PR TITLE
Allow importing to use arbitrary monads

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -1955,8 +1955,8 @@ type Normalizer a = NormalizerM Identity a
 
 -- | A reified 'Normalizer', which can be stored in structures without
 -- running into impredicative polymorphism.
-data ReifiedNormalizer a = ReifiedNormalizer
-  { getReifiedNormalizer :: Normalizer a }
+data ReifiedNormalizer m a = ReifiedNormalizer
+  { getReifiedNormalizer :: NormalizerM m a }
 
 -- | Check if an expression is in a normal form given a context of evaluation.
 --   Unlike `isNormalized`, this will fully normalize and traverse through the expression.

--- a/dhall/src/Dhall/Import/HTTP.hs
+++ b/dhall/src/Dhall/Import/HTTP.hs
@@ -75,7 +75,7 @@ renderPrettyHttpException e = case e of
         <> show e'
 #endif
 
-needManager :: StateT (Status m) IO Manager
+needManager :: MonadIO m => StateT (Status m) m Manager
 needManager = do
     x <- zoom manager State.get
     case join (fmap fromDynamic x) of
@@ -95,9 +95,10 @@ needManager = do
             return m
 
 fetchFromHttpUrl
-    :: String
+    :: MonadIO m
+    => String
     -> Maybe [(CI ByteString, ByteString)]
-    -> StateT (Status m) IO (String, Text.Text)
+    -> StateT (Status m) m (String, Text.Text)
 fetchFromHttpUrl url mheaders = do
     m <- needManager
 

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -48,7 +48,7 @@ data Status m = Status
 
     , _standardVersion :: StandardVersion
 
-    , _normalizer :: ReifiedNormalizer X
+    , _normalizer :: ReifiedNormalizer m X
 
     , _startingContext :: Context (Expr Src X)
 
@@ -59,7 +59,8 @@ data Status m = Status
 
 -- | Default starting `Status` that is polymorphic in the base `Monad`
 emptyStatusWith
-    :: (Import -> StateT (Status m) m (Expr Src Import))
+    :: Applicative m
+    => (Import -> StateT (Status m) m (Expr Src Import))
     -> (Import -> Expr Src X -> StateT (Status m) m ())
     -> FilePath
     -> Status m
@@ -107,7 +108,7 @@ standardVersion :: Functor f => LensLike' f (Status m) StandardVersion
 standardVersion k s =
     fmap (\x -> s { _standardVersion = x }) (k (_standardVersion s))
 
-normalizer :: Functor f => LensLike' f (Status m) (ReifiedNormalizer X)
+normalizer :: Functor f => LensLike' f (Status m) (ReifiedNormalizer m X)
 normalizer k s = fmap (\x -> s { _normalizer = x }) (k (_normalizer s))
 
 startingContext :: Functor f => LensLike' f (Status m) (Context (Expr Src X))


### PR DESCRIPTION
Continuing to try and solve https://github.com/dhallix/nix-derivation/issues/8 - I found out that I can't actually use the `normalizeWithM` work with importing as it doesn't let me choose `m`. This work is trying to do the bare minimum to allow me to choose a more interesting monad.