### PR TITLE
Fix compiling of dhall-lsp test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+.cache

--- a/dhall-lsp-server/src/LSP/Handlers/Diagnostics.hs
+++ b/dhall-lsp-server/src/LSP/Handlers/Diagnostics.hs
@@ -1,5 +1,6 @@
 {-| This module contains everything related on how LSP server handles diagnostic messages. -}
-module LSP.Handlers.Diagnostics( sendEmptyDiagnostics
+module LSP.Handlers.Diagnostics( compilerDiagnostics
+                               , sendEmptyDiagnostics
                                , sendDiagnostics
                                ) where
 

--- a/dhall-lsp-server/test/Backend/Dhall/DiagnosticsSpec.hs
+++ b/dhall-lsp-server/test/Backend/Dhall/DiagnosticsSpec.hs
@@ -12,7 +12,7 @@ import Language.Haskell.LSP.Types(
     , Position(..)
     )
 
-import Backend.Dhall.Diagnostics
+import Backend.Dhall.Diagnostics hiding (Range)
 
 import qualified Data.Text
 import qualified Data.Text.IO

--- a/dhall-lsp-server/test/Backend/Dhall/DiagnosticsSpec.hs
+++ b/dhall-lsp-server/test/Backend/Dhall/DiagnosticsSpec.hs
@@ -7,12 +7,11 @@ import Language.Haskell.LSP.Types(
       Diagnostic(..)
     , Range(..)
     , DiagnosticSeverity(..)
-    , DiagnosticSource(..)
-    , DiagnosticRelatedInformation(..)
     , Position(..)
     )
 
-import Backend.Dhall.Diagnostics hiding (Range)
+import Data.Foldable (traverse_)
+import LSP.Handlers.Diagnostics (compilerDiagnostics)
 
 import qualified Data.Text
 import qualified Data.Text.IO
@@ -97,7 +96,8 @@ getDiagnostics :: FilePath -> IO [Diagnostic]
 getDiagnostics path = do
   text <- Data.Text.IO.readFile path
   compilerDiagnostics path text
-  
+
+successImports :: [String]
 successImports = [ "../dhall/dhall-lang/tests/import/success/alternativeEnvNaturalA.dhall"
                  , "../dhall/dhall-lang/tests/import/success/alternativeEnvSimpleA.dhall"
                  , "../dhall/dhall-lang/tests/import/success/alternativeNaturalA.dhall"
@@ -109,6 +109,10 @@ successImports = [ "../dhall/dhall-lang/tests/import/success/alternativeEnvNatur
                  , "../dhall/dhall-lang/tests/import/success/asTextB.dhall"
                  , "../dhall/dhall-lang/tests/import/success/fieldOrderB.dhall"]  
 
+mkDiagnostics :: Data.Text.Text
+              -> (Int, Int)
+              -> (Int, Int)
+              -> [Diagnostic]
 mkDiagnostics msg (sl, sc) (el, ec) = [
   Diagnostic {
   _range = Range {


### PR DESCRIPTION
Before the change `stack test` failed for me when compiling:
```
[1 of 3] Compiling Backend.Dhall.DiagnosticsSpec ( test\Backend\Dhall\DiagnosticsSpec.hs, .stack-work\dist\e626a42b\build\dhall-lsp-server-test\dhall-lsp-server-test-tmp\Backend\Dhall\DiagnosticsSpec.o )

    test\Backend\Dhall\DiagnosticsSpec.hs:114:12: error:
        Ambiguous occurrence `Range'
        It could refer to either `Language.Haskell.LSP.Types.Range',
                                 imported from `Language.Haskell.LSP.Types' at test\Backend\Dhall\DiagnosticsSpec.hs:8:7-15
                                 (and originally defined in `haskell-lsp-types-0.8.2.0:Language.Haskell.LSP.Types.Location')
                              or `Backend.Dhall.Diagnostics.Range',
                                 imported from `Backend.Dhall.Diagnostics' at test\Backend\Dhall\DiagnosticsSpec.hs:15:1-32
        |
    114 |   _range = Range {
        |            ^^^^^
```
It seems the tests needed to sync with the last refactoring: #982