### PR TITLE
dhall-json: fix yaml dependency.

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -30,6 +30,10 @@ Source-Repository head
     Type: git
     Location: https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-json
 
+Flag yaml-pre-0_11
+  Default: False
+  Manual: False
+
 Library
     Hs-Source-Dirs: src
     Build-Depends:
@@ -41,10 +45,17 @@ Library
         optparse-applicative      >= 0.14.0.0 && < 0.15,
         text                      >= 0.11.1.0 && < 1.3 ,
         unordered-containers                     < 0.3 ,
-        vector                                         ,
-        yaml                      >= 0.5.0    && < 0.12
+        vector
     Exposed-Modules: Dhall.JSON
     GHC-Options: -Wall
+
+    if flag(yaml-pre-0_11)
+        Build-Depends:
+            yaml >= 0.5.0 && < 0.11
+    else
+        Build-Depends:
+            libyaml >= 0.1.1.0 && < 0.2 ,
+            yaml    >= 0.11.0  && < 0.12
 
 Executable dhall-to-json
     Hs-Source-Dirs: dhall-to-json

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -21,6 +21,8 @@ extra-deps:
 flags:
   transformers-compat:
     five-three: true
+  dhall-json:
+    yaml-pre-0_11: true
 nix:
   packages:
     - ncurses


### PR DESCRIPTION
In yaml-0.11, Text.Libyaml was split into the libyaml package. Hence,
as dhall-json imports that module, a libyaml dependency is needed.
Further, the lower bound on yaml needs to be bumped to 0.11, or else
that module can be provided by both a pre-0.11 yaml or libyaml.