### PR TITLE
Small improvements to `dhall format`

### DIFF
--- a/dhall/src/Dhall/Format.hs
+++ b/dhall/src/Dhall/Format.hs
@@ -68,9 +68,9 @@ format (Format {..}) =
 
                     let doc =   Pretty.pretty header
                             <>  Pretty.unAnnotate (Dhall.Pretty.prettyCharacterSet characterSet expr)
+                            <>  "\n"
                     System.IO.withFile file System.IO.WriteMode (\handle -> do
-                        Pretty.Terminal.renderIO handle (Pretty.layoutSmart layoutOpts doc)
-                        Data.Text.IO.hPutStrLn handle "" )
+                        Pretty.Terminal.renderIO handle (Pretty.layoutSmart layoutOpts doc))
                 Nothing -> do
                     inText <- Data.Text.IO.getContents
 
@@ -78,6 +78,7 @@ format (Format {..}) =
 
                     let doc =   Pretty.pretty header
                             <>  Dhall.Pretty.prettyCharacterSet characterSet expr
+                            <>  "\n"
 
                     supportsANSI <- System.Console.ANSI.hSupportsANSI System.IO.stdout
 

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -195,12 +195,30 @@ braces docs =
 
 -- | Pretty-print anonymous functions and function types
 arrows :: CharacterSet -> [(Doc Ann, Doc Ann)] -> Doc Ann
-arrows characterSet =
+arrows ASCII =
+    enclose'
+        ""
+        "    "
+        (" " <> rarrow ASCII <> " ")
+        (rarrow ASCII <> "  ")
+arrows Unicode =
     enclose'
         ""
         "  "
-        (" " <> rarrow characterSet <> " ")
-        (rarrow characterSet <> space)
+        (" " <> rarrow Unicode <> " ")
+        (rarrow Unicode <> " ")
+
+combine :: CharacterSet -> Text
+combine ASCII   = "/\\"
+combine Unicode = "∧"
+
+combineTypes :: CharacterSet -> Text
+combineTypes ASCII   = "//\\\\"
+combineTypes Unicode = "⩓"
+
+prefer :: CharacterSet -> Text
+prefer ASCII   = "//"
+prefer Unicode = "⫽"
 
 {-| Format an expression that holds a variable number of elements, such as a
     list, record, or union
@@ -612,7 +630,7 @@ prettyCharacterSet characterSet = prettyExpression
 
     prettyCombineExpression :: Pretty a => Expr s a -> Doc Ann
     prettyCombineExpression a0@(Combine _ _) =
-        prettyOperator "∧" (docs a0)
+        prettyOperator (combine characterSet) (docs a0)
       where
         docs (Combine a b) = prettyPreferExpression b : docs a
         docs (Note    _ b) = docs b
@@ -624,7 +642,7 @@ prettyCharacterSet characterSet = prettyExpression
 
     prettyPreferExpression :: Pretty a => Expr s a -> Doc Ann
     prettyPreferExpression a0@(Prefer _ _) =
-        prettyOperator "⫽" (docs a0)
+        prettyOperator (prefer characterSet) (docs a0)
       where
         docs (Prefer a b) = prettyCombineTypesExpression b : docs a
         docs (Note   _ b) = docs b
@@ -636,7 +654,7 @@ prettyCharacterSet characterSet = prettyExpression
 
     prettyCombineTypesExpression :: Pretty a => Expr s a -> Doc Ann
     prettyCombineTypesExpression a0@(CombineTypes _ _) =
-        prettyOperator "⩓" (docs a0)
+        prettyOperator (combineTypes characterSet) (docs a0)
       where
         docs (CombineTypes a b) = prettyTimesExpression b : docs a
         docs (Note         _ b) = docs b


### PR DESCRIPTION
This includes two changes:

* Fix a missing newline at the end of `dhall format` output when not using
  the `--inplace` option

* Better align ASCII output