### PR TITLE
Add --immediate flag to resolve mode

### DIFF
--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -97,10 +97,11 @@ data Mode
     | Encode { json :: Bool }
     | Decode { json :: Bool }
 
-data ResolveMode 
+data ResolveMode
     = Dot
     | ListDependencies
-    
+    | ListImmediateDependencies
+
 
 -- | `Parser` for the `Options` type
 parseOptions :: Parser Options
@@ -197,6 +198,12 @@ parseMode =
               (   Options.Applicative.long "dot"
               <>  Options.Applicative.help
                     "Output import dependency graph in dot format"
+              )
+        <|>
+          Options.Applicative.flag' (Just ListImmediateDependencies)
+              (   Options.Applicative.long "immediate"
+              <>  Options.Applicative.help
+                    "List immediate import dependencies"
               )
         <|>
           Options.Applicative.flag' (Just ListDependencies)
@@ -325,28 +332,43 @@ command (Options {..}) = do
 
             render System.IO.stdout annotatedExpression
 
-        Resolve rMode -> do
+        Resolve (Just Dot) -> do
             expression <- getExpression
 
-            (resolvedExpression, Dhall.Import.Types.Status { _dot, _cache}) <-
+            (Dhall.Import.Types.Status { _dot}) <-
+                State.execStateT (Dhall.Import.loadWith expression) status
+
+            putStr . ("strict " <>) . Text.Dot.showDot $
+                   Text.Dot.attribute ("rankdir", "LR") >>
+                   _dot
+
+        Resolve (Just ListImmediateDependencies) -> do
+            expression <- getExpression
+
+            mapM_ (print
+                        . Pretty.pretty
+                        . Dhall.Core.importHashed) expression
+
+        Resolve (Just ListDependencies) -> do
+            expression <- getExpression
+
+            (Dhall.Import.Types.Status { _cache }) <-
+                State.execStateT (Dhall.Import.loadWith expression) status
+
+            mapM_ print
+                 .   fmap (   Pretty.pretty
+                          .   Dhall.Core.importType
+                          .   Dhall.Core.importHashed )
+                 .   Data.Map.keys
+                 $   _cache
+
+        Resolve (Nothing) -> do
+            expression <- getExpression
+
+            (resolvedExpression, _) <-
                 State.runStateT (Dhall.Import.loadWith expression) status
-            
-            case rMode of
-                Just Dot -> 
-                    putStr . ("strict " <>) . Text.Dot.showDot $
-                    Text.Dot.attribute ("rankdir", "LR") >> 
-                    _dot
+            render System.IO.stdout resolvedExpression
 
-                Just ListDependencies -> 
-                        mapM_ print 
-                    .   fmap (   Pretty.pretty 
-                             .   Dhall.Core.importType 
-                             .   Dhall.Core.importHashed ) 
-                    .   Data.Map.keys 
-                    $   _cache
-
-                Nothing -> 
-                     render System.IO.stdout resolvedExpression
         Normalize -> do
             expression <- getExpression
 


### PR DESCRIPTION
This patch adds means for listing only the immediate dependencies of
given dhall expression.

This is useful for integrating dhall to build systems where dhall
expressions (e.g. of type `Text`) are build products.

I would expect there to be other, more sensible, uses for this also.