### PR TITLE
Warn about missing cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ cabal.project.local~
 .ghc.environment.*
 .cache
 .history
-stack.yaml.lock
+stack*.yaml.lock

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -823,8 +823,8 @@ getOrCreateCacheDirectory showWarning cacheName = do
             catch (liftIO (Directory.doesDirectoryExist dir))
                   (handler "check the existence of" dir)
 
-    let existsPath path =
-            catch (liftIO (Directory.doesPathExist path))
+    let existsFile path =
+            catch (liftIO (Directory.doesFileExist path))
                   (handler "check the existence of" path)
 
     let createDirectory dir =
@@ -839,9 +839,9 @@ getOrCreateCacheDirectory showWarning cacheName = do
                     assertPermissions dir
 
                 else do
-                    existsPath' <- existsPath dir
+                    existsFile' <- existsFile dir
 
-                    if existsPath'
+                    if existsFile'
                         then do
                             let message =
                                      "The given path:\n"

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -773,7 +773,7 @@ warnAboutMissingCache cacheName = alternative₀ <|> alternative₁
     alternative₁ = return (Just warning)
 
       where warning = "It has not been possible to get a cache directory \"" ++ cacheName ++ "\" with read/write permission.\n"
-                   ++ "You can enable cache pointing the $XDG_CACHE_HOME environment variable\n"
+                   ++ "You can provide a cache directory by pointing the $XDG_CACHE_HOME environment variable\n"
                    ++ "to a directory with the required permission.\n"
                    ++ "A subdirectory named \"" ++ cacheName ++ "\" will be created inside if it isn't exist.\n"
 

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -913,7 +913,7 @@ getCacheBaseDirectory showWarning = alternative₀ <|> alternative₁ <|> altern
              <> "\ESC[1;33mWarning\ESC[0m: "
              <> "It hasn't been possible get a cache base directory from environment.\n"
              <> "\n"
