### PR TITLE
Fix REPL autocomplete

### DIFF
--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -455,6 +455,7 @@ completeFunc reversedPrev word
 
   -- Complete record fields and union alternatives
   | var : subFields <- Text.split (== '.') (Text.pack word)
+  , not $ null subFields
   = do
     Env { envBindings } <- get
 


### PR DESCRIPTION
This PR fixes an issue that made the last branch of the REPL autocompleter
unreachable.

The second to last branch was always `True`:

```
> split (== '.') "anything"
["anything"]
```