### PR TITLE
Improve error message for unsaturated `merge`

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -314,7 +314,7 @@ completeExpression embedded = completeExpression_
             alternative07 = do
                 _merge
                 a <- importExpression
-                b <- importExpression
+                b <- importExpression <?> "second argument to ❰merge❱"
                 return (Merge a b Nothing)
 
             alternative09 = do


### PR DESCRIPTION
This improves the error message when users attempt to apply `merge` to only
one argument, as suggested by:

https://github.com/dhall-lang/dhall-lang/issues/106#issuecomment-503523358

For example:

```
$ dhall <<< 'merge { Foo = True }'

Error: Invalid input

(stdin):2:1:
  |
2 | <empty line>
  | ^
unexpected end of input
expecting '.', second argument to ❰merge❱, or whitespace
```