### PR TITLE
Improve GHCJS support (cabal build, SHA256 hashing)

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -449,7 +449,6 @@ Library
         cborg-json                                 < 0.3 ,
         containers                  >= 0.5.0.0  && < 0.7 ,
         contravariant                              < 1.6 ,
-        cryptonite                  >= 0.23     && < 1.0 ,
         data-fix                                   < 0.3 ,
         deepseq                                    < 1.5 ,
         Diff                        >= 0.2      && < 0.4 ,
@@ -480,17 +479,24 @@ Library
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
         uri-encode                                 < 1.6 ,
         vector                      >= 0.11.0.0 && < 0.13
-    if flag(with-http)
-      Build-Depends:
-        http-types                  >= 0.7.0    && < 0.13,
-        http-client                 >= 0.4.30   && < 0.7 ,
-        http-client-tls             >= 0.2.0    && < 0.4
     if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
       Build-Depends: semigroups == 0.18.*
       Build-Depends: transformers == 0.4.2.*
       Build-Depends: fail == 4.9.*
     if impl(ghcjs)
-      Build-Depends: ghcjs-xhr
+      Hs-Source-Dirs: ghcjs-src
+      Build-Depends:
+        ghcjs-base ,
+        ghcjs-xhr
+    else
+      Hs-Source-Dirs: ghc-src
+      Build-Depends:
+        cryptonite                  >= 0.23     && < 1.0
+      if flag(with-http)
+        Build-Depends:
+          http-types                  >= 0.7.0    && < 0.13,
+          http-client                 >= 0.4.30   && < 0.7 ,
+          http-client-tls             >= 0.2.0    && < 0.4
 
     Other-Extensions:
         BangPatterns
@@ -548,8 +554,10 @@ Library
         Exposed-Modules:
             Dhall.TH
     Other-Modules:
+        Dhall.Crypto,
         Dhall.Pretty.Internal,
         Dhall.Parser.Combinators,
+        Dhall.URL,
         Dhall.Import.Types,
         Dhall.Eval,
         Paths_dhall

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -531,6 +531,7 @@ Library
         Dhall.Binary,
         Dhall.Context,
         Dhall.Core,
+        Dhall.Crypto,
         Dhall.Diff,
         Dhall.Format,
         Dhall.Freeze,
@@ -554,7 +555,6 @@ Library
         Exposed-Modules:
             Dhall.TH
     Other-Modules:
-        Dhall.Crypto,
         Dhall.Pretty.Internal,
         Dhall.Parser.Combinators,
         Dhall.URL,

