### PR TITLE
Try to improve AppVeyor's dependency caching

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,12 +24,7 @@ install:
   - git submodule update --init --recursive
 
 cache:
-  - C:\sr -> '%STACK_YAML%'
-  - .stack-work -> '%STACK_YAML%'
-  - dhall\.stack-work -> '%STACK_YAML%'
-  - dhall-json\.stack-work -> '%STACK_YAML%'
-  - dhall-bash\.stack-work -> '%STACK_YAML%'
-  - dhall-lsp-server\.stack-work -> '%STACK_YAML%'
+  - '%STACK_ROOT% -> %STACK_YAML%, appveyor.yml'
 
 for:
 -


### PR DESCRIPTION
* This might fix a syntax problem:
  https://www.appveyor.com/docs/build-cache/#configuring-cache-items
  says:

      Note the use of single quotes around the entire line, when
      environment variables are used.

* This adds the AppVeyor config to the files which invalidate the cache
  when changed.

Context: #1063.