### PR TITLE
Remove deprecated `Path` constructor

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -26,7 +26,6 @@ module Dhall.Core (
     , ImportMode(..)
     , ImportType(..)
     , URL(..)
-    , Path
     , Scheme(..)
     , Var(..)
     , Binding(..)
@@ -282,11 +281,6 @@ instance Pretty Import where
         suffix = case importMode of
             RawText -> " as Text"
             Code    -> ""
-
--- | Type synonym for `Import`, provided for backwards compatibility
-type Path = Import
-
-{-# DEPRECATED Path "Use Dhall.Core.Import instead" #-}
 
 {-| Label for a bound variable
 


### PR DESCRIPTION
The `Path` constructor was deprecated a long time ago, so it's pretty
safe to remove now