### PR TITLE
Fix incorrect `Canonicalize` law

### DIFF
--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -337,7 +337,7 @@ instance Show CannotImportHTTPURL where
 {-|
 > canonicalize . canonicalize = canonicalize
 
-> canonicalize (a <> b) = canonicalize a <> canonicalize b
+> canonicalize (a <> b) = canonicalize (canonicalize a <> canonicalize b)
 -}
 class Semigroup path => Canonicalize path where
     canonicalize :: path -> path


### PR DESCRIPTION
It is not the case that
```
canonicalize (a <> b) = canonicalize a <> canonicalize b.
```
For example
```
canonicalize (Directory ["asd"] <> Directory [".."]) = Directory [],
```
but
```
canonicalize (Directory ["asd"]) <> canonicalize (Directory [".."]) = Directory ["..", "asd"].
```

The law we want instead is:
```
canonicalize (a <> b) = canonicalize (canonicalize a <> canonicalize b)
```