### PR TITLE
Save and load REPL context via :save and :load commands

### DIFF
--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -26,7 +26,7 @@ import Dhall.Pretty (CharacterSet(..))
 import Lens.Family (set)
 import System.Console.Haskeline (Interrupt(..))
 import System.Console.Haskeline.Completion ( Completion, simpleCompletion )
-import System.Directory (listDirectory)
+import System.Directory ( getDirectoryContents )
 import System.Environment ( getEnvironment )
 
 import qualified Control.Monad.Trans.State.Strict as State
@@ -270,7 +270,7 @@ saveFilePrefix = ".dhall-repl"
 -- | Find the index for the current _active_ dhall save file
 currentSaveFileIndex :: MonadIO m => m (Maybe Int)
 currentSaveFileIndex = do
-  files <- liftIO $ listDirectory "."
+  files <- liftIO $ getDirectoryContents "."
 
   let parseIndex file
         | saveFilePrefix `isPrefixOf` file


### PR DESCRIPTION
This PR closes #706

The format for the save file is a plain Dhall file where we expect the normal form to be a record literal. This will hopefully mean that the save file can be edited manually if need be without too much effort.

The save files are always kept by default (their index is incrementing) and only the last one is loaded by default.

It is possible to manually specify where to save and load the context to.