### PR TITLE
dhall-lsp-server: (new feature) annotate lets

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -24,6 +24,7 @@ library
       Dhall.LSP.Backend.Diagnostics
       Dhall.LSP.Backend.Formatting
       Dhall.LSP.Backend.Linting
+      Dhall.LSP.Backend.Parsing
       Dhall.LSP.Backend.ToJSON
       Dhall.LSP.Backend.Typing
       Dhall.LSP.Handlers

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Formatting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Formatting.hs
@@ -1,6 +1,6 @@
 module Dhall.LSP.Backend.Formatting (formatDocument, formatExpr) where
 
-import Dhall.Core (Expr, Import)
+import Dhall.Core (Expr)
 import Dhall.Pretty (CharacterSet(..), layoutOpts, prettyCharacterSet)
 import Dhall.Parser(exprAndHeaderFromText, ParseError(..))
 
@@ -13,7 +13,7 @@ formatDocument text = do
   (header, expr) <- exprAndHeaderFromText "" text
   pure (formatExpr header expr)
 
-formatExpr :: Text -> Expr a Import -> Text
+formatExpr :: Pretty.Pretty b => Text -> Expr a b -> Text
 formatExpr header expr = Pretty.renderStrict
   (Pretty.layoutSmart layoutOpts doc)
   where

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
@@ -2,7 +2,6 @@ module Dhall.LSP.Backend.Parsing (getLetInner, getLetAnnot) where
 
 import Dhall.Src (Src(..))
 import Dhall.Parser
--- import Dhall.Parser.Combinators
 import Dhall.Parser.Token
 import Dhall.Parser.Expression
 

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
@@ -1,0 +1,42 @@
+module Dhall.LSP.Backend.Parsing (getLetInner) where
+
+import Dhall.Src (Src(..))
+import Dhall.Parser
+-- import Dhall.Parser.Combinators
+import Dhall.Parser.Token
+import Dhall.Parser.Expression
+
+import Control.Applicative (optional)
+import qualified Data.Text as Text
+import qualified Text.Megaparsec as Megaparsec
+import Text.Megaparsec (SourcePos(..))
+
+parseLetInnerOffset :: Parser (Int, SourcePos)
+parseLetInnerOffset = do
+  _let
+  _ <- label
+  _ <- optional (do
+    _ <- _colon
+    expr)
+  _equal
+  _ <- expr
+  _ <- optional _in
+  off <- getOffset
+  pos <- getSourcePos
+  _ <- Megaparsec.takeRest
+  return (off, pos)
+
+-- | Parse the outermost binding in a Src descriptor of a let-block and return
+--   the rest. Ex. on input `let a = 0 let b = a in b` parses `let a = 0 ` and
+--   returns the Src descriptor containing `let b = a in b`.
+getLetInner :: Src -> Maybe Src
+getLetInner (Src left right text) =
+  case Megaparsec.parseMaybe (unParser parseLetInnerOffset) text of
+    Just (n, dpos) -> Just $ Src (addPosDelta left dpos) right (Text.drop n text)
+    Nothing -> Nothing
+
+addPosDelta :: SourcePos -> SourcePos -> SourcePos
+addPosDelta (SourcePos name line col) (SourcePos _ dline dcol) =
+  (SourcePos name
+    (Megaparsec.mkPos $ Megaparsec.unPos line + Megaparsec.unPos dline - 1)
+    (Megaparsec.mkPos $ Megaparsec.unPos col + Megaparsec.unPos dcol - 1))

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
@@ -1,4 +1,4 @@
-module Dhall.LSP.Backend.Parsing (getLetInner) where
+module Dhall.LSP.Backend.Parsing (getLetInner, getLetAnnot) where
 
 import Dhall.Src (Src(..))
 import Dhall.Parser
@@ -7,7 +7,6 @@ import Dhall.Parser.Token
 import Dhall.Parser.Expression
 
 import Control.Applicative (optional)
