### PR TITLE
dhall-lsp-server: add tasty-discover to build-tool-depends.

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -102,6 +102,8 @@ test-suite dhall-lsp-server-test
       test
   default-extensions: LambdaCase OverloadedStrings FlexibleInstances TypeApplications RecordWildCards ScopedTypeVariables
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      tasty-discover:tasty-discover
   build-depends:
       aeson
     , base-noprelude >=4.7 && <5


### PR DESCRIPTION
The test-suite uses the executable at build-time. New-style
cabal-install requires it to be mentioned in build-tool-depends.