### PR TITLE
Build against `optparse-applicative-0.15`

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -49,7 +49,7 @@ Library
         containers                                     ,
         dhall                     >= 1.24.0   && < 1.25,
         exceptions                >= 0.8.3    && < 0.11,
-        optparse-applicative      >= 0.14.0.0 && < 0.15,
+        optparse-applicative      >= 0.14.0.0 && < 0.16,
         scientific                >= 0.3.0.0  && < 0.4 ,
         text                      >= 0.11.1.0 && < 1.3 ,
         unordered-containers                     < 0.3 ,

--- a/dhall-text/dhall-text.cabal
+++ b/dhall-text/dhall-text.cabal
@@ -26,7 +26,7 @@ Executable dhall-to-text
     Build-Depends:
         base                 >= 4.8.0.0  && < 5   ,
         dhall                >= 1.15.0   && < 1.25,
-        optparse-applicative                < 0.15,
+        optparse-applicative                < 0.16,
         text                 >= 0.11.1.0 && < 1.3
     GHC-Options: -Wall
     Other-Modules:

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -416,7 +416,7 @@ Library
         megaparsec                  >= 6.5.0    && < 7.1 ,
         memory                      >= 0.14     && < 0.15,
         mtl                         >= 2.2.1    && < 2.3 ,
-        optparse-applicative        >= 0.14.0.0 && < 0.15,
+        optparse-applicative        >= 0.14.0.0 && < 0.16,
         parsers                     >= 0.12.4   && < 0.13,
         prettyprinter               >= 1.2.0.1  && < 1.3 ,
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/4693