### PR TITLE
Bump up lower bound of aeson-pretty

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
     - STACK_YAML: stack-lts-6.yaml
 
 install:
-  - choco install -dv -y haskell-stack --version %STACK_VERSION%
+  - choco install -y haskell-stack --version %STACK_VERSION%
   - stack setup > nul
   - cd %APPVEYOR_BUILD_FOLDER%
   - git submodule update --init --recursive

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -69,7 +69,7 @@ Executable dhall-to-json
     Build-Depends:
         base                       ,
         aeson                      ,
-        aeson-pretty         < 0.9 ,
+        aeson-pretty         >= 0.8.5 && < 0.9 ,
         bytestring           < 0.11,
         dhall                      ,
         dhall-json                 ,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.16
+resolver: lts-13.19
 packages:
   - dhall
   - dhall-bash
@@ -7,7 +7,6 @@ packages:
   - dhall-lsp-server
 extra-deps:
   - repline-0.2.1.0
-  - yaml-0.10.4.0
 nix:
   packages:
     - ncurses


### PR DESCRIPTION
`dhall-to-json`uses the field `Data.Aeson.Encode.Pretty.confTrailingNewline`, introduced in `aeson-pretty-0.8.5`