### PR TITLE
Treat multi-lets as syntactic sugar

### DIFF
--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -649,17 +649,12 @@ convertToHomogeneousMaps (Conversion {..}) e0 = loop (Core.normalize e0)
             a' = loop a
             b' = loop b
 
-        Core.Let as b ->
-            Core.Let as' b'
+        Core.Let a b c d ->
+            Core.Let a b' c' d'
           where
-            f (Core.Binding x y z) = Core.Binding x y' z'
-              where
-                y' = fmap loop y
-                z' =      loop z
-
-            as' = fmap f as
-
-            b' = loop b
+            b' = fmap loop b
+            c' =      loop c
+            d' =      loop d
 
         Core.Annot a b ->
             Core.Annot a' b'

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
@@ -9,10 +9,9 @@ import System.Environment (getEnvironment)
 import System.Timeout (timeout)
 
 import Dhall.Context (empty, toList)
-import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Text as Text
 import Dhall.Context (Context, insert)
-import Dhall.Core (Expr(..), Binding(..), Var(..), normalize, shift, subst, pretty, reservedIdentifiers)
+import Dhall.Core (Expr(..), Var(..), normalize, shift, subst, pretty, reservedIdentifiers)
 import Dhall.TypeCheck (X, typeWithA, typeOf)
 import Dhall.Parser (Src, exprFromText)
 import qualified Dhall.Map
@@ -78,7 +77,7 @@ buildCompletionContext = buildCompletionContext' empty empty
 
 buildCompletionContext' :: Context (Expr Src X) -> Context (Expr Src X)
   -> Expr Src X -> CompletionContext
-buildCompletionContext' context values (Let (Binding x mA a :| []) e)
+buildCompletionContext' context values (Let x mA a e)
   -- We prefer the actual value over the annotated type in order to get
   -- 'dependent let' behaviour whenever possible.
   | Right _A <- typeWithA absurd context a =

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
@@ -6,14 +6,16 @@ module Dhall.LSP.Backend.Linting
 where
 
 import Dhall.Parser (Src)
-import Dhall.Core (Expr(..), Binding(..), Var(..), subExpressions, freeIn, Import)
+import Dhall.Core ( Expr(..), Binding(..), MultiLet(..), Var(..), Import
+                  , subExpressions, freeIn, multiLet, wrapInLets)
 import qualified Dhall.Lint as Dhall
 
 import Dhall.LSP.Backend.Diagnostics
 
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Maybe (maybeToList)
 import Data.Monoid ((<>))
 import Data.Text (Text)
