### PR TITLE
Fix import alternatives to recover from type errors

### DIFF
--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -597,7 +597,7 @@ loadImportFresh (Chained (Import (ImportHashed _ importType) Code)) = do
     Status {..} <- State.get
 
     importSemantics <- case Dhall.TypeCheck.typeWith _startingContext loadedExpr of
-        Left  err -> throwM (Imported _stack err)
+        Left  err -> throwMissingImport (Imported _stack err)
         Right _   -> do
             let betaNormal = Dhall.Core.normalizeWith _normalizer loadedExpr
                 alphaBetaNormal = Dhall.Core.alphaNormalize betaNormal

--- a/dhall/tests/Dhall/Test/Regression.hs
+++ b/dhall/tests/Dhall/Test/Regression.hs
@@ -22,8 +22,8 @@ import qualified System.Timeout
 import qualified Test.Tasty
 import qualified Test.Tasty.HUnit
 
-import Dhall.Import (Imported)
-import Dhall.Parser (Src)
+import Dhall.Import (Imported, MissingImports(..))
+import Dhall.Parser (Src, SourcedException(..))
 import Dhall.TypeCheck (TypeError, X)
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit ((@?=))
@@ -93,8 +93,13 @@ issue126 = Test.Tasty.HUnit.testCase "Issue #126" (do
 issue151 :: TestTree
 issue151 = Test.Tasty.HUnit.testCase "Issue #151" (do
     let shouldNotTypeCheck text = do
-            let handler :: Imported (TypeError Src X) -> IO Bool
-                handler _ = return True
+            let handler :: SourcedException MissingImports -> IO Bool
+                handler (SourcedException _ (MissingImports [e])) =
+                    case Control.Exception.fromException e :: Maybe (Imported (TypeError Src X)) of
+                        Just _ -> return True
+                        Nothing -> return False
+                handler _ = do
+                    return True
 
             let typeCheck = do
                     _ <- Util.code text


### PR DESCRIPTION
Previously, `BAD="0 0" dhall <<< "env:BAD ? 0"` resulted in the
following error:
```
↳ env:BAD

Error: Not a function

1│ 0 0

BAD:1:1
```

According to the standard the above expression was supposed to evaluate
successfully to `0`. See #1146 for further discussion.