### PR TITLE
Add `--file` flag

### DIFF
--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -262,6 +262,7 @@ getExpression :: Maybe FilePath -> IO (Expr Src Import)
 getExpression maybeFile = do
     inText <- do
         case maybeFile of
+            Just "-"  -> Data.Text.IO.getContents
             Just file -> Data.Text.IO.readFile file
             Nothing   -> Data.Text.IO.getContents
 
@@ -290,8 +291,9 @@ command (Options {..}) = do
                 (Dhall.Import.emptyStatus file)
           where
             file = case maybeFile of
-                Just f  -> f
-                Nothing -> "."
+                Just "-" -> "."
+                Just f   -> f
+                Nothing  -> "."
 
     let handle =
                 Control.Exception.handle handler2

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -83,19 +83,19 @@ data Options = Options
 
 -- | The subcommands for the @dhall@ executable
 data Mode
-    = Default { annotate :: Bool, alpha :: Bool }
+    = Default { file :: Maybe FilePath, annotate :: Bool, alpha :: Bool }
     | Version
-    | Resolve { resolveMode :: Maybe ResolveMode }
-    | Type
-    | Normalize { alpha :: Bool }
+    | Resolve { file :: Maybe FilePath, resolveMode :: Maybe ResolveMode }
+    | Type { file :: Maybe FilePath }
+    | Normalize { file :: Maybe FilePath, alpha :: Bool }
     | Repl
     | Format { formatMode :: Dhall.Format.FormatMode }
     | Freeze { inplace :: Maybe FilePath, all_ :: Bool }
     | Hash
     | Diff { expr1 :: Text, expr2 :: Text }
     | Lint { inplace :: Maybe FilePath }
-    | Encode { json :: Bool }
-    | Decode { json :: Bool }
+    | Encode { file :: Maybe FilePath, json :: Bool }
+    | Decode { file :: Maybe FilePath, json :: Bool }
 
 data ResolveMode
     = Dot
@@ -141,15 +141,15 @@ parseMode =
     <|> subcommand
             "resolve"
             "Resolve an expression's imports"
-            (Resolve <$> parseResolveMode)
+            (Resolve <$> optional parseFile <*> parseResolveMode)
     <|> subcommand
             "type"
             "Infer an expression's type"
-            (pure Type)
+            (Type <$> optional parseFile)
     <|> subcommand
             "normalize"
             "Normalize an expression"
-            (Normalize <$> parseAlpha)
+            (Normalize <$> optional parseFile <*> parseAlpha)
     <|> subcommand
             "repl"
             "Interpret expressions in a REPL"
@@ -177,17 +177,24 @@ parseMode =
     <|> subcommand
             "encode"
             "Encode a Dhall expression to binary"
-            (Encode <$> parseJSONFlag)
+            (Encode <$> optional parseFile <*> parseJSONFlag)
     <|> subcommand
             "decode"
             "Decode a Dhall expression from binary"
-            (Decode <$> parseJSONFlag)
-    <|> (Default <$> parseAnnotate <*> parseAlpha)
+            (Decode <$> optional parseFile <*> parseJSONFlag)
+    <|> (Default <$> optional parseFile <*> parseAnnotate <*> parseAlpha)
   where
     argument =
             fmap Data.Text.pack
         .   Options.Applicative.strArgument
         .   Options.Applicative.metavar
+
+    parseFile =
+        Options.Applicative.strOption
+            (   Options.Applicative.long "file"
+            <>  Options.Applicative.help "Read expression from a file instead of standard input"
+            <>  Options.Applicative.metavar "FILE"
+            )
 
     parseAlpha =
         Options.Applicative.switch
@@ -251,9 +258,12 @@ parseMode =
         adapt True  path    = Dhall.Format.Check {..}
         adapt False inplace = Dhall.Format.Modify {..}
 
-getExpression :: IO (Expr Src Import)
-getExpression = do
-    inText <- Data.Text.IO.getContents
+getExpression :: Maybe FilePath -> IO (Expr Src Import)
+getExpression maybeFile = do
+    inText <- do
+        case maybeFile of
+            Just file -> Data.Text.IO.readFile file
+            Nothing   -> Data.Text.IO.getContents
 
     Dhall.Core.throws (Dhall.Parser.exprFromText "(stdin)" inText)
 
@@ -275,9 +285,13 @@ command (Options {..}) = do
 
     GHC.IO.Encoding.setLocaleEncoding System.IO.utf8
 
