### PR TITLE
Simplify import error handling logic

### DIFF
--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -745,14 +745,15 @@ loadWith expr₀ = case expr₀ of
                             :: (MonadCatch m)
                             => MissingImports
                             -> StateT (Status m) m (Expr Src Import)
-                        handler₀ e@(MissingImports []) = throwM e
-                        handler₀ (MissingImports [e]) =
-                          throwMissingImport (Imported imports' e)
-                        handler₀ (MissingImports es) = throwM
-                          (MissingImports
-                           (fmap
-                             (\e -> (toException (Imported imports' e)))
-                             es))
+                        handler₀ (MissingImports es) =
+                          throwM
+                            (MissingImports
+                               (map
+                                 (\e -> toException (Imported imports' e))
+                                 es
+                               )
+                             )
+
                         handler₁
                             :: (MonadCatch m)
                             => SomeException


### PR DESCRIPTION
The first two cases of the `handler₀` function are just special cases
of the last case