### PR TITLE
Expand "Try dhall" into `dhall-lang.org` home page

### DIFF
--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -34,6 +34,14 @@
       .nav-link {
         outline: 0;
       }
+
+      .navbar span {
+        margin-left: 7px;
+      }
+
+      .navbar {
+        margin-bottom: 20px;
+      };
     </style>
     <link rel="stylesheet" href="./css/codemirror.css">
     <link rel="stylesheet" href="./css/bootstrap.min.css">
@@ -46,8 +54,35 @@
     <script language="javascript" src="./js/out.js"></script>
   </head>
   <body>
-    <a href="https://dhall-lang.org"><img src="./img/dhall-logo.png" height="50px"></a>
+    <nav class="navbar navbar-light bg-light">
+      <a class="navbar-left" href="https://dhall-lang.org"><img src="./img/dhall-logo.png" height="32px"></a>
+      <div class="nav-item">
+        <a class="nav-link" href="https://github.com/dhall-lang/dhall-lang/wiki">📚<span>Learn</span></a>
+      </div>
+      <div class="nav-item">
+        <a class="nav-link" href="https://github.com/dhall-lang/dhall-lang/blob/master/README.md"><img src = "./img/github-logo.png" height="32px"><span>GitHub</a></a>
+      </div>
+      <div class="nav-item">
+        <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md"><img src = "./img/yaml-logo.png" height="32px"><span>YAML</span></a>
+      </div>
+      <div class="nav-item">
+        <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md"><img src = "./img/json-logo.svg" height="32px"><span>JSON</span></a>
+      </div>
+      <div class="nav-item">
+        <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-bash/README.md"><img src = "./img/bash-logo.png" height="32px"><span>Bash</span></a>
+      </div>
+      <div class="nav-item">
+        <a class="nav-link" href="https://github.com/f-f/dhall-clj/blob/master/README.md"><img src = "./img/clojure-logo.svg" height="32px"><span>Clojure</span></a>
+      </div>
+      <div class="nav-item">
+        <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall/README.md"><img src = "./img/haskell-logo.png" height="32px"><span>Haskell</span></a>
+      </div>
+      <div class="nav-item">
+        <a class="nav-link" href="https://github.com/dhall-lang/dhall-nix/blob/master/README.md"><img src = "./img/nix-logo.png" height="32px"><span>Nix</span></a>
+      </div>
+    </nav>
     <h1 id="title">Try the Dhall configuration language</h1>
+    <p class="text-center"><b>Dhall ≈ JSON + Functions + Types + Imports</b></p>
     <div id="editor">
       <div id="input-pane">
         <ul class="nav nav-tabs example-tab">

