### PR TITLE
Fix repl autocomplete for Records and Unions

### DIFF
--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -504,10 +504,8 @@ completeFunc reversedPrev word
                               fmap (("." <> f) <>) (algebraicComplete fs e)
 
       in  case expr of
-            Dhall.Core.Record       m -> withMap (fmap Just m)
             Dhall.Core.RecordLit    m -> withMap (fmap Just m)
             Dhall.Core.Union        m -> withMap m
-            Dhall.Core.UnionLit _ _ m -> withMap m
             _                         -> []
 
 


### PR DESCRIPTION
Remove autocomplete for Record types and Union literals as the field accessor/Union construction is not valid in these cases:

```
⊢ :let x = { foo : Natural, bar : Text }

x : Type

⊢ x.
x.bar  x.foo
⊢ x.bar

y : { bar : Text, foo : Natural }
it : Text

Error: Not a record or a union

x.bar
(stdin):1:1
```

```
⊢ :let y = < Foo = 3 | Bar >

y : < Foo : Natural | Bar >

⊢ y.Bar

y : { bar : Text, foo : Natural }
y : < Bar | Foo : Natural >
it : Text

Error: Not a record or a union

y.Bar
(stdin):1:1
```