### PR TITLE
Fix tutorial typo

### DIFF
--- a/dhall/src/Dhall/Tutorial.hs
+++ b/dhall/src/Dhall/Tutorial.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 {-| Dhall is a programming language specialized for configuration files.  This
-    module contains a tutorial explaning how to author configuration files using
+    module contains a tutorial explaining how to author configuration files using
     this language
 -}
 module Dhall.Tutorial (


### PR DESCRIPTION
Fix a tiny typo in the tutorial.

This is a small thing, but it's one of the first things you see when reading the docs on hackage.