### PR TITLE
Improve HTTP errors

### DIFF
--- a/dhall/src/Dhall/Import/HTTP.hs
+++ b/dhall/src/Dhall/Import/HTTP.hs
@@ -61,28 +61,24 @@ renderPrettyHttpException _ (InvalidUrlException _ r) =
       "\n"
   <>  "\ESC[1;31mError\ESC[0m: Invalid URL\n"
   <>  "\n"
-  <>  "↳ " <> show r <> "\n"
+  <>  "URL: " <> show r <> "\n"
 renderPrettyHttpException url (HttpExceptionRequest _ e) =
   case e of
     ConnectionFailure _ ->
           "\n"
       <>  "\ESC[1;31mError\ESC[0m: Remote host not found\n"
       <>  "\n"
-      <>  "URL:\n"
-      <>  "\n"
-      <>  "↳ " <> url <> "\n"
+      <>  "URL: " <> url <> "\n"
     InvalidDestinationHost host ->
           "\n"
       <>  "\ESC[1;31mError\ESC[0m: Invalid remote host name:\n"
       <>  "\n"
-      <>  "↳ " <> show host <> "\n"
+      <>  "Host: " <> show host <> "\n"
     ResponseTimeout ->
           "\n"
       <>  "\ESC[1;31mError\ESC[0m: The remote host took too long to respond\n"
       <>  "\n"
-      <>  "URL:\n"
-      <>  "\n"
-      <>  "↳ " <> url <> "\n"
+      <>  "URL: " <> url <> "\n"
     StatusCodeException response body -> prefix <> suffix
       where
         prefix
@@ -113,13 +109,9 @@ renderPrettyHttpException url (HttpExceptionRequest _ e) =
 
         suffix =
                 "\n"
-            <>  "HTTP status code:\n"
+            <>  "HTTP status code: " <> show statusCode <> "\n"
             <>  "\n"
-            <>  "↳ " <> show statusCode <> "\n"
-            <>  "\n"
-            <>  "URL:\n"
-            <>  "\n"
-            <>  "↳ " <> url <> "\n"
+            <>  "URL: " <> url <> "\n"
             <>  message
 
         statusCode =
@@ -170,18 +162,16 @@ renderPrettyHttpException url e = case e of
             "\n"
         <>  "\ESC[1;31mError\ESC[0m: Wrong host:\n"
         <>  "\n"
-        <>  "↳ " <> show e' <> "\n"
+        <>  "Host: " <> show e' <> "\n"
     InvalidDestinationHost host ->
             "\n"
         <>  "\ESC[1;31mError\ESC[0m: Invalid host name:\n"
         <>  "\n"
-        <>  "↳ " <> show host <> "\n"
+        <>  "Host: " <> show host <> "\n"
     ResponseTimeout ->
             "\ESC[1;31mError\ESC[0m: The host took too long to respond\n"
         <>  "\n"
-        <>  "URL:\n"
-        <>  "\n"
-        <>  "↳ " <> url <> "\n"
+        <>  "URL: " <> url <> "\n"
     e' ->   "\n"
         <>  show e' <> "\n"
 #endif

--- a/dhall/src/Dhall/Import/HTTP.hs
+++ b/dhall/src/Dhall/Import/HTTP.hs
@@ -94,7 +94,7 @@ renderPrettyHttpException url (HttpExceptionRequest _ e) =
                 <>  "\ESC[1;31mError\ESC[0m: Access forbidden\n"
             | statusCode == 404 =
                     "\n"
-                <>  "\ESC[1;31mError\ESC[0m: Remote file missing\n"
+                <>  "\ESC[1;31mError\ESC[0m: Remote file not found\n"
             | statusCode == 500 =
                     "\n"
                 <>  "\ESC[1;31mError\ESC[0m: Server-side failure\n"

--- a/dhall/src/Dhall/Import/HTTP.hs
+++ b/dhall/src/Dhall/Import/HTTP.hs
@@ -109,12 +109,14 @@ renderPrettyHttpException url (HttpExceptionRequest _ e) =
                 <>  "\ESC[1;31mError\ESC[0m: Upstream timeout\n"
             | otherwise =
                     "\n"
-                <>  "\ESC[1;31mError\ESC[0m: Unexpected HTTP status code:\n"
-                <>  "\n"
-                <>  "↳ " <> show statusCode <> "\n"
+                <>  "\ESC[1;31mError\ESC[0m: HTTP request failure\n"
 
         suffix =
                 "\n"
+            <>  "HTTP status code:\n"
+            <>  "\n"
+            <>  "↳ " <> show statusCode <> "\n"
+            <>  "\n"
             <>  "URL:\n"
             <>  "\n"
             <>  "↳ " <> url <> "\n"


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1251

This improves HTTP error messages by:

* Expanding the set of recognized status codes
* Adding up to 7 lines of the response body

For example:

```
Error: Remote file missing

URL:

↳ https://httpbin.org/statu

Message:

1│ <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
2│ <title>404 Not Found</title>
3│ <h1>Not Found</h1>
4│ <p>The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again.</p>
```