### PR TITLE
Fix type-checking bug for unions

### DIFF
--- a/dhall/tests/Dhall/Test/TypeCheck.hs
+++ b/dhall/tests/Dhall/Test/TypeCheck.hs
@@ -62,6 +62,12 @@ tests =
         , should
             "allow a record of a record of types"
             "success/recordOfRecordOfTypes"
+        , should
+            "allow a union of types of of mixed kinds"
+            "success/simple/unionsOfTypes"
+        , shouldNotTypeCheck
+            "Unions mixing terms and and types"
+            "failure/mixedUnions"
         ]
 
 preludeExamples :: TestTree

--- a/dhall/tests/typecheck/failure/mixedUnions.dhall
+++ b/dhall/tests/typecheck/failure/mixedUnions.dhall
@@ -1,0 +1,1 @@
+< Left : Natural | Right : Type >

--- a/dhall/tests/typecheck/success/simple/unionsOfTypesA.dhall
+++ b/dhall/tests/typecheck/success/simple/unionsOfTypesA.dhall
@@ -1,0 +1,1 @@
+< Left = List | Right : Type >

--- a/dhall/tests/typecheck/success/simple/unionsOfTypesB.dhall
+++ b/dhall/tests/typecheck/success/simple/unionsOfTypesB.dhall
@@ -1,0 +1,1 @@
+< Left : Type → Type | Right : Type >


### PR DESCRIPTION
The Haskell implementation was not matching the specification for
type-checking union types:

* The inferred type of union types was (incorrectly) always returning `Type`
* Unions of mixed alternative types were not being properly rejected

I also discovered several mistakes in the error messages, which I fixed along
the way.