### PR TITLE
Fix diff so that an empty list is equal to itself

### DIFF
--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -11,7 +11,9 @@
 
 module Dhall.Diff (
     -- * Diff
-      diffNormalized
+      Diff (..)
+    , diffExpression
+    , diffNormalized
     , Dhall.Diff.diff
     ) where
 

--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -364,7 +364,7 @@ diffList l r
   | allDifferent parts = difference listSkeleton listSkeleton
   | otherwise          = bracketed (foldMap diffPart parts)
   where
-    allDifferent = not . any isBoth
+    allDifferent = any (not . isBoth)
 
     -- Sections of the list that are only in left, only in right, or in both
     parts =

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -8,6 +8,7 @@ module Dhall.Test.QuickCheck where
 
 import Codec.Serialise (DeserialiseFailure(..))
 import Control.Monad (guard)
+import Data.Either (isRight)
 import Data.List.NonEmpty (NonEmpty(..))
 import Dhall.Map (Map)
 import Dhall.Core
@@ -29,7 +30,7 @@ import Dhall.Core
 import Dhall.Set (Set)
 import Numeric.Natural (Natural)
 import Test.QuickCheck
-    (Arbitrary(..), Gen, Property, genericShrink, (===))
+    (Arbitrary(..), Gen, Property, genericShrink, (===), (==>))
 import Test.QuickCheck.Instances ()
 import Test.Tasty (TestTree)
 
@@ -39,7 +40,9 @@ import qualified Dhall.Map
 import qualified Data.Sequence
 import qualified Dhall.Binary
 import qualified Dhall.Core
+import qualified Dhall.Diff
 import qualified Dhall.Set
+import qualified Dhall.TypeCheck
 import qualified Test.QuickCheck
 import qualified Test.Tasty.QuickCheck
 
@@ -350,6 +353,14 @@ isNormalizedIsConsistentWithNormalize expression =
         Dhall.Core.isNormalized expression
     === (Dhall.Core.normalize expression == expression)
 
+isSameAsSelf :: Expr () Import -> Property
+isSameAsSelf expression =
+  hasNoImportAndTypechecks ==> Dhall.Diff.same (Dhall.Diff.diffExpression expression expression)
+  where hasNoImportAndTypechecks =
+          case traverse (\_ -> Left ()) expression of
+            Right importlessExpression -> isRight (Dhall.TypeCheck.typeOf importlessExpression)
+            Left _ -> False
+
 tests :: TestTree
 tests =
     Test.Tasty.QuickCheck.testProperties
@@ -360,5 +371,9 @@ tests =
         , ( "isNormalized should be consistent with normalize"
           , Test.QuickCheck.property
               (Test.QuickCheck.withMaxSuccess 10000 isNormalizedIsConsistentWithNormalize)
+          )
+        , ( "An expression should have no difference with itself"
+          , Test.QuickCheck.property
+              (Test.QuickCheck.withMaxSuccess 10000 isSameAsSelf)
           )
         ]


### PR DESCRIPTION
While using `dhall diff`, I realized that empty lists are considered to be different. This PR contains two commits:
- The first one adds a quickcheck test to ensure an expression is always the same as itself (as long as it typechecks ; things go weird when you have an invalid expression, I guess because `Diff` assume the expression is well-formed).
- The second one is the actual fix.

Sadly, the test required me to expose some previously private part of `Dhall.diff`. If that's a problem, feel free to cherry-pick the second commit.