### PR TITLE
dhall-lsp-server: Towards implementing a "convert to JSON" command

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -23,6 +23,7 @@ library
       Dhall.LSP.Backend.Dhall
       Dhall.LSP.Backend.Diagnostics
       Dhall.LSP.Backend.Formatting
+      Dhall.LSP.Backend.Hover
       Dhall.LSP.Backend.Linting
       Dhall.LSP.Backend.ToJSON
       Dhall.LSP.Handlers

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -20,6 +20,7 @@ source-repository head
 
 library
   exposed-modules:
+      Dhall.LSP.Backend.Dhall
       Dhall.LSP.Backend.Diagnostics
       Dhall.LSP.Backend.Formatting
       Dhall.LSP.Backend.Linting

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -23,13 +23,13 @@ library
       Dhall.LSP.Backend.Dhall
       Dhall.LSP.Backend.Diagnostics
       Dhall.LSP.Backend.Formatting
-      Dhall.LSP.Backend.Hover
       Dhall.LSP.Backend.Linting
       Dhall.LSP.Backend.ToJSON
       Dhall.LSP.Handlers
       Dhall.LSP.Handlers.Command
       Dhall.LSP.Handlers.Diagnostics
       Dhall.LSP.Handlers.DocumentFormatting
+      Dhall.LSP.Handlers.Hover
       Dhall.LSP.Server
   other-modules:
       Paths_dhall_lsp_server

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -24,7 +24,9 @@ library
       Dhall.LSP.Backend.Diagnostics
       Dhall.LSP.Backend.Formatting
       Dhall.LSP.Backend.Linting
+      Dhall.LSP.Backend.ToJSON
       Dhall.LSP.Handlers
+      Dhall.LSP.Handlers.Command
       Dhall.LSP.Handlers.Diagnostics
       Dhall.LSP.Handlers.DocumentFormatting
       Dhall.LSP.Server
@@ -36,10 +38,13 @@ library
   default-extensions: LambdaCase OverloadedStrings FlexibleInstances TypeApplications RecordWildCards ScopedTypeVariables
   build-depends:
       aeson
+    , aeson-pretty
     , base >=4.7 && <5
+    , bytestring
     , containers
     , data-default
     , dhall
+    , dhall-json
     , filepath
     , haskell-lsp
     , hslogger
@@ -98,7 +103,7 @@ test-suite dhall-lsp-server-test
   other-modules:
       Paths_dhall_lsp_server
       Backend.Dhall.DiagnosticsSpec
