### PR TITLE
Improve performance of type-checking record literals

### DIFF
--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -42,6 +42,7 @@ module Dhall.Map
       -- * Traversals
     , mapWithKey
     , traverseWithKey
+    , unorderedTraverseWithKey
     , unorderedTraverseWithKey_
     , foldMapWithKey
 
@@ -452,6 +453,15 @@ traverseWithKey f m =
   where
     f' (k, a) = fmap ((,) k) (f k a)
 {-# INLINABLE traverseWithKey #-}
+
+{-| Same as `traverseWithKey`, except that the order of effects is not
+    necessarily the same as the order of the keys
+-}
+unorderedTraverseWithKey
+    :: Ord k => Applicative f => (k -> a -> f b) -> Map k a -> f (Map k b)
+unorderedTraverseWithKey f (Map m ks) =
+    fmap (\m' -> Map m' ks) (Data.Map.traverseWithKey f m)
+{-# INLINABLE unorderedTraverseWithKey #-}
 
 {-| Traverse all of the key-value pairs in a 'Map', not preserving their
     original order, where the result of the computation can be forgotten.


### PR DESCRIPTION
While benchmarking the example from #769 I saw that a significant
amount of time was spent benchmarking record literals.  When I looked
at the code more closely I saw that the first key in the record literal
was being type-checked twice (once to figure out the record's associated
type-checking constant and once as part of the `process` loop).

This change fixes that, which speeds up interpretation of the large
example by 9%:

Before:

```
time                 18.13 s    (18.11 s .. 18.16 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 18.09 s    (18.07 s .. 18.11 s)
std dev              21.92 ms   (10.66 ms .. 29.76 ms)
variance introduced by outliers: 19% (moderately inflated)
```

After:

```
time                 16.53 s    (16.49 s .. 16.60 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 16.59 s    (16.56 s .. 16.64 s)
std dev              43.65 ms   (6.227 ms .. 56.35 ms)
variance introduced by outliers: 19% (moderately inflated)
```

This also includes a small change to use a new `unorderedTraverseWithKey`
utility instead of `traverseWithKey`.  This appears to have no effect on
performance, but I did this anyway so that I could be sure that any
slowness in this code is not related to any `Dhall.Map`-specific weirdness.