--- a/dhall/doctest/Main.hs
+++ b/dhall/doctest/Main.hs
@@ -27,6 +27,7 @@ main = do
         Test.DocTest.doctest
             [ "--fast"
             , "-i" <> (prefix </> "src")
+            , "-i" <> (prefix </> "ghc-src")
             , prefix </> "src/Dhall.hs"
             , prefix </> "src/Dhall/Import.hs"
             , prefix </> "src/Dhall/Tutorial.hs"

--- a/dhall/ghc-src/Dhall/Crypto.hs
+++ b/dhall/ghc-src/Dhall/Crypto.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Dhall.Crypto where
+module Dhall.Crypto (
+      SHA256Digest(..)
+    , sha256DigestFromByteString
+    , sha256Hash
+    ) where
 
 import Control.DeepSeq (NFData)
 import Crypto.Hash (SHA256)
@@ -11,13 +15,13 @@ import Data.ByteString (ByteString)
 import GHC.Generics (Generic)
 
 import qualified Crypto.Hash
-import qualified Data.ByteString.Char8 as BC8
+import qualified Data.ByteString.Char8 as ByteString.Char8
 
-newtype SHA256Digest = SHA256Digest ByteString
+newtype SHA256Digest = SHA256Digest { unSHA256Digest :: ByteString }
   deriving (Eq, Generic, Ord, NFData, ByteArrayAccess)
 
 instance Show SHA256Digest where
-  show (SHA256Digest bytes) = BC8.unpack $ convertToBase Base16 bytes
+  show (SHA256Digest bytes) = ByteString.Char8.unpack $ convertToBase Base16 bytes
 
 sha256DigestFromByteString :: ByteString -> Maybe SHA256Digest
 sha256DigestFromByteString bytes = SHA256Digest . convert <$> mh

--- a/dhall/ghc-src/Dhall/Crypto.hs
+++ b/dhall/ghc-src/Dhall/Crypto.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Dhall.Crypto where
+
+import Control.DeepSeq (NFData)
+import Crypto.Hash (SHA256)
+import Data.ByteArray (ByteArrayAccess, convert)
+import Data.ByteArray.Encoding (Base(Base16), convertToBase)
+import Data.ByteString (ByteString)
+import GHC.Generics (Generic)
+
+import qualified Crypto.Hash
+import qualified Data.ByteString.Char8 as BC8
+
+newtype SHA256Digest = SHA256Digest ByteString
+  deriving (Eq, Generic, Ord, NFData, ByteArrayAccess)
+
+instance Show SHA256Digest where
+  show (SHA256Digest bytes) = BC8.unpack $ convertToBase Base16 bytes
+
+sha256DigestFromByteString :: ByteString -> Maybe SHA256Digest
+sha256DigestFromByteString bytes = SHA256Digest . convert <$> mh
+  where
+    mh = Crypto.Hash.digestFromByteString bytes :: Maybe (Crypto.Hash.Digest SHA256)
+
+sha256Hash :: ByteString -> SHA256Digest
+sha256Hash bytes = SHA256Digest $ convert h
+  where
+    h = Crypto.Hash.hash bytes :: Crypto.Hash.Digest SHA256

--- a/dhall/ghcjs-src/Dhall/Crypto.hs
+++ b/dhall/ghcjs-src/Dhall/Crypto.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE JavaScriptFFI #-}
+
+module Dhall.Crypto where
+
+import Control.DeepSeq (NFData)
+import Data.ByteArray (ByteArrayAccess)
+import Data.ByteArray.Encoding (Base(Base16), convertToBase)
+import Data.ByteString (ByteString)
+import GHC.Generics (Generic)
+import JavaScript.TypedArray.ArrayBuffer (ArrayBuffer)
+import System.IO.Unsafe (unsafePerformIO)
+
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as BC8
+import qualified GHCJS.Buffer as Buffer
+
+newtype SHA256Digest = SHA256Digest { unSHA256Digest :: ByteString }
+  deriving (Eq, Generic, Ord, NFData, ByteArrayAccess)
+
+instance Show SHA256Digest where
+  show (SHA256Digest bytes) = BC8.unpack $ convertToBase Base16 bytes
+
+sha256DigestFromByteString :: ByteString -> Maybe SHA256Digest
+sha256DigestFromByteString bytes
+  | ByteString.length bytes == 32 = Just $ SHA256Digest bytes
+  | otherwise = Nothing
+
+-- Use NodeJS' crypto module if there's a 'process' module, e.g. we're running
+-- inside GHCJS' THRunner. If we're running in the browser, use the WebCrypto
+-- interface.
+foreign import javascript interruptible
+  "if (typeof process === 'undefined') { \
+  \  crypto.subtle.digest('SHA-256', $1).then($c) \
+  \} else { \
+  \  $c(require('crypto').createHash('sha256').update(Buffer.from($1)).digest().buffer) \
+  \}"
+  js_sha256Hash :: ArrayBuffer -> IO ArrayBuffer
+
+byteStringToArrayBuffer :: ByteString -> ArrayBuffer
+byteStringToArrayBuffer b =
+  js_arrayBufferSlice offset len $ Buffer.getArrayBuffer buffer
+  where
+    (buffer, offset, len) = Buffer.fromByteString b
+
+foreign import javascript unsafe "$3.slice($1, $1 + $2)"
+  js_arrayBufferSlice :: Int -> Int -> ArrayBuffer -> ArrayBuffer
+
+arrayBufferToByteString :: ArrayBuffer -> ByteString
+arrayBufferToByteString =
+  Buffer.toByteString 0 Nothing . Buffer.createFromArrayBuffer
+
+sha256Hash :: ByteString -> SHA256Digest
+sha256Hash bytes
+  | ByteString.length out == 32 = SHA256Digest out
+  | otherwise = error "sha256Hash: didn't produce 32 bytes"
+  where
+    out =
+      arrayBufferToByteString $
+      unsafePerformIO $ js_sha256Hash (byteStringToArrayBuffer bytes)

--- a/dhall/ghcjs-src/Dhall/Crypto.hs
+++ b/dhall/ghcjs-src/Dhall/Crypto.hs
@@ -2,7 +2,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE JavaScriptFFI #-}
 
-module Dhall.Crypto where
+module Dhall.Crypto (
+      SHA256Digest(..)
+    , sha256DigestFromByteString
+    , sha256Hash
+    ) where
 
 import Control.DeepSeq (NFData)
 import Data.ByteArray (ByteArrayAccess)
@@ -12,15 +16,15 @@ import GHC.Generics (Generic)
 import JavaScript.TypedArray.ArrayBuffer (ArrayBuffer)
 import System.IO.Unsafe (unsafePerformIO)
 
-import qualified Data.ByteString as ByteString
-import qualified Data.ByteString.Char8 as BC8
-import qualified GHCJS.Buffer as Buffer
+import qualified Data.ByteString        as ByteString
+import qualified Data.ByteString.Char8  as ByteString.Char8
+import qualified GHCJS.Buffer           as Buffer
 
 newtype SHA256Digest = SHA256Digest { unSHA256Digest :: ByteString }
   deriving (Eq, Generic, Ord, NFData, ByteArrayAccess)
 
 instance Show SHA256Digest where
-  show (SHA256Digest bytes) = BC8.unpack $ convertToBase Base16 bytes
+  show (SHA256Digest bytes) = ByteString.Char8.unpack $ convertToBase Base16 bytes
 
 sha256DigestFromByteString :: ByteString -> Maybe SHA256Digest
 sha256DigestFromByteString bytes

--- a/dhall/ghcjs-src/Dhall/Import/HTTP.hs
+++ b/dhall/ghcjs-src/Dhall/Import/HTTP.hs
@@ -22,7 +22,7 @@ fetchFromHttpUrl
     -> Maybe [(CI ByteString, ByteString)]
     -> StateT Status IO Text.Text
 fetchFromHttpUrl _ childURL Nothing = do
-    let childURLText = renderURL childURLString
+    let childURLText = renderURL childURL
 
     let childURLString = Text.unpack childURLText
 

--- a/dhall/ghcjs-src/Dhall/Import/HTTP.hs
+++ b/dhall/ghcjs-src/Dhall/Import/HTTP.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+module Dhall.Import.HTTP where
+
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.Trans.State.Strict (StateT)
+import Data.ByteString (ByteString)
+import Data.CaseInsensitive (CI)
+import Data.Semigroup ((<>))
+
+import qualified Data.Text as Text
+import qualified JavaScript.XHR
+
+import Dhall.Core (URL(..))
+import Dhall.URL (renderURL)
+import Dhall.Import.Types
+
+fetchFromHttpUrl
+    :: a
+    -> URL
+    -> Maybe [(CI ByteString, ByteString)]
+    -> StateT Status IO Text.Text
+fetchFromHttpUrl _ childURL Nothing = do
+    let childURLText = renderURL childURLString
+
+    let childURLString = Text.unpack childURLText
+
+    -- No need to add a CORS compliance check when using GHCJS.  The browser
+    -- will already check the CORS compliance of the following XHR
+    (statusCode, body) <- liftIO (JavaScript.XHR.get childURLText)
+
+    case statusCode of
+        200 -> return ()
+        _   -> fail (childURLString <> " returned a non-200 status code: " <> show statusCode)
+
+    return body
+fetchFromHttpUrl _ _ _ = do
+    fail "Dhall does not yet support custom headers when built using GHCJS"

--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -50,12 +50,12 @@ import Data.Text (Text)
 import Data.Void (Void, absurd)
 import GHC.Float (double2Float, float2Double)
 
-import qualified Crypto.Hash
 import qualified Control.Monad       as Monad
 import qualified Data.ByteArray
 import qualified Data.ByteString
 import qualified Data.Sequence
 import qualified Dhall.Core
+import qualified Dhall.Crypto
 import qualified Dhall.Map
 import qualified Dhall.Set
 
@@ -767,7 +767,7 @@ instance FromTerm Import where
                     "\x12\x20" -> return ()
                     _          -> empty
 
-                digest <- case Crypto.Hash.digestFromByteString suffix of
+                digest <- case Dhall.Crypto.sha256DigestFromByteString suffix of
                     Nothing     -> empty
                     Just digest -> return digest
 

--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -82,7 +82,6 @@ import Control.Applicative (empty)
 import Control.DeepSeq (NFData)
 import Control.Exception (Exception)
 import Control.Monad.IO.Class (MonadIO(..))
-import Crypto.Hash (SHA256)
 import Data.Bifunctor (Bifunctor(..))
 import Data.Data (Data)
 import Data.Foldable
@@ -107,7 +106,6 @@ import Prelude hiding (succ)
 
 import qualified Control.Exception
 import qualified Control.Monad
-import qualified Crypto.Hash
 import qualified Data.Char
 import {-# SOURCE #-} qualified Dhall.Eval
 import qualified Data.HashSet
@@ -116,6 +114,7 @@ import qualified Data.Sequence
 import qualified Data.Set
 import qualified Data.Text
 import qualified Data.Text.Prettyprint.Doc  as Pretty
+import qualified Dhall.Crypto
 import qualified Dhall.Map
 import qualified Dhall.Set
 import qualified Network.URI                as URI
@@ -289,7 +288,7 @@ data ImportMode = Code | RawText | Location
 
 -- | A `ImportType` extended with an optional hash for semantic integrity checks
 data ImportHashed = ImportHashed
-    { hash       :: Maybe (Crypto.Hash.Digest SHA256)
+    { hash       :: Maybe Dhall.Crypto.SHA256Digest
     , importType :: ImportType
     } deriving (Eq, Generic, Ord, Show, NFData)
 

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -20,7 +20,6 @@ import Prelude hiding (const, pi)
 import Text.Parser.Combinators (choice, try, (<?>))
 
 import qualified Control.Monad
-import qualified Crypto.Hash
 import qualified Data.ByteArray.Encoding
 import qualified Data.ByteString
 import qualified Data.Char               as Char
@@ -30,6 +29,7 @@ import qualified Data.List.NonEmpty
 import qualified Data.Sequence
 import qualified Data.Text
 import qualified Data.Text.Encoding
+import qualified Dhall.Crypto
 import qualified Text.Megaparsec
 #if !MIN_VERSION_megaparsec(7, 0, 0)
 import qualified Text.Megaparsec.Char    as Text.Megaparsec
@@ -768,7 +768,7 @@ importType_ = do
 
     choice [ local, http, env, missing ]
 
-importHash_ :: Parser (Crypto.Hash.Digest Crypto.Hash.SHA256)
+importHash_ :: Parser Dhall.Crypto.SHA256Digest
 importHash_ = do
     _ <- Text.Parser.Char.text "sha256:"
     text <- count 64 (satisfy hexdig <?> "hex digit")
@@ -777,7 +777,7 @@ importHash_ = do
     strictBytes <- case Data.ByteArray.Encoding.convertFromBase Base16 strictBytes16 of
         Left  string      -> fail string
         Right strictBytes -> return (strictBytes :: Data.ByteString.ByteString)
-    case Crypto.Hash.digestFromByteString strictBytes of
+    case Dhall.Crypto.sha256DigestFromByteString strictBytes of
       Nothing -> fail "Invalid sha256 hash"
       Just h  -> pure h
 

--- a/dhall/src/Dhall/URL.hs
+++ b/dhall/src/Dhall/URL.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+module Dhall.URL where
+
+import Data.Text (Text)
+
+import Dhall.Core
+    ( Scheme(..)
+    , URL(..)
+    , File(..)
+    , Directory(..)
+    )
+
+import qualified Network.URI.Encode as URI.Encode
+
+renderComponent :: Text -> Text
+renderComponent component = "/" <> URI.Encode.encodeText component
+
+renderQuery :: Text -> Text
+renderQuery query = "?" <> query
+
+renderURL :: URL -> Text
+renderURL url =
+        schemeText
+    <>  authority
+    <>  pathText
+    <>  queryText
+  where
+    URL {..} = url
+
+    File {..} = path
+
+    Directory {..} = directory
+
+    schemeText = case scheme of
+        HTTP  -> "http://"
+        HTTPS -> "https://"
+
+    pathText =
+            foldMap renderComponent (reverse components)
+        <>  renderComponent file
+
+    queryText = foldMap renderQuery query

--- a/dhall/src/Dhall/URL.hs
+++ b/dhall/src/Dhall/URL.hs
@@ -3,6 +3,7 @@
 
 module Dhall.URL where
 
+import Data.Monoid ((<>))
 import Data.Text (Text)
 
 import Dhall.Core


### PR DESCRIPTION
This fixes the GHCJS build when using cabal, and adds SHA256 hashing support to GHCJS both when running in the browser and at compile time (THRunner on Node).

I have tested these changes using cabal on GHC and GHCJS, as well as etlas, but I could use some help to test nix/test suite/try-dhall. I would also love your blunt opinion on the organizational/style choices.

Motivation:
  - The `dhall` package doesn't compile using cabal/GHCJS (outside nix) due to the dependency on http-client (given -with-http) and cryptonite (breaking since, I think, 1.24.)
  - Importing anything with a SHA256 digest causes an error

Summary of changes:
  - Don't require `cryptonite`, `http-types`, `http-client`, or `http-client-tls` when compiling with GHCJS
  - Add `ghc-src` and `ghcjs-src` for platform-specific code to avoid a huge CPP mess
  - Add `ghc-src/Dhall/Crypto.hs` (using cryptonite) and `ghcjs-src/Dhall/Crypto.hs` (using JS FFI)
  - Split `src/Dhall/Import/HTTP.hs` into `ghc-src/Dhall/Import/HTTP.hs` and `ghcjs-src/Dhall/Import/HTTP.hs`
  - Add `src/Dhall/URL.hs` (for renderURL, used by both Import/HTTP modules)

Random thoughts:
  - Not happy about `typeof process` to detect Node vs. Browser, but it was the most reliable thing I could find (suggestions to look for CommonJS seem bad)
  - I don't think the use of `unsafePerformIO` in the GHCJS FFI call is necessary. You could just remove `IO` from the type signature, but that would make the intent less clear...