### PR TITLE
Fix error message for not-equal when type checking

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -3488,7 +3488,7 @@ prettyTypeMessage (CantEQ expr0 expr1) =
         buildBooleanOperator "==" expr0 expr1
 
 prettyTypeMessage (CantNE expr0 expr1) =
-        buildBooleanOperator "/=" expr0 expr1
+        buildBooleanOperator "!=" expr0 expr1
 
 prettyTypeMessage (CantInterpolate expr0 expr1) = ErrorMessages {..}
   where


### PR DESCRIPTION
According to the standard https://github.com/dhall-lang/dhall-lang/blob/master/standard/dhall.abnf\#L399 the correct operator is `!=`

Here is an example of the error message:

```haskell
⊢ 2 != 3

Error: ❰/=❱ only works on ❰Bool❱s

2 != 3
(stdin):1:1
```