### PR TITLE
Teach genericAuto about new-style union construction.

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -943,8 +943,8 @@ possible e = case e of
     _                    -> Just e
 
 extractUnionConstructor
-  :: Expr Src X
-  -> Maybe (Text, Expr Src X, Dhall.Map.Map Text (Maybe (Expr Src X)))
+  :: Expr s a
+  -> Maybe (Text, Expr s a, Dhall.Map.Map Text (Maybe (Expr s a)))
 extractUnionConstructor (UnionLit fld e rest) =
   return (fld, e, rest)
 extractUnionConstructor (App (Field (Union kts) fld) e) =


### PR DESCRIPTION
I discovered it wasn't working right in #926. The underlying bug is
very similar to #915, and in fact this builds on the fix for that in #918.

It looks like the single-constructor case is a different underlying
bug that I don't understand just yet, so let's tackle that separately.