### PR TITLE
[POC] Add 'quoted' option

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   # Override the temp directory to avoid sed escaping issues
   # See https://github.com/haskell/cabal/issues/5386
   TMP: c:\tmp
-  
+
   matrix:
     # Commenting out for now default stack (lts-13) cause
     # compilations times are reaching appveyor default build timeout
@@ -35,21 +35,44 @@ cache:
   - dhall-bash\.stack-work -> '%STACK_YAML%'
   - dhall-lsp-server\.stack-work -> '%STACK_YAML%'
 
-build_script:
-  - stack build
-  - stack install --local-bin-path bin
-  - if /I "%APPVEYOR_REPO_TAG%" EQU "true" (set DEPLOY_TAG=%APPVEYOR_REPO_TAG_NAME%) else (set DEPLOY_TAG=%APPVEYOR_REPO_COMMIT:~0,5%)
-  - set DEPLOY_SUFFIX=%DEPLOY_TAG%-x86_64-windows.zip
-  - 7z a "bin\dhall-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall.exe"
-  - 7z a "bin\dhall-json-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-json.exe"
-  - 7z a "bin\dhall-json-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-yaml.exe"
-  - 7z a "bin\dhall-json-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\json-to-dhall.exe"
-  - 7z a "bin\dhall-text-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-text.exe"
-  - 7z a "bin\dhall-bash-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-bash.exe"
-  # dhall-lsp-server can't be built with lts-6
-  - if exist "%APPVEYOR_BUILD_FOLDER%\bin\dhall-lsp-server.exe" ( 7z a "bin\dhall-lsp-server-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-lsp-server.exe" )
-  
 for:
+-
+  matrix:
+    except:
+      # dhall-json is not supported for LTS 6
+      - STACK_YAML: stack-lts-6.yaml
+
+  build_script:
+    - stack build
+    - stack install --local-bin-path bin
+    - if /I "%APPVEYOR_REPO_TAG%" EQU "true" (set DEPLOY_TAG=%APPVEYOR_REPO_TAG_NAME%) else (set DEPLOY_TAG=%APPVEYOR_REPO_COMMIT:~0,5%)
+    - set DEPLOY_SUFFIX=%DEPLOY_TAG%-x86_64-windows.zip
+    - 7z a "bin\dhall-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall.exe"
+    - 7z a "bin\dhall-json-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-json.exe"
+    - 7z a "bin\dhall-json-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-yaml.exe"
+    - 7z a "bin\dhall-json-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\json-to-dhall.exe"
+    - 7z a "bin\dhall-text-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-text.exe"
+    - 7z a "bin\dhall-bash-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-bash.exe"
+    # dhall-lsp-server can't be built with lts-6
+    - if exist "%APPVEYOR_BUILD_FOLDER%\bin\dhall-lsp-server.exe" ( 7z a "bin\dhall-lsp-server-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-lsp-server.exe" )
+-
+  matrix:
+    only:
+      - STACK_YAML: stack-lts-6.yaml
+
+  build_script:
+    - stack build
+    - stack install --local-bin-path bin
+    - if /I "%APPVEYOR_REPO_TAG%" EQU "true" (set DEPLOY_TAG=%APPVEYOR_REPO_TAG_NAME%) else (set DEPLOY_TAG=%APPVEYOR_REPO_COMMIT:~0,5%)
+    - set DEPLOY_SUFFIX=%DEPLOY_TAG%-x86_64-windows.zip
+    # dhall-json is not supported for LTS 6, so do not try to copy the
+    # corresponding binaries
+    - 7z a "bin\dhall-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall.exe"
+    - 7z a "bin\dhall-text-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-text.exe"
+    - 7z a "bin\dhall-bash-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-to-bash.exe"
+    # dhall-lsp-server can't be built with lts-6
+    - if exist "%APPVEYOR_BUILD_FOLDER%\bin\dhall-lsp-server.exe" ( 7z a "bin\dhall-lsp-server-%DEPLOY_SUFFIX%" "%APPVEYOR_BUILD_FOLDER%\bin\dhall-lsp-server.exe" )
+
 -
   matrix:
     except:
