### PR TITLE
CPP out Monad.fail definition.

### DIFF
--- a/dhall/src/Dhall/Parser/Combinators.hs
+++ b/dhall/src/Dhall/Parser/Combinators.hs
@@ -138,8 +138,10 @@ instance Monad Parser where
     Parser n >>= k = Parser (n >>= unParser . k)
     {-# INLINE (>>=) #-}
 
+#if !(MIN_VERSION_base(4,13,0))
     fail = Control.Monad.Fail.fail
     {-# INLINE fail #-}
+#endif
 
 instance Control.Monad.Fail.MonadFail Parser where
     fail = Parser . Control.Monad.Fail.fail


### PR DESCRIPTION
As Dhall's bounds don't allow base 4.13, this doesn't actually affect
anyone running in a supported configuration (i.e., without
--allow-newer). Further note that base 4.13 (i.e., GHC 8.8) isn't
tested in CI at present.

This could well be the last GHC 8.8-related change needed to
code (bounds will definitely need to be adjusted). In this case, a
Dhall release with relaxed bounds will suffice to finish off GHC 8.8
support.

However, it's also possible that dependencies might bundle together
breaking changes with 8.8 support, in which case adaptations will
still need to be made.