### PR TITLE
dhall-lsp-server: Only underline link in import

### DIFF
--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Diagnostics.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Diagnostics.hs
@@ -22,6 +22,7 @@ import Dhall.Core (Expr(Note, Embed), subExpressions)
 
 import Dhall.LSP.Util
 import Dhall.LSP.Backend.Dhall
+import Dhall.LSP.Backend.Parsing (getImportLink)
 
 import Control.Lens (toListOf)
 import Control.Monad.Trans.Writer (Writer, execWriter, tell)
@@ -155,7 +156,7 @@ offsetToPosition txt off = (length ls - 1, Text.length (NonEmpty.last ls))
 --   with their associated range in the source code.
 embedsWithRanges :: Expr Src a -> [(Range, a)]
 embedsWithRanges =
-  map (\(src, a) -> (rangeFromDhall src, a)) . execWriter . go
+  map (\(src, a) -> (rangeFromDhall . getImportLink $ src, a)) . execWriter . go
   where go :: Expr Src a -> Writer [(Src, a)] ()
         go (Note src (Embed a)) = tell [(src, a)]
         go expr = mapM_ go (toListOf subExpressions expr)


### PR DESCRIPTION
This restricts the clickable link part of an import to just the actual
link; previously we also underlined hash and headers if those were
present.

Now:
```
./Bool/package.dhall sha256:7ee950e7c2142be5923f76d00263e536b71d96cb9c190d7743c1679501ddeb0a
~~~~~~~~~~~~~~~~~~~~
```

Previously:
```
./Bool/package.dhall sha256:7ee950e7c2142be5923f76d00263e536b71d96cb9c190d7743c1679501ddeb0a
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```