### PR TITLE
Add eta support and update stack config to lts-13

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -335,7 +335,7 @@ Library
         http-types                  >= 0.7.0    && < 0.13,
         http-client                 >= 0.4.30   && < 0.6 ,
         http-client-tls             >= 0.2.0    && < 0.4
-    if !impl(ghc >= 8.0)
+    if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
       Build-Depends: semigroups == 0.18.*
       Build-Depends: transformers == 0.4.2.*
       Build-Depends: fail == 4.9.*

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -1,0 +1,17 @@
+resolver: lts-12.26
+packages:
+  - dhall
+  - dhall-bash
+  - dhall-json
+  - dhall-text
+extra-deps:
+  - megaparsec-7.0.3
+  - repline-0.2.0.0
+  - serialise-0.2.1.0
+  - neat-interpolation-0.3.2.4
+  - dotgen-0.4.2@sha256:309b7cc8a3593a8e48bee7b53020d5f72db156d58edf78a0214f58fbb84b292b
+  - cborg-json-0.2.1.0
+nix:
+  packages:
+    - ncurses
+    - zlib

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -29,6 +29,9 @@ extra-deps:
 - cborg-0.2.1.0
 - serialise-0.2.1.0
 - shell-escape-0.2.0
+- cborg-json-0.2.1.0
+- dotgen-0.4.2
+- aeson-pretty-0.8.7
 nix:
   packages:
     - ncurses

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,9 @@
-resolver: lts-12.16
+resolver: lts-13.2
 packages:
   - dhall
   - dhall-bash
   - dhall-json
   - dhall-text
-extra-deps:
-  - megaparsec-7.0.3
-  - repline-0.2.0.0
-  - serialise-0.2.1.0
-  - neat-interpolation-0.3.2.4
-  - dotgen-0.4.2@sha256:309b7cc8a3593a8e48bee7b53020d5f72db156d58edf78a0214f58fbb84b292b
-  - cborg-json-0.2.1.0
 nix:
   packages:
     - ncurses


### PR DESCRIPTION
Hi, this pr has two (unrelated) changes:
* Add a condition in `dhall.cabal` to allow `etlas/eta` build the package.
  * I've tested the cabal config with `cabal-2.4.0.0` and `cabal-2.2.0.0` both with `ghc-7.10.3` and `ghc-8.6.3`
  * With stack lts 13, 12 and 6
* Change `stack.yaml` to use `lts-13` and keep `lts-12` in `stack-lts-12.yaml`
  * Change `stack-lts-6.yaml` to take in account last deps