-    
+
   hs-source-dirs:
       test
   default-extensions: LambdaCase OverloadedStrings FlexibleInstances TypeApplications RecordWildCards ScopedTypeVariables

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
@@ -1,0 +1,23 @@
+module Dhall.LSP.Backend.Dhall where
+
+import Dhall.Parser (Src(..))
+import Dhall.TypeCheck (X)
+import Dhall.Core (Expr)
+import Dhall
+  (rootDirectory, sourceName, defaultInputSettings, inputExprWithSettings)
+
+import Data.Text (Text)
+import System.FilePath (splitFileName)
+import Lens.Family (set)
+import Control.Exception (handle, SomeException)
+
+runDhall :: FilePath -> Text -> IO (Expr Src X)
+runDhall path = inputExprWithSettings dhallparams
+  where
+    dhallparams = (set rootDirectory dir . set sourceName file)
+                  defaultInputSettings
+    (dir, file) = splitFileName path
+
+runDhallSafe :: FilePath -> Text -> IO (Maybe (Expr Src X))
+runDhallSafe path text = handle (\(_ :: SomeException) -> return Nothing)
+                                (Just <$> runDhall path text)

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Diagnostics.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Diagnostics.hs
@@ -2,7 +2,7 @@
 
 module Dhall.LSP.Backend.Diagnostics
   ( DhallException
-  , runDhall
+  , checkDhall
   , diagnose
   , explain
   , rangeFromDhall
@@ -17,16 +17,13 @@ import Dhall.Parser (ParseError, SourcedException(..), Src(..), unwrap)
 import Dhall.Import (MissingImports)
 import Dhall.TypeCheck (DetailedTypeError(..), TypeError(..), X)
 import Dhall.Core (Expr(Note))
-import Dhall
-  (rootDirectory, sourceName, defaultInputSettings, inputExprWithSettings)
 
 import Dhall.LSP.Util
+import Dhall.LSP.Backend.Dhall (runDhall)
 
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Control.Exception (handle, SomeException)
-import Lens.Family (set)
-import System.FilePath (splitFileName)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Text.Megaparsec as Megaparsec
 
@@ -56,26 +53,17 @@ data Diagnosis = Diagnosis {
 
 -- | Parse, type-check and normalise the given Dhall code, collecting any
 --   occurring errors.
-runDhall :: FilePath -> Text -> IO [DhallException]
-runDhall path txt =
+checkDhall :: FilePath -> Text -> IO [DhallException]
+checkDhall path txt =
   (handle' ExceptionInternal
     . handle' ExceptionCBOR
     . handle' ExceptionImport
     . handle' ExceptionTypecheck
     . handle' ExceptionParse
     )
-    go
+    (const [] <$> runDhall path txt)
   where
     handle' constructor = handle (return . return . constructor)
-    -- we need to tell Dhall the path in order for relative imports to be resolved correctly
-    (dir, file) = splitFileName path
-    dhallparams =
-      (set rootDirectory dir . set sourceName file) defaultInputSettings
-    go :: IO [DhallException]
-    go = do
-      _ <- inputExprWithSettings dhallparams txt
-      return []  -- If we got this far the input was a valid Dhall program.
-
 
 -- | Give a short diagnosis for a given error that can be shown to the end user.
 diagnose :: Text -> DhallException -> [Diagnosis]

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/ToJSON.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/ToJSON.hs
@@ -1,0 +1,27 @@
+module Dhall.LSP.Backend.ToJSON where
+
+import qualified Dhall.JSON as Dhall
+import qualified Data.Aeson.Encode.Pretty as Aeson
+
+import Dhall.LSP.Backend.Dhall
+
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+import Data.ByteString.Lazy (toStrict)
+
+-- | Try to convert the given Dhall file to JSON.
+dhallToJSON :: FilePath -> Text -> IO (Maybe Text)
+dhallToJSON path text = do
+  mexpr <- runDhallSafe path text
+  case mexpr of
+    Just expr -> case Dhall.dhallToJSON expr of
+      Right value -> do
+        let config = Aeson.Config
+              { Aeson.confIndent = Aeson.Spaces 2
+              , Aeson.confCompare = compare
+              , Aeson.confNumFormat = Aeson.Generic
+              , Aeson.confTrailingNewline = False }
+        return . Just . decodeUtf8 . toStrict $
+          Aeson.encodePretty' config value
+      _ -> return Nothing
+    Nothing -> return Nothing

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
@@ -58,7 +58,7 @@ hoverHandler lsp request = do
       Nothing -> fail "Failed to parse URI in ReqHover."
       Just path -> path
   txt <- readUri lsp uri
-  errors <- runDhall fileName txt
+  errors <- checkDhall fileName txt
   let
     explanations = mapMaybe (explain txt) errors
     isHovered :: Diagnosis -> Bool

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
@@ -3,29 +3,21 @@ module Dhall.LSP.Handlers where
 import qualified Language.Haskell.LSP.Core as LSP
 import qualified Language.Haskell.LSP.Messages as LSP
 import qualified Language.Haskell.LSP.Utility as LSP
-import qualified Language.Haskell.LSP.VFS as LSP
 
 import qualified Language.Haskell.LSP.Types as J
 import qualified Language.Haskell.LSP.Types.Lens as J
 
 import qualified Dhall.LSP.Handlers.Diagnostics as Diagnostics
 import qualified Dhall.LSP.Handlers.DocumentFormatting as Formatting
-import Dhall.LSP.Backend.Diagnostics
 
 import Control.Lens ((^.))
 import Control.Monad.Reader (runReaderT)
-import qualified Network.URI.Encode as URI
-import qualified Data.Text as Text
-import Data.Text (Text)
-import Data.Maybe (mapMaybe)
-import qualified Yi.Rope as Rope
 
 -- handler that doesn't do anything. Useful for example to make haskell-lsp shut
 -- up about unhandled DidChangeTextDocument notifications (which are already
 -- handled haskell-lsp itself).
 nullHandler :: LSP.LspFuncs () -> a -> IO ()
 nullHandler _ _ = return ()
-
 
 {- Currently implemented by the dummy nullHandler:
 initializedHandler :: LSP.LspFuncs () -> J.InitializedNotification -> IO ()
@@ -42,73 +34,19 @@ cancelNotificationHandler
 responseHandler :: LSP.LspFuncs () -> J.BareResponseMessage -> IO ()
 -}
 
-
--- This is a quick-and-dirty prototype implementation that will be completely
--- rewritten!
-hoverHandler :: LSP.LspFuncs () -> J.HoverRequest -> IO ()
-hoverHandler lsp request = do
-  LSP.logs "LSP Handler: processing HoverRequest"
-  let
-    uri = request ^. J.params . J.textDocument . J.uri
-    (J.Position line col) = request ^. (J.params . J.position)
-    fileName = case J.uriToFilePath uri of
-      Nothing -> fail "Failed to parse URI in ReqHover."
-      Just path -> path
-  txt <- readUri lsp uri
-  errors <- checkDhall fileName txt
-  let
-    explanations = mapMaybe (explain txt) errors
-    isHovered :: Diagnosis -> Bool
-    isHovered (Diagnosis _ Nothing _) = False
-    isHovered (Diagnosis _ (Just (Range left right)) _) =
-      left <= (line, col) && (line, col) <= right
-    hover = case filter isHovered explanations of
-      [] -> Nothing
-      (diag : _) -> hoverFromDiagnosis diag
-  LSP.sendFunc lsp $ LSP.RspHover $ LSP.makeResponseMessage request hover
-
-
-hoverFromDiagnosis :: Diagnosis -> Maybe J.Hover
-hoverFromDiagnosis (Diagnosis _ Nothing _) = Nothing
-hoverFromDiagnosis (Diagnosis _ (Just (Range left right)) diagnosis) = Just
-  J.Hover { .. }
-  where
-    _range =
-      Just $ J.Range (uncurry J.Position left) (uncurry J.Position right)
-    encodedDiag = URI.encode (Text.unpack diagnosis)
-    command =
-      "[Explain error](dhall-explain:?" <> Text.pack encodedDiag <> " )"
-    _contents = J.List [J.PlainString command]
-
-
--- | Called by @didOpenTextDocumentNotificationHandler@ and
---   @didSaveTextDocumentNotificationHandler@.
-diagnosticsHandler :: LSP.LspFuncs () -> J.Uri -> IO ()
-diagnosticsHandler lsp uri = do
-  LSP.logs $ "LSP Handler: processing diagnostics for " <> show uri
-  let fileName = case J.uriToFilePath uri of
-        Nothing -> fail "Failed to parse URI when computing diagnostics."
-        Just path -> path
-  txt <- readUri lsp uri
-  let lintDiags = Diagnostics.linterDiagnostics txt
-  compDiags <- Diagnostics.compilerDiagnostics fileName txt
-  Diagnostics.publishDiagnostics lsp uri (compDiags ++ lintDiags)
-
 didOpenTextDocumentNotificationHandler
   :: LSP.LspFuncs () -> J.DidOpenTextDocumentNotification -> IO ()
 didOpenTextDocumentNotificationHandler lsp notification = do
   LSP.logs "LSP Handler: processing DidOpenTextDocumentNotification"
   let uri = notification ^. J.params . J.textDocument . J.uri
-  diagnosticsHandler lsp uri
-
+  Diagnostics.diagnosticsHandler lsp uri
 
 didSaveTextDocumentNotificationHandler
   :: LSP.LspFuncs () -> J.DidSaveTextDocumentNotification -> IO ()
 didSaveTextDocumentNotificationHandler lsp notification = do
   LSP.logs "LSP Handler: processing DidSaveTextDocumentNotification"
   let uri = notification ^. J.params . J.textDocument . J.uri
-  diagnosticsHandler lsp uri
-
+  Diagnostics.diagnosticsHandler lsp uri
 
 documentFormattingHandler
   :: LSP.LspFuncs () -> J.DocumentFormattingRequest -> IO ()
@@ -120,11 +58,3 @@ documentFormattingHandler lsp request = do
   LSP.sendFunc lsp $ LSP.RspDocumentFormatting $ LSP.makeResponseMessage
     request
     formattedDocument
-
--- helper function to query haskell-lsp's VFS
-readUri :: LSP.LspFuncs () -> J.Uri -> IO Text
-readUri lsp uri = do
-  asd <- LSP.getVirtualFileFunc lsp uri
-  case asd of
-    Just (LSP.VirtualFile _ rope) -> return (Rope.toText rope)
-    Nothing -> fail $ "Could not find " <> show uri <> " in VFS."

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Command.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Command.hs
@@ -1,0 +1,93 @@
+module Dhall.LSP.Handlers.Command where
+
+import qualified Language.Haskell.LSP.Core as LSP
+import qualified Language.Haskell.LSP.Messages as LSP
+import qualified Language.Haskell.LSP.Utility as LSP
+
+import qualified Data.Aeson as J
+import qualified Language.Haskell.LSP.Types as J
+import qualified Language.Haskell.LSP.Types.Lens as J
+
+import qualified Dhall.LSP.Backend.Linting as Linting
+import qualified Dhall.LSP.Backend.ToJSON as ToJSON
+import Dhall.LSP.Handlers (readUri)
+
+import System.FilePath (replaceExtension)
+import Data.HashMap.Strict (singleton)
+import Control.Lens ((^.))
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+executeCommandHandler :: LSP.LspFuncs () -> J.ExecuteCommandRequest -> IO ()
+executeCommandHandler lsp request
+  | command == "dhall.server.lint" = do
+    LSP.logs "LSP Handler: executing dhall.lint"
+    let uri = parseUriArgument request
+    txt <- readUri lsp uri
+    case Linting.lintAndFormatDocument txt of
+      Right linted -> overwriteContents lsp uri linted
+      _ -> LSP.logs "LSP Handler: linting failed"
+  | command == "dhall.server.toJSON" =
+    executeDhallToJSON lsp (parseUriArgument request)
+  | otherwise = LSP.logs
+    ("LSP Handler: asked to execute unknown command: " ++ show command)
+  where command = request ^. J.params . J.command
+
+-- implements dhall.server.toJSON
+executeDhallToJSON :: LSP.LspFuncs () -> J.Uri -> IO ()
+executeDhallToJSON lsp uri = do
+  txt <- readUri lsp uri
+  let filepath = case J.uriToFilePath uri of
+        Nothing -> fail "Failed to parse URI when converting Dhall to JSON."
+        Just path -> path
+  mconverted <- ToJSON.dhallToJSON filepath txt
+  case mconverted of
+    Just converted -> do
+      let edit = J.List [ J.TextEdit (J.Range (J.Position 0 0) (J.Position 0 0))
+                                     converted ]
+          -- TODO: this doesn't work; we need to fix haskell-lsp-types to
+          -- support file creation!
+          edits = Just (singleton (appendSuffixToUri uri ".json") edit)
+      lid <- LSP.getNextReqId lsp
+      LSP.sendFunc lsp $ LSP.ReqApplyWorkspaceEdit
+                       $ LSP.fmServerApplyWorkspaceEditRequest lid
+                       $ J.ApplyWorkspaceEditParams
+                       $ J.WorkspaceEdit edits Nothing
+    Nothing -> LSP.sendFunc lsp $ LSP.NotShowMessage
+                                $ LSP.fmServerShowMessageNotification J.MtError
+                                  "Failed to convert Dhall to JSON. Make sure\
+                                  \ the Dhall file is free of errors first!"
+
+-- implements dhall.server.lint
+executeLintAndFormat :: LSP.LspFuncs () -> J.Uri -> IO ()
+executeLintAndFormat lsp uri = do
+  txt <- readUri lsp uri
+  case Linting.lintAndFormatDocument txt of
+    Right linted -> do
+      let endline = length $ Text.lines oldcontent
+      let edit = J.List [ J.TextEdit
+                           (J.Range (J.Position 0 0) (J.Position endline 0))
+                           newcontent ]
+      lid <- LSP.getNextReqId lsp
+      LSP.sendFunc lsp $ LSP.ReqApplyWorkspaceEdit
+                   $ LSP.fmServerApplyWorkspaceEditRequest lid
+                   $ J.ApplyWorkspaceEditParams
+                   $ J.WorkspaceEdit (Just (singleton uri edit)) Nothing
+    _ -> LSP.logs "LSP Handler: linting failed"
+
+-- Helper that appends a suffix to a uri. Fails if the uri does not represent a
+-- file path.
+appendSuffixToUri :: J.Uri -> Text -> J.Uri
+appendSuffixToUri uri suffix = case J.uriToFilePath uri of
+  Just path -> J.filePathToUri $ replaceExtension path (show suffix)
+  Nothing -> error $ "failed to append suffix to uri " ++ show uri
+                     ++ " because it's not a valid file path"
+
+parseUriArgument :: J.ExecuteCommandRequest -> J.Uri
+parseUriArgument request = case request ^. J.params . J.arguments of
+  Just (J.List (x : _)) -> case J.fromJSON x of
+    J.Success uri -> uri
+    _             -> error $ "unable to parse uri argument to " <> show
+      (request ^. J.params . J.command)
+  _ -> error $ "unable to parse uri argument to " <> show
+    (request ^. J.params . J.command)

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Command.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Command.hs
@@ -20,7 +20,7 @@ import qualified Data.Text as Text
 
 executeCommandHandler :: LSP.LspFuncs () -> J.ExecuteCommandRequest -> IO ()
 executeCommandHandler lsp request
-  | command == "dhall.server.lint" = do
+  | command == "dhall.server.lint" =
     executeLintAndFormat lsp (parseUriArgument request)
   | command == "dhall.server.toJSON" =
     executeDhallToJSON lsp (parseUriArgument request)

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Command.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Command.hs
@@ -10,7 +10,7 @@ import qualified Language.Haskell.LSP.Types.Lens as J
 
 import qualified Dhall.LSP.Backend.Linting as Linting
 import qualified Dhall.LSP.Backend.ToJSON as ToJSON
-import Dhall.LSP.Handlers (readUri)
+import Dhall.LSP.Util (readUri)
 
 import System.FilePath (replaceExtension)
 import Data.HashMap.Strict (singleton)

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Diagnostics.hs
@@ -32,7 +32,7 @@ diagnosisToLSP Diagnosis{..} = J.Diagnostic {..}
 
 compilerDiagnostics :: FilePath -> Text -> IO [J.Diagnostic]
 compilerDiagnostics path txt = do
-  errors <- runDhall path txt
+  errors <- checkDhall path txt
   let diagnoses = concatMap (diagnose txt) errors
   return (map diagnosisToLSP diagnoses)
 

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Hover.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Hover.hs
@@ -1,0 +1,53 @@
+module Dhall.LSP.Handlers.Hover (hoverHandler) where
+
+import qualified Language.Haskell.LSP.Core as LSP
+import qualified Language.Haskell.LSP.Messages as LSP
+import qualified Language.Haskell.LSP.Utility as LSP
+
+import qualified Language.Haskell.LSP.Types as J
+import qualified Language.Haskell.LSP.Types.Lens as J
+
+import Dhall.LSP.Backend.Diagnostics
+import Dhall.LSP.Util (readUri)
+
+import Control.Lens ((^.))
+import qualified Network.URI.Encode as URI
+import qualified Data.Text as Text
+import Data.Maybe (mapMaybe)
+
+-- | This is a prototype implementation. We should avoid recomputing the
+-- diagnostics each time.
+hoverHandler :: LSP.LspFuncs () -> J.HoverRequest -> IO ()
+hoverHandler lsp request = do
+  LSP.logs "LSP Handler: processing HoverRequest"
+  let
+    uri = request ^. J.params . J.textDocument . J.uri
+    (J.Position line col) = request ^. (J.params . J.position)
+    fileName = case J.uriToFilePath uri of
+      Nothing -> fail "Failed to parse URI in ReqHover."
+      Just path -> path
+  txt <- readUri lsp uri
+  errors <- checkDhall fileName txt
+  let
+    explanations = mapMaybe (explain txt) errors
+    isHovered :: Diagnosis -> Bool
+    isHovered (Diagnosis _ Nothing _) = False
+    isHovered (Diagnosis _ (Just (Range left right)) _) =
+      left <= (line, col) && (line, col) <= right
+    hover = case filter isHovered explanations of
+      [] -> Nothing
+      (diag : _) -> hoverFromDiagnosis diag
+  LSP.sendFunc lsp $ LSP.RspHover $ LSP.makeResponseMessage request hover
+
+
+hoverFromDiagnosis :: Diagnosis -> Maybe J.Hover
+hoverFromDiagnosis (Diagnosis _ Nothing _) = Nothing
+hoverFromDiagnosis (Diagnosis _ (Just (Range left right)) diagnosis) = Just
+  J.Hover { .. }
+  where
+    _range =
+      Just $ J.Range (uncurry J.Position left) (uncurry J.Position right)
+    encodedDiag = URI.encode (Text.unpack diagnosis)
+    command =
+      "[Explain error](dhall-explain:?" <> Text.pack encodedDiag <> " )"
+    _contents = J.List [J.PlainString command]

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -71,7 +71,7 @@ lspOptions = def { LSP.Core.textDocumentSync = Just syncOptions
                      -- with VSCode, which means that our plugin can't expose a
                      -- command of the same name. In the case of dhall.lint we
                      -- name the server-side command dhall.server.lint to work
-                     -- around peculiarity.
+                     -- around this peculiarity.
                      Just (J.ExecuteCommandOptions (J.List ["dhall.server.lint", "dhall.server.toJSON"]))
                  }
 

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -17,6 +17,7 @@ import GHC.Conc (atomically)
 
 import qualified Dhall.LSP.Handlers as Handlers
 import qualified Dhall.LSP.Handlers.Command as Handlers
+import qualified Dhall.LSP.Handlers.Hover as Handlers
 
 -- | The main entry point for the LSP server.
 run :: Maybe FilePath -> IO ()

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -16,6 +16,7 @@ import qualified System.Log.Logger
 import GHC.Conc (atomically)
 
 import qualified Dhall.LSP.Handlers as Handlers
+import qualified Dhall.LSP.Handlers.Command as Handlers
 
 -- | The main entry point for the LSP server.
 run :: Maybe FilePath -> IO ()
@@ -71,7 +72,7 @@ lspOptions = def { LSP.Core.textDocumentSync = Just syncOptions
                      -- command of the same name. In the case of dhall.lint we
                      -- name the server-side command dhall.server.lint to work
                      -- around peculiarity.
-                     Just (J.ExecuteCommandOptions (J.List ["dhall.server.lint"]))
+                     Just (J.ExecuteCommandOptions (J.List ["dhall.server.lint", "dhall.server.toJSON"]))
                  }
 
 lspHandlers :: TVar (Maybe (LSP.Core.LspFuncs ())) -> LSP.Core.Handlers

--- a/dhall-lsp-server/src/Dhall/LSP/Util.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Util.hs
@@ -3,8 +3,14 @@
 module Dhall.LSP.Util (
   tshow,
   lines',
+  readUri,
   unlines'
 ) where
+
+import qualified Language.Haskell.LSP.Core as LSP
+import qualified Language.Haskell.LSP.VFS as LSP
+import qualified Language.Haskell.LSP.Types as J
+import qualified Yi.Rope as Rope
 
 import Data.Text
 import Data.List.NonEmpty
@@ -26,3 +32,11 @@ lines' text =
 --   vice-versa).
 unlines' :: [Text] -> Text
 unlines' = intercalate "\n"
+
+-- | A helper function to query haskell-lsp's VFS.
+readUri :: LSP.LspFuncs () -> J.Uri -> IO Text
+readUri lsp uri = do
+  asd <- LSP.getVirtualFileFunc lsp uri
+  case asd of
+    Just (LSP.VirtualFile _ rope) -> return (Rope.toText rope)
+    Nothing -> fail $ "Could not find " <> show uri <> " in VFS."


### PR DESCRIPTION
At the moment the VSCode plugin contains a prototype of
a dhall-to-json (and -to-yaml) preview feature. We should ultimately
move that kind of functionality to dhall-lsp-server to 1) minimise the
amount of VSCode specific code and 2) avoid having to work with and fix
bugs in typescript code ;)

This takes us most of the way there; what is missing is the
ability to create files (via a WorkspaceEditRequest), which is not yet
implemented by haskell-lsp-types. I will wait with exposing the
corresponding command (and removing the existing preview code) in
vscode-dhall-lsp-server until this is fixed upstream.

Also contains some amount of refactoring of the Handlers code, for good measure.