### PR TITLE
Replace criterion with gauge

### DIFF
--- a/dhall/benchmark/deep-nested-large-record/Main.hs
+++ b/dhall/benchmark/deep-nested-large-record/Main.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import Criterion.Main (defaultMain)
+import Gauge(defaultMain)
 
-import qualified Criterion as Criterion
 import qualified Data.Sequence as Seq
 import qualified Dhall.Core as Core
 import qualified Dhall.Import as Import
 import qualified Dhall.TypeCheck as TypeCheck
+import qualified Gauge
 
 dhallPreludeImport :: Core.Import
 dhallPreludeImport = Core.Import
@@ -21,8 +21,8 @@ dhallPreludeImport = Core.Import
     }
   }
 
-issue412 :: Core.Expr s TypeCheck.X -> Criterion.Benchmarkable
-issue412 prelude = Criterion.whnf TypeCheck.typeOf expr
+issue412 :: Core.Expr s TypeCheck.X -> Gauge.Benchmarkable
+issue412 prelude = Gauge.whnf TypeCheck.typeOf expr
   where
     expr
       = Core.Let (pure (Core.Binding "prelude" Nothing prelude))
@@ -30,8 +30,8 @@ issue412 prelude = Criterion.whnf TypeCheck.typeOf expr
       $ Seq.replicate 5
       $ Core.Var (Core.V "prelude" 0) `Core.Field` "types" `Core.Field` "Little" `Core.Field` "Foo"
 
-unionPerformance :: Core.Expr s TypeCheck.X -> Criterion.Benchmarkable
-unionPerformance prelude = Criterion.whnf TypeCheck.typeOf expr
+unionPerformance :: Core.Expr s TypeCheck.X -> Gauge.Benchmarkable
+unionPerformance prelude = Gauge.whnf TypeCheck.typeOf expr
   where
     innerBinding =
         Core.Binding "big" Nothing
@@ -47,6 +47,6 @@ main :: IO ()
 main = do
   prelude <- Import.load (Core.Embed dhallPreludeImport)
   defaultMain
