### PR TITLE
Add new `--omitEmpty` option

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -63,6 +63,7 @@ Executable dhall-to-yaml
     Main-Is: Main.hs
     Build-Depends:
         base                                   ,
+        aeson                                  ,
         bytestring                       < 0.11,
         dhall                                  ,
         dhall-json                             ,


### PR DESCRIPTION
... as proposed in https://github.com/dhall-lang/dhall-kubernetes/issues/46#issuecomment-468530601

`--omitEmpty` is the same as `--omitNull` except it also omits fields that
are empty records.  To be precise, it omits fields whose transitive fields
are all `null` (and an empty record is a special case of a record whose
transitive fields are all `null` since it is vacuously true when there are
no fields).

This allows Dhall configurations that target YAML to avoid having to nest
sub-records inside of an `Optional` value.  Omitting unnecessary `Optional`
layers reduces the number of default values that the configuration format
needs to thread around.