### PR TITLE
dhall-json: Use Dhall.Optics instead of lens

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -47,7 +47,7 @@ Library
         aeson-pretty                             < 0.9 ,
         bytestring                               < 0.11,
         containers                                     ,
-        dhall                     >= 1.22.0   && < 1.25,
+        dhall                     >= 1.24.0   && < 1.25,
         exceptions                >= 0.8.3    && < 0.11,
         optparse-applicative      >= 0.14.0.0 && < 0.15,
         scientific                >= 0.3.0.0  && < 0.4 ,

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -49,7 +49,6 @@ Library
         containers                                     ,
         dhall                     >= 1.22.0   && < 1.25,
         exceptions                >= 0.8.3    && < 0.11,
-        lens                      >= 2.5      && < 4.18,
         optparse-applicative      >= 0.14.0.0 && < 0.15,
         scientific                >= 0.3.0.0  && < 0.4 ,
         text                      >= 0.11.1.0 && < 1.3 ,

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -204,7 +204,6 @@ import Dhall.Map (Map)
 import Dhall.JSON.Util (pattern V)
 import Options.Applicative (Parser)
 
-import qualified Control.Lens
 import qualified Data.Aeson          as Aeson
 import qualified Data.Foldable       as Foldable
 import qualified Data.HashMap.Strict as HashMap
@@ -215,6 +214,7 @@ import qualified Data.Vector         as Vector
 import qualified Dhall.Core          as Core
 import qualified Dhall.Import
 import qualified Dhall.Map
+import qualified Dhall.Optics
 import qualified Dhall.Parser
 import qualified Dhall.TypeCheck
 import qualified Options.Applicative
@@ -884,7 +884,7 @@ data SpecialDoubleMode
 handleSpecialDoubles
     :: SpecialDoubleMode -> Expr s X -> Either CompileError (Expr s X)
 handleSpecialDoubles specialDoubleMode =
-    Control.Lens.rewriteMOf Core.subExpressions rewrite
+    Dhall.Optics.rewriteMOf Core.subExpressions rewrite
   where
     rewrite =
         case specialDoubleMode of


### PR DESCRIPTION
This removes the following packages from `dhall-json`'s dependencies:

- adjunctions
- call-stack
- free
- invariant
- kan-extensions
- lens
- parallel
- reflection
- transformers-base
- void