### PR TITLE
Minor bug fixes for yaml-to-dhall error messages

### DIFF
--- a/dhall-json/src/Dhall/JSONToDhall.hs
+++ b/dhall-json/src/Dhall/JSONToDhall.hs
@@ -236,7 +236,6 @@ import qualified Options.Applicative as O
 import           Options.Applicative (Parser)
 
 import           Dhall.JSON.Util (pattern V)
-import qualified Dhall
 import qualified Dhall.Core as D
 import           Dhall.Core (Expr(App), Chunks(..))
 import qualified Dhall.Import
@@ -480,9 +479,9 @@ dhallFromJSON (Conversion {..}) expressionType =
 
     -- number ~> Natural
     loop D.Natural (A.Number x)
-        | Right n <- floatingOrInteger x :: Either Double Dhall.Natural
+        | Right n <- floatingOrInteger x :: Either Double Integer
         , n >= 0
-        = Right (D.NaturalLit n)
+        = Right (D.NaturalLit (fromInteger n))
         | otherwise
         = Left (Mismatch D.Natural (A.Number x))
 
@@ -645,7 +644,7 @@ showCompileError format showValue = let prefix = red "\nError: "
         where sep = red "\n--------\n" :: Text
 
     Mismatch e v -> prefix
-      <> "Dhall type expression and json value do not match:"
+      <> "Dhall type expression and " <> format <> " value do not match:"
       <> "\n\nExpected Dhall type:\n" <> showExpr e
       <> "\n\n" <> format <> ":\n"  <> showValue v
       <> "\n"


### PR DESCRIPTION
Fixes a type mismatch error message which mentions JSON.

---

Fixes an "arithmetic overflow" exception which occurs when attempting to parse a negative number as a `Natural`.

Current behaviour:
```
$ yaml-to-dhall Natural <<< -1

arithmetic underflow
```

With fix applied:
```
$ yaml-to-dhall Natural <<< -1

Error: Dhall type expression and YAML value do not match:

Expected Dhall type:
Natural

YAML:
-1
```