### PR TITLE
Fix LSP diagnostics to trailing whitespace

### DIFF
--- a/dhall-lsp-server/app/Main.hs
+++ b/dhall-lsp-server/app/Main.hs
@@ -17,8 +17,10 @@ import qualified System.IO
 import qualified Data.Map as Map
 import Options.Applicative (Parser, ParserInfo)
 import qualified Options.Applicative
+import Control.Applicative ((<|>))
 
 import qualified System.IO.Unsafe
+import System.Exit (exitSuccess, exitWith)
 
 import LSP.Server(run)
 

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -28,7 +28,6 @@ library
       LSP.Handlers.Diagnostics
       LSP.Handlers.DocumentFormatting
       LSP.Server
-      Prelude
   other-modules:
       Paths_dhall_lsp_server
   hs-source-dirs:
@@ -36,7 +35,7 @@ library
   default-extensions: LambdaCase OverloadedStrings FlexibleInstances TypeApplications RecordWildCards ScopedTypeVariables
   build-depends:
       aeson
-    , base-noprelude >=4.7 && <5
+    , base >=4.7 && <5
     , containers
     , data-default
     , dhall
@@ -49,7 +48,6 @@ library
     , mtl
     , optparse-applicative
     , prettyprinter
-    , relude
     , sorted-list
     , stm
     , text
@@ -68,7 +66,7 @@ executable dhall-lsp-server
   ghc-options: -rtsopts
   build-depends:
       aeson
-    , base-noprelude >=4.7 && <5
+    , base >=4.7 && <5
     , containers
     , data-default
     , dhall
@@ -82,7 +80,6 @@ executable dhall-lsp-server
     , mtl
     , optparse-applicative
     , prettyprinter
-    , relude
     , sorted-list
     , stm
     , text
@@ -106,7 +103,7 @@ test-suite dhall-lsp-server-test
       tasty-discover:tasty-discover
   build-depends:
       aeson
-    , base-noprelude >=4.7 && <5
+    , base >=4.7 && <5
     , containers
     , data-default
     , dhall
@@ -120,7 +117,6 @@ test-suite dhall-lsp-server-test
     , mtl
     , optparse-applicative
     , prettyprinter
-    , relude
     , sorted-list
     , stm
     , tasty

--- a/dhall-lsp-server/src/Backend/Dhall/DhallErrors.hs
+++ b/dhall-lsp-server/src/Backend/Dhall/DhallErrors.hs
@@ -12,6 +12,7 @@ import Dhall.Pretty(Ann(..), layoutOpts)
 import qualified Dhall.Diff
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.String as R
+import Data.Text (Text)
 import qualified Data.Text as T
 
 prettyDiff :: (Eq a, Pretty.Pretty a, ToTerm a) => Expr s a -> Expr s a -> Text

--- a/dhall-lsp-server/src/Backend/Dhall/Formatting.hs
+++ b/dhall-lsp-server/src/Backend/Dhall/Formatting.hs
@@ -3,7 +3,7 @@ module Backend.Dhall.Formatting(formatDocument) where
 import Dhall.Pretty (CharacterSet(..), layoutOpts)
 import Dhall.Parser(exprAndHeaderFromText, ParseError(..))
 
-import qualified Data.Text
+import Data.Text (Text)
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty.Text
 import qualified Dhall.Pretty

--- a/dhall-lsp-server/src/LSP/Common.hs
+++ b/dhall-lsp-server/src/LSP/Common.hs
@@ -7,6 +7,9 @@ import qualified Language.Haskell.LSP.Core as LSP.Core
 import qualified Data.Aeson                            as J
 import qualified Language.Haskell.LSP.Types            as J
 import qualified Language.Haskell.LSP.Types.Lens       as J
+import Control.Monad.Reader.Class (ask, asks)
+import Control.Monad.Reader (ReaderT)
+import Control.Monad.IO.Class (liftIO)
 
 
 sendToClient :: FromServerMessage -> ReaderT (LSP.Core.LspFuncs ()) IO ()

--- a/dhall-lsp-server/src/LSP/Dispatcher.hs
+++ b/dhall-lsp-server/src/LSP/Dispatcher.hs
@@ -15,7 +15,12 @@ import LSP.Common
 import LSP.Handlers.Diagnostics
 import LSP.Handlers.DocumentFormatting
 
-import Control.Lens 
+import Control.Lens
+import Control.Monad (forever)
+import Control.Monad.Trans (liftIO)
+import Control.Monad.Reader (ReaderT, runReaderT)
+import Control.Monad.Reader.Class (ask)
+import GHC.Conc (atomically)
 
 -- ! FIXME: replace logs/logm (which are just utilities) with own logging functions to make intent clearer
 -- | A basic router, which reads from Client messages queue `inp` and executes appropriate actions

--- a/dhall-lsp-server/src/LSP/Handlers/Diagnostics.hs
+++ b/dhall-lsp-server/src/LSP/Handlers/Diagnostics.hs
@@ -19,6 +19,9 @@ import qualified System.IO.Unsafe
 import qualified Data.Text.IO
 import qualified Data.SortedList
 import qualified Data.Map.Strict as Map
+import Control.Monad.Reader (ReaderT)
+import Control.Monad.Reader.Class (ask)
+import Control.Monad.Trans (lift, liftIO)
 
 import Backend.Dhall.Diagnostics
 

--- a/dhall-lsp-server/src/LSP/Handlers/DocumentFormatting.hs
+++ b/dhall-lsp-server/src/LSP/Handlers/DocumentFormatting.hs
@@ -15,6 +15,8 @@ import           Language.Haskell.LSP.Messages
 import qualified Data.Text
 import qualified Data.Text.IO
 import qualified Data.SortedList
+import Control.Monad.Trans (lift)
+import Control.Monad.Reader (ReaderT)
 
 -- TODO: implement tabSize and spaces/tabs options
 -- * Note: any formatting errors would be swallowed. I think this is fine in this case, but generally we'd like to send user a notification

--- a/dhall-lsp-server/src/LSP/Server.hs
+++ b/dhall-lsp-server/src/LSP/Server.hs
@@ -19,6 +19,7 @@ import qualified Language.Haskell.LSP.Types            as J
 import qualified Language.Haskell.LSP.Types.Lens       as J
 
 import qualified System.Log.Logger
+import GHC.Conc (atomically)
 
 import LSP.Dispatcher(dispatcher) 
 

--- a/dhall-lsp-server/src/Prelude.hs
+++ b/dhall-lsp-server/src/Prelude.hs
@@ -1,5 +1,0 @@
-module Prelude
-       ( module Relude
-       ) where
-
-import Relude


### PR DESCRIPTION
Dhall's current parser includes trailing whitespace in source range
annotations. Until now, we simply passed these "loose" ranges on to the
LSP client when generating diagnostic messages.

Previously (assuming funcTion is misspelled):
```
 funcTion argument
 ~~~~~~~~~

```
Now:
```
  funcTion argument
  ~~~~~~~~
```