### PR TITLE
Fix `dhall decode` bug

### DIFF
--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -111,13 +111,16 @@ renderStandardVersion V_5_0_0   = "5.0.0"
     the list of arguments
 -}
 unApply :: Expr s a -> (Expr s a, [Expr s a])
-unApply e = (baseFunction₀, diffArguments₀ [])
+unApply e₀ = (baseFunction₀, diffArguments₀ [])
   where
-    ~(baseFunction₀, diffArguments₀) = go e
+    ~(baseFunction₀, diffArguments₀) = go e₀
 
     go (App f a) = (baseFunction, diffArguments . (a :))
       where
         ~(baseFunction, diffArguments) = go f
+
+    go (Note _ e) = go e
+
     go baseFunction = (baseFunction, id)
 
 -- | Encode a Dhall expression to a CBOR `Term`


### PR DESCRIPTION
... as caught by @singpolyma

`Dhall.Binary.unApply` was failing to uncurry functions due to the presence of
`Note` constructors.  This caused `dhall encode` to produce different
results from `dhall hash` since the latter was normalizing the expression
(and therefore removing `Note` constructors) whereas the former was not.