### PR TITLE
Unique dependencies in dot graph

### DIFF
--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -300,7 +300,7 @@ command (Options {..}) = do
                 State.runStateT (Dhall.Import.loadWith expression) status
 
             if   dot
-            then putStr . Text.Dot.showDot $
+            then putStr . ("strict " <>) . Text.Dot.showDot $
                  Text.Dot.attribute ("rankdir", "LR") >> _dot
             else render System.IO.stdout resolvedExpression
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,7 @@ extra-deps:
   - repline-0.2.0.0
   - serialise-0.2.1.0
   - neat-interpolation-0.3.2.4
+  - dotgen-0.4.2@sha256:309b7cc8a3593a8e48bee7b53020d5f72db156d58edf78a0214f58fbb84b292b
 nix:
   packages:
     - ncurses


### PR DESCRIPTION
Sometimes the same import is used multiple times in a given `dhall` file. This just adds extra noise in the generated graph.

For example here:

https://github.com/dhall-lang/dhall-to-cabal/blob/8967220bd3618c876bbc4f7b0c93d49fa47a30ee/dhall/unconditional.dhall#L21-L26

![2018-11-26-152926_1196x79_scrot](https://user-images.githubusercontent.com/3369034/49021827-cc9b0c80-f193-11e8-8fbd-8dcbb205dacf.png)

It results in 4 connections between two nodes where 1 would be enough.

By making the generated graph `strict` we prune away all the redundant connection making the graph more readable.

With `dhall-to-cabal` as a *real world example*:

Before this PR:

![old-dhall-to-cabal](https://user-images.githubusercontent.com/3369034/49022528-5dbeb300-f195-11e8-9a9e-88b16d7d4d9a.png)

After this PR:

![new-dhall-to-cabal](https://user-images.githubusercontent.com/3369034/49022538-644d2a80-f195-11e8-9d65-10114dc5766e.png)