-    let status =
-            set Dhall.Import.standardVersion standardVersion (Dhall.Import.emptyStatus ".")
-
+    let toStatus maybeFile =
+            set Dhall.Import.standardVersion standardVersion
+                (Dhall.Import.emptyStatus file)
+          where
+            file = case maybeFile of
+                Just f  -> f
+                Nothing -> "."
 
     let handle =
                 Control.Exception.handle handler2
@@ -342,9 +356,9 @@ command (Options {..}) = do
             Data.Text.IO.putStrLn line₁
 
         Default {..} -> do
-            expression <- getExpression
+            expression <- getExpression file
 
-            resolvedExpression <- State.evalStateT (Dhall.Import.loadWith expression) status
+            resolvedExpression <- State.evalStateT (Dhall.Import.loadWith expression) (toStatus file)
 
             inferredType <- Dhall.Core.throws (Dhall.TypeCheck.typeOf resolvedExpression)
 
@@ -362,28 +376,28 @@ command (Options {..}) = do
 
             render System.IO.stdout annotatedExpression
 
-        Resolve (Just Dot) -> do
-            expression <- getExpression
+        Resolve { resolveMode = Just Dot, ..} -> do
+            expression <- getExpression file
 
             (Dhall.Import.Types.Status { _dot}) <-
-                State.execStateT (Dhall.Import.loadWith expression) status
+                State.execStateT (Dhall.Import.loadWith expression) (toStatus file)
 
             putStr . ("strict " <>) . Text.Dot.showDot $
                    Text.Dot.attribute ("rankdir", "LR") >>
                    _dot
 
-        Resolve (Just ListImmediateDependencies) -> do
-            expression <- getExpression
+        Resolve { resolveMode = Just ListImmediateDependencies, ..} -> do
+            expression <- getExpression file
 
             mapM_ (print
                         . Pretty.pretty
                         . Dhall.Core.importHashed) expression
 
-        Resolve (Just ListTransitiveDependencies) -> do
-            expression <- getExpression
+        Resolve { resolveMode = Just ListTransitiveDependencies, ..} -> do
+            expression <- getExpression file
 
             (Dhall.Import.Types.Status { _cache }) <-
-                State.execStateT (Dhall.Import.loadWith expression) status
+                State.execStateT (Dhall.Import.loadWith expression) (toStatus file)
 
             mapM_ print
                  .   fmap (   Pretty.pretty
@@ -392,15 +406,15 @@ command (Options {..}) = do
                  .   Data.Map.keys
                  $   _cache
 
-        Resolve (Nothing) -> do
-            expression <- getExpression
+        Resolve { resolveMode = Nothing, ..} -> do
+            expression <- getExpression file
 
             (resolvedExpression, _) <-
-                State.runStateT (Dhall.Import.loadWith expression) status
+                State.runStateT (Dhall.Import.loadWith expression) (toStatus file)
             render System.IO.stdout resolvedExpression
 
         Normalize {..} -> do
-            expression <- getExpression
+            expression <- getExpression file
 
             resolvedExpression <- Dhall.Import.assertNoImports expression
 
@@ -415,8 +429,8 @@ command (Options {..}) = do
 
             render System.IO.stdout alphaNormalizedExpression
 
-        Type -> do
-            expression <- getExpression
+        Type {..} -> do
+            expression <- getExpression file
 
             resolvedExpression <- Dhall.Import.assertNoImports expression
 
@@ -473,7 +487,7 @@ command (Options {..}) = do
                     renderDoc System.IO.stdout doc
 
         Encode {..} -> do
-            expression <- getExpression
+            expression <- getExpression file
 
             let term = Dhall.Binary.encode expression
 
@@ -493,7 +507,10 @@ command (Options {..}) = do
                     Data.ByteString.Lazy.putStr bytes
 
         Decode {..} -> do
-            bytes <- Data.ByteString.Lazy.getContents
+            bytes <- do
+                case file of
+                    Just f  -> Data.ByteString.Lazy.readFile f
+                    Nothing -> Data.ByteString.Lazy.getContents
 
             term <- do
                 if json


### PR DESCRIPTION
This allows users to supply the Dhall expression by path instead of via
standard input.  This also ensures that transitive imports are resolved
appropriately relative to the file's path.

In other words, instead of this:

```
$ dhall <<< './foo/bar.dhall'
```

Users can now do:

```
$ dhall --file foo/bar.dhall
```