-    [ Criterion.bench "issue 412" (issue412 prelude)
-    , Criterion.bench "union performance" (unionPerformance prelude)
+    [ Gauge.bench "issue 412" (issue412 prelude)
+    , Gauge.bench "union performance" (unionPerformance prelude)
     ]

--- a/dhall/benchmark/map/Main.hs
+++ b/dhall/benchmark/map/Main.hs
@@ -3,22 +3,22 @@
 
 module Main where
 
-import Criterion.Main (defaultMain, bgroup, bench, whnf, nfIO)
+import Gauge (defaultMain, bgroup, bench, whnf, nfIO)
 
-import qualified Criterion.Main as Criterion
+import qualified Gauge
 import qualified Dhall.Map as Map
 
 testData :: Integer -> Map.Map Integer Integer
 testData i = foldr (\j -> Map.insert j j) mempty [1 .. i]
 
-benchOrderedTraversal :: String -> Map.Map Integer Integer -> Criterion.Benchmark
+benchOrderedTraversal :: String -> Map.Map Integer Integer -> Gauge.Benchmark
 benchOrderedTraversal dataLabel mapData =
     bgroup ("Ordered Traversals: " <> dataLabel)
         [ bench "traverseWithKey" $
             whnf (Map.traverseWithKey (\_ i -> pure @Maybe $ i ^ i)) mapData
         ]
 
-benchUnorderedTraversal :: String -> Map.Map Integer Integer -> Criterion.Benchmark
+benchUnorderedTraversal :: String -> Map.Map Integer Integer -> Gauge.Benchmark
 benchUnorderedTraversal dataLabel mapData =
     bgroup ("Unordered Traversals: " <> dataLabel)
         [ bench "unorderedTraverseWithKey_" $

--- a/dhall/benchmark/parser/Main.hs
+++ b/dhall/benchmark/parser/Main.hs
@@ -4,14 +4,14 @@
 module Main where
 
 import Control.Monad (forM)
-import Criterion.Main (defaultMain, bgroup, bench, whnf, nfIO)
 import Data.Map (Map, foldrWithKey, singleton, unions)
 import Data.Monoid ((<>))
+import Gauge (defaultMain, bgroup, bench, whnf, nfIO)
 
 import System.Directory
 
 import qualified Codec.Serialise
-import qualified Criterion.Main as Criterion
+import qualified Gauge
 import qualified Data.ByteString.Lazy
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
@@ -55,17 +55,17 @@ loadPreludeFiles = loadDirectory "Prelude"
         loadFile :: FilePath -> IO PreludeFiles
         loadFile path = singleton path <$> TIO.readFile path
 
-benchParser :: PreludeFiles -> Criterion.Benchmark
+benchParser :: PreludeFiles -> Gauge.Benchmark
 benchParser =
       bgroup "exprFromText"
     . foldrWithKey (\name expr -> (benchExprFromText name expr :)) []
 
-benchExprFromText :: String -> T.Text -> Criterion.Benchmark
+benchExprFromText :: String -> T.Text -> Gauge.Benchmark
 benchExprFromText name expr =
     bench name $ whnf (Dhall.exprFromText "(input)") expr
 
 benchExprFromBytes
-    :: String -> Data.ByteString.Lazy.ByteString -> Criterion.Benchmark
+    :: String -> Data.ByteString.Lazy.ByteString -> Gauge.Benchmark
 benchExprFromBytes name bytes = bench name (whnf f bytes)
   where
     f bytes = do

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -587,9 +587,9 @@ Benchmark dhall-parser
         base                      >= 4        && < 5  ,
         bytestring                                    ,
         containers                >= 0.5.0.0  && < 0.7,
-        criterion                 >= 1.1      && < 1.6,
         dhall                                         ,
         directory                                     ,
+        gauge                     >= 0.2.4    && < 0.3,
         serialise                                     ,
         text                      >= 0.11.1.0 && < 1.3
     Default-Language: Haskell2010
@@ -604,8 +604,8 @@ Benchmark deep-nested-large-record
     Build-Depends:
         base                      >= 4        && < 5  ,
         containers                >= 0.5.0.0  && < 0.7,
-        criterion                 >= 1.1      && < 1.6,
-        dhall
+        dhall                                         ,
+        gauge                     >= 0.2.4    && < 0.3
     Default-Language: Haskell2010
 
 Benchmark dhall-command
@@ -624,7 +624,7 @@ Benchmark map-operations
     Hs-Source-Dirs: benchmark/map
     Build-Depends:
         base                      >= 4        && < 5  ,
-        criterion                 >= 1.1      && < 1.6,
-        dhall
+        dhall                                         ,
+        gauge                     >= 0.2.4    && < 0.3
     Default-Language: Haskell2010
     ghc-options: -rtsopts -O2


### PR DESCRIPTION
This reduces build times for the benchmarks.

The CLI are fairly similar:

criterion:

```
≻ cabal run -- dhall:bench:map-operations -h
Up to date
Microbenchmark suite - built with criterion 1.5.5.0

Usage: map-operations [-I|--ci CI] [-L|--time-limit SECS] [--resamples COUNT]
                      [--regress RESP:PRED..] [--raw FILE] [-o|--output FILE]
                      [--csv FILE] [--json FILE] [--junit FILE]
                      [-v|--verbosity LEVEL] [-t|--template FILE]
                      ([-m|--match MATCH] [NAME...] | [-n|--iters ITERS]
                      [-m|--match MATCH] [NAME...] | [-l|--list] | [--version])

Available options:
  -h,--help                Show this help text
  -I,--ci CI               Confidence interval
  -L,--time-limit SECS     Time limit to run a benchmark
  --resamples COUNT        Number of bootstrap resamples to perform
  --regress RESP:PRED..    Regressions to perform
  --raw FILE               File to write raw data to
  -o,--output FILE         File to write report to
  --csv FILE               File to write CSV summary to
  --json FILE              File to write JSON summary to
  --junit FILE             File to write JUnit summary to
  -v,--verbosity LEVEL     Verbosity level
  -t,--template FILE       Template to use for report
  -m,--match MATCH         How to match benchmark names ("prefix", "glob",
                           "pattern", or "ipattern")
  -n,--iters ITERS         Run benchmarks, don't analyse
  -m,--match MATCH         How to match benchmark names ("prefix", "glob",
                           "pattern", or "ipattern")
  -l,--list                List benchmarks
  --version                Show version info

Regression metrics (for use with --regress):
  time                     wall-clock time
  cpuTime                  CPU time
  cycles                   CPU cycles
  iters                    loop iterations
  allocated                (+RTS -T) bytes allocated
  numGcs                   (+RTS -T) number of garbage collections
  bytesCopied              (+RTS -T) number of bytes copied during GC
  mutatorWallSeconds       (+RTS -T) wall-clock time for mutator threads
  mutatorCpuSeconds        (+RTS -T) CPU time spent running mutator threads
  gcWallSeconds            (+RTS -T) wall-clock time spent doing GC
  gcCpuSeconds             (+RTS -T) CPU time spent doing GC
```

gauge:

```
≻ cabal run -- dhall:bench:map-operations -h
Up to date
Microbenchmark suite - built with gauge 0.2.4
  -I CI     --ci=CI                   Confidence interval
  -G        --no-gc                   Do not collect garbage between iterations
  -L SECS   --time-limit=SECS         Min seconds for each benchmark run, default is 5.0 in normal mode, 0.0 in quick mode
            --min-samples=COUNT       Min no. of samples for each benchmark, default is 10 in normal mode, 1 in quick mode
            --min-duration=MILLISECS  Min duration for each sample, default is MilliSeconds 30, when 0 stops after first iteration
            --include-first-iter      Do not discard the measurement of the first iteration
  -q        --quick                   Perform a quick measurement and report results without statistical analysis
            --measure-only=FILE       Just measure the benchmark and place the raw data in the given file
            --measure-with=FILE       Perform measurements in a separate process using this program.
            --resamples=COUNT         Number of boostrap resamples to perform
            --regress=RESP:PRED..     Regressions to perform
            --raw=FILE                File to write raw data to
  -o FILE   --output=FILE             File to write report to
            --csvraw=FILE             File to write CSV measurements to
            --csv=FILE                File to write CSV summary to
            --json=FILE               File to write JSON summary to
            --junit=FILE              File to write JUnit summary to
  -v LEVEL  --verbosity=LEVEL         Verbosity level
  -t FILE   --template=FILE           Template to use for report
  -n ITERS  --iters=ITERS             Run benchmarks, don't analyse
  -m MATCH  --match=MATCH             Benchmark match style: prefix (default), exact, pattern (substring), or ipattern (case insensitive)
  -l        --list                    List benchmarks
            --version                 Show version info
  -s        --small                   Set benchmark display to the minimum useful information
  -h        --help                    Show help
```