### PR TITLE
Use vertical bars for the left margin of source spans

### DIFF
--- a/dhall/src/Dhall/Src.hs
+++ b/dhall/src/Dhall/Src.hs
@@ -55,6 +55,6 @@ instance Pretty Src where
             inputString = Text.unpack line
 
             outputString =
-                Printf.printf ("%" <> show numberWidth <> "d: %s") n inputString
+                Printf.printf ("%" <> show numberWidth <> "d│ %s") n inputString
 
         numberedLines = Text.unlines (zipWith adapt [minimumNumber..] ls)

--- a/dhall/src/Dhall/Tutorial.hs
+++ b/dhall/src/Dhall/Tutorial.hs
@@ -317,7 +317,7 @@ import Dhall
 -- - Bool
 -- + Natural
 -- ...
--- 1: 1 : Bool
+-- 1│ 1 : Bool
 -- ...
 -- (input):1:1
 -- ...
@@ -517,7 +517,7 @@ import Dhall
 -- *** Exception:
 -- ...Error...: An empty list requires a type annotation
 -- ...
--- 1: []
+-- 1│ []
 -- ...
 -- (input):1:1
 --
@@ -531,7 +531,7 @@ import Dhall
 -- - Natural
 -- + Bool
 -- ...
--- 1:     True
+-- 1│     True
 -- ...
 -- (input):1:5
 -- ...


### PR DESCRIPTION
This separates the source from the line numbers using vertical bars
instead of colons.  The main reason for this is to more clearly
delimit the two and to also prevent the old colon from being confused
as a type annotation.