### PR TITLE
Add an example of using imports

### DIFF
--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -64,7 +64,7 @@
             <a id="example3" class="nav-link example-tab" href="#" onClick="set(example3, 'example3')">Types</a>
           </li>
           <li class="nav-item">
-            <a id="example4" class="nav-link example-tab" href="#" onClick="set(example4, 'example4')">Built-ins</a>
+            <a id="example4" class="nav-link example-tab" href="#" onClick="set(example4, 'example4')">Imports</a>
           </li>
         </ul>
         <textarea id="dhall-input"></textarea>
@@ -175,14 +175,22 @@ let configs : List Config =
 in  configs
 `;
 
-    example4 = `{- The language provides built-in functions, such as:
+    example4 = `{- Need to generate a lot of users?
 
-       Natural/show : Natural -> Text
-
-    You can find all built-ins here:
-
-    https://github.com/dhall-lang/dhall-lang/wiki/Built-in-types%2C-functions%2C-and-operators
+   Use the \`generate\` function from the Dhall Prelude
 -}
+
+let generate = https://prelude.dhall-lang.org/List/generate
+
+{- You can import Dhall expressions from URLs that support
+   CORS
+
+   The command-line tools also let you import from files,
+   environment variables, and URLs without CORS support.
+
+   Browse https://prelude.dhall-lang.org for more utilities
+-}
+
 let makeUser = \\(user : Text) ->
       let home       = "/home/\${user}"
       let privateKey = "\${home}/id_ed25519.pub"
@@ -193,10 +201,19 @@ let makeUser = \\(user : Text) ->
           }
 
 let buildUser = \\(index : Natural) ->
-      {- What happens if you delete \`Natural/show\` -}
+      {- \`Natural/show\` is a "built-in", meaning that
+         you can use \`Natural/show\` without an import
+      -}
       makeUser "build\${Natural/show index}"
 
-in  [ buildUser 0, buildUser 1 ]`
+let Config =
+      { home : Text
+      , privateKey : Text
+      , publicKey : Text
+      }
+
+in  {- Try generating 20 users instead of 10 -}
+    generate 10 Config buildUser`
 
     function set(example, tabId){
       input.setValue(example);

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -167,7 +167,6 @@ let
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/mode/javascript/javascript.js $out/js
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/lib/codemirror.css $out/css
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.dhall-logo} $out/img/dhall-logo.png
-      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.dhall.prelude} $out/Prelude
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.haskell.packages.ghcjs.dhall-try}/bin/dhall-try.jsexe/{lib,out,rts,runmain}.js $out/js/
 
       ${pkgsNew.coreutils}/bin/mkdir $out/nix-support


### PR DESCRIPTION
We can import expressions from `https://prelude.dhall-lang.org`
now that it provides CORS support.  See:

https://github.com/dhall-lang/dhall-lang/pull/315