@@ -74,7 +97,7 @@ artifacts:
     name: dhall-bash
   - path: bin\dhall-lsp-server-%DEPLOY_SUFFIX%
     name: dhall-lsp-server
-    
+
 deploy:
   - provider: GitHub
     auth_token:

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -35,10 +35,13 @@ Library
     Build-Depends:
         base                      >= 4.8.0.0  && < 5   ,
         aeson                     >= 1.0.0.0  && < 1.5 ,
+        bytestring                               < 0.11,
         dhall                     >= 1.22.0   && < 1.24,
         optparse-applicative      >= 0.14.0.0 && < 0.15,
         text                      >= 0.11.1.0 && < 1.3 ,
-        unordered-containers                     < 0.3
+        unordered-containers                     < 0.3 ,
+        vector                                         ,
+        yaml                      >= 0.5.0    && < 0.12
     Exposed-Modules: Dhall.JSON
     GHC-Options: -Wall
 
@@ -68,8 +71,6 @@ Executable dhall-to-yaml
         dhall                                  ,
         dhall-json                             ,
         optparse-applicative                   ,
-        yaml                 >= 0.5.0 && < 0.12,
-        vector                                 ,
         text
     GHC-Options: -Wall
 

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -69,6 +69,7 @@ Executable dhall-to-yaml
         dhall-json                             ,
         optparse-applicative                   ,
         yaml                 >= 0.5.0 && < 0.12,
+        libyaml                                ,
         vector                                 ,
         text
     GHC-Options: -Wall

--- a/dhall-json/dhall-to-yaml/Main.hs
+++ b/dhall-json/dhall-to-yaml/Main.hs
@@ -12,6 +12,7 @@ import Options.Applicative (Parser, ParserInfo)
 import qualified Control.Exception
 import qualified Data.ByteString
 import qualified Data.Text.IO
+import qualified Data.Text
 import qualified Data.Vector
 import qualified Data.Yaml
 import qualified Text.Libyaml
@@ -90,7 +91,13 @@ main = do
     where
         encodeYaml = Data.Yaml.encodeWith
 
