### PR TITLE
Use cabal-doctest to fix doctests with v2-build.

### DIFF
--- a/dhall/Setup.hs
+++ b/dhall/Setup.hs
@@ -1,2 +1,9 @@
-import Distribution.Simple
-main = defaultMain
+module Main
+  ( main
+  )
+  where
+
+import Distribution.Extra.Doctest ( defaultMainWithDoctests )
+
+main :: IO ()
+main = defaultMainWithDoctests "doctest"

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -1,7 +1,7 @@
 Name: dhall
 Version: 1.27.0
 Cabal-Version: >=1.10
-Build-Type: Simple
+Build-Type: Custom
 Tested-With: GHC == 7.10.3, GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
 License-File: LICENSE
@@ -630,6 +630,7 @@ Test-Suite doctest
     Build-Depends:
         base                          ,
         directory                     ,
+        dhall                         ,
         filepath                < 1.5 ,
         mockery                 < 0.4 ,
         special-values                ,
@@ -670,3 +671,9 @@ Benchmark deep-nested-large-record
         dhall                                         ,
         gauge                     >= 0.2.3    && < 0.3
     Default-Language: Haskell2010
+
+Custom-Setup
+  Setup-Depends:
+      Cabal
+    , base
+    , cabal-doctest

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -632,7 +632,9 @@ Test-Suite doctest
         directory                     ,
         filepath                < 1.5 ,
         mockery                 < 0.4 ,
-        doctest   >= 0.7.0   && < 0.17
+        special-values                ,
+        doctest   >= 0.7.0   && < 0.17,
+        QuickCheck
     Default-Language: Haskell2010
     -- `doctest` doesn't work with `MIN_VERSION` macros before GHC 8
     --

--- a/dhall/doctest/Main.hs
+++ b/dhall/doctest/Main.hs
@@ -3,6 +3,8 @@ module Main where
 import Data.Monoid ((<>))
 import System.FilePath ((</>))
 
+import Build_doctests (flags, pkgs, module_sources)
+
 import qualified GHC.IO.Encoding
 import qualified System.Directory
 import qualified System.IO
@@ -24,20 +26,8 @@ main = do
         writeFile "file2" "./file1"
         writeFile "file1" "./file2"
 
-        Test.DocTest.doctest
-            [ "-DWITH_HTTP"
-            , "--fast"
-            , prefix </> "ghc-src"
-
-            -- Unfortunately we cannot target the entire @src@ directory.
-            -- The reason is that src/Dhall/Version.hs depends on
-            -- the generated Paths_dhall module which is "out-of-scope"
-            -- when running the testsuite with cabal v1-test.
-            -- Instead, we target a selection of modules whose combined module
-            -- dependency tree covers all modules that contain doctests.
-
-            -- , prefix </> "src"
-            , "-i" <> (prefix </> "src")
-            , prefix </> "src/Dhall/Tags.hs"
-            , prefix </> "src/Dhall/Tutorial.hs"
-            ]
+        let cpp_flags =
+              [ "-DWITH_CPP"
+              ]
+        Test.DocTest.doctest $
+            cpp_flags ++ flags ++ pkgs ++ module_sources

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -491,6 +491,7 @@ prettyEnvironmentVariable t
 'prettyCharacterSet' largely ignores 'Note's. 'Note's do however matter for
 the layout of let-blocks:
 
+>>> let unusedSourcePos = Text.Megaparsec.SourcePos "" (Text.Megaparsec.mkPos 1) (Text.Megaparsec.mkPos 1)
 >>> let inner = Let (Binding Nothing "x" Nothing Nothing Nothing (NaturalLit 1)) (Var (V "x" 0)) :: Expr Src ()
 >>> prettyCharacterSet ASCII (Let (Binding Nothing "y" Nothing Nothing Nothing (NaturalLit 2)) inner)
 let y = 2 let x = 1 in x

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -201,6 +201,10 @@ makeBinding name = Binding Nothing name Nothing Nothing Nothing
 newtype DhallDouble = DhallDouble { getDhallDouble :: Double }
     deriving (Show, Data, NFData, Generic)
 
+-- Note: the property doctest has to be written all on one line
+-- because of <https://github.com/sol/doctest/issues/174> and
+-- <https://github.com/sol/doctest/issues/131>.
+--
 -- | This instance satisfies all the customary 'Eq' laws except substitutivity.
 --
 -- In particular:
@@ -211,9 +215,7 @@ newtype DhallDouble = DhallDouble { getDhallDouble :: Double }
 --
 -- This instance is also consistent with with the binary encoding of Dhall @Double@s:
 --
--- >>> toBytes n = Dhall.Binary.encodeExpression (DoubleLit n :: Expr Void Import)
---
--- prop> \a b -> (a == b) == (toBytes a == toBytes b)
+-- prop> let toBytes n = Dhall.Binary.encodeExpression (DoubleLit (DhallDouble n) :: Expr Void Import) in \a b -> (a == b) == (toBytes a == toBytes b)
 instance Eq DhallDouble where
     DhallDouble a == DhallDouble b
         | isNaN a && isNaN b                      = True

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -90,6 +90,7 @@ extra-deps:
 - x509-system-1.6.6
 - x509-validation-1.6.11
 - yaml-0.10.4.0
+- cabal-doctest-1.0.6
 flags:
   transformers-compat:
     four: true


### PR DESCRIPTION
Fixes #1100.