-import Data.List.NonEmpty (NonEmpty(..), tails, toList)
 import Control.Lens (universeOf)
 
 data Suggestion = Suggestion {
@@ -21,31 +23,35 @@ data Suggestion = Suggestion {
     suggestion :: Text
     }
 
--- Diagnose nested let blocks.
-diagLetInLet :: Expr Src a -> [Suggestion]
-diagLetInLet (Note _ (Let _ (Note src (Let _ _)))) =
-  [Suggestion (rangeFromDhall src) "Superfluous 'in' before nested let binding"]
-diagLetInLet _ = []
+-- Diagnose nested let-blocks.
+--
+-- Pattern matching on a 'Let' wrapped in a 'Note' prevents us from repeating
+-- the search beginning at different @let@s in the same let-block – only
+-- the outermost 'Let' of a let-block is wrapped in a 'Note'.
+diagLetInLet :: Expr Src a -> Maybe Suggestion
+diagLetInLet (Note _ (Let x mA a b)) = case multiLet x mA a b of
+    MultiLet _ (Note src (Let _ _ _ _)) ->
+      Just (Suggestion (rangeFromDhall src) "Superfluous 'in' before nested let binding")
+    _ -> Nothing
+diagLetInLet _ = Nothing
 
--- Given a (noted) let block compute all unused variables in the block.
-unusedBindings :: Eq a => Expr s a -> [Text]
-unusedBindings (Note _ (Let bindings d)) =
-  let go (Binding var _ _ : []) | not (V var 0 `freeIn` d) = [var]
-      go (Binding var _ _ : (b : bs)) | not (V var 0 `freeIn` Let (b :| bs) d) = [var]
+-- Given a let-block compute all unused variables in the block.
+unusedBindings :: Eq a => MultiLet s a -> [Text]
+unusedBindings (MultiLet bindings d) =
+  let go (Binding var _ _ : bs) | not (V var 0 `freeIn` wrapInLets bs d) = [var]
       go _ = []
-  in concatMap go (toList $ tails bindings)
-unusedBindings _ = []
+  in foldMap go (NonEmpty.tails bindings)
 
 -- Diagnose unused let bindings.
-diagUnusedBinding :: Eq a => Expr Src a -> [Suggestion]
-diagUnusedBinding e@(Note src (Let _ _)) = map
+diagUnusedBindings :: Eq a => Expr Src a -> [Suggestion]
+diagUnusedBindings (Note src (Let x mA a e)) = map
   (\var ->
     Suggestion (rangeFromDhall src) ("Unused let binding '" <> var <> "'"))
-  (unusedBindings e)
-diagUnusedBinding _ = []
+  (unusedBindings (multiLet x mA a e))
+diagUnusedBindings _ = []
 
 -- | Given an dhall expression suggest all the possible improvements that would
 --   be made by the linter.
 suggest :: Expr Src Import -> [Suggestion]
-suggest expr = concat [ diagLetInLet e ++ diagUnusedBinding e
+suggest expr = concat [ maybeToList (diagLetInLet e) ++ diagUnusedBindings e
                       | e <- universeOf subExpressions expr ]

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
@@ -11,9 +11,8 @@ module Dhall.LSP.Backend.Parsing
   )
 where
 
-import Data.List.NonEmpty (NonEmpty(..))
 import Data.Text (Text)
-import Dhall.Core (Expr(..), Import, Binding(..), Var(..))
+import Dhall.Core (Expr(..), Import, Var(..))
 import Dhall.Src (Src(..))
 import Dhall.Parser
 import Dhall.Parser.Token
@@ -227,7 +226,7 @@ binderExprFromText txt =
       value <- try (do _equal; expr)
           <|> (do skipManyTill anySingle (lookAhead boundary <|> _in); return holeExpr)
       inner <- parseBinderExpr
-      return (Let (Binding name mType value :| []) inner)
+      return (Let name mType value inner)
 
     forallBinder = do
       _forall

--- a/dhall-nix/src/Dhall/Nix.hs
+++ b/dhall-nix/src/Dhall/Nix.hs
@@ -96,7 +96,7 @@ import Data.Fix (Fix(..))
 import Data.Traversable (for)
 import Data.Typeable (Typeable)
 import Data.Void (absurd)
-import Dhall.Core (Chunks(..), Const(..), Expr(..), Var(..))
+import Dhall.Core (Chunks(..), Const(..), Expr(..), MultiLet(..), Var(..))
 import Dhall.TypeCheck (X)
 import Nix.Atoms (NAtom(..))
 import Nix.Expr
@@ -230,7 +230,8 @@ dhallToNix e = loop (Dhall.Core.normalize e)
         a' <- loop a
         b' <- loop b
         return (Fix (NBinary NApp a' b'))
-    loop (Let as b) = do
+    loop (Let x mA a0 b0) = do
+        let MultiLet as b = Dhall.Core.multiLet x mA a0 b0
         as' <- for as $ \a -> do
           val <- loop $ Dhall.Core.value a
           pure $ NamedVar [StaticKey $ Dhall.Core.variable a] val Nix.nullPos

--- a/dhall/benchmark/deep-nested-large-record/Main.hs
+++ b/dhall/benchmark/deep-nested-large-record/Main.hs
@@ -25,7 +25,7 @@ issue412 :: Core.Expr s TypeCheck.X -> Gauge.Benchmarkable
 issue412 prelude = Gauge.whnf TypeCheck.typeOf expr
   where
     expr
-      = Core.Let (pure (Core.Binding "prelude" Nothing prelude))
+      = Core.Let "prelude" Nothing prelude
       $ Core.ListLit Nothing
       $ Seq.replicate 5
       $ Core.Var (Core.V "prelude" 0) `Core.Field` "types" `Core.Field` "Little" `Core.Field` "Foo"
@@ -33,15 +33,12 @@ issue412 prelude = Gauge.whnf TypeCheck.typeOf expr
 unionPerformance :: Core.Expr s TypeCheck.X -> Gauge.Benchmarkable
 unionPerformance prelude = Gauge.whnf TypeCheck.typeOf expr
   where
-    innerBinding =
-        Core.Binding "big" Nothing
-            (prelude `Core.Field` "types" `Core.Field` "Big")
-
-    outerBinding =
-        Core.Binding "x" Nothing
-            (Core.Let (pure innerBinding) (Core.Prefer "big" "big"))
-
-    expr = Core.Let (pure outerBinding) "x"
+    expr =
+        Core.Let "x" Nothing
+            (Core.Let "big" Nothing (prelude `Core.Field` "types" `Core.Field` "Big")
+                (Core.Prefer "big" "big")
+            )
+            "x"
 
 main :: IO ()
 main = do

--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -25,7 +25,7 @@ import Data.String (IsString(..))
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty)
 import Data.Void (Void)
