### PR TITLE
Mention submodule in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ $ brew install dhall-json
 
 ## Building from source
 
+For all of the following instructions, make sure to first check out the
+`dhall-lang` submodule:
+
+```bash
+$ git submodule init
+$ git submodule update
+```
+
 ### [cabal](https://www.haskell.org/cabal)
 
 You can build all of the packages by running:


### PR DESCRIPTION
This prevents build failures when running tests for the `dhall` package