### PR TITLE
`UnionType` and `UnionInputType`, analogues of `RecordType` and `RecordInputType`

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -127,6 +127,7 @@ import qualified Data.Foldable
 import qualified Data.Functor.Compose
 import qualified Data.Functor.Product
 import qualified Data.Monoid
+import qualified Data.Semigroup
 import qualified Data.Scientific
 import qualified Data.Sequence
 import qualified Data.Set
@@ -1419,11 +1420,12 @@ newtype UnionType a =
       ( Data.Functor.Compose.Compose (Dhall.Map.Map Text) Type a )
   deriving (Functor)
 
-instance Semigroup (UnionType a) where
+instance Data.Semigroup.Semigroup (UnionType a) where
     (<>) = coerce ((<>) :: Dhall.Map.Map Text (Type a) -> Dhall.Map.Map Text (Type a) -> Dhall.Map.Map Text (Type a))
 
 instance Monoid (UnionType a) where
     mempty = coerce (mempty :: Dhall.Map.Map Text (Type a))
+    mappend = (Data.Semigroup.<>)
 
 -- | Run a 'UnionType' parser to build a 'Type' parser.
 union :: UnionType a -> Type a


### PR DESCRIPTION
Allows us to generate an `Input` for a union:

```
data Status = Queued Natural
            | Result Text
            | Errored Text

status :: Type Status
status =
  union
    ( (Queued  <$> constructor "Queued"  natural)    -- or `constructor "Queued" (Queued <$> natural)`
   <> (Result  <$> constructor "Result"  string )
   <> (Errored <$> constructor "Errored" string )
    )
```

And (potentially partially) create an `InputType`:

```
injectStatus :: InputType Status
injectStatus =
  inputUnion
    (  inputConstructor "Queued"  (\case Queued n  -> Just n; _ -> Nothing)
    <> inputConstructor "Result"  (\case Result t  -> Just t; _ -> Nothing)
    <> inputConstructor "Errored" (\case Errored e -> Just e; _ -> Nothing)
    )
-- (could potentially be simplified with a prism-based interface, but this would incur a profunctors dep)
```

I couldn't really think of a way to write `inputUnion` in a way that would make sure it was total without a "two-pass" solution, where the user provides the "injecting" logic and the "specify type" logic in two different places; one alternative was a quasi-one-pass system where the user specifies the total logic up-front, but the result can be optionally "validated" by providing a proof of totality before being used.  However, that requires encoding the number of branches in the type level, so I'm not sure if the benefit pays for the cost in complexity.

Let me know if this isn't something that fits in the vision of the library, or if there's anything I could fix :)