### PR TITLE
Fix relative precedence of `!=` and `==`

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -176,9 +176,9 @@ completeExpression embedded = completeExpression_
                 CombineTypes <$ _combineTypes
             <|> Prefer       <$ _prefer
             <|> NaturalTimes <$ _times
-            <|> BoolNE       <$ _notEqual
+            <|> BoolEQ       <$ _doubleEqual
 
-    precedence3Operator = BoolEQ <$ _doubleEqual
+    precedence3Operator = BoolNE <$ _notEqual
 
     precedence0Expression =
             makeOperatorExpression precedence1Expression precedence0Operator


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/issues/373

The standard specifies that `!=` should have higher precedence than `==`,
which this change fixes.