### PR TITLE
Add `--censor` switch for disabling source code display

### DIFF
--- a/dhall/src/Dhall/Hash.hs
+++ b/dhall/src/Dhall/Hash.hs
@@ -8,6 +8,7 @@ module Dhall.Hash
     ) where
 
 import Dhall.Import (hashExpressionToCode)
+import Dhall.Util (Censor, Input(..))
 
 import qualified Control.Monad.Trans.State.Strict as State
 import qualified Control.Exception
@@ -18,12 +19,9 @@ import qualified Dhall.Util
 import qualified Data.Text.IO
 
 -- | Implementation of the @dhall hash@ subcommand
-hash
-    :: Bool
-    -- ^ Censor the source code?
-    -> IO ()
+hash :: Censor -> IO ()
 hash censor = do
-    parsedExpression <- Dhall.Util.getExpression censor Nothing
+    parsedExpression <- Dhall.Util.getExpression censor StandardInput
 
     let status = Dhall.Import.emptyStatus "."
 

--- a/dhall/src/Dhall/Hash.hs
+++ b/dhall/src/Dhall/Hash.hs
@@ -7,7 +7,6 @@ module Dhall.Hash
       hash
     ) where
 
-import Dhall.Parser (exprFromText)
 import Dhall.Import (hashExpressionToCode)
 
 import qualified Control.Monad.Trans.State.Strict as State
@@ -15,16 +14,16 @@ import qualified Control.Exception
 import qualified Dhall.Core
 import qualified Dhall.Import
 import qualified Dhall.TypeCheck
+import qualified Dhall.Util
 import qualified Data.Text.IO
 
 -- | Implementation of the @dhall hash@ subcommand
-hash :: IO ()
-hash = do
-    inText <- Data.Text.IO.getContents
-
-    parsedExpression <- case exprFromText "(stdin)" inText of
-        Left  exception        -> Control.Exception.throwIO exception
-        Right parsedExpression -> return parsedExpression
+hash
+    :: Bool
+    -- ^ Censor the source code?
+    -> IO ()
+hash censor = do
+    parsedExpression <- Dhall.Util.getExpression censor Nothing
 
     let status = Dhall.Import.emptyStatus "."
 

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -7,17 +7,26 @@ module Dhall.Util
     , snipDoc
     , insert
     , _ERROR
+    , getExpression
+    , getExpressionAndHeader
     ) where
 
+import Data.Bifunctor (first)
 import Data.Monoid ((<>))
 import Data.String (IsString)
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty)
+import Dhall.Core (Expr, Import)
+import Dhall.Parser (ParseError)
 import Dhall.Pretty (Ann)
+import Dhall.Src (Src)
 
 import qualified Data.Text
+import qualified Data.Text.IO
 import qualified Data.Text.Prettyprint.Doc             as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
+import qualified Dhall.Core
+import qualified Dhall.Parser
 import qualified Dhall.Pretty
 
 -- | Utility function to cut out the interior of a large text block
@@ -81,3 +90,35 @@ insert expression =
 -- | Prefix used for error messages
 _ERROR :: IsString string => string
 _ERROR = "\ESC[1;31mError\ESC[0m"
+
+get :: (String -> Text -> Either ParseError a) -> Bool -> Maybe FilePath -> IO a
+get parser censor maybeFile = do
+    inText <- do
+        case maybeFile of
+            Just file -> Data.Text.IO.readFile file
+            Nothing   -> Data.Text.IO.getContents
+
+    let name =
+            case maybeFile of
+                Just file -> file
+                Nothing   -> "(stdin)"
+
+    let result = parser name inText
+
+    let censoredResult =
+            if censor then first Dhall.Parser.censor result else result
+
+    Dhall.Core.throws censoredResult
+
+-- | Convenient utility for retrieving an expression
+getExpression
+    :: Bool
+    -- ^ Censor the source code?
+    -> Maybe FilePath
+    -- ^ Path to input (@stdin@ if `Nothing`)
+    -> IO (Expr Src Import)
+getExpression = get Dhall.Parser.exprFromText
+
+-- | Convenient utility for retrieving an expression along with its header
+getExpressionAndHeader :: Bool -> Maybe FilePath -> IO (Text, Expr Src Import)
+getExpressionAndHeader = get Dhall.Parser.exprAndHeaderFromText


### PR DESCRIPTION
Related to #1294

This currently only affects parse errors, but can later be extended
to type errors, too