### PR TITLE
Converted sample code to doctest for `RecordType`, `UnionInputType`, `RecordInputType`

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -1506,12 +1506,10 @@ field key valueType =
     However, we can use a 'UnionType' to build a 'Type' for @Status@:
 
 > status :: Type Status
-> status =
->   union
->     ( Queued  <$> constructor "Queued"  natural
->    <> Result  <$> constructor "Result"  string
->    <> Errored <$> constructor "Errored" string
->     )
+> status = union
+>    $  ( Queued  <$> constructor "Queued"  natural )
+>    <> ( Result  <$> constructor "Result"  strictText )
+>    <> ( Errored <$> constructor "Errored" strictText )
 
 -}
 newtype UnionType a =

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -146,6 +146,7 @@ import qualified Dhall.Util
 
 -- $setup
 -- >>> :set -XOverloadedStrings
+-- >>> :set -XRecordWildCards
 
 {-| Every `Type` must obey the contract that if an expression's type matches the
     the `expected` type then the `extract` function must succeed.  If not, then
@@ -1401,11 +1402,13 @@ instance (Selector s, Inject a) => GenericInject (M1 S s (K1 i a)) where
 
     For example, let's take the following Haskell data type:
 
-> data Project = Project
->   { projectName :: Text
->   , projectDescription :: Text
->   , projectStars :: Natural
->   }
+>>> :{
+data Project = Project
+  { projectName :: Text
+  , projectDescription :: Text
+  , projectStars :: Natural
+  }
+:}
 
     And assume that we have the following Dhall record that we would like to
     parse as a @Project@:
@@ -1422,14 +1425,15 @@ instance (Selector s, Inject a) => GenericInject (M1 S s (K1 i a)) where
     smaller parsers, as 'Type's cannot be combined (they are only 'Functor's).
     However, we can use a 'RecordType' to build a 'Type' for @Project@:
 
-> project :: Type Project
-> project =
->   record
->     ( Project <$> field "name" string
->               <*> field "description" string
->               <*> field "stars" natural
->     )
-
+>>> :{
+project :: Type Project
+project =
+  record
+    ( Project <$> field "name" strictText
+              <*> field "description" strictText
+              <*> field "stars" natural
+    )
+:}
 -}
 
 newtype RecordType a =
@@ -1489,9 +1493,11 @@ field key valueType =
 
     For example, let's take the following Haskell data type:
 
-> data Status = Queued Natural
->             | Result Text
->             | Errored Text
+>>> :{
+data Status = Queued Natural
+            | Result Text
+            | Errored Text
+:}
 
     And assume that we have the following Dhall union that we would like to
     parse as a @Status@:
@@ -1505,14 +1511,13 @@ field key valueType =
     smaller parsers, as 'Type's cannot be combined (they are only 'Functor's).
     However, we can use a 'UnionType' to build a 'Type' for @Status@:
 
->>> data Status = Queued Natural | Result Text | Errored Text
 >>> :{
-  status :: Type Status
-  status = union
-      (  ( Queued  <$> constructor "Queued"  natural )
-      <> ( Result  <$> constructor "Result"  strictText )
-      <> ( Errored <$> constructor "Errored" strictText )
-      )
+status :: Type Status
+status = union
+  (  ( Queued  <$> constructor "Queued"  natural )
+  <> ( Result  <$> constructor "Result"  strictText )
+  <> ( Errored <$> constructor "Errored" strictText )
+  )
 :}
 
 -}
@@ -1553,11 +1558,13 @@ constructor key valueType = UnionType
 
     For example, let's take the following Haskell data type:
 
-> data Project = Project
->   { projectName :: Text
->   , projectDescription :: Text
->   , projectStars :: Natural
->   }
+>>> :{
+data Project = Project
+  { projectName :: Text
+  , projectDescription :: Text
+  , projectStars :: Natural
+  }
+:}
 
     And assume that we have the following Dhall record that we would like to
     parse as a @Project@:
@@ -1574,27 +1581,31 @@ constructor key valueType = UnionType
     smaller injectors, as 'InputType's cannot be combined (they are only 'Contravariant's).
     However, we can use an 'InputRecordType' to build an 'InputType' for @Project@:
 
-> injectProject :: InputType Project
-> injectProject =
->   inputRecord
->     (  adapt >$< inputFieldWith "name" inject
->              >*< inputFieldWith "description" inject
->              >*< inputFieldWith "stars" inject
->     )
->   where
->     adapt (Project{..}) = (projectName, (projectDescription, projectStars))
+>>> :{
+injectProject :: InputType Project
+injectProject =
+  inputRecord
+    ( adapt >$< inputFieldWith "name" inject
+            >*< inputFieldWith "description" inject
+            >*< inputFieldWith "stars" inject
+    )
+  where
+    adapt (Project{..}) = (projectName, (projectDescription, projectStars))
+:}
 
     Or, since we are simply using the `Inject` instance to inject each field, we could write
 
