### PR TITLE
Fix bug when linting multi-`let` expressions

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -33,6 +33,7 @@ Extra-Source-Files:
     tests/import/data/foo/bar/*.dhall
     tests/import/failure/*.dhall
     tests/import/success/*.dhall
+    tests/lint/success/*.dhall
     tests/normalization/success/*.dhall
     tests/normalization/success/haskell-tutorial/access/*.dhall
     tests/normalization/success/haskell-tutorial/combineTypes/*.dhall
@@ -383,6 +384,7 @@ Test-Suite tasty
     Other-Modules:
         Format
         Import
+        Lint
         Normalization
         Parser
         QuickCheck

--- a/dhall/src/Dhall/Lint.hs
+++ b/dhall/src/Dhall/Lint.hs
@@ -55,7 +55,7 @@ lint expression = loop (Dhall.Core.denote expression)
 
         d' = loop d
     loop (Let (Binding a b c :| (l : ls)) d)
-        | not (V a 0 `Dhall.Core.freeIn` d') =
+        | not (V a 0 `Dhall.Core.freeIn` Let (l' :| ls') d') =
             Let (l' :| ls') d'
         | otherwise =
             Let (Binding a b' c' :| (l' : ls'))  d'

--- a/dhall/tests/Lint.hs
+++ b/dhall/tests/Lint.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Lint where
+
+import Data.Monoid (mempty, (<>))
+import Data.Text (Text)
+import Test.Tasty (TestTree)
+
+import qualified Control.Exception
+import qualified Data.Text
+import qualified Data.Text.IO
+import qualified Dhall.Core
+import qualified Dhall.Import
+import qualified Dhall.Lint
+import qualified Dhall.Parser
+import qualified Test.Tasty
+import qualified Test.Tasty.HUnit
+
+lintTests :: TestTree
+lintTests =
+    Test.Tasty.testGroup "format tests"
+        [ should
+            "correctly handle multi-let expressions"
+            "success/multilet"
+        ]
+
+should :: Text -> Text -> TestTree
+should name basename =
+    Test.Tasty.HUnit.testCase (Data.Text.unpack name) $ do
+        let inputFile =
+                Data.Text.unpack ("./tests/lint/" <> basename <> "A.dhall")
+        let outputFile =
+                Data.Text.unpack ("./tests/lint/" <> basename <> "B.dhall")
+
+        inputText <- Data.Text.IO.readFile inputFile
+
+        parsedInput <- case Dhall.Parser.exprFromText mempty inputText of
+            Left  exception  -> Control.Exception.throwIO exception
+            Right expression -> return expression
+
+        let lintedInput = Dhall.Lint.lint parsedInput
+
+        actualExpression <- Dhall.Import.load lintedInput
+
+        outputText <- Data.Text.IO.readFile outputFile
+
+        parsedOutput <- case Dhall.Parser.exprFromText mempty outputText of
+            Left  exception  -> Control.Exception.throwIO exception
+            Right expression -> return expression
+
+        resolvedOutput <- Dhall.Import.load parsedOutput
+
+        let expectedExpression = Dhall.Core.denote resolvedOutput
+
+        let message =
+                "The linted expression did not match the expected output"
+
+        Test.Tasty.HUnit.assertEqual message expectedExpression actualExpression

--- a/dhall/tests/Tests.hs
+++ b/dhall/tests/Tests.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import Lint (lintTests)
 import Normalization (normalizationTests)
 import Parser (parserTests)
 import Regression (regressionTests)
@@ -25,6 +26,7 @@ allTests =
         , typecheckTests
         , importTests
         , quickcheckTests
+        , lintTests
         ]
 
 main :: IO ()

--- a/dhall/tests/lint/success/multiletA.dhall
+++ b/dhall/tests/lint/success/multiletA.dhall
@@ -1,0 +1,35 @@
+-- example0.dhall
+
+let Person
+    : Type
+    =   ∀(Person : Type)
+      → ∀(MakePerson : { children : List Person, name : Text } → Person)
+      → Person
+
+let example
+    : Person
+    =   λ(Person : Type)
+      → λ(MakePerson : { children : List Person, name : Text } → Person)
+      → MakePerson
+        { children =
+            [ MakePerson { children = [] : List Person, name = "Mary" }
+            , MakePerson { children = [] : List Person, name = "Jane" }
+            ]
+        , name =
+            "John"
+        }
+
+let everybody
+    : Person → List Text
+    = let concat = http://prelude.dhall-lang.org/List/concat
+      
+      in    λ(x : Person)
+          → x
+            (List Text)
+            (   λ(p : { children : List (List Text), name : Text })
+              → [ p.name ] # concat Text p.children
+            )
+
+let result : List Text = everybody example
+
+in  result

--- a/dhall/tests/lint/success/multiletB.dhall
+++ b/dhall/tests/lint/success/multiletB.dhall
@@ -1,0 +1,35 @@
+-- example0.dhall
+
+let Person
+    : Type
+    =   ∀(Person : Type)
+      → ∀(MakePerson : { children : List Person, name : Text } → Person)
+      → Person
+
+let example
+    : Person
+    =   λ(Person : Type)
+      → λ(MakePerson : { children : List Person, name : Text } → Person)
+      → MakePerson
+        { children =
+            [ MakePerson { children = [] : List Person, name = "Mary" }
+            , MakePerson { children = [] : List Person, name = "Jane" }
+            ]
+        , name =
+            "John"
+        }
+
+let everybody
+    : Person → List Text
+    = let concat = http://prelude.dhall-lang.org/List/concat
+      
+      in    λ(x : Person)
+          → x
+            (List Text)
+            (   λ(p : { children : List (List Text), name : Text })
+              → [ p.name ] # concat Text p.children
+            )
+
+let result : List Text = everybody example
+
+in  result


### PR DESCRIPTION
`dhall lint` was incorrectly deleting `let` bindings that are being used
due to not checking other `let` bindings within the same multi-`let`
expression for free variable occurrences.

This change fixes that and adds the first regression test for `dhall
lint`