### PR TITLE
Increase lines of context for error messages

### DIFF
--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -23,15 +23,17 @@ import qualified Dhall.Pretty
 -- | Utility function to cut out the interior of a large text block
 snip :: Text -> Text
 snip text
-    | length ls <= 7 = text
+    | length ls <= numberOfLinesOfContext * 2 + 1 = text
     | otherwise =
          if Data.Text.last text == '\n' then preview else Data.Text.init preview
   where
+    numberOfLinesOfContext = 20
+
     ls = Data.Text.lines text
 
-    header = take 3 ls
+    header = take numberOfLinesOfContext ls
 
-    footer = takeEnd 3 ls
+    footer = takeEnd numberOfLinesOfContext ls
 
     excerpt = filter (Data.Text.any (/= ' ')) (header <> footer)
 


### PR DESCRIPTION
Related to https://github.com/dhall-lang/dhall-haskell/issues/905

This increases the size of expressions that we display in error messages to
20 on each side before we begin truncating the output