### PR TITLE
Set syntax highlighting for Dhall files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.dhall linguist-language=Haskell


### PR DESCRIPTION
Syntax highlighting for Dhall files, refer to https://github.com/dhall-lang/dhall-lang/pull/533 for details.