### PR TITLE
Fix for UnionType

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -1517,7 +1517,8 @@ union (UnionType (Data.Functor.Compose.Compose mp)) = Type
     extractF e0 = do
       UnionLit fld e1 rest <- Just e0
       t <- Dhall.Map.lookup fld mp
-      guard $ rest == Dhall.Map.delete fld expect
+      guard $ Dhall.Map.toMap rest
+           == Dhall.Map.toMap (Dhall.Map.delete fld expect)
       Dhall.extract t e1
 
 -- | Parse a single constructor of a union

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -1517,8 +1517,8 @@ union (UnionType (Data.Functor.Compose.Compose mp)) = Type
     extractF e0 = do
       UnionLit fld e1 rest <- Just e0
       t <- Dhall.Map.lookup fld mp
-      guard $ Dhall.Map.toMap rest
-           == Dhall.Map.toMap (Dhall.Map.delete fld expect)
+      guard $ Dhall.Core.Union rest `Dhall.Core.judgmentallyEqual`
+                Dhall.Core.Union (Dhall.Map.delete fld expect)
       Dhall.extract t e1
 
 -- | Parse a single constructor of a union


### PR DESCRIPTION
I noticed that I used the wrong type of equality for union subtypes for `union`.  This causes the `Type` to falsely reject situations where the "other branches" of a union lit are what are expected, but are not in a normalized form.  Using `judgmentallyEqual` gives the proper equality and gets rid of false negatives when testing for equality.