### PR TITLE
Change `dhall type` to resolve imports

### DIFF
--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -460,7 +460,7 @@ command (Options {..}) = do
         Type {..} -> do
             expression <- getExpression file
 
-            resolvedExpression <- Dhall.Import.assertNoImports expression
+            resolvedExpression <- Dhall.Import.load expression
 
             inferredType <- Dhall.Core.throws (Dhall.TypeCheck.typeOf resolvedExpression)
 

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -460,7 +460,7 @@ command (Options {..}) = do
         Type {..} -> do
             expression <- getExpression file
 
-            resolvedExpression <- Dhall.Import.load expression
+            resolvedExpression <- Dhall.Import.loadRelativeTo (rootDirectory file) expression
 
             inferredType <- Dhall.Core.throws (Dhall.TypeCheck.typeOf resolvedExpression)
 


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1277

The original motivation was that `dhall type` would represent a
type-inference-only phase.  However, in practice that wasn't very useful
so `dhall type` now performs import resolution followed by type inference.