### PR TITLE
Build macOS binaries with Travis

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -1,3 +1,3 @@
-get_cabal_version() { cat $1/$1.cabal | grep '^Version: ' | gsed -e 's/^Version: //g'; }
+get_cabal_version() { cat $1/$1.cabal | grep '^Version: ' | sed -e 's/^Version: //g'; }
 
 mk_release_name() { echo "$1-$(get_cabal_version $1)-x86_64-macos.tar.bz2"; }

--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -1,0 +1,3 @@
+get_cabal_version() { cat $1/$1.cabal | grep '^Version: ' | gsed -e 's/^Version: //g'; }
+
+mk_release_name() { echo "$1-$(get_cabal_version $1)-x86_64-macos.tar.bz2"; }

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 
 script:
   - export PATH="${PATH}:$(pwd)/artifacts"
-  - stack build --copy-bins --local-bin-path ./bin;
+  - stack build --copy-bins --local-bin-path ./bin
   - get_cabal_version() { cat $1/$1.cabal | grep '^Version: ' | gsed -e 's/^Version: //g'; }
   - mk_release_name() { echo "$1-$(get_cabal_version $1)-x86_64-macos.tar.bz2"; }
   - tar -jcvf $(mk_release_name dhall) bin/dhall

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_deploy:
 
 deploy:
   - provider: releases
