### PR TITLE
Dhall.Map: Reflect original key ordering in Ord instance

### DIFF
--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -76,7 +76,8 @@ instance (Eq k, Eq v) => Eq (Map k v) where
   {-# INLINABLE (==) #-}
 
 instance (Ord k, Ord v) => Ord (Map k v) where
-  compare (Map mL ksL) (Map mR ksR) = compare mL mR <> compare ksL ksR
+  compare m1 m2 = compare (toList m1) (toList m2)
+  {-# INLINABLE compare #-}
 
 instance Functor (Map k) where
   fmap f (Map m ks) = Map (fmap f m) ks

--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -75,6 +75,10 @@ instance (Eq k, Eq v) => Eq (Map k v) where
   Map m1 ks == Map m2 ks' = m1 == m2 && ks == ks'
   {-# INLINABLE (==) #-}
 
+{-|
+>>> fromList [("A",1),("B",2)] < fromList [("B",1),("A",0)]
+True
+-}
 instance (Ord k, Ord v) => Ord (Map k v) where
   compare m1 m2 = compare (toList m1) (toList m2)
   {-# INLINABLE compare #-}


### PR DESCRIPTION
This definition is similar to the one in Data.Map:

    instance (Ord k, Ord v) => Ord (Map k v) where
        compare m1 m2 = compare (toAscList m1) (toAscList m2)