### PR TITLE
Re-export `Data.Void.absurd` from `Dhall.TypeCheck`

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -16,6 +16,7 @@ module Dhall.TypeCheck (
     -- * Types
     , Typer
     , X
+    , absurd
     , TypeError(..)
     , DetailedTypeError(..)
     , TypeMessage(..)


### PR DESCRIPTION
... as suggested by @quasicomputational in:

https://github.com/dhall-lang/dhall-haskell/pull/1286#issuecomment-529137803