### PR TITLE
dhall-lsp-server: Use LSP VFS rather than disk IO

### DIFF
--- a/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
@@ -23,10 +23,21 @@ import Data.Maybe (mapMaybe)
 nullHandler :: LSP.LspFuncs () -> a -> IO ()
 nullHandler _ _ = return ()
 
+
+{- Currently implemented by the dummy nullHandler:
 initializedHandler :: LSP.LspFuncs () -> J.InitializedNotification -> IO ()
-initializedHandler _lsp _notification = do
-  LSP.logs "LSP Handler: processing InitializedNotification"
-  return ()
+
+didChangeTextDocumentNotificationHandler
+  :: LSP.LspFuncs () -> J.DidChangeTextDocumentNotification -> IO ()
+
+cancelNotificationHandler
+  :: LSP.LspFuncs () -> J.CancelNotification -> IO ()
+
+responseHandler :: LSP.LspFuncs () -> J.BareResponseMessage -> IO ()
+
+executeCommandHandler :: LSP.LspFuncs () -> J.ExecuteCommandRequest -> IO ()
+-}
+
 
 -- This is a quick-and-dirty prototype implementation that will be completely
 -- rewritten!
@@ -65,6 +76,7 @@ hoverFromDiagnosis (Diagnosis _ (Just (Range left right)) diagnosis) = Just
       "[Explain error](dhall-explain:?" <> Text.pack encodedDiag <> " )"
     _contents = J.List [J.PlainString command]
 
+
 didOpenTextDocumentNotificationHandler
   :: LSP.LspFuncs () -> J.DidOpenTextDocumentNotification -> IO ()
 didOpenTextDocumentNotificationHandler lsp notification = do
@@ -85,9 +97,6 @@ didSaveTextDocumentNotificationHandler lsp notification = do
   LSP.logs $ "\turi=" <> show uri
   flip runReaderT lsp $ Handlers.sendDiagnostics uri Nothing
 
-{- didChangeTextDocumentNotificationHandler
-  :: LSP.LspFuncs () -> J.DidChangeTextDocumentNotification -> IO ()
--}
 
 didCloseTextDocumentNotificationHandler
   :: LSP.LspFuncs () -> J.DidCloseTextDocumentNotification -> IO ()
@@ -98,17 +107,6 @@ didCloseTextDocumentNotificationHandler lsp notification = do
   LSP.logs $ "\turi=" <> show uri
   flip runReaderT lsp $ Handlers.sendEmptyDiagnostics uri Nothing
 
-{- cancelNotificationHandler
-  :: LSP.LspFuncs () -> J.CancelNotification -> IO ()
--}
-
-responseHandler :: LSP.LspFuncs () -> J.BareResponseMessage -> IO ()
-responseHandler _lsp response =
-  LSP.logs $ "LSP Handler: Ignoring ResponseMessage: " ++ show response
-
-executeCommandHandler :: LSP.LspFuncs () -> J.ExecuteCommandRequest -> IO ()
-executeCommandHandler _lsp request =
-  LSP.logs $ "LSP Handler: Ignoring ExecuteCommandRequest: " ++ show request
 
 documentFormattingHandler
   :: LSP.LspFuncs () -> J.DocumentFormattingRequest -> IO ()

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
@@ -85,7 +85,7 @@ didOpenTextDocumentNotificationHandler lsp notification = do
     uri = notification ^. J.params . J.textDocument . J.uri
     version = notification ^. J.params . J.textDocument . J.version
   LSP.logs $ "\turi=" <> show uri <> " version: " <> show version
-  flip runReaderT lsp $ Handlers.sendDiagnostics uri (Just version)
+  Handlers.sendDiagnostics lsp uri
 
 
 didSaveTextDocumentNotificationHandler
@@ -95,7 +95,7 @@ didSaveTextDocumentNotificationHandler lsp notification = do
   let
     uri = notification ^. J.params . J.textDocument . J.uri
   LSP.logs $ "\turi=" <> show uri
