### PR TITLE
Reject record projection when there is a field type mismatch

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -805,7 +805,12 @@ typeWithA tpa = loop
                 _ <- loop ctx t
 
                 case Dhall.Core.normalize t of
-                    nf_t@(Record ktsT) -> do
+                    Record ktsT -> do
+                        let actualSubset =
+                                Record (Dhall.Map.intersection ktsR ktsT)
+
+                        let expectedSubset = t
+
                         let process k tT = do
                                 case Dhall.Map.lookup k ktsR of
                                     Nothing -> do
@@ -815,7 +820,7 @@ typeWithA tpa = loop
                                             then do
                                                 return ()
                                             else do
-                                                Left (TypeError ctx e (ProjectionTypeMismatch k tT tR _R nf_t))
+                                                Left (TypeError ctx e (ProjectionTypeMismatch k tT tR expectedSubset actualSubset))
 
                         Dhall.Map.unorderedTraverseWithKey_ process ktsT
 

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -3546,7 +3546,9 @@ prettyTypeMessage (MissingField k expr0) = ErrorMessages {..}
 
 prettyTypeMessage (ProjectionTypeMismatch k expr0 expr1) = ErrorMessages {..}
   where
-    short = "Projection type mismatch"
+    short = "Projection type mismatch\n"
+        <>  "\n"
+        <>  prettyDiff expr0 expr1
 
     long =
         "Explanation: You can project a subset of fields from a record by specifying the \n\

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -798,7 +798,7 @@ typeWithA tpa = loop
 
                 Left (TypeError ctx e (CantProject text r t))
     loop ctx e@(Project r (Right t)) = do
-        _R <- loop ctx r
+        _R <- fmap Dhall.Core.normalize (loop ctx r)
 
         case _R of
             Record ktsR -> do

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -817,7 +817,7 @@ typeWithA tpa = loop
                                             else do
                                                 Left (TypeError ctx e (ProjectionTypeMismatch k tT tR))
 
-                        Dhall.Map.traverseWithKey_ process ktsT
+                        Dhall.Map.unorderedTraverseWithKey_ process ktsT
 
                         return (Record ktsT)
                     _ -> do


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1020

This also includes small fixes to the `MissingField` error message,
which I found along the way.