### PR TITLE
Fix linting of unused let bindings

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -1943,8 +1943,9 @@ False
 False
 -}
 freeIn :: Eq a => Var -> Expr s a -> Bool
-variable `freeIn` expression =
-    Dhall.Core.shift 1 variable strippedExpression /= strippedExpression
+variable@(V var i) `freeIn` expression =
+    Dhall.Core.subst variable (Var (V var (i + 1))) strippedExpression
+      /= strippedExpression
   where
     denote' :: Expr t b -> Expr () b
     denote' = denote

--- a/dhall/src/Dhall/Lint.hs
+++ b/dhall/src/Dhall/Lint.hs
@@ -38,23 +38,13 @@ removeLetInLet :: Eq a => Expr s a -> Maybe (Expr s a)
 removeLetInLet (Let a (Let b c)) = Just (Let (a <> b) c)
 removeLetInLet _ = Nothing
 
--- Remove unused Let bindings. Only considers the first variable in each Let
--- block -- unfold Let blocks first to make sure we don't miss any rewrite
+-- Remove unused Let bindings. Only considers Let blocks binding a single
+-- variable -- unfold Let blocks first to make sure we don't miss any rewrite
 -- opportunities!
--- todo: need to adjust de Bruijn indices!
 removeUnusedBindings :: Eq a => Expr s a -> Maybe (Expr s a)
 removeUnusedBindings (Let (Binding a _ _ :| []) d)
     | not (V a 0 `Dhall.Core.freeIn` d) =
-        Just d
-    | otherwise =
-        Nothing
-removeUnusedBindings (Let (Binding a _ _ :| (l : ls)) d)
-    | not (V a 0 `Dhall.Core.freeIn` e) =
-        Just e
-    | otherwise =
-        Nothing
-  where
-    e = Let (l :| ls) d
+        Just (Dhall.Core.shift (-1) (V a 0) d)
 removeUnusedBindings _ = Nothing
 
 -- Unfold Let blocks into nested Let bindings binding a single variable each.

--- a/dhall/src/Dhall/Lint.hs
+++ b/dhall/src/Dhall/Lint.hs
@@ -3,9 +3,6 @@
 module Dhall.Lint
     ( -- * Lint
       lint
-    , removeLetInLet
-    , removeUnusedBindings
-    , optionalLitToSomeNone
     ) where
 
 import Control.Monad (mplus)


### PR DESCRIPTION
- ### Find unused bindings inside nested lets
  Fixes cases like `let a = 0 let b = 0 in a`, that didn't get correctly linted (whereas `let a = 
0 in let b = 0 in a` would).
- ### Fix `freeIn` to correctly handle de Briujn indices 
  Fixes Core.Dhall.freeIn -- previously `freeIn "x@0" "x@1"`; as a result, the linter did not notice cases like `let a = 0 in let a = 0 in a@1`.
- ### Fix `removeUnusedBindings` to update de Bruijn indices
  Fixes `removeUnusedBindings` to correctly update any affected de Bruijn indices. 