-> injectProject :: InputType Project
-> injectProject =
->   inputRecord
->     (  adapt >$< inputField "name"
->              >*< inputField "description"
->              >*< inputField "stars"
->     )
->   where
->     adapt (Project{..}) = (projectName, (projectDescription, projectStars))
+>>> :{
+injectProject :: InputType Project
+injectProject =
+  inputRecord
+    ( adapt >$< inputField "name"
+            >*< inputField "description"
+            >*< inputField "stars"
+    )
+  where
+    adapt (Project{..}) = (projectName, (projectDescription, projectStars))
+:}
 
 -}
 
@@ -1635,9 +1646,11 @@ inputRecord (RecordInputType inputTypeRecord) = InputType makeRecordLit recordTy
 
     For example, let's take the following Haskell data type:
 
-> data Status = Queued Natural
->             | Result Text
->             | Errored Text
+>>> :{
+data Status = Queued Natural
+            | Result Text
+            | Errored Text
+:}
 
     And assume that we have the following Dhall union that we would like to
     parse as a @Status@:
@@ -1649,31 +1662,36 @@ inputRecord (RecordInputType inputTypeRecord) = InputType makeRecordLit recordTy
 
     Our injector has type 'InputType' @Status@, but we can't build that out of any
     smaller injectors, as 'InputType's cannot be combined.
-    However, we can use an 'InputUnionType' to build an 'InputType' for @Status@:
+    However, we can use an 'UnionInputType' to build an 'InputType' for @Status@:
 
-> injectStatus :: InputType Status
-> injectStatus =
->           adapt
->     >$< inputConstructorWith "Queued"  inject
->     >|< inputConstructorWith "Result"  inject
->     >|< inputConstructorWith "Errored" inject
->   where
->     adapt (Queued  n) = Left (Left  n)
->     adapt (Result  t) = Left (Right t)
->     adapt (Errored e) = Right e
+>>> :{
+injectStatus :: InputType Status
+injectStatus = adapt >$< inputUnion
+  (   inputConstructorWith "Queued"  inject
+  >|< inputConstructorWith "Result"  inject
+  >|< inputConstructorWith "Errored" inject
+  )
+  where
+    adapt (Queued  n) = Left n
+    adapt (Result  t) = Right (Left t)
+    adapt (Errored e) = Right (Right e)
+:}
 
     Or, since we are simply using the `Inject` instance to inject each branch, we could write
 
-> injectStatus :: InputType Status
-> injectStatus =
->           adapt
->     >$< inputConstructor "Queued"
->     >|< inputConstructor "Result"
->     >|< inputConstructor "Errored"
->   where
->     adapt (Queued  n) = Left (Left  n)
->     adapt (Result  t) = Left (Right t)
->     adapt (Errored e) = Right e
+>>> :{
+injectStatus :: InputType Status
+injectStatus = adapt >$< inputUnion
+  (   inputConstructor "Queued"
+  >|< inputConstructor "Result"
+  >|< inputConstructor "Errored"
+  )
+  where
+    adapt (Queued  n) = Left n
+    adapt (Result  t) = Right (Left t)
+    adapt (Errored e) = Right (Right e)
+:}
+
 -}
 newtype UnionInputType a =
   UnionInputType

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -1505,11 +1505,15 @@ field key valueType =
     smaller parsers, as 'Type's cannot be combined (they are only 'Functor's).
     However, we can use a 'UnionType' to build a 'Type' for @Status@:
 
-> status :: Type Status
-> status = union
->    $  ( Queued  <$> constructor "Queued"  natural )
->    <> ( Result  <$> constructor "Result"  strictText )
->    <> ( Errored <$> constructor "Errored" strictText )
+>>> data Status = Queued Natural | Result Text | Errored Text
+>>> :{
+  status :: Type Status
+  status = union
+      (  ( Queued  <$> constructor "Queued"  natural )
+      <> ( Result  <$> constructor "Result"  strictText )
+      <> ( Errored <$> constructor "Errored" strictText )
+      )
+:}
 
 -}
 newtype UnionType a =


### PR DESCRIPTION
`<>` is `infixr 6`, `<$>` is `infixr 4`, therefore existing example is incorrect.

It might be a good idea to reflect every piece of sample code in the tests, so that the docs will never become outdated.

I could dedicate some time to this. Should I add a test to `Dhall.Test.Tutorial` or is there a more suitable module?