### PR TITLE
Fix typechecking of toMap

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -668,8 +668,8 @@ typeWithA tpa = loop
         _TKvsX <- loop ctx tKvsX
 
         case _TKvsX of
-          Const Type -> return ()
-          kind       -> Left (TypeError ctx e (InvalidToMapRecordKind tKvsX kind))
+            Const Type -> return ()
+            kind       -> Left (TypeError ctx e (InvalidToMapRecordKind tKvsX kind))
 
         Data.Foldable.traverse_ (loop ctx) mT₁
 

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -2874,7 +2874,7 @@ prettyTypeMessage (MustMapARecord _expr0 _expr1) = ErrorMessages {..}
         \                                                                                \n\
         \                                                                                \n\
         \    ┌─────────────────────────────────────────────────────────────────────┐     \n\
-        \    │     let record = { one = 1, two = 2 }                               │     \n\
+        \    │ let record = { one = 1, two = 2 }                                   │     \n\
         \    │ in  toMap record : List { mapKey : Text, mapValue : Natural}        │     \n\
         \    └─────────────────────────────────────────────────────────────────────┘     \n\
         \                                                                                \n\
@@ -2891,7 +2891,7 @@ prettyTypeMessage (InvalidToMapRecordKind type_ kind) = ErrorMessages {..}
         \                                                                                \n\
         \                                                                                \n\
         \    ┌─────────────────────────────────────────────────────────────────────┐     \n\
-        \    │     let record = { one = 1, two = 2 }                               │     \n\
+        \    │ let record = { one = 1, two = 2 }                                   │     \n\
         \    │ in  toMap record : List { mapKey : Text, mapValue : Natural}        │     \n\
         \    └─────────────────────────────────────────────────────────────────────┘     \n\
         \                                                                                \n\
@@ -2916,7 +2916,7 @@ prettyTypeMessage (HeterogenousRecordToMap _expr0 _expr1 _expr2) = ErrorMessages
         \                                                                                \n\
         \                                                                                \n\
         \    ┌─────────────────────────────────────────────────────────────────────┐     \n\
-        \    │     let record = { one = 1, two = 2 }                               │     \n\
+        \    │ let record = { one = 1, two = 2 }                                   │     \n\
         \    │ in  toMap record : List { mapKey : Text, mapValue : Natural}        │     \n\
         \    └─────────────────────────────────────────────────────────────────────┘     \n\
         \                                                                                \n\
@@ -2972,7 +2972,7 @@ prettyTypeMessage MissingToMapType =
         \                                                                                \n\
         \                                                                                \n\
         \    ┌─────────────────────────────────────────────────────────────────────┐     \n\
-        \    │     let record = { one = 1, two = 2 }                               │     \n\
+        \    │ let record = { one = 1, two = 2 }                                   │     \n\
         \    │ in  toMap record                                                    │     \n\
         \    └─────────────────────────────────────────────────────────────────────┘     \n\
         \                                                                                \n\


### PR DESCRIPTION
Fixes #1278.

```
⊢ toMap {x = Bool}

Error: ❰toMap❱ expects a record of kind ❰Type❱

Explanation: You can apply ❰toMap❱ to any homogenous record of kind ❰Type❱, like
 this:                                                                          
                                                                                
                                                                                
    ┌─────────────────────────────────────────────────────────────────────┐     
    │ let record = { one = 1, two = 2 }                                   │     
    │ in  toMap record : List { mapKey : Text, mapValue : Natural}        │     
    └─────────────────────────────────────────────────────────────────────┘     
                                                                                
                                                                                
... but records of kind ❰Kind❱ or ❰Sort❱ cannot be turned into ❰List❱s.         
────────────────────────────────────────────────────────────────────────────────
                                                                                
You applied ❰toMap❱ to a record of the following type:                          
                                                                                
↳ { x : Type }
                                                                                
... which has kind                                                              
                                                                                
↳ Kind

────────────────────────────────────────────────────────────────────────────────

1│ toMap {x = Bool}

(stdin):1:1
```

I'll also add a testcase to the acceptance test suite.