### PR TITLE
RFC: Dhall.Map: Change fromList to be left-biased in the values

### DIFF
--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -100,10 +100,17 @@ instance Ord k => Traversable (Map k) where
   traverse f m = traverseWithKey (\_ v -> f v) m
   {-# INLINABLE traverse #-}
 
+{-|
+prop> \x y z -> x <> (y <> z) == (x <> y) <> (z :: Map Int Int)
+-}
 instance Ord k => Data.Semigroup.Semigroup (Map k v) where
     (<>) = union
     {-# INLINABLE (<>) #-}
 
+{-|
+prop> \x -> x <> mempty == (x :: Map Int Int)
+prop> \x -> mempty <> x == (x :: Map Int Int)
+-}
 instance Ord k => Monoid (Map k v) where
     mempty = Map Data.Map.empty []
     {-# INLINABLE mempty #-}
@@ -519,3 +526,11 @@ keys (Map _ ks) = ks
 elems :: Ord k => Map k v -> [v]
 elems (Map m ks) = fmap (\k -> m Data.Map.! k) ks
 {-# INLINABLE elems #-}
+
+{- $setup
+>>> import Test.QuickCheck (Arbitrary(..))
+>>> :{
+  instance (Ord k, Arbitrary k, Arbitrary v) => Arbitrary (Map k v) where
+    arbitrary = fromList <$> arbitrary
+:}
+-}

--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -141,9 +141,12 @@ singleton k v = Map m ks
 
 {-| Create a `Map` from a list of key-value pairs
 
-> fromList empty = mempty
->
-> fromList (x <|> y) = fromList x <> fromList y
+'fromList' is a monoid homomorphism:
+
+>>> fromList mempty == mempty
+True
+
+prop> \x y -> fromList (x <> y) == fromList x <> fromList y
 
 >>> fromList [("B",1),("A",2)]  -- The map preserves order
 fromList [("B",1),("A",2)]

--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -147,13 +147,13 @@ singleton k v = Map m ks
 
 >>> fromList [("B",1),("A",2)]  -- The map preserves order
 fromList [("B",1),("A",2)]
->>> fromList [("A",1),("A",2)]  -- For duplicates, later values take precedence
-fromList [("A",2)]
+>>> fromList [("A",1),("A",2)]  -- For duplicates, earlier values take precedence
+fromList [("A",1)]
 -}
 fromList :: Ord k => [(k, v)] -> Map k v
 fromList kvs = Map m ks
   where
-    m = Data.Map.fromList kvs
+    m = Data.Map.fromListWith (\_new old -> old) kvs
 
     ks = nubOrd (map fst kvs)
 {-# INLINABLE fromList #-}


### PR DESCRIPTION
Given

    fromList [(2,True),(1,True),(1,False),(2,False)]

previously the resulting Dhall.Map was:

    fromList [(2,False),(1,False)]

Now we get

    fromList [(2,True),(1,True)]

So both the order of keys and the values are determined by each first
unique key. Duplicate keys don't change the result at all.

The property

    fromList (x <|> y) = fromList x <> fromList y

now holds.

Closes #1052.

Also add some doctest properties.