### PR TITLE
Simplify `dhall version` output to just version string

### DIFF
--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -363,14 +363,7 @@ command (Options {..}) = do
 
     handle $ case mode of
         Version -> do
-            let line₀ = "Haskell package version: "
-                    <>  Data.Text.pack (showVersion Meta.version)
-
-            let line₁ = "Standard version: "
-                    <>  Dhall.Binary.renderStandardVersion Dhall.Binary.defaultStandardVersion
-
-            Data.Text.IO.putStrLn line₀
-            Data.Text.IO.putStrLn line₁
+            putStrLn (showVersion Meta.version)
 
         Default {..} -> do
             expression <- getExpression file


### PR DESCRIPTION
The motivation for this is two-fold:

* To get rid of the standard version from the output

  Currently it's just "None", which could be fixed, but keeping it up to
  date is error-prone, so I prefer to just remove it.

* To make the output machine-readable

Example:

```
$ dhall version
1.24.0
```