### PR TITLE
Add "Try Dhall" examples and JSON output

### DIFF
--- a/dhall-try/dhall-try.cabal
+++ b/dhall-try/dhall-try.cabal
@@ -15,7 +15,9 @@ cabal-version:       >=1.10
 executable dhall-try
   main-is:             Main.hs
   build-depends:       base           >= 4.11.0.0 && < 5
+                     , aeson-pretty
                      , dhall          >= 1.19.0   && < 1.20
+                     , dhall-json
                      , prettyprinter  >= 1.2.1    && < 1.3
                      , text           >= 1.2.3.0  && < 1.3
                      , ghcjs-base     >= 0.2.0.0  && < 0.3

--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -2,30 +2,46 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
     <style>
-      * {
-        -webkit-box-sizing: border-box;
-           -moz-box-sizing: border-box;
-                box-sizing: border-box;
-      }
-
       #title {
         text-align: center;
+        margin-bottom: 20px;
+      }
+
+      #editor {
+        display: flex;
+      }
+
+      #input-pane {
+        order: 0;
+        flex: 1;
+        width: 80ch;
+        overflow: auto;
+      }
+
+      #output-pane {
+        order: 1;
+        flex: 1;
+        overflow: auto;
       }
 
       .CodeMirror {
-        margin-left: auto;
-        margin-right: auto;
-        margin-top: 20px;
         margin-bottom: 20px;
         outline: 1px solid black;
-        width: 86ch;
-        height: 24em;
+        height: 24rem !important;
+      }
+
+      .nav-link {
+        outline: 0;
+        border-bottom: 1px;
       }
     </style>
     <link rel="stylesheet" href="./css/codemirror.css">
     <script language="javascript" src="./js/codemirror.js"></script>
     <script language="javascript" src="./js/haskell.js"></script>
+    <script language="javascript" src="./js/javascript.js"></script>
     <script language="javascript" src="./js/rts.js"></script>
     <script language="javascript" src="./js/lib.js"></script>
     <script language="javascript" src="./js/out.js"></script>
@@ -33,12 +49,52 @@
   <body>
     <a href="https://dhall-lang.org"><img src="./img/dhall-logo.png" height="50px"></a>
     <h1 id="title">Try the Dhall configuration language</h1>
-    <textarea id="dhall-input">Natural/even (1 + 1)</textarea>
-    <textarea id="dhall-output"></textarea>
+    <div id="editor">
+      <div id="input-pane">
+        <ul class="nav nav-tabs example-tab">
+          <li class="nav-item">
+            <a id="example0" class="nav-link example-tab active" href="#" onClick="set(example0, 'example0')">Hello, world!</a>
+          </li>
+          <li class="nav-item">
+            <a id="example1" class="nav-link example-tab" href="#" onClick="set(example1, 'example1')">Definitions</a>
+          </li>
+          <li class="nav-item">
+            <a id="example2" class="nav-link example-tab" href="#" onClick="set(example2, 'example2')">Functions</a>
+          </li>
+          <li class="nav-item">
+            <a id="example3" class="nav-link example-tab" href="#" onClick="set(example3, 'example3')">Types</a>
+          </li>
+          <li class="nav-item">
+            <a id="example4" class="nav-link example-tab" href="#" onClick="set(example4, 'example4')">Built-ins</a>
+          </li>
+        </ul>
+        <textarea id="dhall-input"></textarea>
+      </div>
+      <div id="output-pane">
+        <ul class="nav nav-tabs">
+          <li class="nav-item">
+            <a id="dhall-tab" class="nav-link mode-tab active" href="#">Dhall</a>
+          </li>
+          <li class="nav-item">
+            <a id="json-tab" class="nav-link mode-tab" href="#">JSON</a>
+          </li>
+        </ul>
+        <textarea id="dhall-output"></textarea>
+      </div>
+    </div>
   </body>
   <script>
     var dhallInput  = document.getElementById("dhall-input");
     var dhallOutput = document.getElementById("dhall-output");
