### PR TITLE
Nix: Upgrade from 8.6.1 to 8.6.5.

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -2,7 +2,7 @@ Name: dhall-bash
 Version: 1.0.20
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
-Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1
+Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.5
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -2,7 +2,7 @@ Name: dhall-json
 Version: 1.2.8
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
-Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1
+Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.5
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/dhall-text/dhall-text.cabal
+++ b/dhall-text/dhall-text.cabal
@@ -2,7 +2,7 @@ Name: dhall-text
 Version: 1.0.17
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
-Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1
+Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.5
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -2,7 +2,7 @@ Name: dhall
 Version: 1.22.0
 Cabal-Version: >=1.10
 Build-Type: Simple
-Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1
+Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.5
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -415,7 +415,7 @@ let
     };
   };
 
-  overlayGHC861 = pkgsNew: pkgsOld: {
+  overlayGHC865 = pkgsNew: pkgsOld: {
     haskell = pkgsOld.haskell // {
       packages = pkgsOld.haskell.packages // {
         "${compiler}" = pkgsOld.haskell.packages."${compiler}".override (old: {
@@ -423,16 +423,6 @@ let
               let
                 extension =
                   haskellPackagesNew: haskellPackagesOld: {
-                    # GHC 8.6.1 accidentally shipped with an unpublished
-                    # unix-2.8 package.  Normally we'd deal with that by
-                    # using `pkgsNew.haskell.lib.jailbreak` but it doesn't
-                    # work for dependencies guarded by conditions.  See:
-                    # 
-                    # https://github.com/peti/jailbreak-cabal/issues/7
-                    turtle =
-                      pkgsNew.haskell.lib.appendPatch
-                        haskellPackagesOld.turtle
-                        ./turtle.patch;
                   };
 
               in
@@ -463,7 +453,7 @@ let
     overlays =
           [ overlayShared overlayCabal2nix ]
       ++  (      if compiler == "ghc7103" then [ overlayGHC7103 ]
-            else if compiler == "ghc861"  then [ overlayGHC861  ]
+            else if compiler == "ghc865"  then [ overlayGHC865  ]
             else                               [                ]
           );
   };

--- a/release.nix
+++ b/release.nix
@@ -4,8 +4,8 @@ let
   shared_7_10_3 =
     import ./nix/shared.nix { compiler = "ghc7103"; };
 
-  shared_8_6_1 =
-    import ./nix/shared.nix { compiler = "ghc861"; };
+  shared_8_6_5 =
+    import ./nix/shared.nix { compiler = "ghc865"; };
 
   shared_ghcjs =
     import ./nix/shared.nix { compiler = "ghcjs"; };
@@ -37,25 +37,21 @@ in
 
           # Verify that the packages build against the latest supported version
           # of the compiler
-          shared_8_6_1.dhall
-          shared_8_6_1.dhall-bash
-          shared_8_6_1.dhall-json
+          shared_8_6_5.dhall
+          shared_8_6_5.dhall-bash
+          shared_8_6_5.dhall-json
           # `base-noprelude` depends on a specific version of `base`
-          # shared_8_6_1.dhall-lsp-server
+          # shared_8_6_5.dhall-lsp-server
           # `hnix` depends on `unix-2.7.*` and doesn't work with GHC 8.6
-          # shared_8_6_1.dhall-nix
-          shared_8_6_1.dhall-text
+          # shared_8_6_5.dhall-nix
+          shared_8_6_5.dhall-text
 
-          # However, we still use GHC 8.4.3 to build the distributed tarballs
-          # due to a bug in GHC 8.6.1.  See:
-          #
-          # https://ghc.haskell.org/trac/ghc/ticket/15696
-          shared.tarball-dhall
-          shared.tarball-dhall-bash
-          shared.tarball-dhall-json
-          shared.tarball-dhall-lsp-server
-          shared.tarball-dhall-nix
-          shared.tarball-dhall-text
+          shared_8_6_5.tarball-dhall
+          shared_8_6_5.tarball-dhall-bash
+          shared_8_6_5.tarball-dhall-json
+          shared_8_6_5.tarball-dhall-lsp-server
+          shared_8_6_5.tarball-dhall-nix
+          shared_8_6_5.tarball-dhall-text
 
           shared_ghcjs.tarball-website
 


### PR DESCRIPTION
8.6.1 had a couple of really awful bugs in it - including two that
were being worked around in the derivations. Upgrading will both
simplify the configuration and mean that there's less risk of a crazy
bug biting in CI.