### PR TITLE
Fix another α-normalization bug

### DIFF
--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -843,7 +843,7 @@ alphaNormalize = goEnv NEmpty where
     go !acc (NBind env x) !i
       | x == topX = if i == 0 then Var (V "_" acc) else go (acc + 1) env (i - 1)
       | otherwise = go (acc + 1) env i
-    go acc NEmpty i = Var (V topX topI)
+    go acc NEmpty i = Var (V topX i)
 
   goEnv :: Names -> Expr s a -> Expr s a
   goEnv !e t = let


### PR DESCRIPTION
This was caught by the following test:

https://github.com/dhall-lang/dhall-lang/blob/372230d1610bd74d130bd09e7408966c8bc2c2d4/tests/alpha-normalization/success/unit/FunctionNestedBindingXXFreeA.dhall