### PR TITLE
Make lts-12 the default stack configuration in appveyor to avoid build timeouts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,9 @@ branches:
 environment:
   STACK_ROOT: C:\sr
   STACK_VERSION: 1.9.3
-  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+  # Override the temp directory to avoid sed escaping issues
+  # See https://github.com/haskell/cabal/issues/5386
+  TMP: c:\tmp
   
   matrix:
     - STACK_YAML: stack.yaml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,11 @@ branches:
 environment:
   STACK_ROOT: C:\sr
   STACK_VERSION: 1.9.3
-
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+  
   matrix:
     - STACK_YAML: stack.yaml
+    - STACK_YAML: stack-lts-12.yaml
     - STACK_YAML: stack-lts-6.yaml
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,9 @@ environment:
   TMP: c:\tmp
   
   matrix:
-    - STACK_YAML: stack.yaml
+    # Commenting out for now default stack (lts-13) cause
+    # compilations times are reaching appveyor default build timeout
+    # - STACK_YAML: stack.yaml
     - STACK_YAML: stack-lts-12.yaml
     - STACK_YAML: stack-lts-6.yaml
 

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -4,6 +4,7 @@ packages:
   - dhall-bash
   - dhall-json
   - dhall-text
+  - dhall-lsp-server
 extra-deps:
   - megaparsec-7.0.3
   - repline-0.2.0.0
@@ -11,6 +12,9 @@ extra-deps:
   - neat-interpolation-0.3.2.4
   - dotgen-0.4.2
   - cborg-json-0.2.1.0
+  - base-noprelude-4.11.1.0
+  - haskell-lsp-0.8.1.0
+  - haskell-lsp-types-0.8.0.1
 nix:
   packages:
     - ncurses

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -6,7 +6,7 @@ packages:
   - dhall-text
   - dhall-lsp-server
 extra-deps:
-  - megaparsec-7.0.3
+  - megaparsec-7.0.4
   - repline-0.2.0.0
   - serialise-0.2.1.0
   - neat-interpolation-0.3.2.4

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -9,7 +9,7 @@ extra-deps:
   - repline-0.2.0.0
   - serialise-0.2.1.0
   - neat-interpolation-0.3.2.4
-  - dotgen-0.4.2@sha256:309b7cc8a3593a8e48bee7b53020d5f72db156d58edf78a0214f58fbb84b292b
+  - dotgen-0.4.2
   - cborg-json-0.2.1.0
 nix:
   packages:


### PR DESCRIPTION
I've tested building times here: https://ci.appveyor.com/project/jneira/dhall-haskell/builds/23842915:

* Environment: STACK_YAML=stack.yaml: 48 min 49 sec
* Environment: STACK_YAML=stack-lts-12.yaml: 18 min 57 sec
* Environment: STACK_YAML=stack-lts-6.yaml: 3 min 22 sec

lts-13 and lts-12 have the same build steps, lts-6 doesn't run tests

So this pr makes lts-12 the default for now. 