### PR TITLE
Fix tests without `with-http` flag

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -686,6 +686,7 @@ Test-Suite tasty
         directory                                      ,
         filepath                                       ,
         foldl                                    < 1.5 ,
+        lens-family-core          >= 1.0.0    && < 2.1 ,
         megaparsec                                     ,
         prettyprinter                                  ,
         QuickCheck                >= 2.10     && < 2.14,
@@ -700,6 +701,9 @@ Test-Suite tasty
         transformers                                   ,
         turtle                                   < 1.6 ,
         vector                    >= 0.11.0.0 && < 0.13
+    if flag(with-http)
+      CPP-Options:
+        -DWITH_HTTP
     Default-Language: Haskell2010
 
 Test-Suite doctest

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -170,7 +170,7 @@ import Dhall.Core
     )
 #ifdef MIN_VERSION_http_client
 import Network.HTTP.Client (Manager)
-import Dhall.Import.HTTP
+import Dhall.Import.HTTP hiding (HTTPHeader)
 #endif
 import Dhall.Import.Types
 

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -117,7 +117,7 @@ module Dhall.Import (
     , cache
     , Depends(..)
     , graph
-    , manager
+    , remote
     , standardVersion
     , normalizer
     , startingContext
@@ -166,6 +166,7 @@ import Dhall.Core
     , URL(..)
     )
 #ifdef MIN_VERSION_http_client
+import Network.HTTP.Client (Manager)
 import Dhall.Import.HTTP
 #endif
 import Dhall.Import.Types
@@ -392,29 +393,6 @@ instance Canonicalize Import where
     canonicalize (Import importHashed importMode) =
         Import (canonicalize importHashed) importMode
 
