### PR TITLE
Fix live editor for `dhall-lang.org`

### DIFF
--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -54,10 +54,6 @@
       header {
         margin-bottom: 2rem;
       }
-
-      textarea {
-        display: none;
-      }
     </style>
     <link rel="stylesheet" href="./css/codemirror.css">
     <link rel="stylesheet" href="./css/bootstrap.min.css">


### PR DESCRIPTION
Setting the `display: none` style for `textarea`s makes the corresponding
CodeMirror blocks uneditable