### PR TITLE
Change `dhall freeze` to only freeze `Remote` imports

### DIFF
--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -90,7 +90,7 @@ data Mode
     | Normalize
     | Repl
     | Format { inplace :: Maybe FilePath }
-    | Freeze { inplace :: Maybe FilePath }
+    | Freeze { inplace :: Maybe FilePath, everything :: Bool }
     | Hash
     | Diff { expr1 :: Text, expr2 :: Text }
     | Lint { inplace :: Maybe FilePath }
@@ -172,7 +172,7 @@ parseMode =
     <|> subcommand
             "freeze"
             "Add hashes to all import statements of an expression"
-            (Freeze <$> optional parseInplace)
+            (Freeze <$> optional parseInplace <*> parseEverythingFlag)
     <|> subcommand
             "encode"
             "Encode a Dhall expression to binary"
@@ -217,6 +217,12 @@ parseMode =
         Options.Applicative.switch
         (   Options.Applicative.long "json"
         <>  Options.Applicative.help "Use JSON representation of CBOR"
+        )
+
+    parseEverythingFlag =
+        Options.Applicative.switch
+        (   Options.Applicative.long "everything"
+        <>  Options.Applicative.help "Freeze all imports (not just remote imports)"
         )
 
 throws :: Exception e => Either e a -> IO a
@@ -381,7 +387,7 @@ command (Options {..}) = do
             Dhall.Format.format characterSet inplace
 
         Freeze {..} -> do
-            Dhall.Freeze.freeze inplace standardVersion
+            Dhall.Freeze.freeze inplace everything standardVersion
 
         Hash -> do
             Dhall.Hash.hash standardVersion

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -90,7 +90,7 @@ data Mode
     | Normalize
     | Repl
     | Format { inplace :: Maybe FilePath }
-    | Freeze { inplace :: Maybe FilePath, everything :: Bool }
+    | Freeze { inplace :: Maybe FilePath, all_ :: Bool }
     | Hash
     | Diff { expr1 :: Text, expr2 :: Text }
     | Lint { inplace :: Maybe FilePath }
@@ -172,8 +172,8 @@ parseMode =
             (Format <$> optional parseInplace)
     <|> subcommand
             "freeze"
-            "Add hashes to all import statements of an expression"
-            (Freeze <$> optional parseInplace <*> parseEverythingFlag)
+            "Add integrity checks to remote import statements of an expression"
+            (Freeze <$> optional parseInplace <*> parseAllFlag)
     <|> subcommand
             "encode"
             "Encode a Dhall expression to binary"
@@ -226,10 +226,10 @@ parseMode =
         <>  Options.Applicative.help "Use JSON representation of CBOR"
         )
 
-    parseEverythingFlag =
+    parseAllFlag =
         Options.Applicative.switch
-        (   Options.Applicative.long "everything"
-        <>  Options.Applicative.help "Freeze all imports (not just remote imports)"
+        (   Options.Applicative.long "all"
+        <>  Options.Applicative.help "Add integrity checks to all imports (not just remote imports)"
         )
 
 throws :: Exception e => Either e a -> IO a
@@ -409,7 +409,7 @@ command (Options {..}) = do
             Dhall.Format.format characterSet inplace
 
         Freeze {..} -> do
-            Dhall.Freeze.freeze inplace everything standardVersion
+            Dhall.Freeze.freeze inplace all_ standardVersion
 
         Hash -> do
             Dhall.Hash.hash standardVersion


### PR DESCRIPTION
The motivation behind this change is so that users can freeze remote imports
(like the Prelude) but ignore local imports so that subsequent runs of the
interpreter reflect changes to local files and environment variables.

The reasoning behind this is that there are two primary benefits of integrity
checks:

* Improved security
* Caching

... and one downside which is that updates to those imports are not pulled in
until the integrity check is updated or removed.

However, environment variables and local file paths do not benefit from
improved security or caching, so there is only a downside to freezing them.

Specifically:

* Environment variables and local file paths are both cheap to resolve

  ... so they don't really benefit from caching.  d

  To be precise, they *could* benefit from caching if the cache expression is
  cheaper to parse and normalize compared to the original file, but with recent
  improvements to the parser this difference should be minor.  Also, even if
  the performance difference were large I believe the right solution would be
  to improve the performance of the interpreter rather than rely on integrity
  checks as an accelerant to type-checking/normalization.

* Environment variables and local file paths are trusted

  For example, when a user runs the `dhall` executable they are implicitly
  trusting their filesystem which provides that executable.  Similarly, when
  they run `dhall` without an absolute path they are implicitly trusting that
  their `PATH` environment variable has not been compromised to point to a
  malicious executable.

  Up until now, Dhall's threat model has always been that local imports are
  trusted but remote imports are not, so this is consistent with that threat
  model.

... so as far as environment variables and local files are concerned there are
only downsides to freezing them and no up-side.  This is why this change
no longer freezes them.

This also renames `hashImport` to `freezeImport` for more terminology
consistency.