### PR TITLE
Make regression test #151 test the right thing

### DIFF
--- a/dhall/tests/regression/issue151a.dhall
+++ b/dhall/tests/regression/issue151a.dhall
@@ -1,1 +1,1 @@
-let foo : (\(x : A) -> x x) (\(x : A) -> x x) = 1 in foo
+\(A : Type) -> let foo : (\(x : A) -> x x) (\(x : A) -> x x) = 1 in foo

--- a/dhall/tests/regression/issue151b.dhall
+++ b/dhall/tests/regression/issue151b.dhall
@@ -1,1 +1,1 @@
-\(omega : ((\(x : A) -> x x) (\(x : A) -> x x))) -> omega 1
+\(A : Type) -> \(omega : ((\(x : A) -> x x) (\(x : A) -> x x))) -> omega 1


### PR DESCRIPTION
From dhall/tests/Dhall/Test/Regression.hs:

> These two examples contain the following expression that loops
> infinitely if you normalize the expression before type-checking the
> expression:
> (λ(x : A) → x x) (λ(x : A) → x x)

The problem is typechecking that snipped already fails even before we
hit the self-application with the following error:
> Unbound variable: A

This is fixed by quantifying over `A`, resulting in the desired type
error:
> Error: Not a function
> 1│                           x x