### PR TITLE
Tune the AppVeyor config some more

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,9 @@ install:
 
 cache:
   - '%STACK_ROOT% -> %STACK_YAML%, appveyor.yml'
+  - '.stack-work -> %STACK_YAML%, appveyor.yml'
+  - 'dhall/.stack-work -> %STACK_YAML%, appveyor.yml'
+  - 'dhall-bash/.stack-work -> %STACK_YAML%, appveyor.yml'
 
 for:
 -

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ for:
     - stack test dhall-json
     - stack test dhall-bash
     # - stack test dhall-lsp-server # Disabled while the tests are broken.
-    - stack bench --benchmark-arguments "--quick --min-duration=0 --include-first-iter"
+    - stack bench dhall --benchmark-arguments "--quick --min-duration=0 --include-first-iter"
     
 -
   matrix:


### PR DESCRIPTION
We are already at ~18 minutes now –  which is nice – but maybe we can speed up the build even some more:

* Try to cache the extra-deps from stack-lts-6.yaml

* Limit `stack bench` to the dhall package

    For some reason `stack bench` triggers a rebuild of _all_ the local
    packages, which we don't need.