### PR TITLE
Support `lens-family-core-2.0.0`

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -548,7 +548,7 @@ Library
         exceptions                  >= 0.8.3    && < 0.11,
         filepath                    >= 1.4      && < 1.5 ,
         haskeline                   >= 0.7.2.1  && < 0.8 ,
-        lens-family-core            >= 1.0.0    && < 1.3 ,
+        lens-family-core            >= 1.0.0    && < 2.1 ,
         megaparsec                  >= 6.5.0    && < 7.1 ,
         memory                      >= 0.14     && < 0.15,
         mtl                         >= 2.2.1    && < 2.3 ,


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/4725