### PR TITLE
dhall type: Don't normalize inferred types

### DIFF
--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -492,7 +492,7 @@ command (Options {..}) = do
 
             inferredType <- Dhall.Core.throws (Dhall.TypeCheck.typeOf resolvedExpression)
 
-            render System.IO.stdout (Dhall.Core.normalize inferredType)
+            render System.IO.stdout inferredType
 
         Repl -> do
             Dhall.Repl.repl characterSet explain


### PR DESCRIPTION
Since some inferred types are in non-normal form, `dhall type`
would previously return types that weren't strictly
standard-conforming. This change prevents further confusion.

Closes #1300.