### PR TITLE
Fix import caching

### DIFF
--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -785,7 +785,7 @@ loadWith expr₀ = case expr₀ of
                     expr''' <- case Dhall.TypeCheck.typeWith _startingContext expr'' of
                         Left  err -> throwM (Imported imports' err)
                         Right _   -> return (Dhall.Core.normalizeWith (getReifiedNormalizer _normalizer) expr'')
-                    zoom cache (State.put $! Map.insert here expr''' _cache)
+                    zoom cache (State.modify' (Map.insert here expr'''))
                     return expr'''
 
     case hash (importHashed import_) of


### PR DESCRIPTION
This fixes an apparently very old bug in import caching caught by @basile-henry

Before this change the import resolution algorithm was:

1. Retrieving the cache
2. Transitively resolving all imports
3. Setting the new cache to be current import insert into the cache retrieved in
   step 1

The bug is that all of the transitive imports resolved in step 2 added
entries of their own to the cache and those new cache entries were being
clobbered by step 3.

The fix is simple: don't use the cache retrieved in step 1 to compute
the updated cache in step 3.  Rather, use `modify` instead of `put` to
create the new cache so that we preserve newly-added cache entries.