-  flip runReaderT lsp $ Handlers.sendDiagnostics uri Nothing
+  Handlers.sendDiagnostics lsp uri
 
 
 didCloseTextDocumentNotificationHandler
@@ -105,7 +105,7 @@ didCloseTextDocumentNotificationHandler lsp notification = do
   let
     uri = notification ^. J.params . J.textDocument . J.uri
   LSP.logs $ "\turi=" <> show uri
-  flip runReaderT lsp $ Handlers.sendEmptyDiagnostics uri Nothing
+  Handlers.sendEmptyDiagnostics lsp uri
 
 
 documentFormattingHandler

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
@@ -30,6 +30,9 @@ initializedHandler :: LSP.LspFuncs () -> J.InitializedNotification -> IO ()
 didChangeTextDocumentNotificationHandler
   :: LSP.LspFuncs () -> J.DidChangeTextDocumentNotification -> IO ()
 
+didCloseTextDocumentNotificationHandler
+  :: LSP.LspFuncs () -> J.DidCloseTextDocumentNotification -> IO ()
+
 cancelNotificationHandler
   :: LSP.LspFuncs () -> J.CancelNotification -> IO ()
 
@@ -96,20 +99,13 @@ didOpenTextDocumentNotificationHandler lsp notification = do
   let uri = notification ^. J.params . J.textDocument . J.uri
   diagnosticsHandler lsp uri
 
+
 didSaveTextDocumentNotificationHandler
   :: LSP.LspFuncs () -> J.DidSaveTextDocumentNotification -> IO ()
 didSaveTextDocumentNotificationHandler lsp notification = do
   LSP.logs "LSP Handler: processing DidSaveTextDocumentNotification"
   let uri = notification ^. J.params . J.textDocument . J.uri
   diagnosticsHandler lsp uri
-
-
-didCloseTextDocumentNotificationHandler
-  :: LSP.LspFuncs () -> J.DidCloseTextDocumentNotification -> IO ()
-didCloseTextDocumentNotificationHandler lsp notification = do
-  LSP.logs "LSP Handler: processing DidCloseTextDocumentNotification"
-  let uri = notification ^. J.params . J.textDocument . J.uri
-  Diagnostics.publishDiagnostics lsp uri []
 
 
 documentFormattingHandler

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
@@ -1,64 +1,45 @@
-{-| This module contains everything related on how LSP server handles diagnostic messages. -}
-module Dhall.LSP.Handlers.Diagnostics( compilerDiagnostics
-                               , sendEmptyDiagnostics
-                               , sendDiagnostics
-                               ) where
+{-| This module contains everything related to how the LSP server handles
+    diagnostic messages. -}
+module Dhall.LSP.Handlers.Diagnostics
+  ( compilerDiagnostics
+  , publishDiagnostics
+  )
+where
 
 import qualified Language.Haskell.LSP.Messages as LSP
-import qualified Language.Haskell.LSP.Core as LSP
-import qualified Language.Haskell.LSP.Types as LSP.Types
-import qualified Language.Haskell.LSP.Utility  as LSP.Utility
+import qualified Language.Haskell.LSP.Core     as LSP
 
-
-import qualified Language.Haskell.LSP.Types            as LSP
--- import qualified Language.Haskell.LSP.Types.Lens       as LSP
-
--- import qualified System.IO.Unsafe
+import qualified Language.Haskell.LSP.Types    as J
 import qualified Data.Text.IO
 
-import Data.Text (Text)
+import           Data.Text                      ( Text )
 
-import Dhall.LSP.Backend.Diagnostics
+import           Dhall.LSP.Backend.Diagnostics
 
