### PR TITLE
Include standard version in `dhall version` output

### DIFF
--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -11,6 +11,7 @@ module Dhall.Binary
       StandardVersion(..)
     , defaultStandardVersion
     , parseStandardVersion
+    , renderStandardVersion
 
     -- * Encoding and decoding
     , encodeWithVersion
@@ -82,6 +83,9 @@ parseStandardVersion =
         case string :: Text of
             "5.0.0" -> return V_5_0_0
             _       -> fail "Unsupported version"
+
+renderStandardVersion :: StandardVersion -> Text
+renderStandardVersion V_5_0_0 = "5.0.0";
 
 {-| Convert a function applied to multiple arguments to the base function and
     the list of arguments

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -287,7 +287,14 @@ command (Options {..}) = do
 
     handle $ case mode of
         Version -> do
-            putStrLn (showVersion Meta.version)
+            let line₀ = "Haskell package version: "
+                    <>  Data.Text.pack (showVersion Meta.version)
+
+            let line₁ = "Standard version: "
+                    <>  Dhall.Binary.renderStandardVersion Dhall.Binary.defaultStandardVersion
+
+            Data.Text.IO.putStrLn line₀
+            Data.Text.IO.putStrLn line₁
 
         Default {..} -> do
             expression <- getExpression


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/791