### PR TITLE
dhall-lsp-server: Remove superfluous language extensions

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -37,7 +37,7 @@ library
       Dhall.LSP.Util
   hs-source-dirs:
       src
-  default-extensions: LambdaCase OverloadedStrings FlexibleInstances TypeApplications RecordWildCards ScopedTypeVariables
+  default-extensions: RecordWildCards OverloadedStrings ScopedTypeVariables
   build-depends:
       aeson                >= 1.3.1.1  && < 1.5
     , aeson-pretty         >= 0.8.7    && < 0.9
@@ -74,7 +74,7 @@ executable dhall-lsp-server
       Paths_dhall_lsp_server
   hs-source-dirs:
       app
-  default-extensions: LambdaCase OverloadedStrings FlexibleInstances TypeApplications RecordWildCards ScopedTypeVariables
+  default-extensions: LambdaCase OverloadedStrings
   ghc-options: -rtsopts
   build-depends:
       base >=4.7 && <5

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -37,7 +37,7 @@ library
       Dhall.LSP.Util
   hs-source-dirs:
       src
-  default-extensions: RecordWildCards OverloadedStrings ScopedTypeVariables
+  default-extensions: RecordWildCards OverloadedStrings
   build-depends:
       aeson                >= 1.3.1.1  && < 1.5
     , aeson-pretty         >= 0.8.7    && < 0.9

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -74,7 +74,7 @@ executable dhall-lsp-server
       Paths_dhall_lsp_server
   hs-source-dirs:
       app
-  default-extensions: LambdaCase OverloadedStrings
+  default-extensions: RecordWildCards OverloadedStrings
   ghc-options: -rtsopts
   build-depends:
       base >=4.7 && <5

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
@@ -29,12 +29,11 @@ diagLetInLet _ = []
 
 -- Given a (noted) let block compute all unused variables in the block.
 unusedBindings :: Eq a => Expr s a -> [Text]
-unusedBindings (Note _ (Let bindings d)) = concatMap
-  (\case
-    Binding var _ _ : [] | not (V var 0 `freeIn` d) -> [var]
-    Binding var _ _ : (b : bs) | not (V var 0 `freeIn` Let (b :| bs) d) -> [var]
-    _ -> [])
-  (toList $ tails bindings)
+unusedBindings (Note _ (Let bindings d)) =
+  let go (Binding var _ _ : []) | not (V var 0 `freeIn` d) = [var]
+      go (Binding var _ _ : (b : bs)) | not (V var 0 `freeIn` Let (b :| bs) d) = [var]
+      go _ = []
+  in concatMap go (toList $ tails bindings)
 unusedBindings _ = []
 
 -- Diagnose unused let bindings.

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
@@ -340,7 +340,7 @@ executeLintAndFormat request = do
 
 executeAnnotateLet :: J.ExecuteCommandRequest -> HandlerM ()
 executeAnnotateLet request = do
-  args :: J.TextDocumentPositionParams <- getCommandArguments request
+  args <- getCommandArguments request :: HandlerM J.TextDocumentPositionParams
   let uri = args ^. J.textDocument . J.uri
       line = args ^. J.position . J.line
       col = args ^. J.position . J.character
@@ -396,7 +396,7 @@ executeFreezeAllImports request = do
 
 executeFreezeImport :: J.ExecuteCommandRequest -> HandlerM ()
 executeFreezeImport request = do
-  args :: J.TextDocumentPositionParams <- getCommandArguments request
+  args <- getCommandArguments request :: HandlerM J.TextDocumentPositionParams
   let uri = args ^. J.textDocument . J.uri
       line = args ^. J.position . J.line
       col = args ^. J.position . J.character


### PR DESCRIPTION
Removes superfluous language extensions from `dhall-lsp-server.cabal`.