### PR TITLE
Minify Javascript code generated by GHCJS

### DIFF
--- a/dhall-try/dhall-try.cabal
+++ b/dhall-try/dhall-try.cabal
@@ -23,5 +23,5 @@ executable dhall-try
                      , ghcjs-base     >= 0.2.0.0  && < 0.3
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options: -Wall
+  ghc-options: -Wall -dedupe
   cpp-options: -DGHCJS_BROWSER

--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -41,9 +41,6 @@
     <script language="javascript" src="./js/codemirror.js"></script>
     <script language="javascript" src="./js/haskell.js"></script>
     <script language="javascript" src="./js/javascript.js"></script>
-    <script language="javascript" src="./js/rts.js"></script>
-    <script language="javascript" src="./js/lib.js"></script>
-    <script language="javascript" src="./js/out.js"></script>
   </head>
   <body>
     <a href="https://dhall-lang.org"><img src="./img/dhall-logo.png" height="50px"></a>
@@ -205,5 +202,5 @@ in  [ buildUser 0, buildUser 1 ]`
 
     input.setValue(example0);
   </script>
-  <script language="javascript" src="./js/runmain.js" defer></script>
+  <script language="javascript" src="./js/all.min.js" defer></script>
 </html>

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -168,7 +168,7 @@ let
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/lib/codemirror.css $out/css
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.dhall-logo} $out/img/dhall-logo.png
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.dhall.prelude} $out/Prelude
-      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.haskell.packages.ghcjs.dhall-try}/bin/dhall-try.jsexe/{lib,out,rts,runmain}.js $out/js/
+      ${pkgsNew.closurecompiler}/bin/closure-compiler ${pkgsNew.haskell.packages.ghcjs.dhall-try}/bin/dhall-try.jsexe/all.js --jscomp_off=checkVars --externs=${pkgsNew.haskell.packages.ghcjs.dhall-try}/bin/dhall-try.jsexe/all.js.externs > $out/js/all.min.js
 
       ${pkgsNew.coreutils}/bin/mkdir $out/nix-support
       ${pkgsNew.coreutils}/bin/echo "doc none $out/index.html" > $out/nix-support/hydra-build-products


### PR DESCRIPTION
This reduces the size of the generated JavaScript code from ~15 MB to ~6 MB