### PR TITLE
Fix first example on `dhall-lang.org`

### DIFF
--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -311,7 +311,9 @@
 
     let example0 = `{- This is an example Dhall configuration file
 
-   Can you spot and correct the mistake?
+   Can you spot the mistake?
+
+   Fix the typo, then move onto the "Definitions" example
 -}
 
 { home       = "/home/bill"


### PR DESCRIPTION
Several people commented that they had difficulty with the first example:

* They didn't realize that the mistake was supposed to be typo because they
  never found it
* They didn't realize they were supposed to progress to the next tab

This changes fixes those two issues