### PR TITLE
Change how `dhall repl` handles prior definitions

### DIFF
--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -1,8 +1,9 @@
 -- | This module contains the implementation of the @dhall repl@ subcommand
 
-{-# language FlexibleContexts #-}
-{-# language NamedFieldPuns #-}
+{-# language FlexibleContexts  #-}
+{-# language NamedFieldPuns    #-}
 {-# language OverloadedStrings #-}
+{-# language RecordWildCards   #-}
 
 module Dhall.Repl
     ( -- * Repl
@@ -13,8 +14,9 @@ import Control.Exception ( SomeException(SomeException), displayException, throw
 import Control.Monad.IO.Class ( MonadIO, liftIO )
 import Control.Monad.State.Class ( MonadState, get, modify )
 import Control.Monad.State.Strict ( evalStateT )
-import Data.List ( foldl' )
+import Data.List.NonEmpty (NonEmpty(..))
 import Dhall.Binary (StandardVersion(..))
+import Dhall.Context (Context)
 import Dhall.Import (standardVersion)
 import Dhall.Pretty (CharacterSet(..))
 import Lens.Family (set)
@@ -149,41 +151,44 @@ typeOf srcs = do
   output System.IO.stdout exprType'
 
 
+applyContext
+    :: Context Binding
+    -> Dhall.Expr Dhall.Src Dhall.X
+    -> Dhall.Expr Dhall.Src Dhall.X
+applyContext context expression =
+  case bindings of
+    []     -> expression
+    b : bs -> Dhall.Core.Let (b :| bs) expression
+  where
+    definitions = Dhall.Context.toList context
+
+    convertBinding (variable, Binding {..}) = Dhall.Core.Binding {..}
+      where
+        annotation = Just bindingType
+        value      = bindingExpr
+
+    bindings = fmap convertBinding definitions
 
 normalize
   :: MonadState Env m
   => Dhall.Expr Dhall.Src Dhall.X -> m ( Dhall.Expr t Dhall.X )
 normalize e = do
-  env <-
-    get
+  env <- get
 
-  return
-    ( Dhall.normalize
-        ( foldl'
-            ( \a (k, Binding { bindingType, bindingExpr }) ->
-                Expr.Let (pure (Dhall.Core.Binding k (Just bindingType) bindingExpr)) a
-            )
-            e
-            ( Dhall.Context.toList ( envToContext env ) )
-        )
-    )
+  return (Dhall.normalize (applyContext (envToContext env) e))
 
 
 typeCheck
   :: ( MonadIO m, MonadState Env m )
   => Dhall.Expr Dhall.Src Dhall.X -> m ( Dhall.Expr Dhall.Src Dhall.X )
-typeCheck expr = do
-  env <-
-    get
+typeCheck expression = do
+  env <- get
 
   let wrap = if explain env then Dhall.detailed else id
 
-  case Dhall.typeWith ( bindingType <$> envToContext env ) expr of
-    Left e ->
-      liftIO ( wrap (throwIO e) )
-
-    Right a ->
-      return a
+  case Dhall.typeOf (applyContext (envToContext env) expression) of
+    Left  e -> liftIO ( wrap (throwIO e) )
+    Right a -> return a
 
 
 addBinding :: ( MonadIO m, MonadState Env m ) => [String] -> m ()


### PR DESCRIPTION
The motivation for this change is so that more code type-checks
within a REPL session.

For example, before this change the following session fails:

```haskell
⊢ :let Either = λ(a : Type) → λ(b : Type) → < Left : a | Right : b >
⊢ :let Example = < Left : Natural | Right : Bool >

Example : Type

⊢ Example.Left

Example : Type

Error: Not a record or a union

Example.Left
(stdin):1:1
```

After this change, the same session works:

```haskell
⊢ :let Example = < Left : Natural | Right : Bool >

Example : Type

⊢ Example.Left

λ(Left : Natural) → < Left = Left | Right : Bool >

```

The difference is in how we incorporate prior definitions when
type-checking code.  Before this change prior definitions were added
to the context, which leads to type-checking failures because type
synonyms don't work when used in this way.  After this change we
incorporate them as extra `let` definitions (same as normalization).