### PR TITLE
Fix diff for `Text` literals

### DIFF
--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -311,15 +311,8 @@ bracketed :: [Diff] -> Diff
 bracketed = enclosed (lbracket <> " ") (comma <> " ") rbracket
 
 diffText :: Text -> Text -> Diff
-diffText l r
-  | null parts         = "\"\""
-  | allDifferent parts = difference textSkeleton textSkeleton
-  | allSame parts      = textSkeleton
-  | otherwise          = "\"" <> foldMap prettyPart parts <> "\""
+diffText l r = "\"" <> foldMap prettyPart parts <> "\""
   where
-    allDifferent = not . any isBoth
-    allSame      = all isBoth
-
     -- TODO: check for color support from the TTY
     colorDiff colorCode chars =
             "\ESC["
@@ -393,12 +386,6 @@ diffList l r = bracketed (foldMap diffPart parts)
         -- Present in both
         Algo.Diff.Both _ _        ->
             pure ignore
-
--- Helper function to check when a diff part is present on both sides
-isBoth :: Algo.Diff.Diff a -> Bool
-isBoth p
-  | Algo.Diff.Both _ _ <- p = True
-  | otherwise               = False
 
 diffRecord
     :: (Eq a, Pretty a)


### PR DESCRIPTION
This is essentially the exact same problem and fix as #1213

Normally I would add a test, except that our test suite for diffs doesn't
yet support escape codes.  However, the basic problem was the following
output:

```
$ dhall diff '"1"' '"2"'
- "…"
+ "…"
```

... which now displays (with color highlighting) this output:

```
$ dhall diff '"1"' '"2"'
"12"  -- Imagine that the 1 is red and the 2 is green
```