### PR TITLE
Fix linting tests to only test linting

### DIFF
--- a/dhall/tests/Dhall/Test/Lint.hs
+++ b/dhall/tests/Dhall/Test/Lint.hs
@@ -4,6 +4,8 @@ module Dhall.Test.Lint where
 
 import Data.Monoid (mempty, (<>))
 import Data.Text (Text)
+import Dhall.Core (Expr, Import)
+import Dhall.TypeCheck (X)
 import Prelude hiding (FilePath)
 import Test.Tasty (TestTree)
 import Turtle (FilePath)
@@ -11,7 +13,6 @@ import Turtle (FilePath)
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO
 import qualified Dhall.Core       as Core
-import qualified Dhall.Import     as Import
 import qualified Dhall.Lint       as Lint
 import qualified Dhall.Parser     as Parser
 import qualified Dhall.Test.Util  as Test.Util
@@ -40,17 +41,15 @@ lintTest prefix =
 
         parsedInput <- Core.throws (Parser.exprFromText mempty inputText)
 
-        let lintedInput = Lint.lint parsedInput
-
-        actualExpression <- Import.load lintedInput
+        let actualExpression :: Expr X Import
+            actualExpression = Core.denote (Lint.lint parsedInput)
 
         outputText <- Text.IO.readFile outputFile
 
         parsedOutput <- Core.throws (Parser.exprFromText mempty outputText)
 
-        resolvedOutput <- Import.load parsedOutput
-
-        let expectedExpression = Core.denote resolvedOutput
+        let expectedExpression :: Expr X Import
+            expectedExpression = Core.denote parsedOutput
 
         let message = "The linted expression did not match the expected output"
 


### PR DESCRIPTION
The tests were unnecessarily attempting to resolve imports, which is
orthogonal to linting