### PR TITLE
dhall-lsp-server: Implement linter diagnostics and "Lint and Format" command

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -22,6 +22,7 @@ library
   exposed-modules:
       Dhall.LSP.Backend.Diagnostics
       Dhall.LSP.Backend.Formatting
+      Dhall.LSP.Backend.Linting
       Dhall.LSP.Handlers
       Dhall.LSP.Handlers.Diagnostics
       Dhall.LSP.Handlers.DocumentFormatting

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Diagnostics.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Diagnostics.hs
@@ -5,6 +5,7 @@ module Dhall.LSP.Backend.Diagnostics
   , runDhall
   , diagnose
   , explain
+  , rangeFromDhall
   , Position
   , Range(..)
   , Diagnosis(..)

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Formatting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Formatting.hs
@@ -1,20 +1,23 @@
-module Dhall.LSP.Backend.Formatting(formatDocument) where
+module Dhall.LSP.Backend.Formatting (formatDocument, formatExpr) where
 
-import Dhall.Pretty (CharacterSet(..), layoutOpts)
+import Dhall.Core (Expr, Import)
+import Dhall.Pretty (CharacterSet(..), layoutOpts, prettyCharacterSet)
 import Dhall.Parser(exprAndHeaderFromText, ParseError(..))
 
 import Data.Text (Text)
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
-import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty.Text
-import qualified Dhall.Pretty
+import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty
 
 formatDocument :: Text -> Either ParseError Text
 formatDocument text = do
-    (header, expr) <- exprAndHeaderFromText "" text
-    let doc =   Pretty.pretty header
-                            <>  Pretty.unAnnotate (Dhall.Pretty.prettyCharacterSet Unicode expr)
-                            <>  "\n"
-        formattedText =
-                Pretty.Text.renderStrict (Pretty.layoutSmart layoutOpts doc)
-    pure formattedText
+  (header, expr) <- exprAndHeaderFromText "" text
+  pure (formatExpr header expr)
 
