### PR TITLE
Add line numbers to error messages

### DIFF
--- a/dhall/src/Dhall/Tutorial.hs
+++ b/dhall/src/Dhall/Tutorial.hs
@@ -314,7 +314,7 @@ import Dhall
 -- - Bool
 -- + Natural
 -- ...
--- 1 : Bool
+-- 1: 1 : Bool
 -- ...
 -- (input):1:1
 -- ...
@@ -514,7 +514,8 @@ import Dhall
 -- *** Exception:
 -- ...Error...: An empty list requires a type annotation
 -- ...
--- []
+-- 1: []
+-- ...
 -- (input):1:1
 --
 -- Also, list elements must all have the same type.  You will get an error if
@@ -527,7 +528,7 @@ import Dhall
 -- - Natural
 -- + Bool
 -- ...
---     True
+-- 1:     True
 -- ...
 -- (input):1:5
 -- ...


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/905

For example, this file:

```haskell
[ 1
, 2
, 3
, Bool

+ 1
]
```

... now produces this error message:

```
Use "dhall --explain" for detailed errors

↳ ./example.dhall

Error: ❰+❱ only works on ❰Natural❱s

4:   Bool
5:
6:
7:
8:
9: + 1

/Users/gabriel/proj/dhall-haskell/dhall/example.dhall:4:3
```