### PR TITLE
Remove most uses of `StandardVersion` from the API

### DIFF
--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
@@ -22,7 +22,6 @@ import Dhall.Parser (Src)
 import Dhall.TypeCheck (X)
 import Dhall.Core (Expr)
 
-import qualified Dhall.Binary as Dhall
 import qualified Dhall.Core as Dhall
 import qualified Dhall.Import as Dhall
 import qualified Dhall.Parser as Dhall
@@ -166,5 +165,5 @@ normalize (WellTyped expr) = Normal $ Dhall.normalize expr
 --   Dhall's hash annotations (prefixed by "sha256:" and base-64 encoded).
 hashNormalToCode :: Normal -> Text
 hashNormalToCode (Normal expr) =
-  Dhall.hashExpressionToCode Dhall.defaultStandardVersion alphaNormal
+  Dhall.hashExpressionToCode alphaNormal
   where alphaNormal = Dhall.alphaNormalize expr

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -30,7 +30,6 @@ module Dhall
     , sourceName
     , startingContext
     , normalizer
-    , standardVersion
     , defaultInputSettings
     , InputSettings
     , defaultEvaluateSettings
@@ -121,7 +120,6 @@ import Data.Text.Prettyprint.Doc (Pretty)
 import Data.Typeable (Typeable)
 import Data.Vector (Vector)
 import Data.Word (Word8, Word16, Word32, Word64)
-import Dhall.Binary (StandardVersion(..))
 import Dhall.Core (Expr(..), Chunks(..))
 import Dhall.Import (Imported(..))
 import Dhall.Parser (Src(..))
@@ -148,7 +146,6 @@ import qualified Data.Text
 import qualified Data.Text.IO
 import qualified Data.Text.Lazy
 import qualified Data.Vector
-import qualified Dhall.Binary
 import qualified Dhall.Context
 import qualified Dhall.Core
 import qualified Dhall.Import
@@ -297,7 +294,6 @@ sourceName k s =
 data EvaluateSettings = EvaluateSettings
   { _startingContext :: Dhall.Context.Context (Expr Src X)
   , _normalizer      :: Maybe (Dhall.Core.ReifiedNormalizer X)
-  , _standardVersion :: StandardVersion
   }
 
 -- | Default evaluation settings: no extra entries in the initial
@@ -308,7 +304,6 @@ defaultEvaluateSettings :: EvaluateSettings
 defaultEvaluateSettings = EvaluateSettings
   { _startingContext = Dhall.Context.empty
   , _normalizer      = Nothing
-  , _standardVersion = Dhall.Binary.defaultStandardVersion
   }
 
 -- | Access the starting context used for evaluation and type-checking.
@@ -334,17 +329,6 @@ normalizer = evaluateSettings . l
     l :: (Functor f)
       => LensLike' f EvaluateSettings (Maybe (Dhall.Core.ReifiedNormalizer X))
     l k s = fmap (\x -> s { _normalizer = x }) (k (_normalizer s))
-
--- | Access the standard version (used primarily when encoding or decoding
--- Dhall expressions to and from a binary representation)
---
--- @since 1.17
-standardVersion
-    :: (Functor f, HasEvaluateSettings s)
-    => LensLike' f s StandardVersion
-standardVersion = evaluateSettings . l
-  where
-  l k s = fmap (\x -> s { _standardVersion = x}) (k (_standardVersion s))
 
 -- | @since 1.16
 class HasEvaluateSettings s where
@@ -408,8 +392,7 @@ inputWithSettings settings (Type {..}) txt = do
     let EvaluateSettings {..} = _evaluateSettings
 
     let transform =
-               set Dhall.Import.standardVersion _standardVersion
-            .  set Dhall.Import.normalizer      _normalizer
+               set Dhall.Import.normalizer      _normalizer
             .  set Dhall.Import.startingContext _startingContext
 
     let status = transform (Dhall.Import.emptyStatus _rootDirectory)
@@ -503,8 +486,7 @@ inputExprWithSettings settings txt = do
     let EvaluateSettings {..} = _evaluateSettings
 
     let transform =
-               set Dhall.Import.standardVersion _standardVersion
-            .  set Dhall.Import.normalizer      _normalizer
+               set Dhall.Import.normalizer      _normalizer
             .  set Dhall.Import.startingContext _startingContext
 
     let status = transform (Dhall.Import.emptyStatus _rootDirectory)