-    api_key: $API_KEY
+    api_key: $GITHUB_OAUTH_TOKEN
     file_glob: true
     file: uploads/*
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   # Download and unpack the stack executable
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
   - mkdir -p ~/.local/bin
-  -  travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  - travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
   # Use the more reliable S3 mirror of Hackage
   - mkdir -p $HOME/.cabal
   - echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,100 +1,75 @@
-# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
-language: c
-sudo: false
+sudo: required
+
+language: generic
 
 cache:
   directories:
-    - $HOME/.cabsnap
-    - $HOME/.cabal/packages
-
-before_cache:
-  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
-  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
+  - $TRAVIS_BUILD_DIR/.stack-work
 
 matrix:
   include:
-    - env: CABALVER=1.24 GHCVER=8.0.1 DEPLOY_GITHUB_RELEASE=true
-      compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.1 DEPLOY_GITHUB_RELEASE=true
-      compiler: ": #GHC 8.0.1"
-      os: osx
+  # Build only on macOS
+  - env: BUILD=stack
+    compiler: ": #stack default osx"
+    os: osx
+
+# Build only master and release tags
+branches:
+  only:
+  - master
+  - /^\d+\.\d+\.\d+(\.\d+)?$/
+
 
 before_install:
- - unset CC
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
- # Work around travis issue by updating Homebrew: https://github.com/travis-ci/travis-ci/issues/8552
- - if [ "$TRAVIS_OS_NAME" = osx ];
-   then
-     brew update;
-     brew install cabal-install;
-     brew install gnu-sed --with-default-names;
-   fi
+  # Using compiler above sets CC to an invalid value, so unset it
+  - unset CC
+  # We want to always allow newer versions of packages when building on GHC HEAD
+  - CABALARGS=""
+  - if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
+  # Download and unpack the stack executable
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
+  - mkdir -p ~/.local/bin
+  -  travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  # Use the more reliable S3 mirror of Hackage
+  - mkdir -p $HOME/.cabal
+  - echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
+  - echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
+
 
 install:
- - cabal --version
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
-   then
-     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
-          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
-   fi
- - travis_retry cabal update -v
- - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
- - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+  - if [ -f configure.ac ]; then autoreconf -i; fi
+  - set -ex
+  - stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+  - set +ex
 
-# check whether current requested install-plan matches cached package-db snapshot
- - if diff -u $HOME/.cabsnap/installplan.txt installplan.txt;
-   then
-     echo "cabal build-cache HIT";
-     rm -rfv .ghc;
-     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
-     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
-   else
-     echo "cabal build-cache MISS";
-     rm -rf $HOME/.cabsnap;
-     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies --enable-tests --enable-benchmarks;
-   fi
 
-# snapshot package-db on cache miss
- - if [ ! -d $HOME/.cabsnap ];
-   then
-      echo "snapshotting package-db to build-cache";
-      mkdir $HOME/.cabsnap;
-      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
-      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
-   fi
-
-# Here starts the actual work to be performed for the package under test;
-# any command which exits with a non-zero exit code causes the build to fail.
 script:
- - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
- - cabal build   # this builds all libraries and executables (including tests/benchmarks)
- - cabal test
- - cabal check
- - cabal sdist   # tests that a source-distribution can be generated
-
-# Check that the resulting source distribution can be built & installed.
-# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
-# `cabal install --force-reinstalls dist/*-*.tar.gz`
- - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+  - export PATH="${PATH}:$(pwd)/artifacts"
+  - stack build --copy-bins --local-bin-path ./bin;
+  - get_cabal_version() { cat $1/$1.cabal | grep '^Version: ' | gsed -e 's/^Version: //g'; }
+  - mk_release_name() { echo "$1-$(get_cabal_version $1)-x86_64-macos.tar.bz2"; }
+  - tar -jcvf $(mk_release_name dhall) bin/dhall
+  - tar -jcvf $(mk_release_name dhall-json) bin/dhall-to-json bin/dhall-to-yaml bin/json-to-dhall bin/yaml-to-dhall
+  - tar -jcvf $(mk_release_name dhall-bash) bin/dhall-to-bash
+  - tar -jcvf $(mk_release_name dhall-lsp-server) bin/dhall-lsp-server
 
 before_deploy:
-  - tar --create --file "$TRAVIS_OS_NAME.tar" --files-from /dev/null
-  - tar --append --file "$TRAVIS_OS_NAME.tar" --directory dist/build/dhall dhall
-  - gzip "$TRAVIS_OS_NAME.tar"
+  - stack build --copy-bins --local-bin-path ./bin;
+  # TODO: move the tar operations here
+  - mkdir -p uploads
+  - mv *.tar.bz2 uploads/
 
 deploy:
-  provider: releases
-  api_key: "$GITHUB_OAUTH_TOKEN"
-  file: "$TRAVIS_OS_NAME.tar.gz"
-  on:
-    condition: $DEPLOY_GITHUB_RELEASE = true
-    tags: true
-  skip_cleanup: true
-
-# EOF
+  - provider: releases
+    api_key: $API_KEY
+    file_glob: true
+    file: uploads/*
+    skip_cleanup: true
+    on:
+      tags: true
+    script:
+      - echo 'done'

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,25 +40,23 @@ before_install:
 
 install:
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+  - SAVED_OPTIONS=$(set +o)
   - set -ex
   - stack --no-terminal --install-ghc build --only-dependencies
-  - set +ex
+  - eval "$SAVED_OPTIONS"
 
 
 script:
-  - export PATH="${PATH}:$(pwd)/artifacts"
+  - export PATH="${PATH}:$(pwd)/bin"
   - stack build --copy-bins --local-bin-path ./bin
   - source .travis-functions.sh
   - tar -jcvf $(mk_release_name dhall) bin/dhall
   - tar -jcvf $(mk_release_name dhall-json) bin/dhall-to-json bin/dhall-to-yaml bin/json-to-dhall bin/yaml-to-dhall
   - tar -jcvf $(mk_release_name dhall-bash) bin/dhall-to-bash
   - tar -jcvf $(mk_release_name dhall-lsp-server) bin/dhall-lsp-server
-
-before_deploy:
-  - stack build --copy-bins --local-bin-path ./bin
-  # TODO: move the tar operations here
   - mkdir -p uploads
   - mv *.tar.bz2 uploads/
+
 
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
   - tar -jcvf $(mk_release_name dhall-lsp-server) bin/dhall-lsp-server
 
 before_deploy:
-  - stack build --copy-bins --local-bin-path ./bin;
+  - stack build --copy-bins --local-bin-path ./bin
   # TODO: move the tar operations here
   - mkdir -p uploads
   - mv *.tar.bz2 uploads/

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,7 @@ install:
 script:
   - export PATH="${PATH}:$(pwd)/artifacts"
   - stack build --copy-bins --local-bin-path ./bin
-  - get_cabal_version() { cat $1/$1.cabal | grep '^Version: ' | gsed -e 's/^Version: //g'; }
-  - mk_release_name() { echo "$1-$(get_cabal_version $1)-x86_64-macos.tar.bz2"; }
+  - source .travis-functions.sh
   - tar -jcvf $(mk_release_name dhall) bin/dhall
   - tar -jcvf $(mk_release_name dhall-json) bin/dhall-to-json bin/dhall-to-yaml bin/json-to-dhall bin/yaml-to-dhall
   - tar -jcvf $(mk_release_name dhall-bash) bin/dhall-to-bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   - $HOME/.ghc
   - $HOME/.cabal
   - $HOME/.stack
+  - $HOME/.local/bin
   - $TRAVIS_BUILD_DIR/.stack-work
 
 matrix:
@@ -26,17 +27,15 @@ branches:
 before_install:
   # Using compiler above sets CC to an invalid value, so unset it
   - unset CC
-  # We want to always allow newer versions of packages when building on GHC HEAD
   - CABALARGS=""
-  - if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
-  # Download and unpack the stack executable
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
-  - mkdir -p ~/.local/bin
-  - travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
-  # Use the more reliable S3 mirror of Hackage
-  - mkdir -p $HOME/.cabal
-  - echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
-  - echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
+  - | # Install stack
+    mkdir -p ~/.local/bin
+    travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    # Use the more reliable S3 mirror of Hackage
+    mkdir -p $HOME/.cabal
+    echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
+    echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
 install:
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - set -ex
-  - stack --no-terminal --install-ghc "" build --only-dependencies
+  - stack --no-terminal --install-ghc build --only-dependencies
   - set +ex
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
   - | # Install stack
     mkdir -p ~/.local/bin
-    travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    travis_retry curl -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
     # Use the more reliable S3 mirror of Hackage
     mkdir -p $HOME/.cabal
     echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
@@ -40,9 +40,8 @@ before_install:
 
 install:
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
-  - if [ -f configure.ac ]; then autoreconf -i; fi
   - set -ex
-  - stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+  - stack --no-terminal --install-ghc "" build --only-dependencies
   - set +ex
 
 


### PR DESCRIPTION
Fix #737 

This PR changes the Travis build (I'm replacing the current one which I don't understand with the one [from spago](https://github.com/spacchetti/spago/blob/master/.travis.yml) which I mostly wrote) to compile macOS binaries and push them to GitHub releases alongside the Linux and Windows binaries.

Things left to do:
- [x] enable the Travis integration (I don't have access to it)
- [x] add an `$API_KEY` variable [to authenticate to GitHub](https://docs.travis-ci.com/user/deployment/releases/) (though I can reuse the current `$GITHUB_OAUTH_TOKEN` if it's still there)
- [ ] verify that packaging is all fine, and move the `tar` operations to the `before_deploy` section