-import Dhall.Core (Binding(..), Chunks (..), Const(..), Expr(..), Var(..))
+import Dhall.Core (Chunks (..), Const(..), Expr(..), Var(..))
 import Dhall.Binary (ToTerm)
 import Dhall.Map (Map)
 import Dhall.Set (Set)
@@ -650,21 +650,20 @@ diff l@(BoolIf {}) r =
     mismatch l r
 diff l r@(BoolIf {}) =
     mismatch l r
-diff (Let asL bL ) (Let asR bR) =
-    enclosed' "" (keyword "in" <> "  ")
-        (Data.List.NonEmpty.zipWith docA asL asR <> pure docB)
+diff l@(Let {}) r@(Let {}) =
+    enclosed' "    " (keyword "in" <> "  ") (docs l r)
   where
-    docA (Binding cL dL eL) (Binding cR dR eR) = align doc
+    docs (Let aL bL cL dL) (Let aR bR cR dR) =
+        Data.List.NonEmpty.cons (align doc) (docs dL dR)
       where
         doc =   keyword "let"
             <>  " "
-            <>  format " " (diffLabel cL cR)
-            <>  format " " (diffMaybe (colon <> " ") diff dL dR)
+            <>  format " " (diffLabel aL aR)
+            <>  format " " (diffMaybe (colon <> " ") diff bL bR)
             <>  equals
             <>  " "
