### PR TITLE
Add json-to-dhall to appveyor artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,7 @@ build_script:
   - 7z a "bin\dhall-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall.exe"
   - 7z a "bin\dhall-json-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-json.exe"
   - 7z a "bin\dhall-json-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-yaml.exe"
+  - 7z a "bin\dhall-json-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\json-to-dhall.exe"
   - 7z a "bin\dhall-text-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-text.exe"
   - 7z a "bin\dhall-bash-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-bash.exe"
   # dhall-lsp-server can't be built with lts-6

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -93,8 +93,8 @@ Executable json-to-dhall
     Other-Modules:
         Paths_dhall_json
     GHC-Options: -Wall
-    if impl(ghc < 8.0)
-      Buildable: False
+--    if impl(ghc < 8.0)
+--      Buildable: False
 
 Test-Suite tasty
     Type: exitcode-stdio-1.0

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -93,8 +93,6 @@ Executable json-to-dhall
     Other-Modules:
         Paths_dhall_json
     GHC-Options: -Wall
---    if impl(ghc < 8.0)
---      Buildable: False
 
 Test-Suite tasty
     Type: exitcode-stdio-1.0

--- a/dhall-json/json-to-dhall/Main.hs
+++ b/dhall-json/json-to-dhall/Main.hs
@@ -495,7 +495,7 @@ dhallFromJSON (Conversion {..}) = loop
 -- ----------
 
 red, purple, green
-    :: (Semigroup a, Data.String.IsString a) => a -> a
+    :: (Monoid a, Data.String.IsString a) => a -> a
 red    s = "\ESC[1;31m" <> s <> "\ESC[0m" -- bold
 purple s = "\ESC[1;35m" <> s <> "\ESC[0m" -- bold
 green  s = "\ESC[0;32m" <> s <> "\ESC[0m" -- plain

--- a/dhall-json/json-to-dhall/Main.hs
+++ b/dhall-json/json-to-dhall/Main.hs
@@ -154,7 +154,6 @@ import qualified Data.HashMap.Strict as HM
 import           Data.List ((\\))
 import           Data.Monoid ((<>))
 import           Data.Scientific (floatingOrInteger, toRealFloat)
-import           Data.Semigroup (Semigroup)
 import qualified Data.Sequence as Seq
 import qualified Data.String
 import qualified Data.Text    as Text


### PR DESCRIPTION
I had to [reduce genericity (from Semigroup to Monoid)](https://github.com/dhall-lang/dhall-haskell/pull/894/files#diff-f78f59aefb8f350f8c05c79481959a80L498) to make it buildable with ghc-7.10