-             <> "You can provide a cache base directory by pointing the $XDG_CACHE_HOME "
+             <> "You can provide a cache base directory by pointing the $XDG_CACHE_HOME\n"
              <> "environment variable to a directory with read and write permissions.\n"
 
         when showWarning (liftIO (System.IO.hPutStrLn System.IO.stderr message))

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DeriveAnyClass      #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
-{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -140,7 +140,7 @@ module Dhall.Import (
 import Control.Applicative (Alternative(..))
 import Codec.CBOR.Term (Term(..))
 import Control.Exception (Exception, SomeException, IOException, toException)
-import Control.Monad (guard)
+import Control.Monad (when)
 import Control.Monad.Catch (throwM, MonadCatch(catch), handle)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Class (lift)
@@ -748,7 +748,7 @@ toHeader _ = do
 getCacheFile
     :: (MonadCatch m, Alternative m, MonadIO m) => FilePath -> Dhall.Crypto.SHA256Digest -> m FilePath
 getCacheFile cacheName hash = do
-    cacheDirectory <- getOrCreateCacheDirectory cacheName
+    cacheDirectory <- getOrCreateCacheDirectory False cacheName
 
     let cacheFile = cacheDirectory </> ("1220" <> show hash)
 
@@ -756,83 +756,129 @@ getCacheFile cacheName hash = do
 
 warnAboutMissingCaches :: (MonadCatch m, Alternative m, MonadIO m) => m ()
 warnAboutMissingCaches = warn <|> return ()
-    where warn = Data.Foldable.traverse_ getOrCreateCacheDirectoryOrWarn ["dhall", "dhall-haskell"]
+    where warn = Data.Foldable.traverse_ (getOrCreateCacheDirectory True) ["dhall", "dhall-haskell"]
 
-getOrCreateCacheDirectoryOrWarn :: (MonadCatch m, Alternative m, MonadIO m) => FilePath -> m FilePath
-getOrCreateCacheDirectoryOrWarn cacheName = do
-    cacheBaseDir <- getCacheBaseDirectoryOrWarn
+getOrCreateCacheDirectory :: (MonadCatch m, Alternative m, MonadIO m) => Bool -> FilePath -> m FilePath
+getOrCreateCacheDirectory showWarning cacheName = do
+    let warn message = do
+            let warning =
+                     "\n"
+                  <> "\ESC[1;33mWarning\ESC[0m: "
+                  <> message
 
-    let message =
-            "\n" 
-         <> "\ESC[1;33mWarning\ESC[0m: " 
-         <> "It hasn't been possible to get or create the default cache directory:\n" 
-         <> "\n"
-         <> "  " ++ cacheBaseDir </> cacheName ++ "\n"
-         <> "\n"
-         <> "Usually it is caused by permissions issues.\n"
-         <> "You should make it readable and writable or provide another cache base directory " 
-         <> "setting the $XDG_CACHE_HOME environment variable.\n"
+            when showWarning (liftIO (System.IO.hPutStrLn System.IO.stderr warning))
+
+            empty
+
+    let handler action dir (ioex :: IOException) = do
+            let ioExMsg =
+                     "when trying to " <> action <> "\n"
+                  <> "\n"
+                  <> "  " <> dir <> "\n"
+                  <> "\n"
+                  <> "the following IO exception was thrown:\n"
+                  <> "\n"
+                  <> "  " <> show ioex <> "\n"
         
-    let warn = liftIO (System.IO.hPutStrLn System.IO.stderr message) >> empty
-    
-    getOrCreateCacheDirectory cacheName <|> warn
+            warn ioExMsg
 
-getOrCreateCacheDirectory :: (MonadCatch m, Alternative m, MonadIO m) => FilePath -> m FilePath
-getOrCreateCacheDirectory cacheName = do
-    let assertDirectory directory = do
+    let setPermissions dir = do
             let private = transform Directory.emptyPermissions
-                  where
-                    transform =
+                    where
+                        transform =
                             Directory.setOwnerReadable   True
-                        .   Directory.setOwnerWritable   True
-                        .   Directory.setOwnerSearchable True
+                          . Directory.setOwnerWritable   True
+                          . Directory.setOwnerSearchable True
 
+            catch
+                (liftIO (Directory.setPermissions dir private))
+                (handler "set read, write an search permissions on" dir)
+
+    let assertPermissions dir = do
             let accessible path =
-                       Directory.readable   path
-                    && Directory.writable   path
-                    && Directory.searchable path
+                    Directory.readable   path
+                 && Directory.writable   path
+                 && Directory.searchable path
 
-            directoryExists <- liftIO (Directory.doesDirectoryExist directory)
+            permissions <-
+                catch (liftIO (Directory.getPermissions dir))
+                      (handler "get permissions of" dir)
 
-            if directoryExists
+            if accessible permissions
+                then
+                    return ()
+                else do
+                    let message =
+                             "the directory:\n"
+                          <> "\n"
+                          <> "  " <> dir <> "\n"
+                          <> "\n"
+                          <> "has not read, write and search permissions.\n"
+                          <> "Its current permissions are:\n"
+                          <> show permissions <> "\n"
+
+                    warn message
+
+    let existsDirectory dir =
+            catch (liftIO (Directory.doesDirectoryExist dir))
+                  (handler "check the existence of" dir)
+
+    let existsPath path =
+            catch (liftIO (Directory.doesPathExist path))
+                  (handler "check the existence of" path)
+
+    let createDirectory dir =
+            catch (liftIO (Directory.createDirectory dir))
+                  (handler "create" dir)
+
+    let assertDirectory dir = do
+            existsDir <- existsDirectory dir
+
+            if existsDir
                 then do
-                    permissions <- liftIO (Directory.getPermissions directory)
-
-                    guard (accessible permissions)
+                    assertPermissions dir
 
                 else do
-                    assertDirectory (FilePath.takeDirectory directory)
+                    existsPath' <- existsPath dir
 
-                    liftIO (Directory.createDirectory directory)
+                    if existsPath'
+                        then do
+                            let message =
+                                     "the given path:\n"
+                                  <> "\n"
+                                  <> "  " <> dir <> "\n"
+                                  <> "\n"
+                                  <> "already exists but it is not a directory.\n"
 
-                    liftIO (Directory.setPermissions directory private)
+                            warn message
 
-    cacheBaseDirectory <- getCacheBaseDirectory
+                        else do
+                            assertDirectory (FilePath.takeDirectory dir)
+
+                            createDirectory dir
+
+                            setPermissions dir
+    
+    cacheBaseDirectory <- getCacheBaseDirectory showWarning
 
     let directory = cacheBaseDirectory </> cacheName
-    
-    let handler (_ :: IOException) = empty
 
-    catch (assertDirectory directory) handler
+    let message =
+             "It hasn't been possible to get or create the default cache directory:\n"
+          <> "\n"
+          <> "  " <> directory <> "\n"
+          <> "\n"
+          <> "You can enable cache creating it if needed and setting read, write and search\n"
+          <> "permissions on it or providing another cache base directory by setting\n"
+          <> "the $XDG_CACHE_HOME environment variable.\n"
+          <> "\n"
+
+    assertDirectory directory <|> warn message
 
     return directory
 
-getCacheBaseDirectoryOrWarn :: (Alternative m, MonadIO m) => m FilePath
-getCacheBaseDirectoryOrWarn = do
-    let message =
-            "\n" 
-         <> "\ESC[1;33mWarning\ESC[0m: " 
-         <> "It hasn't been possible get a cache base directory from environment.\n"
-         <> "\n"
-         <> "You can provide a cache base directory by pointing the $XDG_CACHE_HOME "
-         <> "environment variable to a directory with read and write permissions.\n"
-
-    let warn = liftIO (System.IO.hPutStrLn System.IO.stderr message) >> empty
-    
-    getCacheBaseDirectory <|> warn
-                
-getCacheBaseDirectory :: (Alternative m, MonadIO m) => m FilePath
-getCacheBaseDirectory = alternative₀ <|> alternative₁
+getCacheBaseDirectory :: (Alternative m, MonadIO m) => Bool -> m FilePath
+getCacheBaseDirectory showWarning = alternative₀ <|> alternative₁ <|> alternative₂
   where
     alternative₀ = do
         maybeXDGCacheHome <- do
@@ -861,6 +907,18 @@ getCacheBaseDirectory = alternative₀ <|> alternative₁
 
         where isWindows = System.Info.os == "mingw32"
 
+    alternative₂ = do
+        let message =
+                "\n"
+             <> "\ESC[1;33mWarning\ESC[0m: "
+             <> "It hasn't been possible get a cache base directory from environment.\n"
+             <> "\n"
+             <> "You can provide a cache base directory by pointing the $XDG_CACHE_HOME "
+             <> "environment variable to a directory with read and write permissions.\n"
+
+        when showWarning (liftIO (System.IO.hPutStrLn System.IO.stderr message))
+
+        empty
 
 -- If the URL contains headers typecheck them and replace them with their normal
 -- forms.

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -775,7 +775,7 @@ warnAboutMissingCache cacheName = alternative₀ <|> alternative₁
       where warning = "It has not been possible to get a cache directory \"" ++ cacheName ++ "\" with read/write permission.\n"
                    ++ "You can provide a cache directory by pointing the $XDG_CACHE_HOME environment variable\n"
                    ++ "to a directory with the required permissions.\n"
-                   ++ "A subdirectory named \"" ++ cacheName ++ "\" will be created inside if it isn't exist.\n"
+                   ++ "A subdirectory named \"" ++ cacheName ++ "\" will be created inside if it doesn't already exist.\n"
 
 getOrCreateCacheDirectory :: (Alternative m, MonadIO m) => FilePath -> m FilePath
 getOrCreateCacheDirectory cacheName = do

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -868,9 +868,9 @@ getOrCreateCacheDirectory showWarning cacheName = do
           <> "\n"
           <> "↳ " <> directory <> "\n"
           <> "\n"
-          <> "You can enable caching by creating it if needed and setting read, write and search\n"
-          <> "permissions on it or providing another cache base directory by setting\n"
-          <> "the $XDG_CACHE_HOME environment variable.\n"
+          <> "You can enable caching by creating it if needed and setting read,\n"
+          <> "write and search permissions on it or providing another cache base\n"
+          <> "directory by setting the $XDG_CACHE_HOME environment variable.\n"
           <> "\n"
 
     assertDirectory directory <|> warn message

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DeriveAnyClass      #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -70,7 +70,7 @@
     > $ export BAR='"Hi"'
     > $ export BAZ='λ(x : Bool) → x == False'
     > $ dhall <<< "{ foo = env:FOO , bar = env:BAR , baz = env:BAZ }"
-> { bar : Text, baz : ∀(x : Bool) → Bool, foo : Integer }
+    > { bar : Text, baz : ∀(x : Bool) → Bool, foo : Integer }
     >
     > { bar = "Hi", baz = λ(x : Bool) → x == False, foo = 1 }
 

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -750,7 +750,7 @@ getCacheFile
 getCacheFile cacheName hash = do
     cacheDirectory <- getOrCreateCacheDirectory cacheName
 
-    let cacheFile = (cacheDirectory </> cacheName) </> ("1220" <> show hash)
+    let cacheFile = cacheDirectory </> ("1220" <> show hash)
 
     return cacheFile
 

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -772,13 +772,13 @@ getOrCreateCacheDirectory showWarning cacheName = do
 
     let handler action dir (ioex :: IOException) = do
             let ioExMsg =
-                     "when trying to " <> action <> "\n"
+                     "When trying to " <> action <> ":\n"
                   <> "\n"
-                  <> "  " <> dir <> "\n"
+                  <> "↳ " <> dir <> "\n"
                   <> "\n"
-                  <> "the following IO exception was thrown:\n"
+                  <> "... the following exception was thrown:\n"
                   <> "\n"
-                  <> "  " <> show ioex <> "\n"
+                  <> "↳ " <> show ioex <> "\n"
         
             warn ioExMsg
 
@@ -792,7 +792,7 @@ getOrCreateCacheDirectory showWarning cacheName = do
 
             catch
                 (liftIO (Directory.setPermissions dir private))
-                (handler "set read, write an search permissions on" dir)
+                (handler "correct the permissions for" dir)
 
     let assertPermissions dir = do
             let accessible path =
@@ -809,12 +809,12 @@ getOrCreateCacheDirectory showWarning cacheName = do
                     return ()
                 else do
                     let message =
-                             "the directory:\n"
+                             "The directory:\n"
                           <> "\n"
-                          <> "  " <> dir <> "\n"
+                          <> "↳ " <> dir <> "\n"
                           <> "\n"
-                          <> "has not read, write and search permissions.\n"
-                          <> "Its current permissions are:\n"
+                          <> "... does not give you permission to read, write, or search files.\n\n"
+                          <> "The directory's current permissions are:\n"
                           <> show permissions <> "\n"
 
                     warn message
@@ -844,11 +844,11 @@ getOrCreateCacheDirectory showWarning cacheName = do
                     if existsPath'
                         then do
                             let message =
-                                     "the given path:\n"
+                                     "The given path:\n"
                                   <> "\n"
-                                  <> "  " <> dir <> "\n"
+                                  <> "↳ " <> dir <> "\n"
                                   <> "\n"
-                                  <> "already exists but it is not a directory.\n"
+                                  <> "... already exists but is not a directory.\n"
 
                             warn message
 
@@ -864,11 +864,11 @@ getOrCreateCacheDirectory showWarning cacheName = do
     let directory = cacheBaseDirectory </> cacheName
 
     let message =
-             "It hasn't been possible to get or create the default cache directory:\n"
+             "Could not get or create the default cache directory:\n"
           <> "\n"
-          <> "  " <> directory <> "\n"
+          <> "↳ " <> directory <> "\n"
           <> "\n"
-          <> "You can enable cache creating it if needed and setting read, write and search\n"
+          <> "You can enable caching by creating it if needed and setting read, write and search\n"
           <> "permissions on it or providing another cache base directory by setting\n"
           <> "the $XDG_CACHE_HOME environment variable.\n"
           <> "\n"
@@ -911,7 +911,7 @@ getCacheBaseDirectory showWarning = alternative₀ <|> alternative₁ <|> altern
         let message =
                 "\n"
              <> "\ESC[1;33mWarning\ESC[0m: "
-             <> "It hasn't been possible get a cache base directory from environment.\n"
+             <> "Could not locate a cache base directory from the environment.\n"
              <> "\n"
              <> "You can provide a cache base directory by pointing the $XDG_CACHE_HOME\n"
              <> "environment variable to a directory with read and write permissions.\n"

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -774,7 +774,7 @@ warnAboutMissingCache cacheName = alternative₀ <|> alternative₁
 
       where warning = "It has not been possible to get a cache directory \"" ++ cacheName ++ "\" with read/write permission.\n"
                    ++ "You can provide a cache directory by pointing the $XDG_CACHE_HOME environment variable\n"
-                   ++ "to a directory with the required permission.\n"
+                   ++ "to a directory with the required permissions.\n"
                    ++ "A subdirectory named \"" ++ cacheName ++ "\" will be created inside if it isn't exist.\n"
 
 getOrCreateCacheDirectory :: (Alternative m, MonadIO m) => FilePath -> m FilePath

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -383,6 +383,8 @@ command (Options {..}) = do
             let doc = Dhall.Pretty.prettyCharacterSet characterSet expression
 
             renderDoc h doc
+    
+    Dhall.Import.warnAboutMissingCache
 
     handle $ case mode of
         Version -> do

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -384,7 +384,7 @@ command (Options {..}) = do
 
             renderDoc h doc
     
-    Dhall.Import.warnAboutMissingCache
+    Dhall.Import.warnAboutMissingCaches
 
     handle $ case mode of
         Version -> do


### PR DESCRIPTION
* As suggested by the [standard](https://github.com/dhall-lang/dhall-lang/blob/master/standard/imports.md).
* Not sure about the concrete message, feedback very welcome!
* Tested pointing `$XDG_CACHE_HOME` to a directory without read/write permissions
* The place where emitting the war is in each dhall execution, maybe it will be better to restrict to commands that couls use cache (most of them?)