--- a/nix/githubLogo.nix
+++ b/nix/githubLogo.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "github-logo";
+
+  src = fetchurl {
+    url = "https://github-media-downloads.s3.amazonaws.com/GitHub-Mark.zip";
+    sha256 = "11znjcl0kwvws0wk600hlhq5z0mp7a0234zwryn20x6ib8qqb9v9";
+  };
+
+  buildInputs = [ unzip ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir $out
+    cp -r * $out/
+  '';
+}

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -15,14 +15,51 @@ let
       builtins.listToAttrs (map toNameValue names);
 
   overlayShared = pkgsNew: pkgsOld: {
-    twitterBootstrap = pkgsNew.callPackage ./twitterBootstrap.nix { };
+    logo = {
+      bash =
+        pkgsNew.fetchurl {
+          url    = "https://raw.githubusercontent.com/odb/official-bash-logo/master/assets/Logos/Icons/PNG/128x128.png";
+          sha256 = "0fybbp6hbqrfw80fbk55bnykzda0m7x4vk38i80bjlmfbrkfvild";
+        };
 
-    dhall-logo =
-      pkgsNew.fetchurl {
-        url = "https://raw.githubusercontent.com/dhall-lang/dhall-lang/8bab26f9515cc1007025e0ab4b4e7dd6e95a7103/img/dhall-logo.png";
+      clojure =
+        pkgsNew.fetchurl {
+          url    = "https://upload.wikimedia.org/wikipedia/commons/5/5d/Clojure_logo.svg";
+          sha256 = "0mrjzv690g9mxljzxsvay8asyr8vlxhhs9smmax7mp3psd49b43g";
+        };
 
-        sha256 = "0j6sfvm4kxqb2m6s1sv9qag7m30cibaxpphprhaibp9s9shpra4p";
-      };
+      dhall =
+        pkgsNew.fetchurl {
+          url    = "https://raw.githubusercontent.com/dhall-lang/dhall-lang/8bab26f9515cc1007025e0ab4b4e7dd6e95a7103/img/dhall-logo.png";
+          sha256 = "0j6sfvm4kxqb2m6s1sv9qag7m30cibaxpphprhaibp9s9shpra4p";
+        };
+
+      github = pkgsNew.callPackage ./githubLogo.nix { };
+
+      haskell =
+        pkgsNew.fetchurl {
+          url    = "https://wiki.haskell.org/wikiupload/4/4a/HaskellLogoStyPreview-1.png";
+          sha256 = "0g26j7vx34m46mwp93qgg3q5x8pfdq2j1ch0vxz5gj0nk3b8fxda";
+        };
+
+      nix =
+        pkgsNew.fetchurl {
+          url    = "https://nixos.org/logo/nix-wiki.png";
+          sha256 = "1hrz7wr7i0b2bips60ygacbkmdzv466lsbxi22hycg42kv4m0173";
+        };
+
+      json =
+        pkgsNew.fetchurl {
+          url    = "https://upload.wikimedia.org/wikipedia/commons/c/c9/JSON_vector_logo.svg";
+          sha256 = "1hqd1qh35v9magjp3rbsw8wszk2wn3hkz981ir49z5cyf11jnx95";
+        };
+
+      yaml =
+        pkgsNew.fetchurl {
+          url    = "https://raw.githubusercontent.com/yaml/yaml-spec/a6f764e13de58d5f753877f588a01b35dc9a5168/logo.png";
+          sha256 = "12grgaxpqi755p2rnvw3x02zc69brpnzx208id1f0z42w387j4hi";
+        };
+    };
 
     dhall-sdist =
       let
@@ -155,6 +192,8 @@ let
 
     npm = pkgsNew.callPackage ./npm { };
 
+    twitterBootstrap = pkgsNew.callPackage ./twitterBootstrap.nix { };
+
     try-dhall-static = pkgsNew.runCommand "try-dhall-static" {} ''
       ${pkgsNew.coreutils}/bin/mkdir $out
       ${pkgsNew.coreutils}/bin/mkdir $out/{css,img,js}
@@ -166,8 +205,15 @@ let
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/mode/haskell/haskell.js $out/js
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/mode/javascript/javascript.js $out/js
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.npm.codemirror}/lib/node_modules/codemirror/lib/codemirror.css $out/css
-      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.dhall-logo} $out/img/dhall-logo.png
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.dhall.prelude} $out/Prelude
+      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.logo.bash} $out/img/bash-logo.png
+      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.logo.clojure} $out/img/clojure-logo.svg
+      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.logo.dhall} $out/img/dhall-logo.png
+      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.logo.github}/PNG/GitHub-Mark-32px.png $out/img/github-logo.png
+      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.logo.haskell} $out/img/haskell-logo.png
+      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.logo.json} $out/img/json-logo.svg
+      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.logo.nix} $out/img/nix-logo.png
+      ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.logo.yaml} $out/img/yaml-logo.png
       ${pkgsNew.coreutils}/bin/ln --symbolic ${pkgsNew.haskell.packages.ghcjs.dhall-try}/bin/dhall-try.jsexe/{lib,out,rts,runmain}.js $out/js/
 
       ${pkgsNew.coreutils}/bin/mkdir $out/nix-support


### PR DESCRIPTION
This expands the "Try dhall" page to serve as a functional home page for
"dhall-lang.org" in the short term by making the following changes:

* Adding a navigation bar to the top that links to useful resources and
  official integrations
* Adding a quick summary explaining what Dhall is

Here is an example of what it looks like:

![screenshot_20181209_181946](https://user-images.githubusercontent.com/1313787/49707183-1564b380-fbdf-11e8-92ae-ef8a6e4cf1ad.png)
