### PR TITLE
Implement semi-semantic caching

### DIFF
--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -100,7 +100,8 @@
 
 module Dhall.Import (
     -- * Import
-      loadWith
+      load
+    , loadWith
     , localToPath
     , hashExpression
     , hashExpressionToCode
@@ -945,6 +946,10 @@ loadWith expr₀ = case expr₀ of
       let handler e = throwM (SourcedException a (e :: MissingImports))
 
       (Note <$> pure a <*> loadWith b) `catch` handler
+
+-- | Resolve all imports within an expression
+load :: Expr Src Import -> IO (Expr Src X)
+load expression = State.evalStateT (loadWith expression) (emptyStatus ".")
 
 encodeExpression
     :: forall s

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -28,7 +28,6 @@ import Dhall.TypeCheck (X)
 import Lens.Family (LensLike')
 import System.FilePath (isRelative, splitDirectories)
 
-import qualified Crypto.Hash
 import qualified Dhall.Binary
 import qualified Dhall.Context
 import qualified Data.Map      as Map
@@ -48,18 +47,6 @@ instance Pretty Chained where
 data ImportSemantics = ImportSemantics
     { importSemantics :: Expr Src X
     -- ^ The fully resolved import, typechecked and alpha-beta-normal.
-    , semanticHash :: Crypto.Hash.Digest Crypto.Hash.SHA256
-    -- ^ Its semantic hash, i.e. the hash of its encoded normal form.
-    }
-
-data ResolvedExpr = ResolvedExpr
-    { resolvedExpr :: Expr Src X
-    -- ^ The fully resolved expression, i.e. any imports where replaced by their
-    --   semantics. Note that the resolved expression has not yet been
-    --   typechecked nor normalised!
-    , imports :: [ImportSemantics]
-    -- ^ The semantics of any imports that were loaded when resolving the
-    --   expression. Used to compute the semi-semantic hash.
     }
 
 -- | `parent` imports (i.e. depends on) `child`

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -52,6 +52,16 @@ data ImportSemantics = ImportSemantics
     -- ^ Its semantic hash, i.e. the hash of its encoded normal form.
     }
 
+data ResolvedExpr = ResolvedExpr
+    { resolvedExpr :: Expr Src X
+    -- ^ The fully resolved expression, i.e. any imports where replaced by their
+    --   semantics. Note that the resolved expression has not yet been
+    --   typechecked nor normalised!
+    , imports :: [ImportSemantics]
+    -- ^ The semantics of any imports that were loaded when resolving the
+    --   expression. Used to compute the semi-semantic hash.
+    }
+
 -- | `parent` imports (i.e. depends on) `child`
 data Depends = Depends { parent :: Chained, child :: Chained }
 

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -28,6 +28,7 @@ import Dhall.TypeCheck (X)
 import Lens.Family (LensLike')
 import System.FilePath (isRelative, splitDirectories)
 
+import qualified Crypto.Hash
 import qualified Dhall.Binary
 import qualified Dhall.Context
 import qualified Data.Map      as Map
@@ -47,6 +48,8 @@ instance Pretty Chained where
 data ImportSemantics = ImportSemantics
     { importSemantics :: Expr Src X
     -- ^ The fully resolved import, typechecked and alpha-beta-normal.
+    , semanticHash :: Crypto.Hash.Digest Crypto.Hash.SHA256
+    -- ^ Its semantic hash, i.e. the hash of its encoded normal form.
     }
 
 -- | `parent` imports (i.e. depends on) `child`


### PR DESCRIPTION
This completes the implementation of the "semi-semantic caching"
proposal (issue #1098).

We compute the semi-semantic hash of a dhall import/file/expression as
follows:

- Parse the input;
- compute the semantic hashes of all imports referenced in the AST, i.e.
the hashes of their normal forms;
- compute the syntactic hash of the input (hashing the parsed AST);
- concatenate the syntactic hash of the input with the semantic hashes
of its imports and hash the result.

The "semi-semantic" cache (normal forms, indexed by semi-semantic
hashes) has the following properties:

- For a given input we can quickly find out if it is in the cache: we
only need to parse the input – we don't need to typecheck or normalise
it!
- The cache stays consistent, that is, we don't need to ‘invalidate’ old
cache entries if their dependencies change!