### PR TITLE
Improve HTTP error messages

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -327,6 +327,7 @@ Library
         vector                      >= 0.11.0.0 && < 0.13
     if flag(with-http)
       Build-Depends:
+        http-types                  >= 0.7.0    && < 0.13,
         http-client                 >= 0.4.30   && < 0.6 ,
         http-client-tls             >= 0.2.0    && < 0.4
     if !impl(ghc >= 8.0)


### PR DESCRIPTION
Fixes #509

The `Dhall.Import.HTTP` module had logic for pretty-printing HTTP error
message, but this logic wasn't being used anywhere!  This change fixes
that and also polishes the error messages a little bit.