### PR TITLE
Fix `dhall-bash` version to 1.0.17

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -1,5 +1,5 @@
 Name: dhall-bash
-Version: 1.0.16
+Version: 1.0.17
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 Tested-With: GHC == 7.10.2, GHC == 8.0.1


### PR DESCRIPTION
I forgot to bump the version number for `dhall-bash` in #691, which this
change fixes