### PR TITLE
GHCJS support for Dhall

### DIFF
--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -1,8 +1,9 @@
 -- | This module contains the implementation of the @dhall repl@ subcommand
 
-{-# language FlexibleContexts #-}
-{-# language NamedFieldPuns #-}
+{-# language FlexibleContexts  #-}
+{-# language NamedFieldPuns    #-}
 {-# language OverloadedStrings #-}
+{-# language RecordWildCards   #-}
 
 module Dhall.Repl
     ( -- * Repl
@@ -13,8 +14,9 @@ import Control.Exception ( SomeException(SomeException), displayException, throw
 import Control.Monad.IO.Class ( MonadIO, liftIO )
 import Control.Monad.State.Class ( MonadState, get, modify )
 import Control.Monad.State.Strict ( evalStateT )
-import Data.List ( foldl' )
+import Data.List.NonEmpty (NonEmpty(..))
 import Dhall.Binary (StandardVersion(..))
+import Dhall.Context (Context)
 import Dhall.Import (standardVersion)
 import Dhall.Pretty (CharacterSet(..))
 import Lens.Family (set)
@@ -149,41 +151,44 @@ typeOf srcs = do
   output System.IO.stdout exprType'
 
 
+applyContext
+    :: Context Binding
+    -> Dhall.Expr Dhall.Src Dhall.X
+    -> Dhall.Expr Dhall.Src Dhall.X
+applyContext context expression =
+  case bindings of
+    []     -> expression
+    b : bs -> Dhall.Core.Let (b :| bs) expression
+  where
+    definitions = Dhall.Context.toList context
+
+    convertBinding (variable, Binding {..}) = Dhall.Core.Binding {..}
+      where
+        annotation = Just bindingType
+        value      = bindingExpr
+
+    bindings = fmap convertBinding definitions
 
 normalize
   :: MonadState Env m
   => Dhall.Expr Dhall.Src Dhall.X -> m ( Dhall.Expr t Dhall.X )
 normalize e = do
-  env <-
-    get
+  env <- get
 
-  return
-    ( Dhall.normalize
-        ( foldl'
-            ( \a (k, Binding { bindingType, bindingExpr }) ->
-                Expr.Let (pure (Dhall.Core.Binding k (Just bindingType) bindingExpr)) a
-            )
-            e
-            ( Dhall.Context.toList ( envToContext env ) )
-        )
-    )
+  return (Dhall.normalize (applyContext (envToContext env) e))
 
 
 typeCheck
   :: ( MonadIO m, MonadState Env m )
   => Dhall.Expr Dhall.Src Dhall.X -> m ( Dhall.Expr Dhall.Src Dhall.X )
-typeCheck expr = do
-  env <-
-    get
+typeCheck expression = do
+  env <- get
 
   let wrap = if explain env then Dhall.detailed else id
 
-  case Dhall.typeWith ( bindingType <$> envToContext env ) expr of
-    Left e ->
-      liftIO ( wrap (throwIO e) )
-
-    Right a ->
-      return a
+  case Dhall.typeOf (applyContext (envToContext env) expression) of
+    Left  e -> liftIO ( wrap (throwIO e) )
+    Right a -> return a
 
 
 addBinding :: ( MonadIO m, MonadState Env m ) => [String] -> m ()

--- a/nix/cborg.nix
+++ b/nix/cborg.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, aeson, array, base, base16-bytestring
+, base64-bytestring, bytestring, containers, deepseq, fail
+, ghc-prim, half, integer-gmp, primitive, QuickCheck, scientific
+, stdenv, tasty, tasty-hunit, tasty-quickcheck, text, vector
+}:
+mkDerivation {
+  pname = "cborg";
+  version = "0.2.1.0";
+  sha256 = "9198735f7645ae492345505448f790433f5fe407b19e1c6b2ec2a4c76bd97483";
+  libraryHaskellDepends = [
+    array base bytestring containers deepseq ghc-prim half integer-gmp
+    primitive text
+  ];
+  testHaskellDepends = [
+    aeson array base base16-bytestring base64-bytestring bytestring
+    deepseq fail half QuickCheck scientific tasty tasty-hunit
+    tasty-quickcheck text vector
+  ];
+  description = "Concise Binary Object Representation";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/haskeline_0_7_3_1.nix
+++ b/nix/haskeline_0_7_3_1.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, bytestring, containers, directory, filepath
+, process, stdenv, stm, transformers, unix
+}:
+mkDerivation {
+  pname = "haskeline";
+  version = "0.7.4.3";
+  sha256 = "046d0930bc2dbc57a7cd9ddb5d1e92c7fdb71c6b91b2bbf673f5406843d6b679";
+  configureFlags = [ "-f-terminfo" ];
+  libraryHaskellDepends = [
+    base bytestring containers directory filepath process stm
+    transformers unix
+  ];
+  homepage = "https://github.com/judah/haskeline";
+  description = "A command-line interface for user input, written in Haskell";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -69,7 +69,11 @@ let
                     "comonad"
                     "distributive"
                     "doctest"
+                    "half"
+                    "http-types"
+                    "megaparsec"
                     "prettyprinter"
+                    "prettyprinter-ansi-terminal"
                     # https://github.com/well-typed/cborg/issues/172
                     "serialise"
                     "unordered-containers"

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -59,7 +59,7 @@ let
                 failOnAllWarnings = drv:
                   # Older versions of GHC incorrectly detect non-exhaustive
                   # pattern matches
-                  if compiler == "ghc7103" || or compiler == "ghcjs"
+                  if compiler == "ghc7103" || compiler == "ghcjs"
                   then drv
                   else pkgsNew.haskell.lib.failOnAllWarnings drv;
 

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -57,9 +57,9 @@ let
                     pkgsNew.haskell.lib.dontCheck drv;
 
                 failOnAllWarnings = drv:
-                  # GHC 7.10.3 incorrectly detects non-exhaustive pattern
-                  # matches
-                  if compiler == "ghc7103"
+                  # Older versions of GHC incorrectly detect non-exhaustive
+                  # pattern matches
+                  if compiler == "ghc7103" || or compiler == "ghcjs"
                   then drv
                   else pkgsNew.haskell.lib.failOnAllWarnings drv;
 

--- a/release.nix
+++ b/release.nix
@@ -5,6 +5,9 @@ let
   shared_8_6_1 =
     import ./nix/shared.nix { compiler = "ghc861"; };
 
+  shared_ghcjs =
+    import ./nix/shared.nix { compiler = "ghcjs"; };
+
   shared =
     import ./nix/shared.nix { };
 
@@ -37,6 +40,9 @@ in
           shared.tarball-dhall-bash
           shared.tarball-dhall-json
           shared.tarball-dhall-text
+
+          # Verify that `dhall` can be built using GHCJS
+          shared_ghcjs.dhall
 
           # This is the only `dhall` build that runs the test suite
           coverage.dhall


### PR DESCRIPTION
This adds a GHCJS build for Dhall so that:

* We can build a `try.dhall-lang.org` to try Dhall in the
  browser until the PureScript implementation comes online
* We can document how to build `dhall` using GHCJS
* We can verify that new changes to `dhall` or its dependencies
  don't break GHCJS support
* CI can build and cache GHCJS-related dependencies