### PR TITLE
Fix unexpected decoding successes in tests

### DIFF
--- a/dhall/tests/Dhall/Test/Parser.hs
+++ b/dhall/tests/Dhall/Test/Parser.hs
@@ -86,13 +86,7 @@ getTests = do
     let binaryDecodeFailureFiles = do
             path <- Turtle.lstree (binaryDecodeDirectory </> "failure")
 
-            let skip =
-                    [ binaryDecodeDirectory </> "failure/unit/ApplyNoArgs.dhallb"
-                    , binaryDecodeDirectory </> "failure/unit/LambdaExplicitlyNamedUnderscore.dhallb"
-                    , binaryDecodeDirectory </> "failure/unit/NaturalNegativeOne.dhallb"
-                    , binaryDecodeDirectory </> "failure/unit/PiExplicitlyNamedUnderscore.dhallb"
-                    , binaryDecodeDirectory </> "failure/unit/VariableExplicitlyNamedUnderscore.dhallb"
-                    ]
+            let skip = []
 
             Monad.guard (path `notElem` skip)
 


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1082

All of the successes are due to accepting expressions that would not
have been produced by a compliant encoder, such as:

* Expressions that use a variable name of `_` that could have been
  encoded more compactly

* An expression tagged as a `Natural` number storing a negative number

* An expression encoding a function appled to 0 arguments