+formatExpr :: Text -> Expr a Import -> Text
+formatExpr header expr = Pretty.renderStrict
+  (Pretty.layoutSmart layoutOpts doc)
+  where
+    doc =
+      Pretty.pretty header
+        <> Pretty.unAnnotate (prettyCharacterSet Unicode expr)
+        <> "\n"

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
@@ -23,8 +23,8 @@ data Suggestion = Suggestion {
 
 -- Diagnose nested Let blocks.
 diagLetInLet :: Expr Src a -> [Suggestion]
-diagLetInLet (Note src (Let _ (Note _ (Let _ _)))) =
-  [Suggestion (rangeFromDhall src) "Superfluous 'in' between let bindings"]
+diagLetInLet (Note _ (Let _ (Note src (Let _ _)))) =
+  [Suggestion (rangeFromDhall src) "Superfluous 'in' before nested let binding"]
 diagLetInLet _ = []
 
 -- Given a (noted) Let block compute all unused variables in the block.

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
@@ -1,0 +1,58 @@
+module Dhall.LSP.Backend.Linting
+  ( suggest
+  , Suggestion(..)
+  , lintAndFormatDocument
+  )
+where
+
+import Dhall.Parser (Src, ParseError, exprAndHeaderFromText)
+import Dhall.Core (Expr(..), Binding(..), Var(..), subExpressions, freeIn)
+import Dhall.Lint (lint)
+
+import Dhall.LSP.Backend.Formatting
+import Dhall.LSP.Backend.Diagnostics
+
+import Data.Text (Text)
+import Data.List.NonEmpty (NonEmpty(..), tails, toList)
+import Control.Lens (universeOf)
+
+data Suggestion = Suggestion {
+    range :: Range,
+    suggestion :: Text
+    }
+
+-- Diagnose nested Let blocks.
+diagLetInLet :: Expr Src a -> [Suggestion]
+diagLetInLet (Note src (Let _ (Note _ (Let _ _)))) =
+  [Suggestion (rangeFromDhall src) "Superfluous 'in' between let bindings"]
+diagLetInLet _ = []
+
+-- Given a (noted) Let block compute all unused variables in the block.
+unusedBindings :: Eq a => Expr s a -> [Text]
+unusedBindings (Note _ (Let bindings d)) = concatMap
+  (\case
+    Binding var _ _ : [] | V var 0 `freeIn` d -> [var]
+    Binding var _ _ : (b : bs) | V var 0 `freeIn` Let (b :| bs) d -> [var]
+    _ -> [])
+  (toList $ tails bindings)
+unusedBindings _ = []
+
+-- Diagnose unused Let bindings.
+diagUnusedBinding :: Eq a => Expr Src a -> [Suggestion]
+diagUnusedBinding e@(Note src (Let _ _)) = map
+  (\var ->
+    Suggestion (rangeFromDhall src) ("Unused let binding '" <> var <> "'"))
+  (unusedBindings e)
+diagUnusedBinding _ = []
+
+-- | Given an expressions suggest all the possible improvements that would be
+--   made by the linter.
+suggest :: Eq a => Expr Src a -> [Suggestion]
+suggest expr = concat [ diagLetInLet e ++ diagUnusedBinding e | e <- subExps ]
+  where subExps = universeOf subExpressions expr
+
+lintAndFormatDocument :: Text -> Either ParseError Text
+lintAndFormatDocument text = do
+    (header, expr) <- exprAndHeaderFromText "" text
+    let expr' = lint expr
+    pure (formatExpr header expr')

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
@@ -5,7 +5,7 @@ module Dhall.LSP.Backend.Linting
   )
 where
 
-import Dhall.Parser (Src, ParseError, exprAndHeaderFromText)
+import Dhall.Parser (Src, ParseError, exprFromText, exprAndHeaderFromText)
 import Dhall.Core (Expr(..), Binding(..), Var(..), subExpressions, freeIn)
 import Dhall.Lint (lint)
 
@@ -45,11 +45,13 @@ diagUnusedBinding e@(Note src (Let _ _)) = map
   (unusedBindings e)
 diagUnusedBinding _ = []
 
--- | Given an expressions suggest all the possible improvements that would be
---   made by the linter.
-suggest :: Eq a => Expr Src a -> [Suggestion]
-suggest expr = concat [ diagLetInLet e ++ diagUnusedBinding e | e <- subExps ]
-  where subExps = universeOf subExpressions expr
+-- | Given an dhall expression suggest all the possible improvements that would
+--   be made by the linter.
+suggest :: Text -> [Suggestion]
+suggest txt = case exprFromText "" txt of
+  Right expr -> concat [ diagLetInLet e ++ diagUnusedBinding e
+                       | e <- universeOf subExpressions expr ]
+  _ -> []
 
 lintAndFormatDocument :: Text -> Either ParseError Text
 lintAndFormatDocument text = do

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
@@ -31,8 +31,8 @@ diagLetInLet _ = []
 unusedBindings :: Eq a => Expr s a -> [Text]
 unusedBindings (Note _ (Let bindings d)) = concatMap
   (\case
-    Binding var _ _ : [] | V var 0 `freeIn` d -> [var]
-    Binding var _ _ : (b : bs) | V var 0 `freeIn` Let (b :| bs) d -> [var]
+    Binding var _ _ : [] | not (V var 0 `freeIn` d) -> [var]
+    Binding var _ _ : (b : bs) | not (V var 0 `freeIn` Let (b :| bs) d) -> [var]
     _ -> [])
   (toList $ tails bindings)
 unusedBindings _ = []

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
@@ -91,8 +91,9 @@ diagnosticsHandler lsp uri = do
         Nothing -> fail "Failed to parse URI when computing diagnostics."
         Just path -> path
   txt <- readUri lsp uri
-  diags <- Diagnostics.compilerDiagnostics fileName txt
-  Diagnostics.publishDiagnostics lsp uri diags
+  let lintDiags = Diagnostics.linterDiagnostics txt
+  compDiags <- Diagnostics.compilerDiagnostics fileName txt
+  Diagnostics.publishDiagnostics lsp uri (compDiags ++ lintDiags)
 
 didOpenTextDocumentNotificationHandler
   :: LSP.LspFuncs () -> J.DidOpenTextDocumentNotification -> IO ()

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
@@ -4,13 +4,17 @@ import qualified Language.Haskell.LSP.Core as LSP
 import qualified Language.Haskell.LSP.Messages as LSP
 import qualified Language.Haskell.LSP.Utility as LSP
 import qualified Language.Haskell.LSP.VFS as LSP
+
+import qualified Data.Aeson as J
 import qualified Language.Haskell.LSP.Types as J
 import qualified Language.Haskell.LSP.Types.Lens as J
 
 import qualified Dhall.LSP.Handlers.Diagnostics as Diagnostics
-import qualified Dhall.LSP.Handlers.DocumentFormatting as Handlers
+import qualified Dhall.LSP.Handlers.DocumentFormatting as Formatting
+import qualified Dhall.LSP.Backend.Linting as Linting
 import Dhall.LSP.Backend.Diagnostics
 
+import Data.HashMap.Strict (singleton)
 import Control.Lens ((^.))
 import Control.Monad.Reader (runReaderT)
 import qualified Network.URI.Encode as URI
@@ -39,8 +43,6 @@ cancelNotificationHandler
   :: LSP.LspFuncs () -> J.CancelNotification -> IO ()
 
 responseHandler :: LSP.LspFuncs () -> J.BareResponseMessage -> IO ()
-
-executeCommandHandler :: LSP.LspFuncs () -> J.ExecuteCommandRequest -> IO ()
 -}
 
 
