### PR TITLE
Change language around security guarantee

### DIFF
--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -215,8 +215,9 @@
       <hr class="my-4">
       <p>We take language security seriously so that your Dhall programs
       never fail, hang, crash, leak secrets, or compromise your system.</p>
-      <p>You can safely import and evaluate untrusted Dhall code, even code
-      authored by malicious users.</p>
+      <p>The language aims to support safely importing and evaluating untrusted
+      Dhall code, even code authored by malicious users.  We treat the inability
+      to do so as a specification bug.</p>
       <a href="https://github.com/dhall-lang/dhall-lang/wiki/Safety-guarantees"class="btn btn-lg btn-outline-dark bg-light">Safety Guarantees<i class="fas fa-shield-alt"></i></a>
     </div>
     <div class="container jumbotron" style="background-color: #cfebfb">


### PR DESCRIPTION
Related to https://github.com/dhall-lang/dhall-lang/issues/333

This softens the language to point out that we can't guarantee
that we are secure against malicious expression but we do aim to be
and we don't settle for less.