-
-sendEmptyDiagnostics :: LSP.LspFuncs () -> LSP.Uri -> IO ()
-sendEmptyDiagnostics lsp fileUri =
-  publishDiagnostics' lsp fileUri []
-
-diagnosisToLSP :: Diagnosis -> LSP.Diagnostic
-diagnosisToLSP Diagnosis{..} = LSP.Diagnostic {..}
+diagnosisToLSP :: Diagnosis -> J.Diagnostic
+diagnosisToLSP Diagnosis{..} = J.Diagnostic {..}
   where
     _range = case range of
       Just (Range (line1, col1) (line2, col2)) ->
-        LSP.Range (LSP.Position line1 col1) (LSP.Position line2 col2)
-      Nothing -> LSP.Range (LSP.Position 0 0) (LSP.Position 0 0)
-    _severity = Just LSP.DsError
+        J.Range (J.Position line1 col1) (J.Position line2 col2)
+      Nothing -> J.Range (J.Position 0 0) (J.Position 0 0)
+    _severity = Just J.DsError
     _source = Just doctor
     _code = Nothing
     _message = diagnosis
     _relatedInformation = Nothing
 
-
-compilerDiagnostics :: FilePath -> Text -> IO [LSP.Diagnostic]
+compilerDiagnostics :: FilePath -> Text -> IO [J.Diagnostic]
 compilerDiagnostics path txt = do
   errors <- runDhall path txt
   let diagnoses = concatMap (diagnose txt) errors
   return (map diagnosisToLSP diagnoses)
-  
--- | Analyze the file and send any diagnostics to the client in a
--- "textDocument/publishDiagnostics" notification
-sendDiagnostics :: LSP.LspFuncs () -> LSP.Uri -> IO ()
-sendDiagnostics lsp fileUri = do
-  let
-   filePath = maybe (error "can't convert uri to file path") id $ LSP.uriToFilePath fileUri -- !FIXME: handle non-file uris
-  txt <- Data.Text.IO.readFile filePath
-  diags <- compilerDiagnostics filePath txt
-  LSP.Utility.logs $ "diagnostic: " <> show diags
-  publishDiagnostics' lsp fileUri diags
 
-
-publishDiagnostics' :: LSP.LspFuncs () -> LSP.Uri -> [LSP.Diagnostic] -> IO ()
-publishDiagnostics' lsp uri diags =
+-- | Publish diagnostics for a given file. Overwrites any existing diagnostics
+--   on the client side! In order to clear the diagnostics for a given file simply
+--   pass the empty list [].
+publishDiagnostics :: LSP.LspFuncs () -> J.Uri -> [J.Diagnostic] -> IO ()
+publishDiagnostics lsp uri diags =
   LSP.sendFunc lsp $ LSP.NotPublishDiagnostics
-    $ LSP.NotificationMessage "2.0" LSP.TextDocumentPublishDiagnostics
-    $ LSP.PublishDiagnosticsParams uri (LSP.List diags)
+    $ J.NotificationMessage "2.0" J.TextDocumentPublishDiagnostics
+    $ J.PublishDiagnosticsParams uri (J.List diags)

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
@@ -4,10 +4,8 @@ module Dhall.LSP.Handlers.Diagnostics( compilerDiagnostics
                                , sendDiagnostics
                                ) where
 
--- import           Language.Haskell.LSP.Messages
-import           Language.Haskell.LSP.Diagnostics
--- import qualified Language.Haskell.LSP.Control as LSP.Control
-import qualified Language.Haskell.LSP.Core as LSP.Core
+import qualified Language.Haskell.LSP.Messages as LSP
+import qualified Language.Haskell.LSP.Core as LSP
 import qualified Language.Haskell.LSP.Types as LSP.Types
 import qualified Language.Haskell.LSP.Utility  as LSP.Utility
 
@@ -17,27 +15,15 @@ import qualified Language.Haskell.LSP.Types            as LSP
 
 -- import qualified System.IO.Unsafe
 import qualified Data.Text.IO
-import qualified Data.SortedList
-import qualified Data.Map.Strict as Map
-import Control.Monad.Reader (ReaderT)
-import Control.Monad.Reader.Class (ask)
-import Control.Monad.Trans (lift, liftIO)
 
 import Data.Text (Text)
 
 import Dhall.LSP.Backend.Diagnostics
 
 
