### PR TITLE
Support GHC 7.10.3 for all Dhall packages

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -2,7 +2,7 @@ Name: dhall-bash
 Version: 1.0.18
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
-Tested-With: GHC == 7.10.2, GHC == 8.0.1
+Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -2,7 +2,7 @@ Name: dhall-json
 Version: 1.2.6
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
-Tested-With: GHC == 7.10.2, GHC == 8.0.1
+Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/dhall-json/dhall-to-json/Main.hs
+++ b/dhall-json/dhall-to-json/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ApplicativeDo     #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -35,13 +34,13 @@ data Options = Options
     }
 
 parseOptions :: Parser Options
-parseOptions = Options.Applicative.helper <*> do
-    explain    <- parseExplain
-    pretty     <- parsePretty
-    omitNull   <- parseOmitNull
-    version    <- parseVersion
-    conversion <- Dhall.JSON.parseConversion
-    return (Options {..})
+parseOptions =
+        Options
+    <$> parseExplain
+    <*> parsePretty
+    <*> parseOmitNull
+    <*> parseVersion
+    <*> Dhall.JSON.parseConversion
   where
     parseExplain =
         Options.Applicative.switch
@@ -84,7 +83,7 @@ parseOptions = Options.Applicative.helper <*> do
 parserInfo :: ParserInfo Options
 parserInfo =
     Options.Applicative.info
-        parseOptions
+        (Options.Applicative.helper <*> parseOptions)
         (   Options.Applicative.fullDesc
         <>  Options.Applicative.progDesc "Compile Dhall to JSON"
         )

--- a/dhall-json/dhall-to-yaml/Main.hs
+++ b/dhall-json/dhall-to-yaml/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ApplicativeDo     #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
@@ -29,12 +28,12 @@ data Options = Options
     }
 
 parseOptions :: Parser Options
-parseOptions = Options.Applicative.helper <*> do
-    explain    <- parseExplain
-    omitNull   <- parseOmitNull
-    documents  <- parseDocuments
-    conversion <- Dhall.JSON.parseConversion
-    return (Options {..})
+parseOptions =
+        Options
+    <$> parseExplain
+    <*> parseOmitNull
+    <*> parseDocuments
+    <*> Dhall.JSON.parseConversion
   where
     parseExplain =
         Options.Applicative.switch
@@ -57,7 +56,7 @@ parseOptions = Options.Applicative.helper <*> do
 parserInfo :: ParserInfo Options
 parserInfo =
     Options.Applicative.info
-        parseOptions
+        (Options.Applicative.helper <*> parseOptions)
         (   Options.Applicative.fullDesc
         <>  Options.Applicative.progDesc "Compile Dhall to YAML"
         )

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ApplicativeDo      #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedLists    #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -699,10 +698,7 @@ parseConversion =
         conversion
     <|> noConversion
   where
-    conversion = do
-        mapKey   <- parseKeyField
-        mapValue <- parseValueField
-        return (Conversion {..})
+    conversion = Conversion <$> parseKeyField <*> parseValueField
       where
         parseKeyField =
             Options.Applicative.strOption

--- a/dhall-text/dhall-text.cabal
+++ b/dhall-text/dhall-text.cabal
@@ -2,7 +2,7 @@ Name: dhall-text
 Version: 1.0.15
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
-Tested-With: GHC == 7.10.2, GHC == 8.0.1
+Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -2,7 +2,7 @@ Name: dhall
 Version: 1.20.1
 Cabal-Version: >=1.10
 Build-Type: Simple
-Tested-With: GHC == 8.0.1
+Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -296,12 +296,22 @@ let
                           haskellPackagesNew.fail
                         ];
 
+                    blaze-builder =
+                      pkgsNew.haskell.lib.addBuildDepend
+                        haskellPackagesOld.blaze-builder
+                        haskellPackagesNew.semigroups;
+
                     cborg =
                       pkgsNew.haskell.lib.addBuildDepends
                         haskellPackagesOld.cborg
                         [ haskellPackagesNew.fail
                           haskellPackagesNew.semigroups
                         ];
+
+                    conduit =
+                      pkgsNew.haskell.lib.addBuildDepend
+                        haskellPackagesOld.conduit
+                        haskellPackagesNew.semigroups;
 
                     contravariant =
                       pkgsNew.haskell.lib.addBuildDepends
@@ -317,14 +327,25 @@ let
                           haskellPackagesNew.mockery
                         ];
 
+                    generic-deriving =
+                      pkgsNew.haskell.lib.dontCheck
+                        haskellPackagesOld.generic-deriving;
+
+                    haskell-src =
+                      pkgsNew.haskell.lib.addBuildDepends
+                        haskellPackagesOld.haskell-src
+                        [ haskellPackagesNew.fail
+                          haskellPackagesNew.semigroups
+                        ];
+
                     megaparsec =
                       pkgsNew.haskell.lib.addBuildDepend
                         haskellPackagesOld.megaparsec
                         haskellPackagesNew.fail;
 
-                    generic-deriving =
-                      pkgsNew.haskell.lib.dontCheck
-                        haskellPackagesOld.generic-deriving;
+                    neat-interpolation =
+                      pkgsNew.haskell.lib.doJailbreak
+                        haskellPackagesOld.neat-interpolation;
 
                     prettyprinter =
                       pkgsNew.haskell.lib.addBuildDepend
@@ -345,6 +366,9 @@ let
                     wcwidth =
                       pkgsNew.haskell.lib.appendPatch
                         haskellPackagesOld.wcwidth ./wcwidth.patch;
+
+                    yaml =
+                      pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.yaml;
                   };
 
               in

--- a/release.nix
+++ b/release.nix
@@ -19,14 +19,15 @@ in
       { name = "dhall";
 
         constituents = [
-          # Eta only requires the `dhall` package to build using GHC 7.10.3.
-          # This is why we don't need to test the other `dhall-*` packages on
-          # GHC 7.10.3
+          # Verify that the packages build against the oldest supported version
+          # of the compiler
           shared_7_10_3.dhall
+          shared_7_10_3.dhall-bash
+          shared_7_10_3.dhall-json
+          shared_7_10_3.dhall-text
 
-          # Verify that the packages build against the latest version of the
-          # compiler
-          shared_8_6_1.dhall
+          # Verify that the packages build against the latest supported version
+          # of the compiler
           shared_8_6_1.dhall
           shared_8_6_1.dhall-bash
           shared_8_6_1.dhall-json


### PR DESCRIPTION
This also updates the declared set of GHC versions tested with in the
`.cabal` files