--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -10,8 +10,6 @@
 module Dhall.Binary
     ( -- * Standard versions
       StandardVersion(..)
-    , defaultStandardVersion
-    , parseStandardVersion
     , renderStandardVersion
 
     -- * Encoding and decoding
@@ -49,7 +47,6 @@ import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid ((<>))
 import Data.Text (Text)
-import Options.Applicative (Parser)
 import Prelude hiding (exponent)
 import GHC.Float (double2Float, float2Double)
 
@@ -61,7 +58,6 @@ import qualified Data.Sequence
 import qualified Dhall.Core
 import qualified Dhall.Map
 import qualified Dhall.Set
-import qualified Options.Applicative
 
 -- | Supported version strings
 data StandardVersion
@@ -78,29 +74,6 @@ data StandardVersion
     | V_1_0_0
     -- ^ Version "1.0.0"
     deriving (Enum, Bounded)
-
-defaultStandardVersion :: StandardVersion
-defaultStandardVersion = NoVersion
-
-parseStandardVersion :: Parser StandardVersion
-parseStandardVersion =
-    Options.Applicative.option readVersion
-        (   Options.Applicative.long "standard-version"
-        <>  Options.Applicative.metavar "X.Y.Z"
-        <>  Options.Applicative.help "The standard version to use"
-        <>  Options.Applicative.value defaultStandardVersion
-        )
-  where
-    readVersion = do
-        string <- Options.Applicative.str
-        case string :: Text of
-            "none"  -> return NoVersion
-            "1.0.0" -> return V_1_0_0
-            "2.0.0" -> return V_2_0_0
-            "3.0.0" -> return V_3_0_0
-            "4.0.0" -> return V_4_0_0
-            "5.0.0" -> return V_5_0_0
-            _       -> fail "Unsupported version"
 
 renderStandardVersion :: StandardVersion -> Text
 renderStandardVersion NoVersion = "none"

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -119,7 +119,6 @@ module Dhall.Import (
     , graph
     , remote
     , toHeaders
-    , standardVersion
     , normalizer
     , startingContext
     , chainImport
@@ -523,8 +522,8 @@ loadImportWithSemanticCache
                 Just bytes -> liftIO $ writeToSemanticCache semanticHash bytes
                 Nothing -> do
                     let expectedHash = semanticHash
-                    Status { _standardVersion, _stack } <- State.get
-                    let actualHash = hashExpression _standardVersion (Dhall.Core.alphaNormalize importSemantics)
+                    Status { _stack } <- State.get
+                    let actualHash = hashExpression (Dhall.Core.alphaNormalize importSemantics)
                     throwMissingImport (Imported _stack (HashMismatch {..}))
 
             return (ImportSemantics {..})
@@ -541,7 +540,7 @@ fetchFromSemanticCache expectedHash = Maybe.runMaybeT $ do
 writeExpressionToSemanticCache :: Expr Src X -> IO ()
 writeExpressionToSemanticCache expression = writeToSemanticCache hash bytes
   where
-    bytes = encodeExpression Dhall.Binary.defaultStandardVersion expression
+    bytes = encodeExpression NoVersion expression
     hash = Crypto.Hash.hash bytes
 
 writeToSemanticCache :: Crypto.Hash.Digest SHA256 -> Data.ByteString.ByteString -> IO ()
@@ -608,7 +607,7 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
                 Left  err -> throwMissingImport (Imported _stack err)
                 Right _ -> return (Dhall.Core.normalizeWith _normalizer resolvedExpr)
 
-            let bytes = encodeExpression _standardVersion betaNormal
+            let bytes = encodeExpression NoVersion betaNormal
             lift $ writeToSemisemanticCache semisemanticHash bytes
 
             return betaNormal
@@ -654,8 +653,7 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Loc
 -- https://github.com/dhall-lang/dhall-haskell/issues/1098 for further
 -- discussion.
 computeSemisemanticHash :: Expr Src X -> Crypto.Hash.Digest Crypto.Hash.SHA256
-computeSemisemanticHash resolvedExpr =
-    hashExpression Dhall.Binary.defaultStandardVersion resolvedExpr
+computeSemisemanticHash resolvedExpr = hashExpression resolvedExpr
 
 -- Fetch encoded normal form from "semi-semantic cache"
 fetchFromSemisemanticCache :: Crypto.Hash.Digest SHA256 -> IO (Maybe Data.ByteString.ByteString)
@@ -977,7 +975,7 @@ load expression = State.evalStateT (loadWith expression) (emptyStatus ".")
 encodeExpression
     :: forall s
     .  StandardVersion
-    -- ^ `Nothing` means to encode without the version tag
+    -- ^ `NoVersion` means to encode without the version tag
     -> Expr s X
     -> Data.ByteString.ByteString
 encodeExpression _standardVersion expression = bytesStrict
@@ -1001,10 +999,9 @@ encodeExpression _standardVersion expression = bytesStrict
     bytesStrict = Data.ByteString.Lazy.toStrict bytesLazy
 
 -- | Hash a fully resolved expression
-hashExpression
-    :: StandardVersion -> Expr s X -> (Crypto.Hash.Digest SHA256)
-hashExpression _standardVersion expression =
-    Crypto.Hash.hash (encodeExpression _standardVersion expression)
+hashExpression :: Expr s X -> (Crypto.Hash.Digest SHA256)
+hashExpression expression =
+    Crypto.Hash.hash (encodeExpression NoVersion expression)
 
 {-| Convenience utility to hash a fully resolved expression and return the
     base-16 encoded hash with the @sha256:@ prefix
@@ -1012,9 +1009,9 @@ hashExpression _standardVersion expression =
     In other words, the output of this function can be pasted into Dhall
     source code to add an integrity check to an import
 -}
-hashExpressionToCode :: StandardVersion -> Expr s X -> Text
-hashExpressionToCode _standardVersion expr =
-    "sha256:" <> Text.pack (show (hashExpression _standardVersion expr))
+hashExpressionToCode :: Expr s X -> Text
+hashExpressionToCode expr =
+    "sha256:" <> Text.pack (show (hashExpression expr))
 
 -- | A call to `assertNoImports` failed because there was at least one import
 data ImportResolutionDisabled = ImportResolutionDisabled deriving (Exception)

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -11,7 +11,6 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import Data.Semigroup ((<>))
 import Data.Text.Prettyprint.Doc (Pretty(..))
-import Dhall.Binary (StandardVersion(..))
 import Dhall.Context (Context)
 import Dhall.Core
   ( Directory (..)
@@ -30,7 +29,6 @@ import Dhall.TypeCheck (X)
 import Lens.Family (LensLike')
 import System.FilePath (isRelative, splitDirectories)
 
-import qualified Dhall.Binary
 import qualified Dhall.Context
 import qualified Data.Map      as Map
 import qualified Data.Text
@@ -71,8 +69,6 @@ data Status = Status
     , _remote :: URL -> StateT Status IO Data.Text.Text
     -- ^ The remote resolver, fetches the content at the given URL.
 
-    , _standardVersion :: StandardVersion
-
     , _normalizer :: Maybe (ReifiedNormalizer X)
 
     , _startingContext :: Context (Expr Src X)
@@ -90,8 +86,6 @@ emptyStatusWith _remote rootDirectory = Status {..}
     _cache = Map.empty
 
     _manager = Nothing
-
-    _standardVersion = Dhall.Binary.defaultStandardVersion
 
     _normalizer = Nothing
 
@@ -125,10 +119,6 @@ cache k s = fmap (\x -> s { _cache = x }) (k (_cache s))
 
 remote :: Functor f => LensLike' f Status (URL -> StateT Status IO Data.Text.Text)
 remote k s = fmap (\x -> s { _remote = x }) (k (_remote s))
-
-standardVersion :: Functor f => LensLike' f Status StandardVersion
-standardVersion k s =
-    fmap (\x -> s { _standardVersion = x }) (k (_standardVersion s))
 
 normalizer :: Functor f => LensLike' f Status (Maybe (ReifiedNormalizer X))
 normalizer k s = fmap (\x -> s {_normalizer = x}) (k (_normalizer s))

--- a/dhall/tests/Dhall/Test/SemanticHash.hs
+++ b/dhall/tests/Dhall/Test/SemanticHash.hs
@@ -10,7 +10,6 @@ import Turtle (FilePath)
 
 import qualified Data.Text                             as Text
 import qualified Data.Text.IO                          as Text.IO
-import qualified Dhall.Binary                          as Binary
 import qualified Dhall.Core                            as Core
 import qualified Dhall.Import                          as Import
 import qualified Dhall.Parser                          as Parser
@@ -40,7 +39,7 @@ hashTest prefix =
 
         let normalized = Core.alphaNormalize (Core.normalize resolved)
 
-        let actualHash = Import.hashExpressionToCode Binary.defaultStandardVersion normalized
+        let actualHash = Import.hashExpressionToCode normalized
 
         expectedHash <- Text.stripEnd <$> Text.IO.readFile (Text.unpack hashFile)
 


### PR DESCRIPTION
We no longer support multiple versions of the standard, except for
supporting old integrity checks, so this change removes all inessential
uses of `StandardVersion` from the API and command-line interface.