### PR TITLE
Build against `ansi-terminal-0.9`

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -370,7 +370,7 @@ Library
         base                        >= 4.8.2.0  && < 5   ,
         aeson                       >= 1.0.0.0  && < 1.5 ,
         aeson-pretty                               < 0.9 ,
-        ansi-terminal               >= 0.6.3.1  && < 0.9 ,
+        ansi-terminal               >= 0.6.3.1  && < 0.10,
         bytestring                                 < 0.11,
         case-insensitive                           < 1.3 ,
         cborg                       >= 0.2.0.0  && < 0.3 ,


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/4329