### PR TITLE
Fix CSS for `dhall-lang.org` in Safari

### DIFF
--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -19,12 +19,14 @@
         overflow: auto;
         width: 60ch !important;
         display: inline-block;
+        vertical-align: middle;
       }
 
       #output-pane {
         overflow: auto;
         width: 60ch !important;
         display: inline-block;
+        vertical-align: middle;
       }
 
       .CodeMirror {


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/issues/609

Safari requires a vertical alignment CSS directive in order to render the
input and output panes side-by-side