### PR TITLE
Allow only valid HTTP(S) reg-names

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -245,6 +245,8 @@ Extra-Source-Files:
     dhall-lang/tests/parser/success/unit/*.dhallb
     dhall-lang/tests/parser/success/unit/import/*.dhall
     dhall-lang/tests/parser/success/unit/import/*.dhallb
+    dhall-lang/tests/parser/success/unit/import/urls/*.dhall
+    dhall-lang/tests/parser/success/unit/import/urls/*.dhallb
     dhall-lang/tests/parser/success/text/*.dhall
     dhall-lang/tests/parser/success/text/*.dhallb
     dhall-lang/tests/semantic-hash/success/*.dhall

--- a/dhall/tests/Dhall/Test/Parser.hs
+++ b/dhall/tests/Dhall/Test/Parser.hs
@@ -41,7 +41,7 @@ getTests = do
                     -- improvement
                     [ parseDirectory </> "success/unit/MergeParenAnnotationA.dhall"
 
-                    -- https://github.com/dhall-lang/dhall-haskell/issues/1110
+                    -- https://github.com/dhall-lang/dhall-lang/pull/655
                     , parseDirectory </> "success/unit/import/urls/potPourriA.dhall"
                     ]
 


### PR DESCRIPTION
Corresponding change to the standard: dhall-lang/dhall-lang#627

Fixes #1110.