### PR TITLE
dhall: fix the dhall-command benchmark.

### DIFF
--- a/dhall/benchmark/dhall-command/Main.hs
+++ b/dhall/benchmark/dhall-command/Main.hs
@@ -8,7 +8,7 @@ import           Dhall.Binary (defaultStandardVersion)
 
 options :: Main.Options
 options = Main.Options
-  { Main.mode = Main.Default False False
+  { Main.mode = Main.Default Nothing False False
   , Main.explain = False
   , Main.plain = False
   , Main.ascii = False


### PR DESCRIPTION
Seems that Main.Default changed in #949, but this use-site wasn't
changed at the same time.