-import qualified Data.Text as Text
 import qualified Text.Megaparsec as Megaparsec
 import Text.Megaparsec (SourcePos(..))
 
@@ -19,24 +18,35 @@ getLetInner :: Src -> Maybe Src
 getLetInner (Src left _ text) = Megaparsec.parseMaybe (unParser parseLetInnerOffset) text
  where parseLetInnerOffset = do
           setSourcePos left
-  _let
-  _ <- label
-  _ <- optional (do
-    _ <- _colon
-    expr)
-  _equal
-  _ <- expr
-  _ <- optional _in
+          _let
+          _ <- label
+          _ <- optional (do
+            _ <- _colon
+            expr)
+          _equal
+          _ <- expr
+          _ <- optional _in
           begin <- getSourcePos
           tokens <- Megaparsec.takeRest
           end <- getSourcePos
           return (Src begin end tokens)
 
-addPosDelta :: SourcePos -> SourcePos -> SourcePos
-addPosDelta (SourcePos name line col) (SourcePos _ dline dcol) =
-  (SourcePos name
-    (Megaparsec.mkPos $ Megaparsec.unPos line + Megaparsec.unPos dline - 1)
-    (Megaparsec.mkPos $ Megaparsec.unPos col + Megaparsec.unPos dcol - 1))
+-- | Given an Src of a let expression return the Src containing the type
+--   annotation. If the let expression does not have a type annotation return
+--   a 0-length Src where we can insert one.
+getLetAnnot :: Src -> Maybe Src
+getLetAnnot (Src left _ text) = Megaparsec.parseMaybe (unParser parseLetAnnot) text
+  where parseLetAnnot = do
+          setSourcePos left
+          _let
+          _ <- label
+          begin <- getSourcePos
+          (tokens, _) <- Megaparsec.match $ optional (do
+            _ <- _colon
+            expr)
+          end <- getSourcePos
+          _ <- Megaparsec.takeRest
+          return (Src begin end tokens)
 
 setSourcePos :: SourcePos -> Parser ()
 setSourcePos src = Megaparsec.updateParserState

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
@@ -72,14 +72,14 @@ annotateLet pos expr = rightToMaybe (annotateLet' pos empty (splitLets expr))
 
 annotateLet' :: Position -> Context (Expr Src X) -> Expr Src X -> Either (TypeError Src X) (Expr Src X)
 -- not yet annotated
-annotateLet' pos ctx (Let (Binding x Nothing a :| []) (Note src e))
-  | not (pos `inside` src) = do
+annotateLet' pos ctx (Let (Binding x Nothing a@(Note src _) :| []) e@(Note src' _))
+  | not (pos `inside` src) && not (pos `inside` src') = do
     _A <- typeWithA absurd ctx a
-    return (Let (Binding x (Just _A) a :| []) (Note src e))
+    return (Let (Binding x (Just _A) a :| []) e)
 
 -- replace existing annotation with normal form
-annotateLet' pos ctx (Let (Binding x (Just (Note src _A)) a :| []) (Note src' e))
-  | not (pos `inside` src) && not (pos `inside` src') = do
+annotateLet' pos ctx (Let (Binding x (Just _A@(Note src _)) a@(Note src' _) :| []) e@(Note src'' _))
+  | not (pos `inside` src) && not (pos `inside` src') && not (pos `inside` src'') = do
     _A' <- typeWithA absurd ctx a
     return (Let (Binding x (Just _A') a :| []) (Note src' e))
 

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
@@ -10,14 +10,13 @@ import Control.Lens (toListOf)
 import qualified Data.Text as Text
 import Control.Applicative ((<|>))
 
+import Dhall.LSP.Util (rightToMaybe)
 import Dhall.LSP.Backend.Diagnostics (Position, positionFromMegaparsec, offsetToPosition)
 
 -- | Find the type of the subexpression at the given position. Assumes that the
 --   input expression is well-typed.
 typeAt :: Position -> Expr Src X -> Maybe (Expr Src X)
-typeAt pos expr = case typeAt' pos empty expr of
-  Right typ -> Just typ
-  _        -> Nothing
+typeAt pos expr = rightToMaybe (typeAt' pos empty expr)
 
 typeAt' :: Position -> Context (Expr Src X) -> Expr Src X -> Either (TypeError Src X) (Expr Src X)
 -- unfold lets to make things simpler
@@ -72,9 +71,7 @@ srcAt pos expr = do e <- exprAt pos expr
 
 -- assume input to be well-typed; assume only singleton lets
 annotateLet :: Position -> Expr Src X -> Maybe (Expr Src X)
-annotateLet pos expr = case annotateLet' pos empty expr of
-  Right typ -> Just typ
-  _        -> Nothing
+annotateLet pos expr = rightToMaybe (annotateLet' pos empty (expr))
 
 annotateLet' :: Position -> Context (Expr Src X) -> Expr Src X -> Either (TypeError Src X) (Expr Src X)
 -- not yet annotated

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
@@ -67,10 +67,8 @@ exprAt pos expr =
 
 -- | Find the smallest Src annotation containing the given position.
 srcAt :: Position -> Expr Src a -> Maybe Src
-srcAt pos expr = do e <- exprAt pos expr
-                    case e of
-                      Note src _ -> Just src
-                      _ -> Nothing
+srcAt pos expr = do Note src _ <- exprAt pos expr
+                    return src
 
 
 -- | Given a well-typed expression and a position find the let binder at that

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
@@ -90,17 +90,17 @@ annotateLet' pos ctx (Note src e@(Let (Binding _ _ a :| []) _))
        return (srcAnnot, ": " <> printExpr _A <> " ")
 
 -- binders
-annotateLet' pos ctx (Let (Binding x _ a :| []) (Note src e))
+annotateLet' pos ctx (Let (Binding x _ a :| []) e@(Note src _))
   | pos `inside` src = do
     _A <- rightToMaybe $ typeWithA absurd ctx a
     let ctx' = fmap (shift 1 (V x 0)) (insert x _A ctx)
     annotateLet' pos ctx' e
-annotateLet' pos ctx (Lam x _A (Note src b))
+annotateLet' pos ctx (Lam x _A b@(Note src _))
   | pos `inside` src = do
     let _A' = Dhall.Core.normalize _A
         ctx' = fmap (shift 1 (V x 0)) (insert x _A' ctx)
     annotateLet' pos ctx' b
-annotateLet' pos ctx (Pi x _A (Note src _B))
+annotateLet' pos ctx (Pi x _A _B@(Note src _))
   | pos `inside` src = do
     let _A' = Dhall.Core.normalize _A
         ctx' = fmap (shift 1 (V x 0)) (insert x _A' ctx)

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Command.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Command.hs
@@ -131,8 +131,8 @@ executeAnnotateLet' lsp request = do
       Just e -> return e
       _ -> throwE  "failed to parse dhall file"
     (src, txt') <- case annotateLet (line, col) expr of
-      Just x -> return x
-      _ -> throwE "there is no let binder at the selected position"
+      Right x -> return x
+      Left err -> throwE err
     let edit = J.List [ J.TextEdit (srcToRange src) txt' ]
     lid <- lift $ LSP.getNextReqId lsp
     lift $ LSP.sendFunc lsp

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers/Hover.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers/Hover.hs
@@ -45,14 +45,14 @@ hoverHandler lsp request = do
                                     $ LSP.makeResponseMessage request Nothing
         Just expr ->
           case typeAt pos expr of
-            Just typ ->
+            Right typ ->
               let _range = fmap (rangeToJSON . sanitiseRange txt . rangeFromDhall)
                                 (srcAt pos expr)
                   _contents = J.List [J.PlainString (pretty typ)]
                   hover = J.Hover{..}
               in LSP.sendFunc lsp $ LSP.RspHover
                                   $ LSP.makeResponseMessage request (Just hover)
-            Nothing -> LSP.sendFunc lsp $ LSP.RspHover
+            _ -> LSP.sendFunc lsp $ LSP.RspHover
                                         $ LSP.makeResponseMessage request Nothing
 
 

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -73,7 +73,10 @@ lspOptions = def { LSP.Core.textDocumentSync = Just syncOptions
                      -- command of the same name. In the case of dhall.lint we
                      -- name the server-side command dhall.server.lint to work
                      -- around this peculiarity.
-                     Just (J.ExecuteCommandOptions (J.List ["dhall.server.lint", "dhall.server.toJSON"]))
+                     Just (J.ExecuteCommandOptions
+                       (J.List ["dhall.server.lint",
+                                "dhall.server.toJSON",
+                                "dhall.server.annotateLet"]))
                  }
 
 lspHandlers :: TVar (Maybe (LSP.Core.LspFuncs ())) -> LSP.Core.Handlers

--- a/dhall-lsp-server/src/Dhall/LSP/Util.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Util.hs
@@ -4,6 +4,7 @@ module Dhall.LSP.Util (
   tshow,
   lines',
   readUri,
+  rightToMaybe,
   unlines'
 ) where
 
@@ -40,3 +41,7 @@ readUri lsp uri = do
   case asd of
     Just (LSP.VirtualFile _ rope) -> return (Rope.toText rope)
     Nothing -> fail $ "Could not find " <> show uri <> " in VFS."
+
+rightToMaybe :: Either a b -> Maybe b
+rightToMaybe (Right b) = Just b
+rightToMaybe (Left _) = Nothing

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -485,7 +485,7 @@ Library
         Dhall.Set,
         Dhall.Src,
         Dhall.Parser,
-        Dhall.Parser.Combinators,
+        Dhall.Parser.Expression,
         Dhall.Parser.Token,
         Dhall.Pretty,
         Dhall.Repl,
@@ -496,7 +496,7 @@ Library
             Dhall.TH
     Other-Modules:
         Dhall.Pretty.Internal,
-        Dhall.Parser.Expression,
+        Dhall.Parser.Combinators,
         Dhall.Import.Types,
         Dhall.Eval,
         Dhall.Util,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -485,7 +485,6 @@ Library
         Dhall.Set,
         Dhall.Src,
         Dhall.Parser,
-        Dhall.Parser.Expression,
         Dhall.Parser.Combinators,
         Dhall.Parser.Token,
         Dhall.Pretty,
@@ -497,6 +496,7 @@ Library
             Dhall.TH
     Other-Modules:
         Dhall.Pretty.Internal,
+        Dhall.Parser.Expression,
         Dhall.Import.Types,
         Dhall.Eval,
         Dhall.Util,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -485,6 +485,9 @@ Library
         Dhall.Set,
         Dhall.Src,
         Dhall.Parser,
+        Dhall.Parser.Expression,
+        Dhall.Parser.Combinators,
+        Dhall.Parser.Token,
         Dhall.Pretty,
         Dhall.Repl,
         Dhall.Tutorial,
@@ -494,9 +497,6 @@ Library
             Dhall.TH
     Other-Modules:
         Dhall.Pretty.Internal,
-        Dhall.Parser.Expression,
-        Dhall.Parser.Combinators,
-        Dhall.Parser.Token,
         Dhall.Import.Types,
         Dhall.Eval,
         Dhall.Util,


### PR DESCRIPTION
The "annotate Let bindings" feature is here!
![](https://raw.githubusercontent.com/EggBaconAndSpam/eggbaconandspam.github.io/master/images/annotate-let.png)

An earlier version modified the AST and pretty-printed afterwards, which was rather annoying. This version instead inserts the annotation directly into the dhall source code.

In order to parse the `let` expressions I needed to access Dhall.Token and Dhall.Expression, which I exposed in dhall.cabal. Is that a good idea?