### PR TITLE
Fix Nix build to reinstate `-Werror`

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -101,7 +101,6 @@ import Control.Monad (guard)
 import Data.Coerce (coerce)
 import Data.Functor.Contravariant (Contravariant(..), (>$<), Op(..))
 import Data.Functor.Contravariant.Divisible (Divisible(..), divided)
-import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Monoid ((<>))
 import Data.Scientific (Scientific)
 import Data.Sequence (Seq)
@@ -126,7 +125,6 @@ import qualified Control.Monad.Trans.State.Strict as State
 import qualified Data.Foldable
 import qualified Data.Functor.Compose
 import qualified Data.Functor.Product
-import qualified Data.Monoid
 import qualified Data.Semigroup
 import qualified Data.Scientific
 import qualified Data.Sequence

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -152,7 +152,7 @@ let
                   ];
 
                 failOnAllWarningsExtension =
-                  mass pkgsNew.haskell.lib.failOnAllWarnings [
+                  mass failOnAllWarnings [
                     "dhall"
                     "dhall-bash"
                     "dhall-json"
@@ -210,9 +210,9 @@ let
                   pkgsNew.lib.composeExtensions
                   (old.overrides or (_: _: {}))
                   [ (pkgsNew.haskell.lib.packagesFromDirectory { directory = ./.; })
+                    extension
                     dontCheckExtension
                     failOnAllWarningsExtension
-                    extension
                   ];
           }
         );


### PR DESCRIPTION
A refactor of the Nix build accidentally removed the `-Werror` flag, which
caused some warnings to get past CI.  This change fixes that and removes the
warnings.