### PR TITLE
Fix `isNormalized` test

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -1807,7 +1807,8 @@ isNormalizedWith ctx e = e == normalizeWith (Just (ReifiedNormalizer ctx)) e
 -- Given a well-typed expression @e@, @'isNormalized' e@ is equivalent to
 -- @e == 'normalize' e@.
 --
--- Given an ill-typed expression, 'isNormalized' may return 'True' or 'False'.
+-- Given an ill-typed expression, 'isNormalized' may fail with an error, or
+-- evaluate to either False or True!
 isNormalized :: Eq a => Expr s a -> Bool
 isNormalized e0 = loop (denote e0)
   where

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -358,9 +358,14 @@ everythingWellTypedNormalizes expression =
 
 isNormalizedIsConsistentWithNormalize :: Expr () Import -> Property
 isNormalizedIsConsistentWithNormalize expression =
-    case Control.Spoon.spoon (Dhall.Core.normalize expression) of
-        Just nf -> Dhall.Core.isNormalized expression === (nf == expression)
+    case maybeProp of
         Nothing -> Test.QuickCheck.discard
+        Just prop -> prop
+  where
+      maybeProp = do
+          nf <- Control.Spoon.spoon (Dhall.Core.normalize expression)
+          isNormalized <- Control.Spoon.spoon (Dhall.Core.isNormalized expression)
+          return $ isNormalized === (nf == expression)
 
 normalizeWithMIsConsistentWithNormalize :: Expr () Import -> Property
 normalizeWithMIsConsistentWithNormalize expression =


### PR DESCRIPTION
The test in question failed intermittently because `isNormalized` is
more thorough than `normalize`, in the sense that it throws exceptions
for more non-welltyped expressions. As a result, we need to use `spoon`
not just when computing the normal form of a raw expression, but also
when calling `isNormalized` on the result. Note that the test may still
randomly fail in the future, because normalizing non-welltyped
expressions needn't terminate!