### PR TITLE
Implement universe support (non-cumulative, non-polymorphic).

### DIFF
--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -190,12 +190,12 @@ instance ToTerm a => ToTerm (Expr s a) where
         TString "Text/show"
     encode List =
         TString "List"
-    encode (Const Type) =
-        TString "Type"
-    encode (Const Kind) =
-        TString "Kind"
-    encode (Const Sort) =
-        TString "Sort"
+    encode (Const (Universe n)) =
+        case n of
+            0 -> TString "Type"
+            1 -> TString "Kind"
+            2 -> TString "Sort"
+            u -> TList [ TInt 27, TInteger (fromIntegral u) ]
     encode e@(App _ _) =
         TList ([ TInt 0, f₁ ] ++ map encode arguments)
       where
@@ -557,11 +557,15 @@ instance FromTerm a => FromTerm (Expr s a) where
     decode (TString "List") =
         return List
     decode (TString "Type") =
-        return (Const Type)
+        return (Const (Universe 0))
     decode (TString "Kind") =
-        return (Const Kind)
+        return (Const (Universe 1))
     decode (TString "Sort") =
-        return (Const Sort)
+        return (Const (Universe 2))
+    decode (TList [ TInt 27, TInt n ]) = do
+        return (Const (Universe (fromIntegral n)))
+    decode (TList [ TInt 27, TInteger n ]) =
+        return (Const (Universe (fromInteger n)))
     decode (TString "_") =
         empty
     decode (TList [ TString x, TInt n ]) =

--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -1164,8 +1164,8 @@ subst _ _ (Embed p) = Embed p
 {-| α-normalize an expression by renaming all bound variables to @\"_\"@ and
     using De Bruijn indices to distinguish them
 
->>> alphaNormalize (Lam "a" (Const Type) (Lam "b" (Const Type) (Lam "x" "a" (Lam "y" "b" "x"))))
-Lam "_" (Const Type) (Lam "_" (Const Type) (Lam "_" (Var (V "_" 1)) (Lam "_" (Var (V "_" 1)) (Var (V "_" 1)))))
+>>> alphaNormalize (Lam "a" (Const (Universe 0)) (Lam "b" (Const (Universe 0)) (Lam "x" "a" (Lam "y" "b" "x"))))
+Lam "_" (Const (Universe 0)) (Lam "_" (Const (Universe 0)) (Lam "_" (Var (V "_" 1)) (Lam "_" (Var (V "_" 1)) (Var (V "_" 1)))))
 
     α-normalization does not affect free variables:
 

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -71,6 +71,7 @@ import Dhall.Core (
   , Const(..)
   , Import
   , Var(..)
+  , pattern Type
   , denote
   )
 

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -263,6 +263,7 @@ completeExpression embedded = completeExpression_
                     , alternative05
                     , alternative06
                     , alternative07
+                    , alternative20
                     , alternative37
                     , alternative09
 
@@ -375,17 +376,21 @@ completeExpression embedded = completeExpression_
                             , Optional         <$ _Optional
                             ]
                     'B' ->    Bool             <$ _Bool
-                    'S' ->    Const Sort       <$ _Sort
                     'T' ->
                         choice
                             [ TextShow         <$ _TextShow
                             , Text             <$ _Text
                             , BoolLit True     <$ _True
-                            , Const Type       <$ _Type
+                            , Const (Universe 0) <$ _Type
                             ]
                     'F' ->    BoolLit False    <$ _False
-                    'K' ->    Const Kind       <$ _Kind
+                    'K' ->    Const (Universe 1) <$ _Kind
                     _   ->    empty
+
+            alternative20 = do
+                _Sort
+                n <- try naturalLiteral
+                return (Const (Universe n))
 
             alternative37 = do
                 a <- identifier

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -334,9 +334,9 @@ prettyDouble :: Double -> Doc Ann
 prettyDouble = literal . Pretty.pretty
 
 prettyConst :: Const -> Doc Ann
-prettyConst Type = builtin "Type"
-prettyConst Kind = builtin "Kind"
-prettyConst Sort = builtin "Sort"
+prettyConst (Universe 0) = builtin "Type"
+prettyConst (Universe 1) = builtin "Kind"
+prettyConst (Universe n) = builtin "Sort" <> prettyNatural n
 
 prettyVar :: Var -> Doc Ann
 prettyVar (V x 0) = label (Pretty.unAnnotate (prettyLabel x))

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -336,7 +336,7 @@ prettyDouble = literal . Pretty.pretty
 prettyConst :: Const -> Doc Ann
 prettyConst (Universe 0) = builtin "Type"
 prettyConst (Universe 1) = builtin "Kind"
-prettyConst (Universe n) = builtin "Sort" <> prettyNatural n
+prettyConst (Universe n) = builtin "Sort" <> space <> prettyNatural n
 
 prettyVar :: Var -> Doc Ann
 prettyVar (V x 0) = label (Pretty.unAnnotate (prettyLabel x))

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -2228,7 +2228,7 @@ prettyTypeMessage (FieldMismatch k0 expr0 c0 k1 expr1 c1) = ErrorMessages {..}
         level (Universe 0) = "term"
         level (Universe 1) = "type"
         level (Universe 2) = "kind"
-        level (Universe n) = "sort " <> Dhall.Pretty.Internal.prettyNatural n
+        level (Universe n) = "sort " <> Dhall.Pretty.Internal.prettyNatural (n - 1)
 
 prettyTypeMessage (InvalidField k expr0) = ErrorMessages {..}
   where
@@ -2561,7 +2561,7 @@ prettyTypeMessage (RecordMismatch c expr0 expr1 const0 const1) = ErrorMessages {
         toClass (Universe 0) = "terms"
         toClass (Universe 1) = "types"
         toClass (Universe 2) = "kinds"
-        toClass (Universe n) = "sorts " <> Dhall.Pretty.Internal.prettyNatural n
+        toClass (Universe n) = "sorts " <> Dhall.Pretty.Internal.prettyNatural (n - 1)
 
         class0 = toClass const0
         class1 = toClass const1

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -144,7 +144,7 @@ instance (Arbitrary s, Arbitrary a) => Arbitrary (Chunks s a) where
     shrink = genericShrink
 
 instance Arbitrary Const where
-    arbitrary = Test.QuickCheck.oneof [ pure Type, pure Kind, pure Sort ]
+    arbitrary = lift1 Universe
 
     shrink = genericShrink
 


### PR DESCRIPTION
Tries to be syntax & binary compatible with previous versions (e.g., Universes
0–2 are serialized as "Type", "Kind", and "Sort"). However, `Sort` is no longer
valid syntax (it could never typecheck before anyway). Instead it must be
followed by a natural number, e.g.: `λ(object : Sort 2)`.

I’m just posting this for illustration. I think adding polymorphism support would require not using naturals for universe indices, so I wouldn’t want to add this then break it again.