### PR TITLE
Use generic-random in Expr's Arbitrary instance

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -598,6 +598,7 @@ Test-Suite tasty
         directory                                      ,
         filepath                                       ,
         foldl                                    < 1.5 ,
+        generic-random            >= 1.2.0.0  && < 1.3 ,
         lens-family-core          >= 1.0.0    && < 2.1 ,
         megaparsec                                     ,
         prettyprinter                                  ,

--- a/nix/generic-random.nix
+++ b/nix/generic-random.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, deepseq, QuickCheck, stdenv }:
+mkDerivation {
+  pname = "generic-random";
+  version = "1.2.0.0";
+  sha256 = "9b1e00d2f06b582695a34cfdb2d8b62b32f64152c6ed43f5c2d776e6e9aa148c";
+  revision = "1";
+  editedCabalFile = "1d0hx41r7yq2a86ydnfh2fv540ah8cz05l071s2z4wxcjw0ymyn4";
+  libraryHaskellDepends = [ base QuickCheck ];
+  testHaskellDepends = [ base deepseq QuickCheck ];
+  homepage = "http://github.com/lysxia/generic-random";
+  description = "Generic random generators";
+  license = stdenv.lib.licenses.mit;
+}

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -30,6 +30,7 @@ extra-deps:
 - foldl-1.4.5
 - formatting-6.3.2
 - foundation-0.0.19
+- generic-random-1.2.0.0
 - hashable-1.2.7.0
 - haskeline-0.7.4.2
 - integer-logarithms-1.0.3


### PR DESCRIPTION
Main benefit of using `generic-random`:
* Full coverage of all `Expr` constructors is checked by the type-checker (`IntegerToDouble`, `TextShow`, `Some` and `None` were missing!)

Also:
* Increase frequency for Lam, Pi and App
* Fix a few inconsistencies in normalization
* Remove some dead code in D.T.QuickCheck