-
--- TODO: Make max number of errors parameter configurable (not rly relevant since we got 1, but still) 
--- ---------------------------------------------------------------------
--- Y no method to flush particular source errors?
-sendEmptyDiagnostics ::  LSP.Uri -> Maybe Int -> ReaderT (LSP.Core.LspFuncs ()) IO ()
-sendEmptyDiagnostics fileUri version =
-  publishDiagnostics 10 fileUri version defaultDiagnosticBySource
-
-defaultDiagnosticBySource :: DiagnosticsBySource
-defaultDiagnosticBySource = Map.singleton (Just "Dhall") (Data.SortedList.toSortedList [])
+sendEmptyDiagnostics :: LSP.LspFuncs () -> LSP.Uri -> IO ()
+sendEmptyDiagnostics lsp fileUri =
+  publishDiagnostics' lsp fileUri []
 
 diagnosisToLSP :: Diagnosis -> LSP.Diagnostic
 diagnosisToLSP Diagnosis{..} = LSP.Diagnostic {..}
@@ -47,8 +33,7 @@ diagnosisToLSP Diagnosis{..} = LSP.Diagnostic {..}
         LSP.Range (LSP.Position line1 col1) (LSP.Position line2 col2)
       Nothing -> LSP.Range (LSP.Position 0 0) (LSP.Position 0 0)
     _severity = Just LSP.DsError
-    -- TODO use @doctor@ instead. Seems incompatible with LSP.Core's API...
-    _source = Just "Dhall"
+    _source = Just doctor
     _code = Nothing
     _message = diagnosis
     _relatedInformation = Nothing
@@ -62,18 +47,18 @@ compilerDiagnostics path txt = do
   
 -- | Analyze the file and send any diagnostics to the client in a
 -- "textDocument/publishDiagnostics" notification
-sendDiagnostics :: LSP.Uri -> Maybe Int ->  ReaderT (LSP.Core.LspFuncs ()) IO ()
-sendDiagnostics fileUri version = do
+sendDiagnostics :: LSP.LspFuncs () -> LSP.Uri -> IO ()
+sendDiagnostics lsp fileUri = do
   let
    filePath = maybe (error "can't convert uri to file path") id $ LSP.uriToFilePath fileUri -- !FIXME: handle non-file uris
