### PR TITLE
Disable tests for dependencies

### DIFF
--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -133,13 +133,14 @@ let
                   else pkgsNew.haskell.lib.failOnAllWarnings drv;
 
                 doCheckExtension =
-                  mass pkgsNew.haskell.lib.doCheck [
-                    "dhall"
-                    "dhall-bash"
-                    "dhall-json"
-                    "dhall-lsp-server"
-                    "dhall-text"
-                  ];
+                  mass pkgsNew.haskell.lib.doCheck
+                    (   [ "dhall-bash"
+                          "dhall-json"
+                          "dhall-lsp-server"
+                          "dhall-text"
+                        ]
+                    ++  pkgsNew.lib.optional (compiler != "ghcjs") "dhall"
+                    );
 
                 failOnAllWarningsExtension =
                   mass failOnAllWarnings [
@@ -521,13 +522,8 @@ let
     };
 
   toShell = drv:
-    if compiler == "ghcjs"
-    then
-        # `doctest` doesn't work with `ghcjs`
-        (pkgs.haskell.lib.dontCheck drv).env
-    else
-        # Benchmark dependencies aren't added by default
-        (pkgs.haskell.lib.doBenchmark drv).env;
+    # Benchmark dependencies aren't added by default
+    (pkgs.haskell.lib.doBenchmark drv).env;
 
 in
   rec {

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -139,7 +139,8 @@ let
                           "dhall-lsp-server"
                           "dhall-text"
                         ]
-                    ++  pkgsNew.lib.optional (compiler != "ghcjs") "dhall"
+                        # Test suite doesn't work on GHCJS or GHC 7.10.3
+                    ++  pkgsNew.lib.optional (!(compiler == "ghcjs" || compiler == "ghc7103")) "dhall"
                     );
 
                 failOnAllWarningsExtension =

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -132,25 +132,13 @@ let
                   then drv
                   else pkgsNew.haskell.lib.failOnAllWarnings drv;
 
-                dontCheckExtension =
-                  mass pkgsNew.haskell.lib.dontCheck [
-                    "aeson"
-                    "base-compat-batteries"
-                    "comonad"
-                    "conduit"
-                    "distributive"
-                    "doctest"
-                    "Glob"
-                    "half"
-                    "http-types"
-                    "megaparsec"
-                    "prettyprinter"
-                    "prettyprinter-ansi-terminal"
-                    # https://github.com/well-typed/cborg/issues/172
-                    "serialise"
-                    "semigroupoids"
-                    "unordered-containers"
-                    "yaml"
+                doCheckExtension =
+                  mass pkgsNew.haskell.lib.doCheck [
+                    "dhall"
+                    "dhall-bash"
+                    "dhall-json"
+                    "dhall-lsp-server"
+                    "dhall-text"
                   ];
 
                 failOnAllWarningsExtension =
@@ -163,6 +151,12 @@ let
 
                 extension =
                   haskellPackagesNew: haskellPackagesOld: {
+                    mkDerivation =
+                      args: haskellPackagesOld.mkDerivation (args // {
+                          doCheck = false;
+                        }
+                      );
+
                     dhall =
                       applyCoverage
                         (haskellPackagesNew.callCabal2nix
@@ -219,7 +213,7 @@ let
                   (old.overrides or (_: _: {}))
                   [ (pkgsNew.haskell.lib.packagesFromDirectory { directory = ./.; })
                     extension
-                    dontCheckExtension
+                    doCheckExtension
                     failOnAllWarningsExtension
                   ];
           }


### PR DESCRIPTION
This no longer tests dependencies, mainly to lower my maintenance burden.  In
particular, this makes it easier for me to test bumping dependencies for
Stackage-related bounds changes.