### PR TITLE
Disable 1-field simplification by default

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -1063,7 +1063,7 @@ data SingletonConstructors
     | Wrapped
     -- ^ Always wrap the field in a record
     | Smart
-    -- ^ Only fields in a record if they are named and don't begin with @\"_\"@
+    -- ^ Only fields in a record if they are named
 
 {-| Default interpret options, which you can tweak or override, like this:
 
@@ -1387,7 +1387,7 @@ instance (Selector s, Interpret a) => GenericInterpret (M1 S s (K1 i a)) where
                 case singletonConstructors of
                     Bare ->
                         expected'
-                    Smart | Data.Text.isPrefixOf "_" name ->
+                    Smart | selName n == "" ->
                         expected'
                     _ ->
                         Record (Dhall.Map.singleton name expected')
@@ -1410,9 +1410,9 @@ instance (Selector s, Interpret a) => GenericInterpret (M1 S s (K1 i a)) where
 
         let extract =
                 case singletonConstructors of
-                    Bare                                  -> extract0
-                    Smart | Data.Text.isPrefixOf "_" name -> extract0
-                    _                                     -> extract1
+                    Bare                    -> extract0
+                    Smart | selName n == "" -> extract0
+                    _                       -> extract1
 
         return (Type {..})
 
@@ -1630,15 +1630,15 @@ instance (Selector s, Inject a) => GenericInject (M1 S s (K1 i a)) where
 
         let embed =
                 case singletonConstructors of
-                    Bare                                  -> embed0
-                    Smart | Data.Text.isPrefixOf "_" name -> embed0
-                    _                                     -> embed1
+                    Bare                    -> embed0
+                    Smart | selName n == "" -> embed0
+                    _                       -> embed1
 
         let declared =
                 case singletonConstructors of
                     Bare ->
                         declared'
-                    Smart | Data.Text.isPrefixOf "_" name ->
+                    Smart | selName n == "" ->
                         declared'
                     _ ->
                         Record (Dhall.Map.singleton name declared')

--- a/dhall/tests/Dhall/Test/Dhall.hs
+++ b/dhall/tests/Dhall/Test/Dhall.hs
@@ -187,11 +187,11 @@ shouldHandleUnionsCorrectly =
         `shouldPassThrough` [ P0 , P1 (), P2 1.0, P3 () (), P4 1.0 2.0 ]
 
     , "λ(x : < N0 : Bool | N1 : Natural | N2 : Text >) → x"
-        `shouldPassThroughCollapse` [ N0 True, N1 5, N2 "ABC" ]
-    , "λ(x : < R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >) → x"
-        `shouldPassThroughCollapse` [ R0 {}, R1 { a = () }, R2 { x = 1.0 }, R3 { a = (), b = () }, R4 { x = 1.0, y = 2.0 } ]
+        `shouldPassThroughSmart` [ N0 True, N1 5, N2 "ABC" ]
+    , "λ(x : < R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >) → x"
+        `shouldPassThroughSmart` [ R0 {}, R1 { a = () }, R2 { x = 1.0 }, R3 { a = (), b = () }, R4 { x = 1.0, y = 2.0 } ]
     , "λ(x : < P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >) → x"
-        `shouldPassThroughCollapse` [ P0 , P1 (), P2 1.0, P3 () (), P4 1.0 2.0 ]
+        `shouldPassThroughSmart` [ P0 , P1 (), P2 1.0, P3 () (), P4 1.0 2.0 ]
 
     , "(< N0 : { _1 : Bool } | N1 : { _1 : Natural } | N2 : { _1 : Text } >).N0 { _1 = True }"
         `shouldMarshalInto` N0 True
@@ -202,11 +202,11 @@ shouldHandleUnionsCorrectly =
         `shouldMarshalInto` N2 "ABC"
 
     , "(< N0 : Bool | N1 : Natural | N2 : Text >).N0 True"
-        `shouldMarshalIntoCollapse` N0 True
+        `shouldMarshalIntoSmart` N0 True
     , "(< N0 : Bool | N1 : Natural | N2 : Text >).N1 5"
-        `shouldMarshalIntoCollapse` N1 5
+        `shouldMarshalIntoSmart` N1 5
     , "(< N0 : Bool | N1 : Natural | N2 : Text >).N2 \"ABC\""
-        `shouldMarshalIntoCollapse` N2 "ABC"
+        `shouldMarshalIntoSmart` N2 "ABC"
 
     , "(< E0 | E1 | E2>).E0" `shouldMarshalInto` E0
     , "(< E0 | E1 | E2>).E1" `shouldMarshalInto` E1
@@ -223,16 +223,16 @@ shouldHandleUnionsCorrectly =
     , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
         `shouldMarshalInto` R4 { x = 1.0, y = 2.0 }
 
-    , "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R0"
-        `shouldMarshalIntoCollapse` R0
-    , "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R1"
-        `shouldMarshalIntoCollapse` R1 { a = () }
-    , "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R2 1.0"
-        `shouldMarshalIntoCollapse` R2 { x = 1.0 }
-    , "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R3 { a = {=}, b = {=} }"
-        `shouldMarshalIntoCollapse` R3 { a = (), b = () }
-    , "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
-        `shouldMarshalIntoCollapse` R4 { x = 1.0, y = 2.0 }
+    , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R0"
+        `shouldMarshalIntoSmart` R0
+    , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R1 { a = {=} }"
+        `shouldMarshalIntoSmart` R1 { a = () }
+    , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R2 { x = 1.0 }"
+        `shouldMarshalIntoSmart` R2 { x = 1.0 }
+    , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R3 { a = {=}, b = {=} }"
+        `shouldMarshalIntoSmart` R3 { a = (), b = () }
+    , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
+        `shouldMarshalIntoSmart` R4 { x = 1.0, y = 2.0 }
 
     , "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
         `shouldMarshalInto` P0
@@ -246,15 +246,15 @@ shouldHandleUnionsCorrectly =
         `shouldMarshalInto` P4 1.0 2.0
 
     , "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
-        `shouldMarshalIntoCollapse` P0
+        `shouldMarshalIntoSmart` P0
     , "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P1"
-        `shouldMarshalIntoCollapse` P1 ()
+        `shouldMarshalIntoSmart` P1 ()
     , "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P2 1.0"
-        `shouldMarshalIntoCollapse` P2 1.0
+        `shouldMarshalIntoSmart` P2 1.0
     , "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P3 { _1 = {=}, _2 = {=} }"
-        `shouldMarshalIntoCollapse` P3 () ()
+        `shouldMarshalIntoSmart` P3 () ()
     , "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P4 { _1 = 1.0, _2 = 2.0 }"
-        `shouldMarshalIntoCollapse` P4 1.0 2.0
+        `shouldMarshalIntoSmart` P4 1.0 2.0
 
     , N0 True
         `shouldInjectInto`
@@ -267,13 +267,13 @@ shouldHandleUnionsCorrectly =
         "(< N0 : { _1 : Bool } | N1 : { _1 : Natural } | N2 : { _1 : Text } >).N2 { _1 = \"ABC\" }"
 
     , N0 True
-        `shouldInjectIntoCollapse`
+        `shouldInjectIntoSmart`
         "(< N0 : Bool | N1 : Natural | N2 : Text >).N0 True"
     , N1 5
-        `shouldInjectIntoCollapse`
+        `shouldInjectIntoSmart`
         "(< N0 : Bool | N1 : Natural | N2 : Text >).N1 5"
     , N2 "ABC"
-        `shouldInjectIntoCollapse`
+        `shouldInjectIntoSmart`
         "(< N0 : Bool | N1 : Natural | N2 : Text >).N2 \"ABC\""
 
     , E0 `shouldInjectInto` "< E0 | E1 | E2 >.E0"
@@ -286,11 +286,11 @@ shouldHandleUnionsCorrectly =
     , R3 { a = (), b = () } `shouldInjectInto` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R3 { a = {=}, b = {=} }"
     , R4 { x = 1.0, y = 2.0 } `shouldInjectInto` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
 
-    , R0 `shouldInjectIntoCollapse` "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R0"
-    , R1 { a = () } `shouldInjectIntoCollapse` "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R1"
-    , R2 { x = 1.0 } `shouldInjectIntoCollapse` "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R2 1.0"
-    , R3 { a = (), b = () } `shouldInjectIntoCollapse` "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R3 { a = {=}, b = {=} }"
-    , R4 { x = 1.0, y = 2.0 } `shouldInjectIntoCollapse` "< R0 | R1 | R2 : Double | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
+    , R0 `shouldInjectIntoSmart` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R0"
+    , R1 { a = () } `shouldInjectIntoSmart` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R1 { a = {=} }"
+    , R2 { x = 1.0 } `shouldInjectIntoSmart` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R2 { x = 1.0}"
+    , R3 { a = (), b = () } `shouldInjectIntoSmart` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R3 { a = {=}, b = {=} }"
+    , R4 { x = 1.0, y = 2.0 } `shouldInjectIntoSmart` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
 
     , P0 `shouldInjectInto` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
     , P1 () `shouldInjectInto` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P1 { _1 = {=} }"
@@ -298,24 +298,24 @@ shouldHandleUnionsCorrectly =
     , P3 () () `shouldInjectInto` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P3 { _1 = {=}, _2 = {=} }"
     , P4 1.0 2.0 `shouldInjectInto` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P4 { _1 = 1.0, _2 = 2.0 }"
 
-    , P0 `shouldInjectIntoCollapse` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
-    , P1 () `shouldInjectIntoCollapse` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P1"
-    , P2 1.0 `shouldInjectIntoCollapse` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P2 1.0"
-    , P3 () () `shouldInjectIntoCollapse` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P3 { _1 = {=}, _2 = {=} }"
-    , P4 1.0 2.0 `shouldInjectIntoCollapse` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P4 { _1 = 1.0, _2 = 2.0 }"
+    , P0 `shouldInjectIntoSmart` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
+    , P1 () `shouldInjectIntoSmart` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P1"
+    , P2 1.0 `shouldInjectIntoSmart` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P2 1.0"
+    , P3 () () `shouldInjectIntoSmart` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P3 { _1 = {=}, _2 = {=} }"
+    , P4 1.0 2.0 `shouldInjectIntoSmart` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P4 { _1 = 1.0, _2 = 2.0 }"
     ]
   where
-    collapseOptions =
+    smartOptions =
         Dhall.defaultInterpretOptions
-            { Dhall.collapseSingletonRecords = True }
+            { Dhall.singletonConstructors = Dhall.Smart }
 
     code `shouldPassThrough` values = testCase "Pass through" $ do
         f <- Dhall.input Dhall.auto code
 
         values @=? map f values
 
-    code `shouldPassThroughCollapse` values = testCase "Pass through" $ do
-        f <- Dhall.input (Dhall.autoWith collapseOptions) code
+    code `shouldPassThroughSmart` values = testCase "Pass through" $ do
+        f <- Dhall.input (Dhall.autoWith smartOptions) code
 
         values @=? map f values
 
@@ -324,8 +324,8 @@ shouldHandleUnionsCorrectly =
 
         expectedValue @=? actualValue
 
-    code `shouldMarshalIntoCollapse` expectedValue = testCase "Marshal" $ do
-        actualValue <- Dhall.input (Dhall.autoWith collapseOptions) code
+    code `shouldMarshalIntoSmart` expectedValue = testCase "Marshal" $ do
+        actualValue <- Dhall.input (Dhall.autoWith smartOptions) code
 
         expectedValue @=? actualValue
 
@@ -336,12 +336,12 @@ shouldHandleUnionsCorrectly =
 
         Dhall.Core.denote resolvedExpression @=? Dhall.embed Dhall.inject value
 
-    value `shouldInjectIntoCollapse` expectedCode = testCase "Inject" $ do
+    value `shouldInjectIntoSmart` expectedCode = testCase "Inject" $ do
         parsedExpression <- Dhall.Core.throws (Dhall.Parser.exprFromText "(test)" expectedCode)
 
         resolvedExpression <- Dhall.Import.assertNoImports parsedExpression
 
-        Dhall.Core.denote resolvedExpression @=? Dhall.embed (Dhall.injectWith collapseOptions) value
+        Dhall.Core.denote resolvedExpression @=? Dhall.embed (Dhall.injectWith smartOptions) value
 
 shouldConvertDhallToHaskellCorrectly :: TestTree
 shouldConvertDhallToHaskellCorrectly =

--- a/dhall/tests/recursive/expr0.dhall
+++ b/dhall/tests/recursive/expr0.dhall
@@ -1,6 +1,7 @@
   λ(Expr : Type)
 → let ExprF =
-        < LitF : Natural
+        < LitF :
+            { _1 : Natural }
         | AddF :
             { _1 : Expr, _2 : Expr }
         | MulF :
@@ -8,7 +9,7 @@
         >
   
   in    λ(Fix : ExprF → Expr)
-      → let Lit = λ(x : Natural) → Fix (ExprF.LitF x)
+      → let Lit = λ(x : Natural) → Fix (ExprF.LitF { _1 = x })
         
         let Add =
               λ(x : Expr) → λ(y : Expr) → Fix (ExprF.AddF { _1 = x, _2 = y })

--- a/dhall/tests/recursive/expr1.dhall
+++ b/dhall/tests/recursive/expr1.dhall
@@ -1,7 +1,7 @@
   λ(a : Type)
 → let ExprF =
         < LitF :
-            Natural
+            { _1 : Natural }
         | AddF :
             { _1 : a, _2 : a }
         | MulF :
@@ -9,7 +9,7 @@
         >
   
   in    λ(a : ExprF → a)
-      → let Lit = λ(x : Natural) → a (ExprF.LitF x)
+      → let Lit = λ(x : Natural) → a (ExprF.LitF { _1 = x })
         
         let Add = λ(x : a@1) → λ(y : a@1) → a (ExprF.AddF { _1 = x, _2 = y })
         


### PR DESCRIPTION
This builds on top of #1315 to minimize disruption by disabling the
breaking change by default and instead requiring the user to opt in
by setting a new `collapseSingletonRecords` option to `True`.

The additional tests added to verify this also caught a bug in the
`Interpret` instance for functions, which this change also fixes.