### PR TITLE
Specialize Expr's ToTerm instance to (Expr X a)

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -639,6 +639,7 @@ Library
         Dhall.Import.Types,
         Dhall.Eval,
         Dhall.Util,
+        Dhall.X
         Paths_dhall
     if flag(with-http)
       Other-Modules:

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -78,6 +78,7 @@ import Dhall.Core (
 -- import Dhall.Import.Types (InternalError)
 import Dhall.Map (Map)
 import Dhall.Set (Set)
+import Dhall.X   (X)
 import GHC.Natural (Natural)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -667,8 +668,8 @@ conv !env t t' =
     (VIntegerToDouble t , VIntegerToDouble t') -> convE t t'
 
     (VDouble       , VDouble)        -> True
-    (VDoubleLit n  , VDoubleLit n')  -> Dhall.Binary.encode (DoubleLit n  :: Expr Void Import) ==
-                                        Dhall.Binary.encode (DoubleLit n' :: Expr Void Import)
+    (VDoubleLit n  , VDoubleLit n')  -> Dhall.Binary.encode (DoubleLit n  :: Expr X Import) ==
+                                        Dhall.Binary.encode (DoubleLit n' :: Expr X Import)
     (VDoubleShow t , VDoubleShow t') -> convE t t'
 
     (VText, VText) -> True

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -972,7 +972,7 @@ encodeExpression _standardVersion expression = bytesStrict
     intermediateExpression = fmap absurd expression
 
     term :: Term
-    term = Dhall.Binary.encode intermediateExpression
+    term = Dhall.Binary.encodeExpression intermediateExpression
 
     taggedTerm :: Term
     taggedTerm =

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -530,7 +530,7 @@ command (Options {..}) = do
         Encode {..} -> do
             expression <- getExpression file
 
-            let term = Dhall.Binary.encode expression
+            let term = Dhall.Binary.encodeExpression expression
 
             let bytes = Codec.Serialise.serialise term
 

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -21,9 +21,7 @@ module Dhall.TypeCheck (
     , TypeMessage(..)
     ) where
 
-import Control.Applicative (empty)
 import Control.Exception (Exception)
-import Data.Data (Data(..))
 import Data.Functor (void)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid (Endo(..), First(..))
@@ -33,10 +31,11 @@ import Data.Set (Set)
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty(..))
 import Data.Typeable (Typeable)
-import Dhall.Binary (FromTerm(..), ToTerm(..))
+import Dhall.Binary (ToTerm(..))
 import Dhall.Core (Binding(..), Const(..), Chunks(..), Expr(..), Var(..))
 import Dhall.Context (Context)
 import Dhall.Pretty (Ann, layoutOpts)
+import Dhall.X (X(..))
 
 import qualified Data.Foldable
 import qualified Data.Map
@@ -868,29 +867,6 @@ typeWithA tpa = loop
 -}
 typeOf :: Expr s X -> Either (TypeError s X) (Expr s X)
 typeOf = typeWith Dhall.Context.empty
-
--- | Like `Data.Void.Void`, except with a shorter inferred type
-newtype X = X { absurd :: forall a . a }
-
-instance Show X where
-    show = absurd
-
-instance Eq X where
-  _ == _ = True
-
-instance Data X where
-    dataTypeOf = absurd
-    gunfold _ _ _ = undefined
-    toConstr = absurd
-
-instance Pretty X where
-    pretty = absurd
-
-instance FromTerm X where
-    decode _ = empty
-
-instance ToTerm X where
-    encode = absurd
 
 -- | The specific type error
 data TypeMessage s a

--- a/dhall/src/Dhall/X.hs
+++ b/dhall/src/Dhall/X.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Dhall.X where
+
+import Data.Data (Data(..))
+import Data.Text.Prettyprint.Doc (Pretty(..))
+
+-- | Like `Data.Void.Void`, except with a shorter inferred type
+newtype X = X { absurd :: forall a . a }
+
+instance Show X where
+    show = absurd
+
+instance Eq X where
+  _ == _ = True
+
+instance Data X where
+    dataTypeOf = absurd
+    gunfold _ _ _ = undefined
+    toConstr = absurd
+
+instance Pretty X where
+    pretty = absurd

--- a/dhall/tests/Dhall/Test/Parser.hs
+++ b/dhall/tests/Dhall/Test/Parser.hs
@@ -121,7 +121,7 @@ shouldParse path = do
 
         expression <- Core.throws (Parser.exprFromText mempty text)
 
-        let term = Binary.encode expression
+        let term = Binary.encodeExpression expression
 
         let bytes = Serialise.serialise term
 


### PR DESCRIPTION
Now we don't have to worry about `Note`s anymore when pattern matching on an `Expr`'s structure while encoding. We also avoid redundant denoting.

Background: https://github.com/dhall-lang/dhall-haskell/pull/1112#discussion_r303644433