### PR TITLE
Fix versions of `dhall-bash`/`dhall-text`

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -1,5 +1,5 @@
 Name: dhall-bash
-Version: 1.0.18
+Version: 1.0.19
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1

--- a/dhall-text/dhall-text.cabal
+++ b/dhall-text/dhall-text.cabal
@@ -1,5 +1,5 @@
 Name: dhall-text
-Version: 1.0.15
+Version: 1.0.16
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1


### PR DESCRIPTION
I forgot to bump these versions when cutting the latest release