### PR TITLE
Check normalizeWithM for consistency with normalize

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -1346,6 +1346,20 @@ normalizeWithM ctx e0 = loop (denote e0)
                     -- build/fold fusion for `List`
                     App (App ListBuild _) (App (App ListFold _) e') -> loop e'
 
+                    App NaturalFold (NaturalLit n) -> do
+                        let natural = Var (V "natural" 0)
+                        let go 0  x = x
+                            go n' x = go (n'-1) (App (Var (V "succ" 0)) x)
+                        let n' = go n (Var (V "zero" 0))
+                        pure
+                            (Lam "natural"
+                                (Const Type)
+                                (Lam "succ"
+                                    (Pi "_" natural natural)
+                                    (Lam "zero"
+                                        natural
+                                        n')))
+
                     -- build/fold fusion for `Natural`
                     App NaturalBuild (App NaturalFold e') -> loop e'
 
@@ -1366,7 +1380,7 @@ normalizeWithM ctx e0 = loop (denote e0)
                         lazyLoop !n = App succ' (lazyLoop (n - 1))
                     App NaturalBuild g -> loop (App (App (App g Natural) succ) zero)
                       where
-                        succ = Lam "x" Natural (NaturalPlus "x" (NaturalLit 1))
+                        succ = Lam "n" Natural (NaturalPlus "n" (NaturalLit 1))
 
                         zero = NaturalLit 0
                     App NaturalIsZero (NaturalLit n) -> pure (BoolLit (n == 0))

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -27,11 +27,12 @@ import Dhall.Core
     , Var(..)
     )
 
+import Data.Functor.Identity (Identity(..))
 import Dhall.Set (Set)
 import Dhall.Src (Src(..))
 import Numeric.Natural (Natural)
 import Test.QuickCheck
-    (Arbitrary(..), Gen, Positive(..), Property, genericShrink, (===), (==>))
+    (Arbitrary(..), Gen, Positive(..), Property, NonNegative(..), genericShrink, (===), (==>))
 import Test.QuickCheck.Instances ()
 import Test.Tasty (TestTree)
 import Text.Megaparsec (SourcePos(..), Pos)
@@ -187,7 +188,7 @@ instance (Arbitrary s, Arbitrary a) => Arbitrary (Expr s a) where
                           bindings <- Test.QuickCheck.vectorOf n arbitrary
                           body     <- arbitrary
                           return (Let (binding :| bindings) body)
-                  in  ( 1, Test.QuickCheck.oneof [ letExpression ])
+                  in  ( 7, letExpression)
                 , ( 1, lift2 Annot)
                 , ( 7, lift0 Bool)
                 , ( 7, lift1 BoolLit)
@@ -327,9 +328,9 @@ instance Arbitrary URL where
 instance Arbitrary Var where
     arbitrary =
         Test.QuickCheck.oneof
-            [ fmap (V "_") (fromIntegral <$> (natural :: Gen Int))
+            [ fmap (V "_") (getNonNegative <$> arbitrary)
             , lift1 (\t -> V t 0)
-            , lift1 V <*> (fromIntegral <$> (natural :: Gen Int))
+            , lift1 V <*> (getNonNegative <$> arbitrary)
             ]
 
     shrink = genericShrink
@@ -358,6 +359,14 @@ isNormalizedIsConsistentWithNormalize expression =
         Just nf -> Dhall.Core.isNormalized expression === (nf == expression)
         Nothing -> Test.QuickCheck.discard
 
+normalizeWithMIsConsistentWithNormalize :: Expr () Import -> Property
+normalizeWithMIsConsistentWithNormalize expression =
+    case Control.Spoon.spoon (Dhall.Core.normalize expression :: Expr () Import) of
+        Just nf ->
+            let nfM = runIdentity (Dhall.Core.normalizeWithM (\_ -> Identity Nothing) expression)
+            in nfM === nf
+        Nothing -> Test.QuickCheck.discard
+
 isSameAsSelf :: Expr () Import -> Property
 isSameAsSelf expression =
   hasNoImportAndTypechecks ==> Dhall.Diff.same (Dhall.Diff.diffExpression expression expression)
@@ -376,6 +385,10 @@ tests =
         , ( "isNormalized should be consistent with normalize"
           , Test.QuickCheck.property
               (Test.QuickCheck.withMaxSuccess 10000 isNormalizedIsConsistentWithNormalize)
+          )
+        , ( "normalizeWithM should be consistent with normalize"
+          , Test.QuickCheck.property
+              (Test.QuickCheck.withMaxSuccess 10000 normalizeWithMIsConsistentWithNormalize)
           )
         , ( "An expression should have no difference with itself"
           , Test.QuickCheck.property

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -112,7 +112,7 @@ lift6 f =
         <*> arbitrary
         <*> arbitrary
 
-natural :: (Arbitrary a, Num a) => Gen a
+natural :: Gen Natural
 natural =
     Test.QuickCheck.frequency
         [ (7, arbitrary)


### PR DESCRIPTION
* Implements constant folding of Natural/fold applications normalizeWithM.

* Changes the Arbitrary Var instance to generate only non-negative indices.
  Otherwise failures like this one would pop up:

```
    normalizeWithM should be consistent with normalize: FAIL (8.51s)
          *** Failed! Falsified (after 318133 tests and 6 shrinks):
          Let (Binding {variable = "", annotation = Nothing, value = List} :| []) (Var (V "" (-1)))
          Var (V "" (-1)) /= Var (V "" (-2))
          Use --quickcheck-replay=180244 to reproduce.
```

Fixes https://github.com/dhall-lang/dhall-haskell/issues/1114.