### PR TITLE
Fix isNormalized for field selections

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -2013,9 +2013,9 @@ isNormalized e0 = loop (denote e0)
       Field r k -> case r of
           RecordLit _ -> False
           Project _ _ -> False
-          Combine x@(RecordLit m) y -> loop x && loop y && Dhall.Map.member k m
-          Combine x (RecordLit m) -> loop x && Dhall.Map.toList (fmap loop m) == [(k, True)]
-          Prefer x@(RecordLit m) y -> loop x && loop y && Dhall.Map.member k m
+          Combine (RecordLit m) _ -> Dhall.Map.member k m && loop r
+          Combine _ (RecordLit m) -> Dhall.Map.keys m == [k] && loop r
+          Prefer (RecordLit m) _ -> Dhall.Map.member k m && loop r
           Prefer _ (RecordLit _) -> False
           _ -> loop r
       Project r p -> loop r &&


### PR DESCRIPTION
In expressions like

    ({ x : Optional/fold } // {=}).x

`isNormalized` didn't check if the expression being selected from
was normalized.

Fixes #1209.