--- Given a well-typed (of type `List { header : Text, value Text }` or
--- `List { mapKey : Text, mapValue Text }`) headers expressions in normal form
--- construct the corresponding binary http headers.
-toHeaders :: Expr s a -> Maybe [HTTPHeader]
-toHeaders (ListLit _ hs) = do
-    hs' <- mapM toHeader hs
-    return (Data.Foldable.toList hs')
-toHeaders _ = do
-    empty
-
-toHeader :: Expr s a -> Maybe HTTPHeader
-toHeader (RecordLit m) = do
-    TextLit (Chunks [] keyText  ) <-
-        Dhall.Map.lookup "header" m <|> Dhall.Map.lookup "mapKey" m
-    TextLit (Chunks [] valueText) <-
-        Dhall.Map.lookup "value" m <|> Dhall.Map.lookup "mapValue" m
-    let keyBytes   = Data.Text.Encoding.encodeUtf8 keyText
-    let valueBytes = Data.Text.Encoding.encodeUtf8 valueText
-    return (Data.CaseInsensitive.mk keyBytes, valueBytes)
-toHeader _ = do
-    empty
-
-
 -- | Exception thrown when an integrity check fails
 data HashMismatch = HashMismatch
     { expectedHash :: Crypto.Hash.Digest SHA256
@@ -619,9 +597,9 @@ loadImportFresh (Chained (Import (ImportHashed _ importType) Location)) = do
             local@(Local _ _) ->
                 App (Field locationType "Local")
                   (TextLit (Chunks [] (Dhall.Pretty.Internal.pretty local)))
-            remote@(Remote _) ->
+            remote_@(Remote _) ->
                 App (Field locationType "Remote")
-                  (TextLit (Chunks [] (Dhall.Pretty.Internal.pretty remote)))
+                  (TextLit (Chunks [] (Dhall.Pretty.Internal.pretty remote_)))
             Env env ->
                 App (Field locationType "Environment")
                   (TextLit (Chunks [] (Dhall.Pretty.Internal.pretty env)))
@@ -645,15 +623,9 @@ fetchFresh (Local prefix file) = do
         then liftIO $ Data.Text.IO.readFile path
         else throwMissingImport (Imported _stack (MissingFile path))
 
-fetchFresh (Remote (url@URL { headers = maybeHeadersExpression })) = do
-#ifdef MIN_VERSION_http_client
-    let maybeHeaders = foldMap toHeaders maybeHeadersExpression
-    fetchFromHttpUrl url maybeHeaders
-#else
-    let urlString = Text.unpack (Dhall.Core.pretty url)
-    Status { _stack } <- State.get
-    throwMissingImport (Imported _stack (CannotImportHTTPURL urlString mheaders))
-#endif
+fetchFresh (Remote url) = do
+    Status { _remote } <- State.get
+    _remote url
 
 fetchFresh (Env env) = do
     Status { _stack } <- State.get
@@ -665,6 +637,46 @@ fetchFresh (Env env) = do
                 throwMissingImport (Imported _stack (MissingEnvironmentVariable env))
 
 fetchFresh Missing = throwM (MissingImports [])
+
+fetchRemote :: URL -> StateT Status IO Data.Text.Text
+#ifndef MIN_VERSION_http_client
+fetchRemote (url@URL { headers = maybeHeadersExpression }) = do
+    let urlString = Text.unpack (Dhall.Core.pretty url)
+    Status { _stack } <- State.get
+    throwMissingImport (Imported _stack (CannotImportHTTPURL urlString maybeHeaders))
+#else
+fetchRemote url = do
+    manager <- liftIO $ newManager
+    zoom remote (State.put (fetchFromHTTP manager))
+    fetchFromHTTP manager url
+  where
+    fetchFromHTTP :: Manager -> URL -> StateT Status IO Data.Text.Text
+    fetchFromHTTP manager (url'@URL { headers = maybeHeadersExpression }) = do
+        let maybeHeaders = foldMap toHeaders maybeHeadersExpression
+        fetchFromHttpUrl manager url' maybeHeaders
+
+    -- Given a well-typed (of type `List { header : Text, value Text }` or
+    -- `List { mapKey : Text, mapValue Text }`) headers expressions in normal form
+    -- construct the corresponding binary http headers.
+    toHeaders :: Expr s a -> Maybe [HTTPHeader]
+    toHeaders (ListLit _ hs) = do
+        hs' <- mapM toHeader hs
+        return (Data.Foldable.toList hs')
+    toHeaders _ = do
+        empty
+
+    toHeader :: Expr s a -> Maybe HTTPHeader
+    toHeader (RecordLit m) = do
+        TextLit (Chunks [] keyText  ) <-
+            Dhall.Map.lookup "header" m <|> Dhall.Map.lookup "mapKey" m
+        TextLit (Chunks [] valueText) <-
+            Dhall.Map.lookup "value" m <|> Dhall.Map.lookup "mapValue" m
+        let keyBytes   = Data.Text.Encoding.encodeUtf8 keyText
+        let valueBytes = Data.Text.Encoding.encodeUtf8 valueText
+        return (Data.CaseInsensitive.mk keyBytes, valueBytes)
+    toHeader _ = do
+        empty
+#endif
 
 getCacheFile
     :: (Alternative m, MonadIO m) => Crypto.Hash.Digest SHA256 -> m FilePath
@@ -773,6 +785,10 @@ normalizeHeaders url@URL { headers = Just headersExpression } = do
     return url { headers = Just (fmap absurd headersExpression') }
 
 normalizeHeaders url = return url
+
+-- | Default starting `Status`, importing relative to the given directory.
+emptyStatus :: FilePath -> Status
+emptyStatus = emptyStatusWith fetchRemote
 
 {-| Generalized version of `load`
 

--- a/dhall/src/Dhall/Import/HTTP.hs
+++ b/dhall/src/Dhall/Import/HTTP.hs
@@ -5,15 +5,13 @@
 module Dhall.Import.HTTP where
 
 import Control.Exception (Exception)
-import Control.Monad (join)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.State.Strict (StateT)
 import Data.ByteString (ByteString)
 import Data.CaseInsensitive (CI)
-import Data.Dynamic (fromDynamic, toDyn)
+import Data.Dynamic (toDyn)
 import Data.Semigroup ((<>))
 import Data.Text (Text)
-import Lens.Family.State.Strict (zoom)
 
 import Dhall.Core
     ( Directory(..)
@@ -109,24 +107,17 @@ renderPrettyHttpException e = case e of
         <> show e'
 #endif
 
-needManager :: StateT Status IO Manager
-needManager = do
-    x <- zoom manager State.get
-    case join (fmap fromDynamic x) of
-        Just m  -> return m
-        Nothing -> do
-            let settings = HTTP.tlsManagerSettings
-
+newManager :: IO Manager
+newManager = do
+    let settings = HTTP.tlsManagerSettings
 #ifdef MIN_VERSION_http_client
 #if MIN_VERSION_http_client(0,5,0)
-                    { HTTP.managerResponseTimeout = HTTP.responseTimeoutMicro (30 * 1000 * 1000) }  -- 30 seconds
+          { HTTP.managerResponseTimeout = HTTP.responseTimeoutMicro (30 * 1000 * 1000) }  -- 30 seconds
 #else
-                    { HTTP.managerResponseTimeout = Just (30 * 1000 * 1000) }  -- 30 seconds
+          { HTTP.managerResponseTimeout = Just (30 * 1000 * 1000) }  -- 30 seconds
 #endif
 #endif
-            m <- liftIO (HTTP.newManager settings)
-            zoom manager (State.put (Just (toDyn m)))
-            return m
+    HTTP.newManager settings
 
 data NotCORSCompliant = NotCORSCompliant
     { expectedOrigins :: [ByteString]
@@ -235,11 +226,12 @@ renderURL url =
 type HTTPHeader = Network.HTTP.Types.Header
 
 fetchFromHttpUrl
-    :: URL
+    :: Manager
+    -> URL
     -> Maybe [HTTPHeader]
     -> StateT Status IO Text.Text
 #ifdef __GHCJS__
-fetchFromHttpUrl childURL Nothing = do
+fetchFromHttpUrl _ childURL Nothing = do
     let childURLText = renderURL childURL
 
     let childURLString = Text.unpack childURLText
@@ -253,13 +245,11 @@ fetchFromHttpUrl childURL Nothing = do
         _   -> fail (childURLString <> " returned a non-200 status code: " <> show statusCode)
 
     return body
-fetchFromHttpUrl _ _ = do
+fetchFromHttpUrl _ _ _ = do
     fail "Dhall does not yet support custom headers when built using GHCJS"
 #else
-fetchFromHttpUrl childURL mheaders = do
+fetchFromHttpUrl manager childURL mheaders = do
     let childURLString = Text.unpack (renderURL childURL)
-
-    m <- needManager
 
     request <- liftIO (HTTP.parseUrlThrow childURLString)
 
@@ -268,7 +258,7 @@ fetchFromHttpUrl childURL mheaders = do
               Nothing      -> request
               Just headers -> request { HTTP.requestHeaders = headers }
 
-    let io = HTTP.httpLbs requestWithHeaders m
+    let io = HTTP.httpLbs requestWithHeaders manager
 
     let handler e = do
             let _ = e :: HttpException

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -58,7 +58,7 @@ successTest path = do
         let unsetCache = Turtle.unset "XDG_CACHE_HOME"
 
         let load =
-                State.evalStateT (Import.loadWith actualExpr) (Import.emptyStatus directoryString)
+                State.evalStateT (Test.Util.loadWith actualExpr) (Import.emptyStatus directoryString)
 
         if Turtle.filename (Turtle.fromText path) == "hashFromCacheA.dhall"
             then do
@@ -81,7 +81,7 @@ failureTest path = do
         actualExpr <- Core.throws (Parser.exprFromText mempty text)
 
         Exception.catch
-          (do _ <- Import.load actualExpr
+          (do _ <- Test.Util.load actualExpr
 
               fail "Import should have failed, but it succeeds")
           (\(SourcedException _ (MissingImports _)) -> pure ()) )

--- a/dhall/tests/Dhall/Test/TypeCheck.hs
+++ b/dhall/tests/Dhall/Test/TypeCheck.hs
@@ -13,7 +13,6 @@ import qualified Control.Exception as Exception
 import qualified Control.Monad     as Monad
 import qualified Data.Text         as Text
 import qualified Dhall.Core        as Core
-import qualified Dhall.Import      as Import
 import qualified Dhall.Parser      as Parser
 import qualified Dhall.Test.Util   as Test.Util
 import qualified Dhall.TypeCheck   as TypeCheck
@@ -58,7 +57,7 @@ successTest prefix =
 
         let annotatedExpr = Core.Annot actualExpr expectedExpr
 
-        resolvedExpr <- Import.load annotatedExpr
+        resolvedExpr <- Test.Util.load annotatedExpr
 
         _ <- Core.throws (TypeCheck.typeOf resolvedExpr)
 
@@ -73,7 +72,7 @@ failureTest path = do
 
         let io :: IO Bool
             io = do
-                _ <- Import.load expression
+                _ <- Test.Util.load expression
                 return True
 
         let handler :: SomeException -> IO Bool

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -169,6 +169,11 @@ let
                           { }
                         );
 
+                    dhall-no-http =
+                      pkgsNew.haskell.lib.appendConfigureFlag
+                        haskellPackagesNew.dhall
+                        [ "-f-with-http" ];
+
                     dhall-bash =
                       haskellPackagesNew.callCabal2nix
                         "dhall-bash"
@@ -612,7 +617,15 @@ in
 
     inherit (pkgs) tarball-website website;
 
-    inherit (pkgs.haskell.packages."${compiler}") dhall dhall-bash dhall-json dhall-lsp-server dhall-nix dhall-try;
+    inherit (pkgs.haskell.packages."${compiler}")
+      dhall
+      dhall-no-http
+      dhall-bash
+      dhall-json
+      dhall-lsp-server
+      dhall-nix
+      dhall-try
+    ;
 
     inherit (pkgs.releaseTools) aggregate;
 

--- a/release.nix
+++ b/release.nix
@@ -60,6 +60,9 @@ in
           coverage.dhall
           coverage.dhall-json
 
+          # Check that the package builds with HTTP support compiled out
+          shared.dhall-no-http
+
           (shared.trivial src.rev)
         ];
       };


### PR DESCRIPTION
**NOTE:** This PR includes the changes in PR #1157.

Implements a mock http client that handles requests to:
- `https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/`
- `https://test.dhall-lang.org/Bool/package.dhall`
- `https://httpbin.org/user-agent`

This allows tests involving remote imports to succeed even when compiled
without the `with-http` flag. Addresses #1135. 