### PR TITLE
Add `linux-dhall*` jobs to Hydra

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,32 @@ For OS X, use `brew` to install the desired package.  For example:
 $ brew install dhall-json
 ```
 
-You can also install pre-built Linux binaries for `master` using Nix by visiting
-one of the following links:
+You can also install pre-built Linux binaries for `master` using Nix using
+Nix's channel mechanism by following the instructions at this link:
+
+* [https://hydra.dhall-lang.org/jobset/dhall-haskell/master/channel/latest](https://hydra.dhall-lang.org/jobset/dhall-haskell/master/channel/latest)
+
+If you want to directly install the latest build without a channel, you can
+visit one of the following links:
 
 * [https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall/latest](https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall/latest)
 * [https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-bash/latest](https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-bash/latest)
 * [https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-json/latest](https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-json/latest)
 * [https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-text/latest](https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-text/latest)
 
-... and then clicking the "Help" button in the bottom right corner, which will
+... and then click the "Help" button in the bottom right corner, which will
 show you a `nix-env` command that you can run to install the prebuilt
 executable.
 
-This also works for any pull request, too, by replacing `master` with the pull
-request number for any of the above links.
+If you have the `jq` command-line tool installed then you can do this in one
+command by running:
+
+```haskell
+$ nix-env -i "$(https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall/latest/api/get-info | jq -r .outPath)"
+```
+
+These instructions also work for any pull request, too, by replacing `master`
+with the pull request number for any of the above URLs.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ For OS X, use `brew` to install the desired package.  For example:
 $ brew install dhall-json
 ```
 
+You can also install pre-built Linux binaries for `master` using Nix by visiting
+one of the following links:
+
+* [https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall/latest](https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall/latest)
+* [https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-bash/latest](https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-bash/latest)
+* [https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-json/latest](https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-json/latest)
+* [https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-text/latest](https://hydra.dhall-lang.org/job/dhall-haskell/master/linux-dhall-text/latest)
+
+... and then clicking the "Help" button in the bottom right corner, which will
+show you a `nix-env` command that you can run to install the prebuilt
+executable.
+
+This also works for any pull request, too, by replacing `master` with the pull
+request number for any of the above links.
+
 ## Building from source
 
 ### [cabal](https://www.haskell.org/cabal)

--- a/release.nix
+++ b/release.nix
@@ -11,6 +11,9 @@ let
   shared =
     import ./nix/shared.nix { };
 
+  shared_linux =
+    import ./nix/shared.nix { system = "x86_64-linux"; };
+
   coverage =
     import ./nix/shared.nix { coverage = true; };
 
@@ -61,4 +64,9 @@ in
       tarball-dhall-json
       tarball-dhall-text
     ;
+
+    linux-dhall      = shared_linux.possibly-static.dhall;
+    linux-dhall-bash = shared_linux.possibly-static.dhall-bash;
+    linux-dhall-json = shared_linux.possibly-static.dhall-json;
+    linux-dhall-text = shared_linux.possibly-static.dhall-text;
   }


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/783

These can be used to conveniently install Dhall using `nix-env` on Linux systems