### PR TITLE
Add `inputNormalizer` field to `InterpretOptions`

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -798,7 +798,9 @@ instance Interpret a => Interpret (Vector a) where
 instance (Inject a, Interpret b) => Interpret (a -> b) where
     autoWith opts = Type extractOut expectedOut
       where
-        extractOut e = Just (\i -> case extractIn (Dhall.Core.normalize (App e (embed i))) of
+        normalizer_ = Dhall.Core.getReifiedNormalizer (inputNormalizer opts)
+
+        extractOut e = Just (\i -> case extractIn (Dhall.Core.normalizeWith normalizer_ (App e (embed i))) of
             Just o  -> o
             Nothing -> error "Interpret: You cannot decode a function if it does not have the correct type" )
 
@@ -835,6 +837,10 @@ data InterpretOptions = InterpretOptions
     , constructorModifier :: Text -> Text
     -- ^ Function used to transform Haskell constructor names into their
     --   corresponding Dhall alternative names
+    , inputNormalizer     :: Dhall.Core.ReifiedNormalizer X
+    -- ^ This is only used by the `Interpret` instance for functions in order
+    --   to normalize the function input before marshaling the input into a
+    --   Dhall expression
     }
 
 {-| Default interpret options, which you can tweak or override, like this:
@@ -846,6 +852,7 @@ defaultInterpretOptions :: InterpretOptions
 defaultInterpretOptions = InterpretOptions
     { fieldModifier       = id
     , constructorModifier = id
+    , inputNormalizer     = Dhall.Core.ReifiedNormalizer (const (pure Nothing))
     }
 
 {-| This is the underlying class that powers the `Interpret` class's support


### PR DESCRIPTION
This fixes the problem found in https://github.com/dhall-lang/dhall-lang/issues/166#issuecomment-452766374

This ensures that the functions marshalled into Haskell can correctly take
advantage of user-supplied language extensions