+    var dhallTab    = document.getElementById("dhall-tab");
+    var jsonTab     = document.getElementById("json-tab");
+
+    function selectTab(tabClass, tabId) {
+      Array.from(document.getElementsByClassName(tabClass)).forEach(element => {
+        element.classList.remove("active");
+      });
+      document.getElementById(tabId).classList.toggle("active");
+    }
 
     var input = CodeMirror.fromTextArea(dhallInput, {
       lineNumbers: true,
@@ -47,8 +103,108 @@
 
     var output = CodeMirror.fromTextArea(dhallOutput, {
       lineNumbers: true,
-      mode: "haskell"
+      mode: "haskell",
+      readOnly: true
     });
+
+    example0 = `{- This is an example Dhall configuration file
+
+   Can you spot and correct the mistake?
+-}
+
+{ home       = "/home/bill"
+, privateKey = "/home/bill/id_ed25519"
+, publicKey  = "/home/blil/id_ed25519.pub"
+}`
+
+    example1 = `{- Don't repeat yourself!
+
+   Repetition is error-prone
+-}
+
+let user = "bill"
+in  { home       = "/home/\${user}"
+    , privateKey = "/home/\${user}/id_ed25519"
+    , publicKey  = "/home/\${user}/id_ed25519.pub"
+    }
+
+{- Change the name "bill" to "jane" -}`;
+
+    example2 = `{- More than one user?  Use a function! -}
+
+let makeUser = \\(user : Text) ->
+      let home       = "/home/\${user}"
+      let privateKey = "\${home}/id_ed25519.pub"
+      let publicKey  = "\${privateKey}.pub"
+      in  { home = home
+          , privateKey = privateKey
+          , publicKey = publicKey
+          }
+    {- Add another user to this list -}
+in  [ makeUser "bill"
+    , makeUser "jane"
+    ]`
+
+    example3 = `{- You can optionally add types
+
+   \`x : T\` means that \`x\` has type \`T\`
+-}
+
+let Config : Type =
+      {- What happens if you add another field here? -}
+      { home : Text
+      , privateKey : Text
+      , publicKey : Text
+      }
+
+let makeUser : Text -> Config = \\(user : Text) ->
+      let home       : Text   = "/home/\${user}"
+      let privateKey : Text   = "\${home}/id_ed25519.pub"
+      let publicKey  : Text   = "\${privateKey}.pub"
+      let config     : Config =
+            { home       = home
+            , privateKey = privateKey
+            , publicKey  = publicKey
+            }
+      in  config
+
+let configs : List Config =
+      [ makeUser "bill"
+      , makeUser "jane"
+      ]
+
+in  configs
+`;
+
+    example4 = `{- The language provides built-in functions, such as:
+
+       Natural/show : Natural -> Text
+
+    You can find all built-ins here:
+
+    https://github.com/dhall-lang/dhall-lang/wiki/Built-in-types%2C-functions%2C-and-operators
+-}
+let makeUser = \\(user : Text) ->
+      let home       = "/home/\${user}"
+      let privateKey = "\${home}/id_ed25519.pub"
+      let publicKey  = "\${privateKey}.pub"
+      in  { home = home
+          , privateKey = privateKey
+          , publicKey = publicKey
+          }
+
+let buildUser = \\(index : Natural) ->
+      {- What happens if you delete \`Natural/show\` -}
+      makeUser "build\${Natural/show index}"
+
+in  [ buildUser 0, buildUser 1 ]`
+
+    function set(example, tabId){
+      input.setValue(example);
+      selectTab("example-tab", tabId);
+    };
+
+    input.setValue(example0);
   </script>
   <script language="javascript" src="./js/runmain.js" defer></script>
 </html>

--- a/dhall-try/src/Main.hs
+++ b/dhall-try/src/Main.hs
@@ -3,18 +3,23 @@
 module Main where
 
 import qualified Control.Exception
+import qualified Data.Aeson.Encode.Pretty
+import qualified Data.IORef
 import qualified Data.JSString
 import qualified Data.Text
+import qualified Data.Text.Lazy
+import qualified Data.Text.Lazy.Encoding
 import qualified Data.Text.Prettyprint.Doc             as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
 import qualified Dhall.Core
 import qualified Dhall.Import
+import qualified Dhall.JSON
 import qualified Dhall.Parser
 import qualified Dhall.Pretty
 import qualified Dhall.TypeCheck
 import qualified GHCJS.Foreign.Callback
 
-import Control.Exception (SomeException)
+import Control.Exception (Exception, SomeException)
 import Data.JSString (JSString)
 import Data.Text (Text)
 import Dhall.Core (Expr(..))
@@ -22,53 +27,115 @@ import GHCJS.Foreign.Callback (Callback)
 
 foreign import javascript unsafe "input.getValue()" getInput :: IO JSString
 
-foreign import javascript unsafe "input.on('change', $1)" registerCallback :: Callback (IO ()) -> IO ()
+foreign import javascript unsafe "input.on('change', $1)" registerInterpret :: Callback (IO ()) -> IO ()
 
-foreign import javascript unsafe "output.setValue($1)" setOutput :: JSString -> IO ()
+foreign import javascript unsafe "dhallTab.onclick = $1" registerDhallOutput :: Callback (IO ()) -> IO ()
+
+foreign import javascript unsafe "jsonTab.onclick = $1" registerJSONOutput :: Callback (IO ()) -> IO ()
+
+foreign import javascript unsafe "output.setValue($1)" setOutput_ :: JSString -> IO ()
+
+foreign import javascript unsafe "selectTab($1, $2)" selectTab :: JSString -> JSString -> IO ()
 
 fixup :: Text -> Text
 fixup = Data.Text.replace "\ESC[1;31mError\ESC[0m" "Error"
 
+setOutput :: Text -> IO ()
+setOutput = setOutput_ . Data.JSString.pack . Data.Text.unpack
+
+errOutput :: Exception e => e -> IO ()
+errOutput = setOutput . fixup . Data.Text.pack . show
+
+jsonConfig :: Data.Aeson.Encode.Pretty.Config
+jsonConfig =
+    Data.Aeson.Encode.Pretty.Config
+        { Data.Aeson.Encode.Pretty.confIndent =
+            Data.Aeson.Encode.Pretty.Spaces 2
+        , Data.Aeson.Encode.Pretty.confCompare =
+            compare
+        , Data.Aeson.Encode.Pretty.confNumFormat =
+            Data.Aeson.Encode.Pretty.Generic
+        , Data.Aeson.Encode.Pretty.confTrailingNewline =
+            False
+        }
+
+data Mode = Dhall | JSON deriving (Show)
+
 main :: IO ()
 main = do
+    modeRef <- Data.IORef.newIORef Dhall
+
     let prettyExpression =
               Pretty.renderStrict
             . Pretty.layoutSmart Dhall.Pretty.layoutOpts
             . Dhall.Pretty.prettyExpr
 
-    let callback :: IO ()
-        callback = do
+    let interpret = do
             inputJSString <- getInput
 
             let inputString = Data.JSString.unpack inputJSString
             let inputText   = Data.Text.pack inputString
 
-            outputText <- case Dhall.Parser.exprFromText "(input)" inputText of
+            case Dhall.Parser.exprFromText "(input)" inputText of
                 Left exception -> do
-                    return (Data.Text.pack (show exception))
+                    errOutput exception
                 Right parsedExpression -> do
                   eitherResolvedExpression <- Control.Exception.try (Dhall.Import.load parsedExpression)
                   case eitherResolvedExpression of
                       Left exception -> do
-                          return (Data.Text.pack (show (exception :: SomeException)))
+                          errOutput (exception :: SomeException)
                       Right resolvedExpression -> do
                           case Dhall.TypeCheck.typeOf resolvedExpression of
                               Left exception -> do
-                                  return (Data.Text.pack (show exception))
+                                  errOutput exception
                               Right inferredType -> do
-                                  let normalizedExpression =
-                                          Dhall.Core.normalize resolvedExpression
-                                  return (prettyExpression (Annot normalizedExpression inferredType))
+                                  mode <- Data.IORef.readIORef modeRef
+                                  case mode of
+                                      Dhall -> do
+                                          let normalizedExpression =
+                                                  Dhall.Core.normalize resolvedExpression
+                                          let dhallText =
+                                                  prettyExpression (Annot normalizedExpression inferredType)
+                                          setOutput dhallText
 
-            let outputString   = Data.Text.unpack (fixup outputText)
-            let outputJSString = Data.JSString.pack outputString
+                                      JSON -> do
+                                          case Dhall.JSON.dhallToJSON resolvedExpression of
+                                              Left exception -> do
+                                                  errOutput exception
+                                              Right value -> do
+                                                  let jsonBytes = Data.Aeson.Encode.Pretty.encodePretty' jsonConfig value
+                                                  case Data.Text.Lazy.Encoding.decodeUtf8' jsonBytes of
+                                                      Left exception -> do
+                                                          errOutput exception
+                                                      Right jsonText -> do
+                                                          setOutput (Data.Text.Lazy.toStrict jsonText)
 
-            setOutput outputJSString
+    interpret
 
-    callback
+    interpretAsync <- GHCJS.Foreign.Callback.asyncCallback interpret
 
-    async <- GHCJS.Foreign.Callback.asyncCallback callback
+    registerInterpret interpretAsync
 
-    registerCallback async
+    let dhallOutput = do
+            Data.IORef.writeIORef modeRef Dhall
+
+            selectTab "mode-tab" "dhall-tab"
+
+            interpret
+
+    dhallOutputAsync <- GHCJS.Foreign.Callback.asyncCallback dhallOutput
+
+    registerDhallOutput dhallOutputAsync
+
+    let jsonOutput = do
+            Data.IORef.writeIORef modeRef JSON
+
+            selectTab "mode-tab" "json-tab"
+
+            interpret
+
+    jsonOutputAsync <- GHCJS.Foreign.Callback.asyncCallback jsonOutput
+
+    registerJSONOutput jsonOutputAsync
 
     return ()

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -75,6 +75,7 @@ let
                     "aeson"
                     "base-compat-batteries"
                     "comonad"
+                    "conduit"
                     "distributive"
                     "doctest"
                     "Glob"
@@ -85,7 +86,9 @@ let
                     "prettyprinter-ansi-terminal"
                     # https://github.com/well-typed/cborg/issues/172
                     "serialise"
+                    "semigroupoids"
                     "unordered-containers"
+                    "yaml"
                   ];
 
                 failOnAllWarningsExtension =
@@ -127,7 +130,10 @@ let
                     dhall-try =
                       haskellPackagesNew.callCabal2nix
                         "dhall-try"
-                        ../dhall-try
+                        (builtins.filterSource
+                          (path: _: baseNameOf path != "index.html")
+                          ../dhall-try
+                        )
                         { };
                   };
 
@@ -153,6 +159,7 @@ let
       ${pkgsNew.coreutils}/bin/cp ${../dhall-try/index.html} $out/index.html
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/lib/codemirror.js $out/js
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/mode/haskell/haskell.js $out/js
+      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/mode/javascript/javascript.js $out/js
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/lib/codemirror.css $out/css
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.dhall-logo} $out/img/dhall-logo.png
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.dhall.prelude} $out/Prelude


### PR DESCRIPTION
This changes the layout to a side-by-side split-pane output
and also adds tabs for each pane:

* Tabs for the left pane let you switch between examples
* Tabs for the right pane let you switch between output modes

![try dhall - 2](https://user-images.githubusercontent.com/1313787/49682694-c9463180-fa6d-11e8-8245-3a10cebebbd7.gif)
