### PR TITLE
Fix diff output to not double-print key-value separators.

### DIFF
--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -256,9 +256,7 @@ diffKeyVals
     -> Map Text (Expr s a)
     -> Map Text (Expr s a)
     -> [Diff]
-diffKeyVals assign = diffKeysWith assign diffVals
-  where
-    diffVals l r = assign <> " " <> diffExpression l r
+diffKeyVals assign = diffKeysWith assign diffExpression
 
 diffKeysWith
     :: Diff


### PR DESCRIPTION
E.g.,
```
{ unit :   …
```
was being printed as
```
{ unit : :   …
```