### PR TITLE
CBOR-encode only some special values as half-floats

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -232,6 +232,7 @@ Extra-Source-Files:
     dhall-lang/tests/normalization/success/simplifications/*.dhall
     dhall-lang/tests/parser/failure/*.dhall
     dhall-lang/tests/parser/success/*.dhall
+    dhall-lang/tests/binary/success/*.dhall
     dhall-lang/tests/typecheck/failure/*.dhall
     dhall-lang/tests/typecheck/success/*.dhall
     dhall-lang/tests/typecheck/success/prelude/Bool/and/*.dhall
@@ -464,6 +465,7 @@ Test-Suite tasty
     Main-Is: Dhall/Test/Main.hs
     GHC-Options: -Wall
     Other-Modules:
+        Dhall.Test.Binary
         Dhall.Test.Format
         Dhall.Test.Import
         Dhall.Test.Lint
@@ -476,6 +478,7 @@ Test-Suite tasty
         Dhall.Test.Util
     Build-Depends:
         base                      >= 4        && < 5   ,
+        bytestring                               < 0.11,
         containers                                     ,
         deepseq                   >= 1.2.0.1  && < 1.5 ,
         dhall                                          ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -233,6 +233,7 @@ Extra-Source-Files:
     dhall-lang/tests/parser/failure/*.dhall
     dhall-lang/tests/parser/success/*.dhall
     dhall-lang/tests/binary/success/*.dhall
+    dhall-lang/tests/binary/success/*.dhallb
     dhall-lang/tests/typecheck/failure/*.dhall
     dhall-lang/tests/typecheck/success/*.dhall
     dhall-lang/tests/typecheck/success/prelude/Bool/and/*.dhall

--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -49,7 +49,6 @@ import Data.Text (Text)
 import Options.Applicative (Parser)
 import Prelude hiding (exponent)
 import GHC.Float (double2Float, float2Double)
-import Codec.CBOR.Magic (floatToWord16, wordToFloat16)
 
 import qualified Crypto.Hash
 import qualified Data.ByteArray.Encoding

--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -378,7 +378,7 @@ encode (DoubleLit n64)
     n32      = double2Float n64
     useFloat = n64 == float2Double n32
     -- the other three cases for Half-floats are 0.0 and the infinities
-    useHalf  = any id $ fmap (n64 ==) [0.0, infinity, -infinity]
+    useHalf  = or $ fmap (n64 ==) [0.0, infinity, -infinity]
     infinity = (read "Infinity") :: Double
 encode (TextLit (Chunks xys₀ z₀)) =
     TList ([ TInt 18 ] ++ xys₁ ++ [ z₁ ])

--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -379,7 +379,7 @@ encode (DoubleLit n64)
     useFloat = n64 == float2Double n32
     -- the other three cases for Half-floats are 0.0 and the infinities
     useHalf  = or $ fmap (n64 ==) [0.0, infinity, -infinity]
-    infinity = (read "Infinity") :: Double
+    infinity = 1/0 :: Double
 encode (TextLit (Chunks xys₀ z₀)) =
     TList ([ TInt 18 ] ++ xys₁ ++ [ z₁ ])
   where

--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -377,9 +377,10 @@ encode (DoubleLit n64)
     | otherwise = TDouble n64
   where
     n32      = double2Float n64
-    n16      = floatToWord16 n32
     useFloat = n64 == float2Double n32
-    useHalf  = n64 == (float2Double . wordToFloat16 . fromIntegral) n16
+    -- the other three cases for Half-floats are 0.0 and the infinities
+    useHalf  = any id $ fmap (n64 ==) [0.0, infinity, -infinity]
+    infinity = (read "Infinity") :: Double
 encode (TextLit (Chunks xys₀ z₀)) =
     TList ([ TInt 18 ] ++ xys₁ ++ [ z₁ ])
   where

--- a/dhall/tests/Dhall/Test/Binary.hs
+++ b/dhall/tests/Dhall/Test/Binary.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Dhall.Test.Binary where
+
+import           Data.Text         (Text)
+import           Test.Tasty        (TestTree)
+
+import qualified Codec.Serialise
+import qualified Control.Exception
+import qualified Data.ByteString.Lazy
+import qualified Data.Text
+import qualified Data.Text.IO
+import qualified Dhall.Binary
+import qualified Dhall.Parser
+import qualified Test.Tasty
+import qualified Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+    Test.Tasty.testGroup "binary format tests"
+        [ shouldMatch
+            "binary encoding of Double values"
+            "./dhall-lang/tests/binary/success/double"
+        ]
+
+shouldMatch :: Text -> FilePath -> TestTree
+shouldMatch name path = Test.Tasty.HUnit.testCase (Data.Text.unpack name) $ do
+    text    <- Data.Text.IO.readFile (path <> "A.dhall")
+    encoded <- Data.ByteString.Lazy.readFile (path <> "B.dhallb")
+
+    expression <- case Dhall.Parser.exprFromText mempty text of
+      Left e -> Control.Exception.throwIO e
+      Right a -> pure a
+
+    let term  = Dhall.Binary.encode expression
+        bytes = Codec.Serialise.serialise term
+
+    case encoded == bytes of
+        True -> return ()
+        _    -> error "Binary representation doesn't match"

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -1,7 +1,8 @@
 module Main where
 
-import Test.Tasty (TestTree)
+import           Test.Tasty               (TestTree)
 
+import qualified Dhall.Test.Binary
 import qualified Dhall.Test.Format
 import qualified Dhall.Test.Import
 import qualified Dhall.Test.Lint
@@ -17,13 +18,14 @@ import qualified System.Environment
 import qualified System.IO
 import qualified Test.Tasty
 
-import System.FilePath ((</>))
+import           System.FilePath          ((</>))
 
 allTests :: TestTree
 allTests =
     Test.Tasty.testGroup "Dhall Tests"
         [ Dhall.Test.Normalization.tests
         , Dhall.Test.Parser.tests
+        , Dhall.Test.Binary.tests
         , Dhall.Test.Regression.tests
         , Dhall.Test.Tutorial.tests
         , Dhall.Test.Format.tests


### PR DESCRIPTION
As standardized in https://github.com/dhall-lang/dhall-lang/pull/376