@@ -117,10 +119,37 @@ documentFormattingHandler lsp request = do
   LSP.logs "LSP Handler: processing DocumentFormattingRequest"
   let uri = request ^. J.params . J.textDocument . J.uri
   formattedDocument <- flip runReaderT lsp
-    $ Handlers.formatDocument uri undefined undefined
+    $ Formatting.formatDocument uri undefined undefined
   LSP.sendFunc lsp $ LSP.RspDocumentFormatting $ LSP.makeResponseMessage
     request
     formattedDocument
+
+executeCommandHandler :: LSP.LspFuncs () -> J.ExecuteCommandRequest -> IO ()
+executeCommandHandler lsp request
+  | command == "dhall.server.lint" = do
+    LSP.logs "LSP Handler: executing dhall.lint"
+    case request ^. J.params . J.arguments of
+      Just (J.List (x : _)) -> case J.fromJSON x of
+        J.Success uri -> do
+          txt                         <- readUri lsp uri
+          (edit :: J.List J.TextEdit) <-
+            case Linting.lintAndFormatDocument txt of
+              Right linted ->
+                let range = J.Range (J.Position 0 0)
+                                    (J.Position (Text.length linted) 0)
+                in  return (J.List [J.TextEdit range linted])
+              _ -> return (J.List [])
+          lid <- LSP.getNextReqId lsp
+          LSP.sendFunc lsp $ LSP.ReqApplyWorkspaceEdit
+                           $ LSP.fmServerApplyWorkspaceEditRequest lid
+                           $ J.ApplyWorkspaceEditParams
+                           $ J.WorkspaceEdit (Just (singleton uri edit)) Nothing
+        _ -> return ()
+      _ -> return ()
+  | otherwise = LSP.logs
+    ("LSP Handler: asked to execute unknown command: " ++ show command)
+  where command = request ^. J.params . J.command
+
 
 -- helper function to query haskell-lsp's VFS
 readUri :: LSP.LspFuncs () -> J.Uri -> IO Text

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
@@ -3,6 +3,7 @@
 module Dhall.LSP.Handlers.Diagnostics
   ( compilerDiagnostics
   , publishDiagnostics
+  , linterDiagnostics
   )
 where
 