-            <>  diff eL eR
-
-    docB = diff bL bR
+            <>  diff cL cR
+    docs aL aR = pure (diff aL aR)
 diff l@(Let {}) r =
     mismatch l r
 diff l r@(Let {}) =

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -159,7 +159,6 @@ import System.FilePath ((</>))
 import Dhall.Binary (StandardVersion(..))
 import Dhall.Core
     ( Expr(..)
-    , Binding(..)
     , Chunks(..)
     , Directory(..)
     , File(..)
@@ -906,9 +905,7 @@ loadWith expr₀ = case expr₀ of
   Lam a b c            -> Lam <$> pure a <*> loadWith b <*> loadWith c
   Pi a b c             -> Pi <$> pure a <*> loadWith b <*> loadWith c
   App a b              -> App <$> loadWith a <*> loadWith b
-  Let as b             -> Let <$> traverse f as <*> loadWith b
-    where
-      f (Binding c d e) = Binding c <$> traverse loadWith d <*> loadWith e
+  Let a b c d          -> Let <$> pure a <*> mapM loadWith b <*> loadWith c <*> loadWith d
   Annot a b            -> Annot <$> loadWith a <*> loadWith b
   Bool                 -> pure Bool
   BoolLit a            -> pure (BoolLit a)

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -152,7 +152,24 @@ parsers embedded = Parsers {..}
 
             b <- expression
 
-            return (Let as b)
+            -- 'Note's in let-in-let:
+            --
+            -- Subsequent @let@s that are not separated by an @in@ only get a
+            -- single surrounding 'Note'. For example:
+            --
+            -- let x = a
+            -- let y = b
+            -- in  let z = c
+            --     in x
+            --
+            -- is parsed as
+            --
+            -- (Note …
+            --   (Let x …
+            --     (Let y …
+            --       (Note …
+            --         (Let z …
+            return (Dhall.Core.wrapInLets as b)
 
         alternative3 = do
             _forall

--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -19,7 +19,6 @@ import Control.Monad.State.Strict ( evalStateT )
 -- For the MonadFail instance for StateT.
 import Control.Monad.Trans.Instances ()
 import Data.List ( isPrefixOf, nub )
-import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe ( mapMaybe )
 import Data.Semigroup ((<>))
 import Data.Text ( Text )
@@ -166,16 +165,12 @@ applyContext
     -> Dhall.Expr Dhall.Src Dhall.X
     -> Dhall.Expr Dhall.Src Dhall.X
 applyContext context expression =
-  case bindings of
-    []     -> expression
-    b : bs -> Dhall.Core.Let (b :| bs) expression
+    Dhall.Core.wrapInLets bindings expression
   where
     definitions = reverse $ Dhall.Context.toList context
 
-    convertBinding (variable, Binding {..}) = Dhall.Core.Binding {..}
-      where
-        annotation = Just bindingType
-        value      = bindingExpr
+    convertBinding (variable, Binding expr type_) =
+        Dhall.Core.Binding variable (Just type_) expr
 
     bindings = fmap convertBinding definitions
 

--- a/dhall/src/Dhall/Src.hs
+++ b/dhall/src/Dhall/Src.hs
@@ -28,9 +28,11 @@ import qualified Text.Megaparsec as Megaparsec
 import qualified Text.Printf     as Printf
 
 -- | Source code extract
-data Src = Src !SourcePos !SourcePos Text
-  -- Text field is intentionally lazy
-  deriving (Data, Eq, Generic, Ord, Show, NFData)
+data Src = Src
+    { srcStart :: !SourcePos
+    , srcEnd   :: !SourcePos
+    , srcText  :: Text -- Text field is intentionally lazy
+    } deriving (Data, Eq, Generic, Ord, Show, NFData)
 
 
 instance Lift Src where

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -24,7 +24,6 @@ module Dhall.TypeCheck (
 import Data.Void (Void, absurd)
 import Control.Exception (Exception)
 import Data.Functor (void)
-import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid (Endo(..), First(..))
 import Data.Sequence (Seq, ViewL(..))
 import Data.Semigroup (Semigroup(..))
@@ -33,7 +32,7 @@ import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty(..))
 import Data.Typeable (Typeable)
 import Dhall.Binary (ToTerm(..))
-import Dhall.Core (Binding(..), Const(..), Chunks(..), Expr(..), Var(..))
+import Dhall.Core (Const(..), Chunks(..), Expr(..), Var(..))
 import Dhall.Context (Context)
 import Dhall.Pretty (Ann, layoutOpts)
 
@@ -150,7 +149,7 @@ typeWithA tpa = loop
                 let nf_A  = Dhall.Core.normalize _A
                 let nf_A' = Dhall.Core.normalize _A'
                 Left (TypeError ctx e (TypeMismatch f nf_A a nf_A'))
-    loop ctx e@(Let (Binding x mA a0 :| ls) b0) = do
+    loop ctx e@(Let x mA a0 b0) = do
         _A1 <- loop ctx a0
         case mA of
             Just _A0 -> do
@@ -165,11 +164,7 @@ typeWithA tpa = loop
         let a1 = Dhall.Core.normalize a0
         let a2 = Dhall.Core.shift 1 (V x 0) a1
 
-        let rest = case ls of
-                []       -> b0
-                l' : ls' -> Let (l' :| ls') b0
-
-        let b1 = Dhall.Core.subst (V x 0) a2 rest
+        let b1 = Dhall.Core.subst (V x 0) a2 b0
         let b2 = Dhall.Core.shift (-1) (V x 0) b1
         loop ctx b2
 

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -8,11 +8,9 @@ module Dhall.Test.QuickCheck where
 
 import Codec.Serialise (DeserialiseFailure(..))
 import Data.Either (isRight)
-import Data.List.NonEmpty (NonEmpty(..))
 import Dhall.Map (Map)
 import Dhall.Core
-    ( Binding(..)
-    , Chunks(..)
+    ( Chunks(..)
     , Const(..)
     , Directory(..)
     , Expr(..)
@@ -136,11 +134,6 @@ instance (Ord k, Arbitrary k, Arbitrary v) => Arbitrary (Map k v) where
         .   shrink
         .   Dhall.Map.toList
 
-instance (Arbitrary s, Arbitrary a) => Arbitrary (Binding s a) where
-    arbitrary = lift3 Binding
-
-    shrink = genericShrink
-
 instance (Arbitrary s, Arbitrary a) => Arbitrary (Chunks s a) where
     arbitrary = do
         n <- Test.QuickCheck.choose (0, 2)
@@ -179,13 +172,7 @@ instance (Arbitrary s, Arbitrary a) => Arbitrary (Expr s a) where
                 , ( 1, Test.QuickCheck.oneof [ lift2 (Lam "_"), lift3 Lam ])
                 , ( 1, Test.QuickCheck.oneof [ lift2 (Pi "_"), lift3 Pi ])
                 , ( 1, lift2 App)
-                , let letExpression = do
-                          n        <- Test.QuickCheck.choose (0, 2)
-                          binding  <- arbitrary
-                          bindings <- Test.QuickCheck.vectorOf n arbitrary
-                          body     <- arbitrary
-                          return (Let (binding :| bindings) body)
-                  in  ( 7, letExpression)
+                , ( 7, Test.QuickCheck.oneof [ lift3 (Let "_"), lift4 Let ])
                 , ( 1, lift2 Annot)
                 , ( 1, lift0 Bool)
                 , ( 7, lift1 BoolLit)

--- a/dhall/tests/format/letA.dhall
+++ b/dhall/tests/format/letA.dhall
@@ -1,0 +1,1 @@
+let x = "Lorem ipsum" let y = "Lorem ipsum" in let z = "Lorem ipsum" in x ++ y ++ z

--- a/dhall/tests/format/letB.dhall
+++ b/dhall/tests/format/letB.dhall
@@ -1,0 +1,5 @@
+let x = "Lorem ipsum"
+
+let y = "Lorem ipsum"
+
+in  let z = "Lorem ipsum" in x ++ y ++ z


### PR DESCRIPTION
Closes #1185.

This mostly reverts "Add support for multi-`let` (#675)" / 8a5bfaa3b9d1c697d9703f984f3fd866a06c21c0.