-  txt <- lift $ Data.Text.IO.readFile filePath
-  diags' <- lift $ compilerDiagnostics filePath txt
-  lift $ LSP.Utility.logs $ "diagnostic: " <> show diags'
-  publishDiagnostics 10 fileUri version (Map.union (partitionBySource diags') defaultDiagnosticBySource)
+  txt <- Data.Text.IO.readFile filePath
+  diags <- compilerDiagnostics filePath txt
+  LSP.Utility.logs $ "diagnostic: " <> show diags
+  publishDiagnostics' lsp fileUri diags
 
 
-publishDiagnostics :: Int -> LSP.Uri -> LSP.TextDocumentVersion -> DiagnosticsBySource -> ReaderT (LSP.Core.LspFuncs ()) IO ()
-publishDiagnostics maxToPublish uri v diags = do
-  lf <- ask
-  liftIO $ (LSP.Core.publishDiagnosticsFunc lf) maxToPublish uri v diags
-
+publishDiagnostics' :: LSP.LspFuncs () -> LSP.Uri -> [LSP.Diagnostic] -> IO ()
+publishDiagnostics' lsp uri diags =
+  LSP.sendFunc lsp $ LSP.NotPublishDiagnostics
+    $ LSP.NotificationMessage "2.0" LSP.TextDocumentPublishDiagnostics
+    $ LSP.PublishDiagnosticsParams uri (LSP.List diags)

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
@@ -10,7 +10,6 @@ import qualified Language.Haskell.LSP.Messages as LSP
 import qualified Language.Haskell.LSP.Core     as LSP
 
 import qualified Language.Haskell.LSP.Types    as J
-import qualified Data.Text.IO
 
 import           Data.Text                      ( Text )
 

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -70,15 +70,15 @@ lspOptions = def { LSP.Core.textDocumentSync = Just syncOptions
 
 lspHandlers :: TVar (Maybe (LSP.Core.LspFuncs ())) -> LSP.Core.Handlers
 lspHandlers lsp
-  = def { LSP.Core.initializedHandler                       = Just $ wrapHandler lsp Handlers.initializedHandler
+  = def { LSP.Core.initializedHandler                       = Just $ wrapHandler lsp Handlers.nullHandler
         , LSP.Core.hoverHandler                             = Just $ wrapHandler lsp Handlers.hoverHandler
         , LSP.Core.didOpenTextDocumentNotificationHandler   = Just $ wrapHandler lsp Handlers.didOpenTextDocumentNotificationHandler
         , LSP.Core.didChangeTextDocumentNotificationHandler = Just $ wrapHandler lsp Handlers.nullHandler
         , LSP.Core.didSaveTextDocumentNotificationHandler   = Just $ wrapHandler lsp Handlers.didSaveTextDocumentNotificationHandler
         , LSP.Core.didCloseTextDocumentNotificationHandler  = Just $ wrapHandler lsp Handlers.didCloseTextDocumentNotificationHandler
         , LSP.Core.cancelNotificationHandler                = Just $ wrapHandler lsp Handlers.nullHandler
-        , LSP.Core.responseHandler                          = Just $ wrapHandler lsp Handlers.responseHandler
-        , LSP.Core.executeCommandHandler                    = Just $ wrapHandler lsp Handlers.executeCommandHandler
+        , LSP.Core.responseHandler                          = Just $ wrapHandler lsp Handlers.nullHandler
+        , LSP.Core.executeCommandHandler                    = Just $ wrapHandler lsp Handlers.nullHandler
         , LSP.Core.documentFormattingHandler                = Just $ wrapHandler lsp Handlers.documentFormattingHandler
         }
 

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -75,7 +75,7 @@ lspHandlers lsp
         , LSP.Core.didOpenTextDocumentNotificationHandler   = Just $ wrapHandler lsp Handlers.didOpenTextDocumentNotificationHandler
         , LSP.Core.didChangeTextDocumentNotificationHandler = Just $ wrapHandler lsp Handlers.nullHandler
         , LSP.Core.didSaveTextDocumentNotificationHandler   = Just $ wrapHandler lsp Handlers.didSaveTextDocumentNotificationHandler
-        , LSP.Core.didCloseTextDocumentNotificationHandler  = Just $ wrapHandler lsp Handlers.didCloseTextDocumentNotificationHandler
+        , LSP.Core.didCloseTextDocumentNotificationHandler  = Just $ wrapHandler lsp Handlers.nullHandler
         , LSP.Core.cancelNotificationHandler                = Just $ wrapHandler lsp Handlers.nullHandler
         , LSP.Core.responseHandler                          = Just $ wrapHandler lsp Handlers.nullHandler
         , LSP.Core.executeCommandHandler                    = Just $ wrapHandler lsp Handlers.nullHandler


### PR DESCRIPTION
This pull request consists of two parts:
1. A minor refactoring regarding diagnostics
 (commit: Publish diagnostics directly)
 Simplifies our code base by getting rid of haskell-lsp's diagnostics machinery (that we didn't use properly to begin with). As a minor side effect we can now attach more fine-grained diagnostic sources to the diagnostics, i.e. we are able to differentiate between parse errors and type errors etc.
2. Use the haskell-lsp's "virtual file system" instead of disk IO.
  (commit: Use LSP VFS instead of disk IO)
 This brings us in line with the LSP specifications, since in general we can't assume the editor to refer to a physical file. Allows us to work with edited files that haven't been written back to disk yet.

