### PR TITLE
dhall-lsp-server: Turn imports into clickable links

### DIFF
--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -14,7 +14,7 @@ import qualified System.Log.Logger
 import Dhall.LSP.State
 import Dhall.LSP.Handlers (nullHandler, wrapHandler, hoverHandler,
   didOpenTextDocumentNotificationHandler, didSaveTextDocumentNotificationHandler,
-  executeCommandHandler, documentFormattingHandler)
+  executeCommandHandler, documentFormattingHandler, documentLinkHandler)
 
 -- | The main entry point for the LSP server.
 run :: Maybe FilePath -> IO ()
@@ -73,6 +73,8 @@ lspOptions = def { LSP.Core.textDocumentSync = Just syncOptions
                      Just (J.ExecuteCommandOptions
                        (J.List ["dhall.server.lint",
                                 "dhall.server.annotateLet"]))
+                 , LSP.Core.documentLinkProvider =
+                    Just (J.DocumentLinkOptions { _resolveProvider = Just False })
                  }
 
 lspHandlers :: MVar ServerState -> LSP.Core.Handlers
@@ -87,4 +89,5 @@ lspHandlers state
         , LSP.Core.responseHandler                          = Just $ wrapHandler state nullHandler
         , LSP.Core.executeCommandHandler                    = Just $ wrapHandler state executeCommandHandler
         , LSP.Core.documentFormattingHandler                = Just $ wrapHandler state documentFormattingHandler
+        , LSP.Core.documentLinkHandler                      = Just $ wrapHandler state documentLinkHandler
         }

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -613,6 +613,7 @@ exprFromUncachedImport import_@(Import {..}) = do
     let resolveImport importType' = case importType' of
           Local prefix file -> liftIO $ do
               path   <- localToPath prefix file
+              absolutePath <- Directory.makeAbsolute path
               exists <- Directory.doesFileExist path
 
               if exists
@@ -621,7 +622,7 @@ exprFromUncachedImport import_@(Import {..}) = do
 
               text <- Data.Text.IO.readFile path
 
-              return (path, text, import_)
+              return (absolutePath, text, import_)
 
           Remote url@URL { headers = maybeHeadersExpression } -> do
               maybeHeadersAndExpression <- case maybeHeadersExpression of

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -104,6 +104,7 @@ module Dhall.Import (
     , exprToImport
     , load
     , loadWith
+    , localToPath
     , hashExpression
     , hashExpressionToCode
     , assertNoImports
@@ -437,6 +438,8 @@ instance Show HashMismatch where
         <>  "\n"
         <>  "↳ " <> show actualHash <> "\n"
 
+-- | Construct the file path corresponding to a local import. If the import is
+--   _relative_ then the resulting path is also relative.
 localToPath :: MonadIO io => FilePrefix -> File -> io FilePath
 localToPath prefix file_ = liftIO $ do
     let File {..} = file_
@@ -451,11 +454,10 @@ localToPath prefix file_ = liftIO $ do
             return "/"
 
         Parent -> do
-            pwd <- Directory.getCurrentDirectory
-            return (FilePath.takeDirectory pwd)
+            return ".."
 
         Here -> do
-            Directory.getCurrentDirectory
+            return "."
 
     let cs = map Text.unpack (file : components)
 


### PR DESCRIPTION
![](https://raw.githubusercontent.com/EggBaconAndSpam/eggbaconandspam.github.io/master/images/follow-imports.png)

Note that remote imports were already clickable since they were recognised by VSCode as urls.