-        customStyle = \_ -> ( Text.Libyaml.NoTag, Text.Libyaml.SingleQuoted )
+        customStyle = \s -> case () of
+            ()
+                | "\n" `Data.Text.isInfixOf` s -> ( noTag, literal )
+                | otherwise -> ( noTag, Text.Libyaml.SingleQuoted )
+            where
+                noTag = Text.Libyaml.NoTag
+                literal = Text.Libyaml.Literal
 
         quotedOptions = Data.Yaml.setStringStyle
                             customStyle

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -166,6 +166,7 @@ module Dhall.JSON (
     , convertToHomogeneousMaps
     , parseConversion
     , codeToValue
+    , jsonToYaml
 
     -- * Exceptions
     , CompileError(..)
@@ -182,17 +183,21 @@ import Dhall.TypeCheck (X)
 import Dhall.Map (Map)
 import Options.Applicative (Parser)
 
+import qualified Data.ByteString
 import qualified Data.Foldable
 import qualified Data.HashMap.Strict
 import qualified Data.List
 import qualified Data.Ord
 import qualified Data.Text
+import qualified Data.Vector
+import qualified Data.Yaml
 import qualified Dhall.Core
 import qualified Dhall.Import
 import qualified Dhall.Map
 import qualified Dhall.Parser
 import qualified Dhall.TypeCheck
 import qualified Options.Applicative
+import qualified Text.Libyaml
 
 {-| This is the exception type for errors that might arise when translating
     Dhall to JSON
@@ -821,3 +826,34 @@ codeToValue conversion name code = do
     case dhallToJSON convertedExpression of
       Left  err  -> Control.Exception.throwIO err
       Right json -> return json
+
+-- | Transform json representation into yaml
+jsonToYaml
+    :: Value
+    -> Bool
+    -> Bool
+    -> Data.ByteString.ByteString
+jsonToYaml json documents quoted = case (documents, json) of
+  (True, Data.Yaml.Array elems)
+    -> Data.ByteString.intercalate "\n---\n"
+       $ fmap (encodeYaml encodeOptions)
+       $ Data.Vector.toList elems
+  _ -> encodeYaml encodeOptions json
+  where
+    encodeYaml = Data.Yaml.encodeWith
+
+    customStyle = \s -> case () of
+        ()
+            | "\n" `Data.Text.isInfixOf` s -> ( noTag, literal )
+            | otherwise -> ( noTag, Text.Libyaml.SingleQuoted )
+        where
+            noTag = Text.Libyaml.NoTag
+            literal = Text.Libyaml.Literal
+
+    quotedOptions = Data.Yaml.setStringStyle
+                        customStyle
+                        Data.Yaml.defaultEncodeOptions
+
+    encodeOptions = if quoted
+        then quotedOptions
+        else Data.Yaml.defaultEncodeOptions

--- a/dhall-json/tasty/data/normal.yaml
+++ b/dhall-json/tasty/data/normal.yaml
@@ -1,0 +1,5 @@
+bool_value: true
+text: |
+  Plain text
+string_value: 2000-01-01
+int_value: 1

--- a/dhall-json/tasty/data/quoted.yaml
+++ b/dhall-json/tasty/data/quoted.yaml
@@ -1,0 +1,5 @@
+'bool_value': true
+'text': |
+  Plain text
+'string_value': '2000-01-01'
+'int_value': 1

--- a/dhall-json/tasty/data/yaml.dhall
+++ b/dhall-json/tasty/data/yaml.dhall
@@ -1,0 +1,5 @@
+{ string_value = "2000-01-01"
+, text = ./tasty/data/yaml.txt as Text
+, int_value = 1
+, bool_value = True
+}

--- a/dhall-json/tasty/data/yaml.txt
+++ b/dhall-json/tasty/data/yaml.txt
@@ -1,0 +1,1 @@
+Plain text

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -72,6 +72,7 @@ module Dhall
 
     , Inject(..)
     , inject
+    , genericInject
     , RecordInputType(..)
     , inputFieldWith
     , inputField
@@ -1139,6 +1140,17 @@ class Inject a where
 -}
 inject :: Inject a => InputType a
 inject = injectWith defaultInterpretOptions
+
+{-| Use the default options for injecting a value, whose structure is
+determined generically.
+
+This can be used when you want to use 'Inject' on types that you don't
+want to define orphan instances for.
+-}
+genericInject
+  :: (Generic a, GenericInject (Rep a)) => InputType a
+genericInject
+    = contramap GHC.Generics.from (evalState (genericInjectWith defaultInterpretOptions) 1)
 
 instance Inject Bool where
     injectWith _ = InputType {..}

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -843,7 +843,7 @@ alphaNormalize = goEnv NEmpty where
     go !acc (NBind env x) !i
       | x == topX = if i == 0 then Var (V "_" acc) else go (acc + 1) env (i - 1)
       | otherwise = go (acc + 1) env i
-    go acc NEmpty i = Var (V topX topI)
+    go acc NEmpty i = Var (V topX i)
 
   goEnv :: Names -> Expr s a -> Expr s a
   goEnv !e t = let

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -17,6 +17,7 @@ extra-deps:
   - haskell-lsp-types-0.8.0.1
   - turtle-1.5.14
   - transformers-compat-0.6.4
+  - yaml-0.10.4.0
 flags:
   transformers-compat:
     five-three: true

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -2,7 +2,6 @@ resolver: lts-6.27
 packages:
   - dhall
   - dhall-bash
-  - dhall-json
   - dhall-text
 extra-deps:
 - ansi-terminal-0.7.1.1

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -38,6 +38,7 @@ extra-deps:
 - resourcet-1.1.11
 - turtle-1.5.14
 - unliftio-core-0.1.2.0
+- yaml-0.10.4.0
 flags:
   transformers-compat:
     four: true


### PR DESCRIPTION
For #933 

Allow to generare quoted scalars if needed via providing a custom encode
options to Data.Yaml.encodeWith. So far two corner cases from yaml
itself (an empty scalar, and special strings) are omitted in the
implementation.