@@ -14,6 +15,7 @@ import qualified Language.Haskell.LSP.Types    as J
 import           Data.Text                      ( Text )
 
 import           Dhall.LSP.Backend.Diagnostics
+import           Dhall.LSP.Backend.Linting
 
 diagnosisToLSP :: Diagnosis -> J.Diagnostic
 diagnosisToLSP Diagnosis{..} = J.Diagnostic {..}
@@ -33,6 +35,23 @@ compilerDiagnostics path txt = do
   errors <- runDhall path txt
   let diagnoses = concatMap (diagnose txt) errors
   return (map diagnosisToLSP diagnoses)
+
+suggestionToDiagnostic :: Suggestion -> J.Diagnostic
+suggestionToDiagnostic Suggestion {..} = J.Diagnostic {..}
+  where
+    _range = case range of
+                Range (line1, col1) (line2, col2) ->
+                  J.Range (J.Position line1 col1) (J.Position line2 col2)
+    _severity = Just J.DsHint
+    _source = Just "Dhall.Lint"
+    _code = Nothing
+    _message = suggestion
+    _relatedInformation = Nothing
+
+-- | Compute the list of possible improvements, as would be carried out by
+--   @Dhall.Lint@.
+linterDiagnostics :: Text -> [J.Diagnostic]
+linterDiagnostics = map suggestionToDiagnostic . suggest
 
 -- | Publish diagnostics for a given file. Overwrites any existing diagnostics
 --   on the client side! In order to clear the diagnostics for a given file simply

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -65,7 +65,13 @@ syncOptions = J.TextDocumentSyncOptions
 -- Server capabilities. Tells the LSP client that we can execute commands etc.
 lspOptions :: LSP.Core.Options
 lspOptions = def { LSP.Core.textDocumentSync = Just syncOptions
-                 , LSP.Core.executeCommandProvider = Just (J.ExecuteCommandOptions (J.List []))  -- no commands implemented
+                 , LSP.Core.executeCommandProvider =
+                     -- Note that this registers the dhall.server.lint command
+                     -- with VSCode, which means that our plugin can't expose a
+                     -- command of the same name. In the case of dhall.lint we
+                     -- name the server-side command dhall.server.lint to work
+                     -- around peculiarity.
+                     Just (J.ExecuteCommandOptions (J.List ["dhall.server.lint"]))
                  }
 
 lspHandlers :: TVar (Maybe (LSP.Core.LspFuncs ())) -> LSP.Core.Handlers
@@ -78,7 +84,7 @@ lspHandlers lsp
         , LSP.Core.didCloseTextDocumentNotificationHandler  = Just $ wrapHandler lsp Handlers.nullHandler
         , LSP.Core.cancelNotificationHandler                = Just $ wrapHandler lsp Handlers.nullHandler
         , LSP.Core.responseHandler                          = Just $ wrapHandler lsp Handlers.nullHandler
-        , LSP.Core.executeCommandHandler                    = Just $ wrapHandler lsp Handlers.nullHandler
+        , LSP.Core.executeCommandHandler                    = Just $ wrapHandler lsp Handlers.executeCommandHandler
         , LSP.Core.documentFormattingHandler                = Just $ wrapHandler lsp Handlers.documentFormattingHandler
         }
 


### PR DESCRIPTION
- The diagnostics now include linter hints. For example:
  ```
  let a = 0 in let b = a in b
               ~
  ```
  Here we mark the `let` after the superfluous `in` (that's the best we can do). 
- Does not implement linting of old-style optionals since those are due to be removed, see #1002.
- Implements a "Lint and format" command (needs a correspondingly patched `vscode-dhall-lsp-server`)