### PR TITLE
Prevent "Natural/subtract 0" from causing a panic

### DIFF
--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -416,7 +416,7 @@ eval !env t =
                                       n             -> VNaturalToInteger n
     NaturalShow      -> VPrim $ \case VNaturalLit n -> VTextLit (VChunks [] (Data.Text.pack (show n)))
                                       n             -> VNaturalShow n
-    NaturalSubtract  -> VPrim $ \x -> VPrim $ \y ->
+    NaturalSubtract  -> VPrim $ \x -> VHLam (Typed "n" VNatural) $ \y ->
                           case (x,y) of
                             (VNaturalLit x, VNaturalLit y)
                               | y >= x    -> VNaturalLit (subtract x y)

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -140,6 +140,7 @@ data HLamInfo a
   | NaturalFoldCl (Val a)
   | ListFoldCl (Val a)
   | OptionalFoldCl (Val a)
+  | NaturalSubtractZero
 
 pattern VPrim :: (Val a -> Val a) -> Val a
 pattern VPrim f = VHLam Prim f
@@ -416,14 +417,19 @@ eval !env t =
                                       n             -> VNaturalToInteger n
     NaturalShow      -> VPrim $ \case VNaturalLit n -> VTextLit (VChunks [] (Data.Text.pack (show n)))
                                       n             -> VNaturalShow n
-    NaturalSubtract  -> VPrim $ \x -> VHLam (Typed "n" VNatural) $ \y ->
-                          case (x,y) of
-                            (VNaturalLit x, VNaturalLit y)
-                              | y >= x    -> VNaturalLit (subtract x y)
-                              | otherwise -> VNaturalLit 0
-                            (VNaturalLit 0, y) -> y
-                            (x, VNaturalLit 0) -> VNaturalLit 0
-                            (x, y) -> VNaturalSubtract x y
+    NaturalSubtract -> VPrim $ \case
+                         VNaturalLit 0 ->
+                           VHLam NaturalSubtractZero id
+                         x@(VNaturalLit m) ->
+                           VPrim $ \case
+                               VNaturalLit n
+                                 | n >= m    -> VNaturalLit (subtract m n)
+                                 | otherwise -> VNaturalLit 0
+                               y -> VNaturalSubtract x y
+                         x ->
+                           VPrim $ \case
+                             VNaturalLit 0 -> VNaturalLit 0
+                             y -> VNaturalSubtract x y
     NaturalPlus t u  -> vNaturalPlus (evalE t) (evalE u)
     NaturalTimes t u -> case (evalE t, evalE u) of
                           (VNaturalLit 1, u            ) -> u
@@ -800,6 +806,7 @@ quote !env !t =
                                        NaturalFoldCl{}           -> quote env (t VPrimVar)
                                        ListFoldCl{}              -> quote env (t VPrimVar)
                                        OptionalFoldCl{}          -> quote env (t VPrimVar)
+                                       NaturalSubtractZero       -> App NaturalSubtract (NaturalLit 0)
 
     VPi a (freshCl -> (x, v, b))  -> Pi x (quoteE a) (quoteBind x (inst b v))
     VHPi (fresh -> (x, v)) a b    -> Pi x (quoteE a) (quoteBind x (b v))


### PR DESCRIPTION
Previously, normalizing `Natural/subtract 0` would result in this error:

    ⊢ Natural/subtract 0

    Error: Compiler bug

    An ill-typed expression was encountered during normalization.
    Explanation: This error message means that there is a bug in the Dhall compiler.
    You didn't do anything wrong, but if you would like to see this problem fixed
    then you should report the bug at:

    https://github.com/dhall-lang/dhall-haskell/issues

    CallStack (from HasCallStack):
      error, called at src/Dhall/Eval.hs:865:38 in dhall-1.25.0-FCOZ7uxqivz8dkVwuN7aED:Dhall.Eval

The new output is

    ⊢ Natural/subtract 0

    λ(n : Natural) → n