### PR TITLE
Remove the `try-dhall-server` build product

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ And each of them with `stack build <package-name>`, for example:
 $ stack build dhall-json
 ```
 
-## Build and serve the "Try Dhall" website
+## Build the "Try Dhall" website
 
-This is currently only supported for Nix on Linux
+Building the website from source is currently only supported for Nix on Linux.
 
 You can build the static assets by running:
 
@@ -107,28 +107,12 @@ You can build the static assets by running:
 $ nix-build --attr try-dhall-static
 ```
 
-For local testing you can open the generated `./result/index.html` directly in
-your browser and everything will work except for relative imports of the
-Prelude.
+... then open `./result/index.html` in your browser.
 
-To also test imports you can build the `try-dhall-server` script which uses
-`warp` to serve the static assets:
+You can also download archive containing the pre-built website from CI using
+this link:
 
-```bash
-$ nix-build --attr try-dhall-server
-$ result/bin/try-dhall-server
-Serving directory /nix/store/i7x86qs888rndrhvw92y69jd5xaji060-try-dhall-static on port 3000 with ["index.html","index.htm"] index files.
-```
-
-... and then open `http://localhost:3000` in your browser.  You will then be
-able to import things from the Prelude within your Dhall configuration using
-a path like `http://localhost:3000/Prelude/List/map`.  Similarly, if you host
-this on some public-facing domain such as `https://try.dhall-lang.org` then you
-can import the Prelude using `https://try.dhall-lang.org/Prelude/List/map`.
-
-Note that imports from other domains (such as `prelude.dhall-lang.org`) will not
-yet work since cross-origin resource-sharing (CORS) is not enabled.  This is why
-the "Try Dhall" server serves its own copy of the Prelude.
+* [try-dhall.tar.bz2](http://hydra.dhall-lang.org/job/dhall-haskell/master/tarball-try-dhall/latest/download-by-type/file/binary-dist)
 
 ## Contributing
 

--- a/default.nix
+++ b/default.nix
@@ -6,5 +6,5 @@ let
 in
   { inherit (shared) dhall dhall-bash dhall-json dhall-text;
 
-    inherit (shared_ghcjs) dhall-try try-dhall-server try-dhall-static;
+    inherit (shared_ghcjs) dhall-try try-dhall-static;
   }

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -270,12 +270,6 @@ let
         ${pkgsNew.coreutils}/bin/install --target-directory "$TMPDIR/inst/try-dhall/js"  -D $src/js/*
       '';
     };
-
-
-
-    try-dhall-server = pkgsNew.writeScriptBin "try-dhall-server" ''
-      ${pkgsNew.haskellPackages.wai-app-static}/bin/warp --docroot ${pkgsNew.try-dhall-static}
-    '';
   };
 
   overlayCabal2nix = pkgsNew: pkgsOld: {


### PR DESCRIPTION
This build product is no longer necessary now that the live demo can import
things from the Prelude