### PR TITLE
dhall-lsp-server: Normalize types before displaying them to the user

### DIFF
--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
@@ -60,9 +60,9 @@ typeAt' pos ctx (Note _ expr) = typeAt' pos ctx expr
 typeAt' pos ctx expr = do
   let subExprs = toListOf subExpressions expr
   case [ (src, e) | (Note src e) <- subExprs, pos `inside` src ] of
-    [] -> typeWithA absurd ctx expr  -- return type of whole subexpression
-    ((src, e):_) -> typeAt' pos ctx (Note src e)  -- continue with leaf-expression
-
+    [] -> do typ <- typeWithA absurd ctx expr
+             return (normalize typ)  -- return type of whole expression
+    ((src, e):_) -> typeAt' pos ctx (Note src e)  -- continue with subexpression
 
 
 -- | Find the smallest Note-wrapped expression at the given position.
@@ -102,7 +102,7 @@ annotateLet' pos ctx (Note src e@(Let (Binding _ _ a :| []) _))
                      Just x -> return x
                      Nothing -> Left "The impossible happened: failed\
                                      \ to re-parse a Let expression."
-       return (srcAnnot, ": " <> printExpr _A <> " ")
+       return (srcAnnot, ": " <> printExpr (normalize _A) <> " ")
 
 -- binders, see typeAt'
 annotateLet' pos ctx (Let (Binding x _ a :| []) e@(Note src _)) | pos `inside` src = do


### PR DESCRIPTION
Previously, the type displayed when hovering over the arrow in a lambda
(or forall) binder would not always be normal:

![](https://github.com/EggBaconAndSpam/eggbaconandspam.github.io/raw/master/images/bug-type-not-normal.png)

This fix normalises types before displaying them to the user (fixes both
the type-on-hover and annotate-let behaviour):

![](https://github.com/EggBaconAndSpam/eggbaconandspam.github.io/raw/master/images/bugfix-type-not-normal.png)