### PR TITLE
Refactor `Dhall.Eval`

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -75,10 +75,6 @@ module Dhall.Core (
     , textShow
     ) where
 
-#if MIN_VERSION_base(4,8,0)
-#else
-import Control.Applicative (Applicative(..), (<$>))
-#endif
 import Control.Applicative (empty)
 import Control.DeepSeq (NFData)
 import Control.Exception (Exception)

--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -35,14 +35,14 @@ module Dhall.Core (
     , Expr(..)
 
     -- * Normalization
-    , Dhall.Core.alphaNormalize
-    , normalize
+    , Eval.alphaNormalize
+    , Eval.normalize
     , normalizeWith
     , normalizeWithM
     , Normalizer
     , NormalizerM
     , ReifiedNormalizer (..)
-    , judgmentallyEqual
+    , Eval.judgmentallyEqual
     , subst
     , shift
     , isNormalized
@@ -72,6 +72,7 @@ module Dhall.Core (
     , escapeText
     , pathCharacter
     , throws
+    , textShow
     ) where
 
 #if MIN_VERSION_base(4,8,0)
@@ -107,7 +108,7 @@ import Prelude hiding (succ)
 import qualified Control.Exception
 import qualified Control.Monad
 import qualified Data.Char
-import {-# SOURCE #-} qualified Dhall.Eval
+import {-# SOURCE #-} qualified Dhall.Eval  as Eval
 import qualified Data.HashSet
 import qualified Data.List.NonEmpty
 import qualified Data.Sequence
@@ -1219,35 +1220,6 @@ subst x e (ImportAlt a b) = ImportAlt a' b'
 -- and `subst` does nothing to a closed expression
 subst _ _ (Embed p) = Embed p
 
-{-| α-normalize an expression by renaming all bound variables to @\"_\"@ and
-    using De Bruijn indices to distinguish them
-
->>> alphaNormalize (Lam "a" (Const Type) (Lam "b" (Const Type) (Lam "x" "a" (Lam "y" "b" "x"))))
-Lam "_" (Const Type) (Lam "_" (Const Type) (Lam "_" (Var (V "_" 1)) (Lam "_" (Var (V "_" 1)) (Var (V "_" 1)))))
-
-    α-normalization does not affect free variables:
-
->>> alphaNormalize "x"
-Var (V "x" 0)
-
--}
-alphaNormalize :: Expr s a -> Expr s a
-alphaNormalize = Dhall.Eval.alphaNormalize
-
-{-| Reduce an expression to its normal form, performing beta reduction
-
-    `normalize` does not type-check the expression.  You may want to type-check
-    expressions before normalizing them since normalization can convert an
-    ill-typed expression into a well-typed expression.
-
-    `normalize` can also fail with `error` if you normalize an ill-typed
-    expression
--}
-
-normalize :: Eq a => Expr s a -> Expr t a
-normalize = Dhall.Eval.nfEmpty
-
-
 {-| This function is used to determine whether folds like @Natural/fold@ or
     @List/fold@ should be lazy or strict in their accumulator based on the type
     of the accumulator
@@ -1368,7 +1340,7 @@ shallowDenote         e  = e
 -}
 normalizeWith :: Eq a => Maybe (ReifiedNormalizer a) -> Expr s a -> Expr t a
 normalizeWith (Just ctx) t = runIdentity (normalizeWithM (getReifiedNormalizer ctx) t)
-normalizeWith _          t = Dhall.Eval.nfEmpty t
+normalizeWith _          t = Eval.normalize t
 
 {-| This function generalizes `normalizeWith` by allowing the custom normalizer
     to use an arbitrary `Monad`
@@ -1459,7 +1431,7 @@ normalizeWithM ctx e0 = loop (denote e0)
                         | otherwise -> pure (NaturalLit 0)
                     App (App NaturalSubtract (NaturalLit 0)) y -> pure y
                     App (App NaturalSubtract _) (NaturalLit 0) -> pure (NaturalLit 0)
-                    App (App NaturalSubtract x) y | judgmentallyEqual x y -> pure (NaturalLit 0)
+                    App (App NaturalSubtract x) y | Eval.judgmentallyEqual x y -> pure (NaturalLit 0)
                     App IntegerShow (IntegerLit n)
                         | 0 <= n    -> pure (TextLit (Chunks [] ("+" <> Data.Text.pack (show n))))
                         | otherwise -> pure (TextLit (Chunks [] (Data.Text.pack (show n))))
@@ -1588,8 +1560,8 @@ normalizeWithM ctx e0 = loop (denote e0)
         decide  l              (BoolLit True ) = l
         decide  _              (BoolLit False) = BoolLit False
         decide  l               r
-            | judgmentallyEqual l r = l
-            | otherwise             = BoolAnd l r
+            | Eval.judgmentallyEqual l r = l
+            | otherwise                  = BoolAnd l r
     BoolOr x y -> decide <$> loop x <*> loop y
       where
         decide (BoolLit False)  r              = r
@@ -1597,30 +1569,30 @@ normalizeWithM ctx e0 = loop (denote e0)
         decide  l              (BoolLit False) = l
         decide  _              (BoolLit True ) = BoolLit True
         decide  l               r
-            | judgmentallyEqual l r = l
-            | otherwise             = BoolOr l r
+            | Eval.judgmentallyEqual l r = l
+            | otherwise                  = BoolOr l r
     BoolEQ x y -> decide <$> loop x <*> loop y
       where
         decide (BoolLit True )  r              = r
         decide  l              (BoolLit True ) = l
         decide  l               r
-            | judgmentallyEqual l r = BoolLit True
-            | otherwise             = BoolEQ l r
+            | Eval.judgmentallyEqual l r = BoolLit True
+            | otherwise                  = BoolEQ l r
     BoolNE x y -> decide <$> loop x <*> loop y
       where
         decide (BoolLit False)  r              = r
         decide  l              (BoolLit False) = l
         decide  l               r
-            | judgmentallyEqual l r = BoolLit False
-            | otherwise             = BoolNE l r
+            | Eval.judgmentallyEqual l r = BoolLit False
+            | otherwise                  = BoolNE l r
     BoolIf bool true false -> decide <$> loop bool <*> loop true <*> loop false
       where
         decide (BoolLit True )  l              _              = l
         decide (BoolLit False)  _              r              = r
         decide  b              (BoolLit True) (BoolLit False) = b
         decide  b               l              r
-            | judgmentallyEqual l r = l
-            | otherwise             = BoolIf b l r
+            | Eval.judgmentallyEqual l r = l
+            | otherwise                  = BoolIf b l r
     Natural -> pure Natural
     NaturalLit n -> pure (NaturalLit n)
     NaturalFold -> pure NaturalFold
@@ -1733,7 +1705,7 @@ normalizeWithM ctx e0 = loop (denote e0)
             l
         decide (RecordLit m) (RecordLit n) =
             RecordLit (Dhall.Map.union n m)
-        decide l r | judgmentallyEqual l r =
+        decide l r | Eval.judgmentallyEqual l r =
             l
         decide l r =
             Prefer l r
@@ -1861,15 +1833,6 @@ textShow text = "\"" <> Data.Text.concatMap f text <> "\""
     f c | c <= '\x1F' = Data.Text.pack (Text.Printf.printf "\\u%04x" (Data.Char.ord c))
         | otherwise   = Data.Text.singleton c
 
-{-| Returns `True` if two expressions are α-equivalent and β-equivalent and
-    `False` otherwise
-
-    `judgmentallyEqual` can fail with an `error` if you compare ill-typed
-    expressions
--}
-judgmentallyEqual :: Eq a => Expr s a -> Expr t a -> Bool
-judgmentallyEqual = Dhall.Eval.convEmpty
-
 -- | Use this to wrap you embedded functions (see `normalizeWith`) to make them
 --   polymorphic enough to be used.
 type NormalizerM m a = forall s. Expr s a -> m (Maybe (Expr s a))
@@ -1928,7 +1891,7 @@ isNormalized e0 = loop (denote e0)
           App (App NaturalSubtract (NaturalLit _)) (NaturalLit _) -> False
           App (App NaturalSubtract (NaturalLit 0)) _ -> False
           App (App NaturalSubtract _) (NaturalLit 0) -> False
-          App (App NaturalSubtract x) y -> not (judgmentallyEqual x y)
+          App (App NaturalSubtract x) y -> not (Eval.judgmentallyEqual x y)
           App NaturalToInteger (NaturalLit _) -> False
           App IntegerShow (IntegerLit _) -> False
           App IntegerToDouble (IntegerLit _) -> False
@@ -1954,28 +1917,28 @@ isNormalized e0 = loop (denote e0)
         where
           decide (BoolLit _)  _          = False
           decide  _          (BoolLit _) = False
-          decide  l           r          = not (judgmentallyEqual l r)
+          decide  l           r          = not (Eval.judgmentallyEqual l r)
       BoolOr x y -> loop x && loop y && decide x y
         where
           decide (BoolLit _)  _          = False
           decide  _          (BoolLit _) = False
-          decide  l           r          = not (judgmentallyEqual l r)
+          decide  l           r          = not (Eval.judgmentallyEqual l r)
       BoolEQ x y -> loop x && loop y && decide x y
         where
           decide (BoolLit True)  _             = False
           decide  _             (BoolLit True) = False
-          decide  l              r             = not (judgmentallyEqual l r)
+          decide  l              r             = not (Eval.judgmentallyEqual l r)
       BoolNE x y -> loop x && loop y && decide x y
         where
           decide (BoolLit False)  _               = False
           decide  _              (BoolLit False ) = False
-          decide  l               r               = not (judgmentallyEqual l r)
+          decide  l               r               = not (Eval.judgmentallyEqual l r)
       BoolIf x y z ->
           loop x && loop y && loop z && decide x y z
         where
           decide (BoolLit _)  _              _              = False
           decide  _          (BoolLit True) (BoolLit False) = False
-          decide  _           l              r              = not (judgmentallyEqual l r)
+          decide  _           l              r              = not (Eval.judgmentallyEqual l r)
       Natural -> True
       NaturalLit _ -> True
       NaturalFold -> True
@@ -2056,7 +2019,7 @@ isNormalized e0 = loop (denote e0)
           decide (RecordLit m) _ | Data.Foldable.null m = False
           decide _ (RecordLit n) | Data.Foldable.null n = False
           decide (RecordLit _) (RecordLit _) = False
-          decide l r = not (judgmentallyEqual l r)
+          decide l r = not (Eval.judgmentallyEqual l r)
       Merge x y t -> loop x && loop y && all loop t
       ToMap x t -> case x of
           RecordLit _ -> False

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -342,19 +342,26 @@ vField t0 k = go t0
 
 vProjectByFields :: Eq a => Environment a -> Val a -> Set Text -> Val a
 vProjectByFields env t ks =
-  if null ks then
-    VRecordLit mempty
-  else case t of
-    VRecordLit kvs -> let
-      kvs' = Map.restrictKeys kvs (Dhall.Set.toSet ks)
-      in VRecordLit kvs'
-    VProject t' _ -> vProjectByFields env t' ks
-    VPrefer l (VRecordLit kvs) -> let
-      ksSet = Dhall.Set.toSet ks
-      kvs' = Map.restrictKeys kvs ksSet
-      ks' = Dhall.Set.fromSet (Data.Set.difference ksSet (Map.keysSet kvs'))
-      in vPrefer env (vProjectByFields env l ks') (VRecordLit kvs')
-    t' -> VProject t' (Left ks)
+    if null ks
+        then VRecordLit mempty
+        else case t of
+            VRecordLit kvs ->
+                let kvs' = Map.restrictKeys kvs (Dhall.Set.toSet ks)
+                in  VRecordLit kvs'
+            VProject t' _ ->
+                vProjectByFields env t' ks
+            VPrefer l (VRecordLit kvs) ->
+                let ksSet = Dhall.Set.toSet ks
+
+                    kvs' = Map.restrictKeys kvs ksSet
+
+                    ks' =
+                        Dhall.Set.fromSet
+                            (Data.Set.difference ksSet (Map.keysSet kvs'))
+
+                in  vPrefer env (vProjectByFields env l ks') (VRecordLit kvs')
+            t' ->
+                VProject t' (Left ks)
 
 eval :: forall a. Eq a => Environment a -> Expr Void a -> Val a
 eval !env t0 =

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -1,106 +1,79 @@
-{-# LANGUAGE
-  BangPatterns,
-  CPP,
-  LambdaCase,
-  OverloadedStrings,
-  PatternSynonyms,
-  RankNTypes,
-  ScopedTypeVariables,
-  TupleSections,
-  ViewPatterns
-  #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE ViewPatterns        #-}
 
-{-# OPTIONS_GHC
-  -O
-  -fno-warn-name-shadowing
-  -fno-warn-unused-matches
-  #-}
+{-# OPTIONS_GHC -O -fno-warn-name-shadowing -fno-warn-unused-matches #-}
 
-{-|
-Eval-apply environment machine with conversion checking and quoting to normal
-forms. Fairly similar to GHCI's STG machine algorithmically, but much simpler,
-with no known call optimization or environment trimming.
+{-| Eval-apply environment machine with conversion checking and quoting to
+    normal forms. Fairly similar to GHCI's STG machine algorithmically, but much
+    simpler, with no known call optimization or environment trimming.
 
-Potential optimizations without changing Expr:
-  - In conversion checking, get non-shadowing variables not by linear
-    Env-walking, but by keeping track of Env size, and generating names which
-    are known to be illegal as source-level names (to rule out shadowing).
-  - Use HashMap Text chunks for large let-definitions blocks. "Large" vs "Small"
-    is fairly cheap to determine at evaluation time.
+    Potential optimizations without changing Expr:
 
-Potential optimizations with changing Expr:
-  - Use Int in Var instead of Integer. Overflow is practically impossible.
-  - Use actual full de Bruijn indices in Var instead of Text counting indices. Then, we'd
-    switch to full de Bruijn levels in Val as well, and use proper constant time non-shadowing
-    name generation.
+    * In conversion checking, get non-shadowing variables not by linear
+      Env-walking, but by keeping track of Env size, and generating names which
+      are known to be illegal as source-level names (to rule out shadowing).
 
+    * Use HashMap Text chunks for large let-definitions blocks. "Large" vs
+      "Small" is fairly cheap to determine at evaluation time.
+
+    Potential optimizations with changing Expr:
+
+    * Use actual full de Bruijn indices in Var instead of Text counting indices.
+      Then, we'd switch to full de Bruijn levels in Val as well, and use proper
+      constant time non-shadowing name generation.
 -}
 
 module Dhall.Eval (
-    Env(..)
-  , Names(..)
-  , Closure(..)
-  , VChunks(..)
-  , Val(..)
-  , Void
-  , inst
-  , eval
-  , conv
-  , convEmpty
-  , quote
-  , nf
-  , nfEmpty
-  , Dhall.Eval.alphaNormalize
+    judgmentallyEqual
+  , normalize
+  , alphaNormalize
   ) where
 
 #if MIN_VERSION_base(4,8,0)
 #else
-import Control.Applicative (Applicative(..), (<$>))
+import Control.Applicative (Applicative(..))
 #endif
 
 import Data.Foldable (foldr', toList)
 import Data.Semigroup (Semigroup(..))
-import Data.Sequence (Seq)
+import Data.Sequence (Seq, ViewL(..), ViewR(..))
 import Data.Text (Text)
 import Data.Void (Void)
 
-import Dhall.Core (
-    Binding(..)
+import Dhall.Core
+  ( Binding(..)
   , Expr(..)
   , Chunks(..)
   , Const(..)
   , Import
   , Var(..)
-  , denote
   )
 
--- import Control.Exception (throw)
--- import Dhall.Import.Types (InternalError)
 import Dhall.Map (Map)
 import Dhall.Set (Set)
 import GHC.Natural (Natural)
 import Unsafe.Coerce (unsafeCoerce)
 
-import qualified Codec.Serialise     as Serialise
-import qualified Data.Char
-import qualified Data.Sequence
-import qualified Data.Set
-import qualified Data.Text
-import qualified Dhall.Binary
-import qualified Dhall.Map
+import qualified Codec.Serialise as Serialise
+import qualified Data.Sequence   as Sequence
+import qualified Data.Set        as Set
+import qualified Data.Text       as Text
+import qualified Dhall.Binary    as Binary
+import qualified Dhall.Core      as Core
+import qualified Dhall.Map       as Map
 import qualified Dhall.Set
-import qualified Text.Printf
 
-----------------------------------------------------------------------------------------------------
-
-data Env a =
-    Empty
-  | Skip !(Env a) {-# unpack #-} !Text
-  | Extend !(Env a) {-# unpack #-} !Text (Val a)
-
-coeExprVoid :: Expr Void a -> Expr s a
-coeExprVoid = unsafeCoerce
-{-# inline coeExprVoid #-}
+data Environment a
+    = Empty
+    | Skip   !(Environment a) {-# UNPACK #-} !Text
+    | Extend !(Environment a) {-# UNPACK #-} !Text (Val a)
 
 errorMsg :: String
 errorMsg = unlines
@@ -118,7 +91,7 @@ errorMsg = unlines
     _ERROR = "\ESC[1;31mError\ESC[0m"
 
 
-data Closure a = Cl !Text !(Env a) !(Expr Void a)
+data Closure a = Closure !Text !(Environment a) !(Expr Void a)
 data VChunks a = VChunks ![(Text, Val a)] !Text
 
 instance Semigroup (VChunks a) where
@@ -132,873 +105,1198 @@ instance Monoid (VChunks a) where
   mappend = (<>)
 #endif
 
+{-| Some information is lost when `eval` converts a `Lam` or a built-in function
+    from the `Expr` type to a `VHLam` of the `Val` type and `quote` needs that
+    information in order to reconstruct an equivalent `Expr`.  This `HLamInfo`
+    type holds that extra information necessary to perform that reconstruction
+-}
 data HLamInfo a
   = Prim
+  -- ^ Don't store any information
   | Typed !Text (Val a)
+  -- ^ Store the original name and type of the variable bound by the `Lam`
   | NaturalFoldCl (Val a)
+  -- ^ The original function was a @Natural/fold@.  We need to preserve this
+  --   information in order to implement @Natural/{build,fold}@ fusion
   | ListFoldCl (Val a)
+  -- ^ The original function was a @List/fold@.  We need to preserve this
+  --   information in order to implement @List/{build,fold}@ fusion
   | OptionalFoldCl (Val a)
+  -- ^ The original function was an @Optional/fold@.  We need to preserve this
+  --   information in order to implement @Optional/{build,fold}@ fusion
   | NaturalSubtractZero
+  -- ^ The original function was a @Natural/subtract 0@.  We need to preserve
+  --   this information in case the @Natural/subtract@ ends up not being fully
+  --   saturated, in which case we need to recover the unsaturated built-in
 
 pattern VPrim :: (Val a -> Val a) -> Val a
 pattern VPrim f = VHLam Prim f
 
 data Val a
-  = VConst !Const
-  | VVar !Text !Int
-  | VPrimVar
-  | VApp !(Val a) !(Val a)
+    = VConst !Const
+    | VVar !Text !Int
+    | VPrimVar
+    | VApp !(Val a) !(Val a)
 
-  | VLam (Val a) {-# unpack #-} !(Closure a)
-  | VHLam !(HLamInfo a) !(Val a -> Val a)
+    | VLam (Val a) {-# UNPACK #-} !(Closure a)
+    | VHLam !(HLamInfo a) !(Val a -> Val a)
 
-  | VPi  (Val a) {-# unpack #-} !(Closure a)
-  | VHPi !Text (Val a) !(Val a -> Val a)
+    | VPi (Val a) {-# UNPACK #-} !(Closure a)
+    | VHPi !Text (Val a) !(Val a -> Val a)
 
-  | VBool
-  | VBoolLit !Bool
-  | VBoolAnd !(Val a) !(Val a)
-  | VBoolOr !(Val a) !(Val a)
-  | VBoolEQ !(Val a) !(Val a)
-  | VBoolNE !(Val a) !(Val a)
-  | VBoolIf !(Val a) !(Val a) !(Val a)
+    | VBool
+    | VBoolLit !Bool
+    | VBoolAnd !(Val a) !(Val a)
+    | VBoolOr !(Val a) !(Val a)
+    | VBoolEQ !(Val a) !(Val a)
+    | VBoolNE !(Val a) !(Val a)
+    | VBoolIf !(Val a) !(Val a) !(Val a)
 
-  | VNatural
-  | VNaturalLit !Natural
-  | VNaturalFold !(Val a) !(Val a) !(Val a) !(Val a)
-  | VNaturalBuild !(Val a)
-  | VNaturalIsZero !(Val a)
-  | VNaturalEven !(Val a)
-  | VNaturalOdd !(Val a)
-  | VNaturalToInteger !(Val a)
-  | VNaturalShow !(Val a)
-  | VNaturalSubtract !(Val a) !(Val a)
-  | VNaturalPlus !(Val a) !(Val a)
-  | VNaturalTimes !(Val a) !(Val a)
+    | VNatural
+    | VNaturalLit !Natural
+    | VNaturalFold !(Val a) !(Val a) !(Val a) !(Val a)
+    | VNaturalBuild !(Val a)
+    | VNaturalIsZero !(Val a)
+    | VNaturalEven !(Val a)
+    | VNaturalOdd !(Val a)
+    | VNaturalToInteger !(Val a)
+    | VNaturalShow !(Val a)
+    | VNaturalSubtract !(Val a) !(Val a)
+    | VNaturalPlus !(Val a) !(Val a)
+    | VNaturalTimes !(Val a) !(Val a)
 
-  | VInteger
-  | VIntegerLit !Integer
-  | VIntegerShow !(Val a)
-  | VIntegerToDouble !(Val a)
+    | VInteger
+    | VIntegerLit !Integer
+    | VIntegerShow !(Val a)
+    | VIntegerToDouble !(Val a)
 
-  | VDouble
-  | VDoubleLit !Double
-  | VDoubleShow !(Val a)
+    | VDouble
+    | VDoubleLit !Double
+    | VDoubleShow !(Val a)
 
-  | VText
-  | VTextLit !(VChunks a)
-  | VTextAppend !(Val a) !(Val a)
-  | VTextShow !(Val a)
+    | VText
+    | VTextLit !(VChunks a)
+    | VTextAppend !(Val a) !(Val a)
+    | VTextShow !(Val a)
 
-  | VList !(Val a)
-  | VListLit !(Maybe (Val a)) !(Seq (Val a))
-  | VListAppend !(Val a) !(Val a)
-  | VListBuild   (Val a) !(Val a)
-  | VListFold    (Val a) !(Val a) !(Val a) !(Val a) !(Val a)
-  | VListLength  (Val a) !(Val a)
-  | VListHead    (Val a) !(Val a)
-  | VListLast    (Val a) !(Val a)
-  | VListIndexed (Val a) !(Val a)
-  | VListReverse (Val a) !(Val a)
+    | VList !(Val a)
+    | VListLit !(Maybe (Val a)) !(Seq (Val a))
+    | VListAppend !(Val a) !(Val a)
+    | VListBuild   (Val a) !(Val a)
+    | VListFold    (Val a) !(Val a) !(Val a) !(Val a) !(Val a)
+    | VListLength  (Val a) !(Val a)
+    | VListHead    (Val a) !(Val a)
+    | VListLast    (Val a) !(Val a)
+    | VListIndexed (Val a) !(Val a)
+    | VListReverse (Val a) !(Val a)
 
-  | VOptional (Val a)
-  | VSome (Val a)
-  | VNone (Val a)
-  | VOptionalFold (Val a) !(Val a) (Val a) !(Val a) !(Val a)
-  | VOptionalBuild (Val a) !(Val a)
-  | VRecord !(Map Text (Val a))
-  | VRecordLit !(Map Text (Val a))
-  | VUnion !(Map Text (Maybe (Val a)))
-  | VCombine !(Val a) !(Val a)
-  | VCombineTypes !(Val a) !(Val a)
-  | VPrefer !(Val a) !(Val a)
-  | VMerge !(Val a) !(Val a) !(Maybe (Val a))
-  | VToMap !(Val a) !(Maybe (Val a))
-  | VField !(Val a) !Text
-  | VInject !(Map Text (Maybe (Val a))) !Text !(Maybe (Val a))
-  | VProject !(Val a) !(Either (Set Text) (Val a))
-  | VAssert !(Val a)
-  | VEquivalent !(Val a) !(Val a)
-  | VEmbed a
+    | VOptional (Val a)
+    | VSome (Val a)
+    | VNone (Val a)
+    | VOptionalFold (Val a) !(Val a) (Val a) !(Val a) !(Val a)
+    | VOptionalBuild (Val a) !(Val a)
+    | VRecord !(Map Text (Val a))
+    | VRecordLit !(Map Text (Val a))
+    | VUnion !(Map Text (Maybe (Val a)))
+    | VCombine !(Val a) !(Val a)
+    | VCombineTypes !(Val a) !(Val a)
+    | VPrefer !(Val a) !(Val a)
+    | VMerge !(Val a) !(Val a) !(Maybe (Val a))
+    | VToMap !(Val a) !(Maybe (Val a))
+    | VField !(Val a) !Text
+    | VInject !(Map Text (Maybe (Val a))) !Text !(Maybe (Val a))
+    | VProject !(Val a) !(Either (Set Text) (Val a))
+    | VAssert !(Val a)
+    | VEquivalent !(Val a) !(Val a)
+    | VEmbed a
 
-vFun :: Val a -> Val a -> Val a
-vFun a b = VHPi "_" a (\_ -> b)
-{-# inline vFun #-}
+(~>) :: Val a -> Val a -> Val a
+(~>) a b = VHPi "_" a (\_ -> b)
+{-# INLINE (~>) #-}
 
--- Evaluation
-----------------------------------------------------------------------------------------------------
-
-textShow :: Text -> Text
-textShow text = "\"" <> Data.Text.concatMap f text <> "\""
+countEnvironment :: Text -> Environment a -> Int
+countEnvironment x = go (0 :: Int)
   where
-    f '"'  = "\\\""
-    f '$'  = "\\u0024"
-    f '\\' = "\\\\"
-    f '\b' = "\\b"
-    f '\n' = "\\n"
-    f '\r' = "\\r"
-    f '\t' = "\\t"
-    f '\f' = "\\f"
-    f c | c <= '\x1F' = Data.Text.pack (Text.Printf.printf "\\u%04x" (Data.Char.ord c))
-        | otherwise   = Data.Text.singleton c
+    go !acc Empty             = acc
+    go  acc (Skip env x'    ) = go (if x == x' then acc + 1 else acc) env
+    go  acc (Extend env x' _) = go (if x == x' then acc + 1 else acc) env
 
-countName :: Text -> Env a -> Int
-countName x = go (0 :: Int) where
-  go !acc Empty             = acc
-  go  acc (Skip env x'    ) = go (if x == x' then acc + 1 else acc) env
-  go  acc (Extend env x' _) = go (if x == x' then acc + 1 else acc) env
-
-inst :: Eq a => Closure a -> Val a -> Val a
-inst (Cl x env t) !u = eval (Extend env x u) t
-{-# inline inst #-}
+instantiate :: Eq a => Closure a -> Val a -> Val a
+instantiate (Closure x env t) !u = eval (Extend env x u) t
+{-# INLINE instantiate #-}
 
 -- Out-of-env variables have negative de Bruijn levels.
-vVar :: Env a -> Var -> Val a
-vVar env (V x i) = go env i where
-  go (Extend env x' v) i
-    | x == x'   = if i == 0 then v else go env (i - 1)
-    | otherwise = go env i
-  go (Skip env x') i
-    | x == x'   = if i == 0 then VVar x (countName x env) else go env (i - 1)
-    | otherwise = go env i
-  go Empty i = VVar x (0 - i - 1)
+vVar :: Environment a -> Var -> Val a
+vVar env (V x i) = go env i
+  where
+    go (Extend env x' v) i
+        | x == x' =
+            if i == 0 then v else go env (i - 1)
+        | otherwise =
+            go env i
+    go (Skip env x') i
+        | x == x' =
+            if i == 0 then VVar x (countEnvironment x env) else go env (i - 1)
+        | otherwise =
+            go env i
+    go Empty i =
+        VVar x (0 - i - 1)
 
 vApp :: Eq a => Val a -> Val a -> Val a
-vApp !t !u = case t of
-  VLam _ t    -> inst t u
-  VHLam _ t   -> t u
-  t           -> VApp t u
-{-# inline vApp #-}
+vApp !t !u =
+    case t of
+        VLam _ t  -> instantiate t u
+        VHLam _ t -> t u
+        t         -> VApp t u
+{-# INLINE vApp #-}
 
-vPrefer :: Eq a => Env a -> Val a -> Val a -> Val a
-vPrefer env t u = case (t, u) of
-  (VRecordLit m, u) | null m -> u
-  (t, VRecordLit m) | null m -> t
-  (VRecordLit m, VRecordLit m') ->
-     VRecordLit (Dhall.Map.union m' m)
-  (t, u) | conv env t u -> t
-  (t, u) -> VPrefer t u
-{-# inline vPrefer #-}
+vPrefer :: Eq a => Environment a -> Val a -> Val a -> Val a
+vPrefer env t u =
+    case (t, u) of
+        (VRecordLit m, u) | null m ->
+            u
+        (t, VRecordLit m) | null m ->
+            t
+        (VRecordLit m, VRecordLit m') ->
+            VRecordLit (Map.union m' m)
+        (t, u) | conv env t u ->
+            t
+        (t, u) ->
+            VPrefer t u
+{-# INLINE vPrefer #-}
 
 vCombine :: Val a -> Val a -> Val a
-vCombine t u = case (t, u) of
-  (VRecordLit m, u) | null m    -> u
-  (t, VRecordLit m) | null m    -> t
-  (VRecordLit m, VRecordLit m') -> VRecordLit (Dhall.Map.unionWith vCombine m m')
-  (t, u)                        -> VCombine t u
+vCombine t u =
+    case (t, u) of
+        (VRecordLit m, u) | null m ->
+            u
+        (t, VRecordLit m) | null m ->
+            t
+        (VRecordLit m, VRecordLit m') ->
+            VRecordLit (Map.unionWith vCombine m m')
+        (t, u) ->
+            VCombine t u
 
 vCombineTypes :: Val a -> Val a -> Val a
-vCombineTypes t u = case (t, u) of
-  (VRecord m, u) | null m -> u
-  (t, VRecord m) | null m -> t
-  (VRecord m, VRecord m') -> VRecord (Dhall.Map.unionWith vCombineTypes m m')
-  (t, u)                  -> VCombineTypes t u
+vCombineTypes t u =
+    case (t, u) of
+        (VRecord m, u) | null m ->
+            u
+        (t, VRecord m) | null m ->
+            t
+        (VRecord m, VRecord m') ->
+            VRecord (Map.unionWith vCombineTypes m m')
+        (t, u) ->
+            VCombineTypes t u
 
 vListAppend :: Val a -> Val a -> Val a
-vListAppend t u = case (t, u) of
-  (VListLit _ xs, u) | null xs   -> u
-  (t, VListLit _ ys) | null ys   -> t
-  (VListLit t xs, VListLit _ ys) -> VListLit t (xs <> ys)
-  (t, u)                         -> VListAppend t u
-{-# inline vListAppend #-}
+vListAppend t u =
+    case (t, u) of
+        (VListLit _ xs, u) | null xs ->
+            u
+        (t, VListLit _ ys) | null ys ->
+            t
+        (VListLit t xs, VListLit _ ys) ->
+            VListLit t (xs <> ys)
+        (t, u) ->
+            VListAppend t u
+{-# INLINE vListAppend #-}
 
 vNaturalPlus :: Val a -> Val a -> Val a
-vNaturalPlus t u = case (t, u) of
-  (VNaturalLit 0, u            ) -> u
-  (t,             VNaturalLit 0) -> t
-  (VNaturalLit m, VNaturalLit n) -> VNaturalLit (m + n)
-  (t,             u            ) -> VNaturalPlus t u
-{-# inline vNaturalPlus #-}
+vNaturalPlus t u =
+    case (t, u) of
+        (VNaturalLit 0, u) ->
+            u
+        (t, VNaturalLit 0) ->
+            t
+        (VNaturalLit m, VNaturalLit n) ->
+            VNaturalLit (m + n)
+        (t, u) ->
+            VNaturalPlus t u
+{-# INLINE vNaturalPlus #-}
 
 vField :: Val a -> Text -> Val a
-vField t0 k = go t0 where
-  go = \case
-    VUnion m -> case Dhall.Map.lookup k m of
-      Just (Just _) -> VPrim $ \ ~u -> VInject m k (Just u)
-      Just Nothing  -> VInject m k Nothing
-      _             -> error errorMsg
-    VRecordLit m
-      | Just v <- Dhall.Map.lookup k m -> v
-      | otherwise -> error errorMsg
-    VProject t _ -> go t
-    VPrefer (VRecordLit m) r -> case Dhall.Map.lookup k m of
-      Just v -> VField (VPrefer (singletonVRecordLit v) r) k
-      Nothing -> go r
-    VPrefer l (VRecordLit m) -> case Dhall.Map.lookup k m of
-      Just v -> v
-      Nothing -> go l
-    VCombine (VRecordLit m) r -> case Dhall.Map.lookup k m of
-      Just v -> VField (VCombine (singletonVRecordLit v) r) k
-      Nothing -> go r
-    VCombine l (VRecordLit m) -> case Dhall.Map.lookup k m of
-      Just v -> VField (VCombine l (singletonVRecordLit v)) k
-      Nothing -> go l
-    t -> VField t k
+vField t0 k = go t0
+  where
+    go = \case
+        VUnion m -> case Map.lookup k m of
+            Just (Just _) -> VPrim $ \ ~u -> VInject m k (Just u)
+            Just Nothing  -> VInject m k Nothing
+            _             -> error errorMsg
+        VRecordLit m
+            | Just v <- Map.lookup k m -> v
+            | otherwise -> error errorMsg
+        VProject t _ -> go t
+        VPrefer (VRecordLit m) r -> case Map.lookup k m of
+            Just v -> VField (VPrefer (singletonVRecordLit v) r) k
+            Nothing -> go r
+        VPrefer l (VRecordLit m) -> case Map.lookup k m of
+            Just v -> v
+            Nothing -> go l
+        VCombine (VRecordLit m) r -> case Map.lookup k m of
+            Just v -> VField (VCombine (singletonVRecordLit v) r) k
+            Nothing -> go r
+        VCombine l (VRecordLit m) -> case Map.lookup k m of
+            Just v -> VField (VCombine l (singletonVRecordLit v)) k
+            Nothing -> go l
+        t -> VField t k
 
-  singletonVRecordLit v = VRecordLit (Dhall.Map.singleton k v)
-{-# inline vField #-}
+    singletonVRecordLit v = VRecordLit (Map.singleton k v)
+{-# INLINE vField #-}
 
-vProjectByFields :: Eq a => Env a -> Val a -> Set Text -> Val a
+vProjectByFields :: Eq a => Environment a -> Val a -> Set Text -> Val a
 vProjectByFields env t ks =
   if null ks then
     VRecordLit mempty
   else case t of
     VRecordLit kvs -> let
-      kvs' = Dhall.Map.restrictKeys kvs (Dhall.Set.toSet ks)
+      kvs' = Map.restrictKeys kvs (Dhall.Set.toSet ks)
       in VRecordLit kvs'
     VProject t' _ -> vProjectByFields env t' ks
     VPrefer l r@(VRecordLit kvs) -> let
       ksSet = Dhall.Set.toSet ks
-      kvs' = Dhall.Map.restrictKeys kvs ksSet
-      ks' = Dhall.Set.fromSet (Data.Set.difference ksSet (Dhall.Map.keysSet kvs'))
+      kvs' = Map.restrictKeys kvs ksSet
+      ks' = Dhall.Set.fromSet (Set.difference ksSet (Map.keysSet kvs'))
       in vPrefer env (vProjectByFields env l ks') (VRecordLit kvs')
     t -> VProject t (Left ks)
 
-eval :: forall a. Eq a => Env a -> Expr Void a -> Val a
+eval :: forall a. Eq a => Environment a -> Expr Void a -> Val a
 eval !env t =
-  let
+    case t of
+        Const k ->
+            VConst k
+        Var v ->
+            vVar env v
+        Lam x a t ->
+            VLam (evalE a) (Closure x env t)
+        Pi x a b ->
+            VPi (evalE a) (Closure x env b)
+        App t u ->
+            vApp (evalE t) (evalE u)
+        Let (Binding _ x _ _mA _ a) b ->
+            let !env' = Extend env x (evalE a)
+            in  eval env' b
+        Annot t _ ->
+            evalE t
+        Bool ->
+            VBool
+        BoolLit b ->
+            VBoolLit b
+        BoolAnd t u ->
+            case (evalE t, evalE u) of
+                (VBoolLit True, u)    -> u
+                (VBoolLit False, u)   -> VBoolLit False
+                (t, VBoolLit True)    -> t
+                (t, VBoolLit False)   -> VBoolLit False
+                (t, u) | conv env t u -> t
+                (t, u)                -> VBoolAnd t u
+        BoolOr t u ->
+            case (evalE t, evalE u) of
+                (VBoolLit False, u)   -> u
+                (VBoolLit True, u)    -> VBoolLit True
+                (t, VBoolLit False)   -> t
+                (t, VBoolLit True)    -> VBoolLit True
+                (t, u) | conv env t u -> t
+                (t, u)                -> VBoolOr t u
+        BoolEQ t u ->
+            case (evalE t, evalE u) of
+                (VBoolLit True, u)    -> u
+                (t, VBoolLit True)    -> t
+                (t, u) | conv env t u -> VBoolLit True
+                (t, u)                -> VBoolEQ t u
+        BoolNE t u ->
+            case (evalE t, evalE u) of
+                (VBoolLit False, u)   -> u
+                (t, VBoolLit False)   -> t
+                (t, u) | conv env t u -> VBoolLit False
+                (t, u)                -> VBoolNE t u
+        BoolIf b t f ->
+            case (evalE b, evalE t, evalE f) of
+                (VBoolLit True,  t, f)   -> t
+                (VBoolLit False, t, f)   -> f
+                (b, VBoolLit True, VBoolLit False) -> b
+                (b, t, f) | conv env t f -> t
+                (b, t, f)                -> VBoolIf b t f
+        Natural ->
+            VNatural
+        NaturalLit n ->
+            VNaturalLit n
+        NaturalFold ->
+            VPrim $ \case
+                VNaturalLit n ->
+                    VHLam (Typed "natural" (VConst Type)) $ \natural ->
+                    VHLam (Typed "succ" (natural ~> natural)) $ \succ ->
+                    VHLam (Typed "zero" natural) $ \zero ->
+                    let go !acc 0 = acc
+                        go  acc n = go (vApp succ acc) (n - 1)
+                    in  go zero (fromIntegral n :: Integer)
+                n ->
+                    VHLam (NaturalFoldCl n) $ \natural ->
+                    VPrim $ \succ ->
+                    VPrim $ \zero ->
+                    VNaturalFold n natural succ zero
+        NaturalBuild ->
+            VPrim $ \case
+                VHLam (NaturalFoldCl x) _ ->
+                    x
+                VPrimVar ->
+                    VNaturalBuild VPrimVar
+                t ->       t
+                    `vApp` VNatural
+                    `vApp` VHLam (Typed "n" VNatural) (\n -> vNaturalPlus n (VNaturalLit 1))
+                    `vApp` VNaturalLit 0
+
+        NaturalIsZero -> VPrim $ \case
+            VNaturalLit n -> VBoolLit (n == 0)
+            n             -> VNaturalIsZero n
+        NaturalEven -> VPrim $ \case
+            VNaturalLit n -> VBoolLit (even n)
+            n             -> VNaturalEven n
+        NaturalOdd -> VPrim $ \case
+            VNaturalLit n -> VBoolLit (odd n)
+            n             -> VNaturalOdd n
+        NaturalToInteger -> VPrim $ \case
+            VNaturalLit n -> VIntegerLit (fromIntegral n)
+            n             -> VNaturalToInteger n
+        NaturalShow -> VPrim $ \case
+            VNaturalLit n -> VTextLit (VChunks [] (Text.pack (show n)))
+            n             -> VNaturalShow n
+        NaturalSubtract -> VPrim $ \case
+            VNaturalLit 0 ->
+                VHLam NaturalSubtractZero id
+            x@(VNaturalLit m) ->
+                VPrim $ \case
+                    VNaturalLit n
+                        | n >= m    -> VNaturalLit (subtract m n)
+                        | otherwise -> VNaturalLit 0
+                    y -> VNaturalSubtract x y
+            x ->
+                VPrim $ \case
+                    VNaturalLit 0    -> VNaturalLit 0
+                    y | conv env x y -> VNaturalLit 0
+                    y                -> VNaturalSubtract x y
+        NaturalPlus t u ->
+            vNaturalPlus (evalE t) (evalE u)
+        NaturalTimes t u ->
+            case (evalE t, evalE u) of
+                (VNaturalLit 1, u            ) -> u
+                (t,             VNaturalLit 1) -> t
+                (VNaturalLit 0, u            ) -> VNaturalLit 0
+                (t,             VNaturalLit 0) -> VNaturalLit 0
+                (VNaturalLit m, VNaturalLit n) -> VNaturalLit (m * n)
+                (t,             u            ) -> VNaturalTimes t u
+        Integer ->
+            VInteger
+        IntegerLit n ->
+            VIntegerLit n
+        IntegerShow ->
+            VPrim $ \case
+                VIntegerLit n
+                    | 0 <= n    -> VTextLit (VChunks [] (Text.pack ('+':show n)))
+                    | otherwise -> VTextLit (VChunks [] (Text.pack (show n)))
+                n -> VIntegerShow n
+        IntegerToDouble ->
+            VPrim $ \case
+                VIntegerLit n -> VDoubleLit (read (show n))
+                -- `(read . show)` is used instead of `fromInteger`
+                -- because `read` uses the correct rounding rule
+                n             -> VIntegerToDouble n
+        Double ->
+            VDouble
+        DoubleLit n ->
+            VDoubleLit n
+        DoubleShow ->
+            VPrim $ \case
+                VDoubleLit n -> VTextLit (VChunks [] (Text.pack (show n)))
+                n            -> VDoubleShow n
+        Text ->
+            VText
+        TextLit cs ->
+            case evalChunks cs of
+                VChunks [("", t)] "" -> t
+                vcs                  -> VTextLit vcs
+        TextAppend t u ->
+            evalE (TextLit (Chunks [("", t), ("", u)] ""))
+        TextShow ->
+            VPrim $ \case
+                VTextLit (VChunks [] x) -> VTextLit (VChunks [] (Core.textShow x))
+                t                       -> VTextShow t
+        List ->
+            VPrim VList
+        ListLit ma ts ->
+            VListLit (fmap evalE ma) (fmap evalE ts)
+        ListAppend t u ->
+            vListAppend (evalE t) (evalE u)
+        ListBuild ->
+            VPrim $ \a ->
+            VPrim $ \case
+                VHLam (ListFoldCl x) _ ->
+                    x
+                VPrimVar ->
+                    VListBuild a VPrimVar
+                t ->       t
+                    `vApp` VList a
+                    `vApp` VHLam (Typed "a" a) (\x ->
+                           VHLam (Typed "as" (VList a)) (\as ->
+                           vListAppend (VListLit Nothing (pure x)) as))
+                    `vApp` VListLit (Just (VList a)) mempty
+
+        ListFold ->
+            VPrim $ \a ->
+            VPrim $ \case
+                VListLit _ as ->
+                    VHLam (Typed "list" (VConst Type)) $ \list ->
+                    VHLam (Typed "cons" (a ~> list ~> list) ) $ \cons ->
+                    VHLam (Typed "nil"  list) $ \nil ->
+                    foldr' (\x b -> cons `vApp` x `vApp` b) nil as
+                as ->
+                    VHLam (ListFoldCl as) $ \t ->
+                    VPrim $ \c ->
+                    VPrim $ \n ->
+                    VListFold a as t c n
+        ListLength ->
+            VPrim $ \ a ->
+            VPrim $ \case
+                VListLit _ as -> VNaturalLit (fromIntegral (Sequence.length as))
+                as            -> VListLength a as
+        ListHead ->
+            VPrim $ \ a ->
+            VPrim $ \case
+                VListLit _ as ->
+                    case Sequence.viewl as of
+                        y :< _ -> VSome y
+                        _      -> VNone a
+                as ->
+                    VListHead a as
+        ListLast ->
+            VPrim $ \ a ->
+            VPrim $ \case
+                VListLit _ as ->
+                    case Sequence.viewr as of
+                        _ :> t -> VSome t
+                        _      -> VNone a
+                as -> VListLast a as
+        ListIndexed ->
+            VPrim $ \ a ->
+            VPrim $ \case
+                VListLit _ as ->
+                    let a' =
+                            if null as
+                            then Just (VList (VRecord (Map.fromList [("index", VNatural), ("value", a)])))
+                            else Nothing
+
+                        as' =
+                            Sequence.mapWithIndex
+                                (\i t ->
+                                    VRecordLit
+                                        (Map.fromList
+                                            [ ("index", VNaturalLit (fromIntegral i))
+                                            , ("value", t)
+                                            ]
+                                        )
+                                )
+                                as
+
+                        in  VListLit a' as'
+                t ->
+                    VListIndexed a t
+        ListReverse ->
+            VPrim $ \ ~a ->
+            VPrim $ \case
+                VListLit t as | null as ->
+                    VListLit t (Sequence.reverse as)
+                VListLit t as ->
+                    VListLit Nothing (Sequence.reverse as)
+                t ->
+                    VListReverse a t
+        Optional ->
+            VPrim VOptional
+        Some t ->
+            VSome (evalE t)
+        None ->
+            VPrim $ \ ~a -> VNone a
+        OptionalFold ->
+            VPrim $ \ ~a ->
+            VPrim $ \case
+                VNone _ ->
+                    VHLam (Typed "optional" (VConst Type)) $ \optional ->
+                    VHLam (Typed "some" (a ~> optional)) $ \some ->
+                    VHLam (Typed "none" optional) $ \none ->
+                    none
+                VSome t ->
+                    VHLam (Typed "optional" (VConst Type)) $ \optional ->
+                    VHLam (Typed "some" (a ~> optional)) $ \some ->
+                    VHLam (Typed "none" optional) $ \none ->
+                    some `vApp` t
+                opt ->
+                    VHLam (OptionalFoldCl opt) $ \o ->
+                    VPrim $ \s ->
+                    VPrim $ \n ->
+                    VOptionalFold a opt o s n
+        OptionalBuild ->
+            VPrim $ \ ~a ->
+            VPrim $ \case
+                VHLam (OptionalFoldCl x) _ -> x
+                VPrimVar -> VOptionalBuild a VPrimVar
+                t ->       t
+                    `vApp` VOptional a
+                    `vApp` VHLam (Typed "a" a) VSome
+                    `vApp` VNone a
+        Record kts ->
+            VRecord (Map.sort (fmap evalE kts))
+        RecordLit kts ->
+            VRecordLit (Map.sort (fmap evalE kts))
+        Union kts ->
+            VUnion (Map.sort (fmap (fmap evalE) kts))
+        Combine t u ->
+            vCombine (evalE t) (evalE u)
+        CombineTypes t u ->
+            vCombineTypes (evalE t) (evalE u)
+        Prefer t u ->
+            vPrefer env (evalE t) (evalE u)
+        Merge x y ma ->
+            case (evalE x, evalE y, fmap evalE ma) of
+                (VRecordLit m, VInject _ k mt, _)
+                    | Just f <- Map.lookup k m -> maybe f (vApp f) mt
+                    | otherwise                -> error errorMsg
+                (x, y, ma) -> VMerge x y ma
+        ToMap x ma ->
+            case (evalE x, fmap evalE ma) of
+                (VRecordLit m, ma'@(Just _)) | null m ->
+                    VListLit ma' (Sequence.empty)
+                (VRecordLit m, _) ->
+                    let entry (k, v) =
+                            VRecordLit
+                                (Map.fromList
+                                    [ ("mapKey", VTextLit $ VChunks [] k)
+                                    , ("mapValue", v)
+                                    ]
+                                )
+
+                        s = (Sequence.fromList . map entry . Map.toList) m
+
+                    in  VListLit Nothing s
+                (x, ma) ->
+                    VToMap x ma
+        Field t k ->
+            vField (evalE t) k
+        Project t (Left ks) ->
+            vProjectByFields env (evalE t) (Dhall.Set.sort ks)
+        Project t (Right e) ->
+            case evalE e of
+                VRecord kts ->
+                    evalE (Project t (Left (Dhall.Set.fromSet (Map.keysSet kts))))
+                e' ->
+                    VProject (evalE t) (Right e')
+        Assert t ->
+            VAssert (evalE t)
+        Equivalent t u ->
+            VEquivalent (evalE t) (evalE u)
+        Note _ e ->
+            evalE e
+        ImportAlt t _ ->
+            evalE t
+        Embed a ->
+            VEmbed a
+  where
     evalE :: Expr Void a -> Val a
     evalE = eval env
-    {-# inline evalE #-}
+    {-# INLINE evalE #-}
 
     evalChunks :: Chunks Void a -> VChunks a
-    evalChunks (Chunks xys z) =
-      foldr' (\(x, t) vcs ->
-                case evalE t of
-                  VTextLit vcs' -> VChunks [] x <> vcs' <> vcs
-                  t             -> VChunks [(x, t)] mempty <> vcs)
-            (VChunks [] z)
-            xys
-    {-# inline evalChunks #-}
+    evalChunks (Chunks xys z) = foldr' cons nil xys
+      where
+        cons (x, t) vcs =
+            case evalE t of
+                VTextLit vcs' -> VChunks [] x <> vcs' <> vcs
+                t             -> VChunks [(x, t)] mempty <> vcs
 
-  in case t of
-    Const k          -> VConst k
-    Var v            -> vVar env v
-    Lam x a t        -> VLam (evalE a) (Cl x env t)
-    Pi x a b         -> VPi (evalE a) (Cl x env b)
-    App t u          -> vApp (evalE t) (evalE u)
-    Let (Binding _ x _ _mA _ a) b ->
-                        let !env' = Extend env x (evalE a)
-                        in eval env' b
-    Annot t _        -> evalE t
-
-    Bool             -> VBool
-    BoolLit b        -> VBoolLit b
-    BoolAnd t u      -> case (evalE t, evalE u) of
-                          (VBoolLit True, u)    -> u
-                          (VBoolLit False, u)   -> VBoolLit False
-                          (t, VBoolLit True)    -> t
-                          (t, VBoolLit False)   -> VBoolLit False
-                          (t, u) | conv env t u -> t
-                          (t, u)                -> VBoolAnd t u
-    BoolOr t u       -> case (evalE t, evalE u) of
-                          (VBoolLit False, u)   -> u
-                          (VBoolLit True, u)    -> VBoolLit True
-                          (t, VBoolLit False)   -> t
-                          (t, VBoolLit True)    -> VBoolLit True
-                          (t, u) | conv env t u -> t
-                          (t, u)                -> VBoolOr t u
-    BoolEQ t u       -> case (evalE t, evalE u) of
-                          (VBoolLit True, u)    -> u
-                          (t, VBoolLit True)    -> t
-                          (t, u) | conv env t u -> VBoolLit True
-                          (t, u)                -> VBoolEQ t u
-    BoolNE t u       -> case (evalE t, evalE u) of
-                          (VBoolLit False, u)   -> u
-                          (t, VBoolLit False)   -> t
-                          (t, u) | conv env t u -> VBoolLit False
-                          (t, u)                -> VBoolNE t u
-    BoolIf b t f     -> case (evalE b, evalE t, evalE f) of
-                          (VBoolLit True,  t, f)   -> t
-                          (VBoolLit False, t, f)   -> f
-                          (b, VBoolLit True, VBoolLit False) -> b
-                          (b, t, f) | conv env t f -> t
-                          (b, t, f)                -> VBoolIf b t f
-
-    Natural          -> VNatural
-    NaturalLit n     -> VNaturalLit n
-    NaturalFold      -> VPrim $ \case
-                          VNaturalLit n ->
-                            VHLam (Typed "natural" (VConst Type)) $ \natural ->
-                            VHLam (Typed "succ" (vFun natural natural)) $ \succ ->
-                            VHLam (Typed "zero" natural) $ \zero ->
-                              let go !acc 0 = acc
-                                  go  acc n = go (vApp succ acc) (n - 1)
-                              in go zero (fromIntegral n :: Integer)
-                          n ->
-                            VHLam (NaturalFoldCl n) $ \natural -> VPrim $ \succ -> VPrim $ \zero ->
-                              VNaturalFold n natural succ zero
-    NaturalBuild     -> VPrim $ \case
-                          VHLam (NaturalFoldCl x) _ -> x
-                          VPrimVar -> VNaturalBuild VPrimVar
-                          t        ->
-                             t `vApp` VNatural
-                               `vApp` VHLam (Typed "n" VNatural) (\n -> vNaturalPlus n (VNaturalLit 1))
-                               `vApp` VNaturalLit 0
-
-    NaturalIsZero    -> VPrim $ \case VNaturalLit n -> VBoolLit (n == 0)
-                                      n             -> VNaturalIsZero n
-    NaturalEven      -> VPrim $ \case VNaturalLit n -> VBoolLit (even n)
-                                      n             -> VNaturalEven n
-    NaturalOdd       -> VPrim $ \case VNaturalLit n -> VBoolLit (odd n)
-                                      n             -> VNaturalOdd n
-    NaturalToInteger -> VPrim $ \case VNaturalLit n -> VIntegerLit (fromIntegral n)
-                                      n             -> VNaturalToInteger n
-    NaturalShow      -> VPrim $ \case VNaturalLit n -> VTextLit (VChunks [] (Data.Text.pack (show n)))
-                                      n             -> VNaturalShow n
-    NaturalSubtract -> VPrim $ \case
-                         VNaturalLit 0 ->
-                           VHLam NaturalSubtractZero id
-                         x@(VNaturalLit m) ->
-                           VPrim $ \case
-                               VNaturalLit n
-                                 | n >= m    -> VNaturalLit (subtract m n)
-                                 | otherwise -> VNaturalLit 0
-                               y -> VNaturalSubtract x y
-                         x ->
-                           VPrim $ \case
-                             VNaturalLit 0 -> VNaturalLit 0
-                             y | conv env x y -> VNaturalLit 0
-                             y -> VNaturalSubtract x y
-    NaturalPlus t u  -> vNaturalPlus (evalE t) (evalE u)
-    NaturalTimes t u -> case (evalE t, evalE u) of
-                          (VNaturalLit 1, u            ) -> u
-                          (t,             VNaturalLit 1) -> t
-                          (VNaturalLit 0, u            ) -> VNaturalLit 0
-                          (t,             VNaturalLit 0) -> VNaturalLit 0
-                          (VNaturalLit m, VNaturalLit n) -> VNaturalLit (m * n)
-                          (t,             u            ) -> VNaturalTimes t u
-
-    Integer          -> VInteger
-    IntegerLit n     -> VIntegerLit n
-    IntegerShow      -> VPrim $ \case
-                          VIntegerLit n
-                            | 0 <= n    -> VTextLit (VChunks [] (Data.Text.pack ('+':show n)))
-                            | otherwise -> VTextLit (VChunks [] (Data.Text.pack (show n)))
-                          n -> VIntegerShow n
-    IntegerToDouble  -> VPrim $ \case VIntegerLit n -> VDoubleLit (read (show n))
-                                      -- `(read . show)` is used instead of `fromInteger`
-                                      -- because `read` uses the correct rounding rule
-                                      n             -> VIntegerToDouble n
-
-    Double           -> VDouble
-    DoubleLit n      -> VDoubleLit n
-    DoubleShow       -> VPrim $ \case VDoubleLit n -> VTextLit (VChunks [] (Data.Text.pack (show n)))
-                                      n            -> VDoubleShow n
-
-    Text             -> VText
-    TextLit cs       -> case evalChunks cs of
-                          VChunks [("", t)] "" -> t
-                          vcs                  -> VTextLit vcs
-    TextAppend t u   -> evalE (TextLit (Chunks [("", t), ("", u)] ""))
-    TextShow         -> VPrim $ \case
-                          VTextLit (VChunks [] x) -> VTextLit (VChunks [] (textShow x))
-                          t                       -> VTextShow t
-
-    List             -> VPrim VList
-    ListLit ma ts    -> VListLit (evalE <$> ma) (evalE <$> ts)
-    ListAppend t u   -> vListAppend (evalE t) (evalE u)
-    ListBuild        -> VPrim $ \a -> VPrim $ \case
-                          VHLam (ListFoldCl x) _ -> x
-                          VPrimVar -> VListBuild a VPrimVar
-                          t ->
-                            t `vApp` VList a
-                              `vApp` VHLam (Typed "a" a) (\x ->
-                                              VHLam (Typed "as" (VList a)) (\as ->
-                                                vListAppend (VListLit Nothing (pure x)) as))
-                              `vApp` VListLit (Just (VList a)) mempty
-
-    ListFold         -> VPrim $ \a -> VPrim $ \case
-                          VListLit _ as ->
-                            VHLam (Typed "list" (VConst Type)) $ \list ->
-                            VHLam (Typed "cons" (vFun a $ vFun list list) ) $ \cons ->
-                            VHLam (Typed "nil"  list) $ \nil ->
-                              foldr' (\x b -> cons `vApp` x `vApp` b) nil as
-                          as ->
-                            VHLam (ListFoldCl as) $ \t -> VPrim $ \c -> VPrim $ \n ->
-                              VListFold a as t c n
-
-    ListLength       -> VPrim $ \ a -> VPrim $ \case
-                          VListLit _ as -> VNaturalLit (fromIntegral (Data.Sequence.length as))
-                          as            -> VListLength a as
-    ListHead         -> VPrim $ \ a -> VPrim $ \case
-                          VListLit _ as -> case Data.Sequence.viewl as of
-                                             y Data.Sequence.:< _ -> VSome y
-                                             _                    -> VNone a
-                          as            -> VListHead a as
-    ListLast         -> VPrim $ \ a -> VPrim $ \case
-                          VListLit _ as -> case Data.Sequence.viewr as of
-                                             _ Data.Sequence.:> t -> VSome t
-                                             _                    -> VNone a
-                          as            -> VListLast a as
-    ListIndexed      -> VPrim $ \ a -> VPrim $ \case
-                          VListLit _ as -> let
-                            a' = if null as then
-                                   Just (VList (VRecord (Dhall.Map.fromList
-                                                         [("index", VNatural), ("value", a)])))
-                                 else
-                                   Nothing
-                            as' = Data.Sequence.mapWithIndex
-                                    (\i t -> VRecordLit
-                                      (Dhall.Map.fromList [("index", VNaturalLit (fromIntegral i)),
-                                                           ("value", t)]))
-                                    as
-                            in VListLit a' as'
-                          t -> VListIndexed a t
-    ListReverse      -> VPrim $ \ ~a -> VPrim $ \case
-                          VListLit t as | null as -> VListLit t (Data.Sequence.reverse as)
-                          VListLit t as -> VListLit Nothing (Data.Sequence.reverse as)
-                          t             -> VListReverse a t
-
-    Optional         -> VPrim VOptional
-    Some t           -> VSome (evalE t)
-    None             -> VPrim $ \ ~a -> VNone a
-
-    OptionalFold     -> VPrim $ \ ~a -> VPrim $ \case
-                          VNone _ ->
-                            VHLam (Typed "optional" (VConst Type)) $ \optional ->
-                            VHLam (Typed "some" (vFun a optional)) $ \some ->
-                            VHLam (Typed "none" optional) $ \none ->
-                            none
-                          VSome t ->
-                            VHLam (Typed "optional" (VConst Type)) $ \optional ->
-                            VHLam (Typed "some" (vFun a optional)) $ \some ->
-                            VHLam (Typed "none" optional) $ \none ->
-                            some `vApp` t
-                          opt ->
-                            VHLam (OptionalFoldCl opt) $ \o ->
-                            VPrim $ \s ->
-                            VPrim $ \n ->
-                            VOptionalFold a opt o s n
-    OptionalBuild    -> VPrim $ \ ~a -> VPrim $ \case
-                          VHLam (OptionalFoldCl x) _ -> x
-                          VPrimVar -> VOptionalBuild a VPrimVar
-                          t -> t `vApp` VOptional a
-                                 `vApp` VHLam (Typed "a" a) VSome
-                                 `vApp` VNone a
-
-    Record kts       -> VRecord (Dhall.Map.sort (evalE <$> kts))
-    RecordLit kts    -> VRecordLit (Dhall.Map.sort (evalE <$> kts))
-    Union kts        -> VUnion (Dhall.Map.sort ((evalE <$>) <$> kts))
-    Combine t u      -> vCombine (evalE t) (evalE u)
-    CombineTypes t u -> vCombineTypes (evalE t) (evalE u)
-    Prefer t u       -> vPrefer env (evalE t) (evalE u)
-    Merge x y ma     -> case (evalE x, evalE y, evalE <$> ma) of
-                          (VRecordLit m, VInject _ k mt, _)
-                            | Just f  <- Dhall.Map.lookup k m -> maybe f (vApp f) mt
-                            | otherwise -> error errorMsg
-                          (x, y, ma) -> VMerge x y ma
-    ToMap x ma       -> case (evalE x, evalE <$> ma) of
-                          (VRecordLit m, ma'@(Just _)) | null m ->
-                            VListLit ma' (Data.Sequence.empty)
-                          (VRecordLit m, _) -> let
-                            entry (k, v) =
-                              VRecordLit (Dhall.Map.fromList [("mapKey", VTextLit $ VChunks [] k),
-                                                              ("mapValue", v)])
-                            s = (Data.Sequence.fromList . map entry . Dhall.Map.toList) m
-                            in VListLit Nothing s
-                          (x, ma) -> VToMap x ma
-    Field t k        -> vField (evalE t) k
-    Project t (Left ks) -> vProjectByFields env (evalE t) (Dhall.Set.sort ks)
-    Project t (Right e) ->
-                        case evalE e of
-                          VRecord kts ->
-                            evalE (Project t (Left (Dhall.Set.fromSet (Dhall.Map.keysSet kts))))
-                          e' -> VProject (evalE t) (Right e')
-    Assert t         -> VAssert (evalE t)
-    Equivalent t u   -> VEquivalent (evalE t) (evalE u)
-    Note _ e         -> evalE e
-    ImportAlt t _    -> evalE t
-    Embed a          -> VEmbed a
-
-
--- Conversion checking
---------------------------------------------------------------------------------
+        nil = VChunks [] z
+    {-# INLINE evalChunks #-}
 
 eqListBy :: (a -> a -> Bool) -> [a] -> [a] -> Bool
-eqListBy f = go where
-  go (x:xs) (y:ys) | f x y = go xs ys
-  go [] [] = True
-  go _  _  = False
-{-# inline eqListBy #-}
+eqListBy f = go
+  where
+    go (x:xs) (y:ys) | f x y = go xs ys
+    go [] [] = True
+    go _  _  = False
+{-# INLINE eqListBy #-}
 
 eqMapsBy :: Ord k => (v -> v -> Bool) -> Map k v -> Map k v -> Bool
 eqMapsBy f mL mR =
-    Dhall.Map.size mL == Dhall.Map.size mR
-    && eqListBy eq (Dhall.Map.toList mL) (Dhall.Map.toList mR)
+    Map.size mL == Map.size mR
+    && eqListBy eq (Map.toList mL) (Map.toList mR)
   where
     eq (kL, vL) (kR, vR) = kL == kR && f vL vR
-{-# inline eqMapsBy #-}
+{-# INLINE eqMapsBy #-}
 
 eqMaybeBy :: (a -> a -> Bool) -> Maybe a -> Maybe a -> Bool
-eqMaybeBy f = go where
-  go (Just x) (Just y) = f x y
-  go Nothing  Nothing  = True
-  go _        _        = False
-{-# inline eqMaybeBy #-}
+eqMaybeBy f = go
+  where
+    go (Just x) (Just y) = f x y
+    go Nothing  Nothing  = True
+    go _        _        = False
+{-# INLINE eqMaybeBy #-}
 
-conv :: forall a. Eq a => Env a -> Val a -> Val a -> Bool
+conv :: forall a. Eq a => Environment a -> Val a -> Val a -> Bool
 conv !env t t' =
-  let
+    case (t, t') of
+        (VConst k, VConst k') ->
+            k == k'
+        (VVar x i, VVar x' i') ->
+            x == x' && i == i'
+        (VLam _ (freshClosure -> (x, v, t)), VLam _ t' ) ->
+            convSkip x (instantiate t v) (instantiate t' v)
+        (VLam _ (freshClosure -> (x, v, t)), VHLam _ t') ->
+            convSkip x (instantiate t v) (t' v)
+        (VLam _ (freshClosure -> (x, v, t)), t'        ) ->
+            convSkip x (instantiate t v) (vApp t' v)
+        (VHLam _ t, VLam _ (freshClosure -> (x, v, t'))) ->
+            convSkip x (t v) (instantiate t' v)
+        (VHLam _ t, VHLam _ t'                    ) ->
+            let (x, v) = fresh "x" in convSkip x (t v) (t' v)
+        (VHLam _ t, t'                            ) ->
+            let (x, v) = fresh "x" in convSkip x (t v) (vApp t' v)
+        (t, VLam _ (freshClosure -> (x, v, t'))) ->
+            convSkip x (vApp t v) (instantiate t' v)
+        (t, VHLam _ t'  ) ->
+            let (x, v) = fresh "x" in convSkip x (vApp t v) (t' v)
+        (VApp t u, VApp t' u') ->
+            convE t t' && convE u u'
+        (VPi a b, VPi a' (freshClosure -> (x, v, b'))) ->
+            convE a a' && convSkip x (instantiate b v) (instantiate b' v)
+        (VPi a b, VHPi (fresh -> (x, v)) a' b') ->
+            convE a a' && convSkip x (instantiate b v) (b' v)
+        (VHPi _ a b, VPi a' (freshClosure -> (x, v, b'))) ->
+            convE a a' && convSkip x (b v) (instantiate b' v)
+        (VHPi _ a b, VHPi (fresh -> (x, v)) a' b') ->
+            convE a a' && convSkip x (b v) (b' v)
+        (VBool, VBool) ->
+            True
+        (VBoolLit b, VBoolLit b') ->
+            b == b'
+        (VBoolAnd t u, VBoolAnd t' u') ->
+            convE t t' && convE u u'
+        (VBoolOr t u, VBoolOr t' u') ->
+            convE t t' && convE u u'
+        (VBoolEQ t u, VBoolEQ t' u') ->
+            convE t t' && convE u u'
+        (VBoolNE t u, VBoolNE t' u') ->
+            convE t t' && convE u u'
+        (VBoolIf t u v, VBoolIf t' u' v') ->
+            convE t t' && convE u u' && convE v v'
+        (VNatural, VNatural) ->
+            True
+        (VNaturalLit n, VNaturalLit n') ->
+            n == n'
+        (VNaturalFold t _ u v, VNaturalFold t' _ u' v') ->
+            convE t t' && convE u u' && convE v v'
+        (VNaturalBuild t, VNaturalBuild t') ->
+            convE t t'
+        (VNaturalIsZero t, VNaturalIsZero t') ->
+            convE t t'
+        (VNaturalEven t, VNaturalEven t') ->
+            convE t t'
+        (VNaturalOdd t, VNaturalOdd t') ->
+            convE t t'
+        (VNaturalToInteger t, VNaturalToInteger t') ->
+            convE t t'
+        (VNaturalShow t, VNaturalShow t') ->
+            convE t t'
+        (VNaturalSubtract x y, VNaturalSubtract x' y') ->
+            convE x x' && convE y y'
+        (VNaturalPlus t u, VNaturalPlus t' u') ->
+            convE t t' && convE u u'
+        (VNaturalTimes t u, VNaturalTimes t' u') ->
+            convE t t' && convE u u'
+        (VInteger, VInteger) ->
+            True
+        (VIntegerLit t, VIntegerLit t') ->
+            t == t'
+        (VIntegerShow t, VIntegerShow t') ->
+            convE t t'
+        (VIntegerToDouble t, VIntegerToDouble t') ->
+            convE t t'
+        (VDouble, VDouble) ->
+            True
+        (VDoubleLit n, VDoubleLit n') ->
+                Serialise.serialise (Binary.encode (DoubleLit n  :: Expr Void Import))
+            ==  Serialise.serialise (Binary.encode (DoubleLit n' :: Expr Void Import))
+        (VDoubleShow t, VDoubleShow t') ->
+            convE t t'
+        (VText, VText) ->
+            True
+        (VTextLit cs, VTextLit cs') ->
+            convChunks cs cs'
+        (VTextAppend t u, VTextAppend t' u') ->
+            convE t t' && convE u u'
+        (VTextShow t, VTextShow t') ->
+            convE t t'
+        (VList a, VList a') ->
+            convE a a'
+        (VListLit _ xs, VListLit _ xs') ->
+            eqListBy convE (toList xs) (toList xs')
+        (VListAppend t u, VListAppend t' u') ->
+            convE t t' && convE u u'
+        (VListBuild a t, VListBuild a' t') ->
+            convE t t'
+        (VListLength a t, VListLength a' t') ->
+            convE a a' && convE t t'
+        (VListHead _ t, VListHead _ t') ->
+            convE t t'
+        (VListLast _ t, VListLast _ t') ->
+            convE t t'
+        (VListIndexed _ t, VListIndexed _ t') ->
+            convE t t'
+        (VListReverse _ t, VListReverse _ t') ->
+            convE t t'
+        (VListFold a l _ t u, VListFold a' l' _ t' u') ->
+            convE a a' && convE l l' && convE t t' && convE u u'
+        (VOptional a, VOptional a') ->
+            convE a a'
+        (VSome t, VSome t') ->
+            convE t t'
+        (VNone _, VNone _) ->
+            True
+        (VOptionalBuild _ t, VOptionalBuild _ t') ->
+            convE t t'
+        (VRecord m, VRecord m') ->
+            eqMapsBy convE m m'
+        (VRecordLit m, VRecordLit m') ->
+            eqMapsBy convE m m'
+        (VUnion m, VUnion m') ->
+            eqMapsBy (eqMaybeBy convE) m m'
+        (VCombine t u, VCombine t' u') ->
+            convE t t' && convE u u'
+        (VCombineTypes t u, VCombineTypes t' u') ->
+            convE t t' && convE u u'
+        (VPrefer t u, VPrefer t' u') ->
+            convE t t' && convE u u'
+        (VMerge t u _, VMerge t' u' _) ->
+            convE t t' && convE u u'
+        (VToMap t _, VToMap t' _) ->
+            convE t t'
+        (VField t k, VField t' k') ->
+            convE t t' && k == k'
+        (VProject t (Left ks), VProject t' (Left ks')) ->
+            convE t t' && ks == ks'
+        (VProject t (Right e), VProject t' (Right e')) ->
+            convE t t' && convE e e'
+        (VAssert t, VAssert t') ->
+            convE t t'
+        (VEquivalent t u, VEquivalent t' u') ->
+            convE t t' && convE u u'
+        (VInject m k mt, VInject m' k' mt') ->
+            eqMapsBy (eqMaybeBy convE) m m' && k == k' && eqMaybeBy convE mt mt'
+        (VEmbed a, VEmbed a') ->
+            a == a'
+        (VOptionalFold a t _ u v, VOptionalFold a' t' _ u' v') ->
+            convE a a' && convE t t' && convE u u' && convE v v'
+        (_, _) ->
+            False
+  where
     fresh :: Text -> (Text, Val a)
-    fresh x = (x, VVar x (countName x env))
-    {-# inline fresh #-}
+    fresh x = (x, VVar x (countEnvironment x env))
+    {-# INLINE fresh #-}
 
-    freshCl :: Closure a -> (Text, Val a, Closure a)
-    freshCl cl@(Cl x _ _) = (x, snd (fresh x), cl)
-    {-# inline freshCl #-}
+    freshClosure :: Closure a -> (Text, Val a, Closure a)
+    freshClosure closure@(Closure x _ _) = (x, snd (fresh x), closure)
+    {-# INLINE freshClosure #-}
 
     convChunks :: VChunks a -> VChunks a -> Bool
     convChunks (VChunks xys z) (VChunks xys' z') =
       eqListBy (\(x, y) (x', y') -> x == x' && conv env y y') xys xys' && z == z'
-    {-# inline convChunks #-}
+    {-# INLINE convChunks #-}
 
     convE :: Val a -> Val a -> Bool
     convE = conv env
-    {-# inline convE #-}
+    {-# INLINE convE #-}
 
     convSkip :: Text -> Val a -> Val a -> Bool
     convSkip x = conv (Skip env x)
-    {-# inline convSkip #-}
+    {-# INLINE convSkip #-}
 
-  in case (t, t') of
-    (VConst k, VConst k') -> k == k'
-    (VVar x i, VVar x' i') -> x == x' && i == i'
+{-| Returns `True` if two expressions are α-equivalent and β-equivalent and
+    `False` otherwise
 
-    (VLam _ (freshCl -> (x, v, t)), VLam _ t' ) -> convSkip x (inst t v) (inst t' v)
-    (VLam _ (freshCl -> (x, v, t)), VHLam _ t') -> convSkip x (inst t v) (t' v)
-    (VLam _ (freshCl -> (x, v, t)), t'        ) -> convSkip x (inst t v) (vApp t' v)
-    (VHLam _ t, VLam _ (freshCl -> (x, v, t'))) -> convSkip x (t v) (inst t' v)
-    (VHLam _ t, VHLam _ t'                    ) -> let (x, v) = fresh "x" in convSkip x (t v) (t' v)
-    (VHLam _ t, t'                            ) -> let (x, v) = fresh "x" in convSkip x (t v) (vApp t' v)
-
-    (t, VLam _ (freshCl -> (x, v, t'))) -> convSkip x (vApp t v) (inst t' v)
-    (t, VHLam _ t'  ) -> let (x, v) = fresh "x" in convSkip x (vApp t v) (t' v)
-
-    (VApp t u, VApp t' u') -> convE t t' && convE u u'
-
-    (VPi a b, VPi a' (freshCl -> (x, v, b'))) ->
-      convE a a' && convSkip x (inst b v) (inst b' v)
-    (VPi a b, VHPi (fresh -> (x, v)) a' b') ->
-      convE a a' && convSkip x (inst b v) (b' v)
-    (VHPi _ a b, VPi a' (freshCl -> (x, v, b'))) ->
-      convE a a' && convSkip x (b v) (inst b' v)
-    (VHPi _ a b, VHPi (fresh -> (x, v)) a' b') ->
-      convE a a' && convSkip x (b v) (b' v)
-
-    (VBool       , VBool            ) -> True
-    (VBoolLit b  , VBoolLit b'      ) -> b == b'
-    (VBoolAnd t u, VBoolAnd t' u'   ) -> convE t t' && convE u u'
-    (VBoolOr  t u, VBoolOr  t' u'   ) -> convE t t' && convE u u'
-    (VBoolEQ  t u, VBoolEQ  t' u'   ) -> convE t t' && convE u u'
-    (VBoolNE  t u, VBoolNE  t' u'   ) -> convE t t' && convE u u'
-    (VBoolIf t u v, VBoolIf t' u' v') -> convE t t' && convE u u' && convE v v'
-
-    (VNatural, VNatural) -> True
-    (VNaturalLit n, VNaturalLit n') -> n == n'
-    (VNaturalFold t _ u v, VNaturalFold t' _ u' v') ->
-      convE t t' && convE u u' && convE v v'
-
-    (VNaturalBuild t      , VNaturalBuild t')       -> convE t t'
-    (VNaturalIsZero t     , VNaturalIsZero t')      -> convE t t'
-    (VNaturalEven t       , VNaturalEven t')        -> convE t t'
-    (VNaturalOdd t        , VNaturalOdd t')         -> convE t t'
-    (VNaturalToInteger t  , VNaturalToInteger t')   -> convE t t'
-    (VNaturalShow t       , VNaturalShow t')        -> convE t t'
-    (VNaturalSubtract x y , VNaturalSubtract x' y') -> convE x x' && convE y y'
-    (VNaturalPlus t u     , VNaturalPlus t' u')     -> convE t t' && convE u u'
-    (VNaturalTimes t u    , VNaturalTimes t' u')    -> convE t t' && convE u u'
-
-    (VInteger           , VInteger)            -> True
-    (VIntegerLit t      , VIntegerLit t')      -> t == t'
-    (VIntegerShow t     , VIntegerShow t')     -> convE t t'
-    (VIntegerToDouble t , VIntegerToDouble t') -> convE t t'
-
-    (VDouble       , VDouble)        -> True
-    (VDoubleLit n  , VDoubleLit n')  ->
-            Serialise.serialise (Dhall.Binary.encode (DoubleLit n  :: Expr Void Import))
-        ==  Serialise.serialise (Dhall.Binary.encode (DoubleLit n' :: Expr Void Import))
-    (VDoubleShow t , VDoubleShow t') -> convE t t'
-
-    (VText, VText) -> True
-
-    (VTextLit cs     , VTextLit cs')      -> convChunks cs cs'
-    (VTextAppend t u , VTextAppend t' u') -> convE t t' && convE u u'
-    (VTextShow t     , VTextShow t')      -> convE t t'
-
-    (VList a        , VList a'      ) -> convE a a'
-    (VListLit _ xs  , VListLit _ xs') -> eqListBy convE (toList xs) (toList xs')
-
-    (VListAppend t u     , VListAppend t' u'       ) -> convE t t' && convE u u'
-    (VListBuild a t      , VListBuild a' t'        ) -> convE t t'
-    (VListLength a t     , VListLength a' t'       ) -> convE a a' && convE t t'
-    (VListHead _ t       , VListHead _ t'          ) -> convE t t'
-    (VListLast _ t       , VListLast _ t'          ) -> convE t t'
-    (VListIndexed _ t    , VListIndexed _ t'       ) -> convE t t'
-    (VListReverse _ t    , VListReverse _ t'       ) -> convE t t'
-    (VListFold a l _ t u , VListFold a' l' _ t' u' ) ->
-      convE a a' && convE l l' && convE t t' && convE u u'
-
-    (VOptional a             , VOptional a'                ) -> convE a a'
-    (VSome t                 , VSome t'                    ) -> convE t t'
-    (VNone _                 , VNone _                     ) -> True
-    (VOptionalBuild _ t      , VOptionalBuild _ t'         ) -> convE t t'
-    (VRecord m               , VRecord m'                  ) -> eqMapsBy convE m m'
-    (VRecordLit m            , VRecordLit m'               ) -> eqMapsBy convE m m'
-    (VUnion m                , VUnion m'                   ) -> eqMapsBy (eqMaybeBy convE) m m'
-    (VCombine t u            , VCombine t' u'              ) -> convE t t' && convE u u'
-    (VCombineTypes t u       , VCombineTypes t' u'         ) -> convE t t' && convE u u'
-    (VPrefer  t u            , VPrefer t' u'               ) -> convE t t' && convE u u'
-    (VMerge t u _            , VMerge t' u' _              ) -> convE t t' && convE u u'
-    (VToMap t _              , VToMap t' _                 ) -> convE t t'
-    (VField t k              , VField t' k'                ) -> convE t t' && k == k'
-    (VProject t (Left ks)    , VProject t' (Left ks')      ) -> convE t t' && ks == ks'
-    (VProject t (Right e)    , VProject t' (Right e')      ) -> convE t t' && convE e e'
-    (VAssert t               , VAssert t'                  ) -> convE t t'
-    (VEquivalent t u         , VEquivalent t' u'           ) -> convE t t' && convE u u'
-    (VInject m k mt          , VInject m' k' mt'           ) -> eqMapsBy (eqMaybeBy convE) m m'
-                                                                  && k == k' && eqMaybeBy convE mt mt'
-    (VEmbed a                , VEmbed a'                   ) -> a == a'
-    (VOptionalFold a t _ u v , VOptionalFold a' t' _ u' v' ) ->
-      convE a a' && convE t t' && convE u u' && convE v v'
-
-    (_, _) -> False
-
-convEmpty :: Eq a => Expr s a -> Expr t a -> Bool
-convEmpty (denote -> t) (denote -> u) = conv Empty (eval Empty t) (eval Empty u)
-
--- Quoting
-----------------------------------------------------------------------------------------------------
+    `judgmentallyEqual` can fail with an `error` if you compare ill-typed
+    expressions
+-}
+judgmentallyEqual :: Eq a => Expr s a -> Expr t a -> Bool
+judgmentallyEqual (Core.denote -> t) (Core.denote -> u) =
+    conv Empty (eval Empty t) (eval Empty u)
 
 data Names
-  = NEmpty
-  | NBind !Names {-# unpack #-} !Text
+  = EmptyNames
+  | Bind !Names {-# UNPACK #-} !Text
   deriving Show
 
-envNames :: Env a -> Names
-envNames Empty = NEmpty
-envNames (Skip   env x  ) = NBind (envNames env) x
-envNames (Extend env x _) = NBind (envNames env) x
+envNames :: Environment a -> Names
+envNames Empty = EmptyNames
+envNames (Skip   env x  ) = Bind (envNames env) x
+envNames (Extend env x _) = Bind (envNames env) x
 
-countName' :: Text -> Names -> Int
-countName' x = go 0 where
-  go !acc NEmpty         = acc
-  go  acc (NBind env x') = go (if x == x' then acc + 1 else acc) env
+countNames :: Text -> Names -> Int
+countNames x = go 0
+  where
+    go !acc EmptyNames         = acc
+    go  acc (Bind env x') = go (if x == x' then acc + 1 else acc) env
 
 -- | Quote a value into beta-normal form.
 quote :: forall a. Eq a => Names -> Val a -> Expr Void a
 quote !env !t =
-  let
-    fresh :: Text -> (Text, Val a)
-    fresh x = (x, VVar x (countName' x env))
-    {-# inline fresh #-}
+    case t of
+        VConst k ->
+            Const k
+        VVar x i ->
+            qVar x i
+        VApp t u ->
+            quoteE t `qApp` u
+        VLam a (freshClosure -> (x, v, t)) ->
+            Lam x (quoteE a) (quoteBind x (instantiate t v))
+        VHLam i t ->
+            case i of
+                Typed (fresh -> (x, v)) a -> Lam x (quoteE a) (quoteBind x (t v))
+                Prim                      -> quote env (t VPrimVar)
+                NaturalFoldCl{}           -> quote env (t VPrimVar)
+                ListFoldCl{}              -> quote env (t VPrimVar)
+                OptionalFoldCl{}          -> quote env (t VPrimVar)
+                NaturalSubtractZero       -> App NaturalSubtract (NaturalLit 0)
 
-    freshCl :: Closure a -> (Text, Val a, Closure a)
-    freshCl cl@(Cl x _ _) = (x, snd (fresh x), cl)
-    {-# inline freshCl #-}
+        VPi a (freshClosure -> (x, v, b)) ->
+            Pi x (quoteE a) (quoteBind x (instantiate b v))
+        VHPi (fresh -> (x, v)) a b ->
+            Pi x (quoteE a) (quoteBind x (b v))
+        VBool ->
+            Bool
+        VBoolLit b ->
+            BoolLit b
+        VBoolAnd t u ->
+            BoolAnd (quoteE t) (quoteE u)
+        VBoolOr t u ->
+            BoolOr (quoteE t) (quoteE u)
+        VBoolEQ t u ->
+            BoolEQ (quoteE t) (quoteE u)
+        VBoolNE t u ->
+            BoolNE (quoteE t) (quoteE u)
+        VBoolIf t u v ->
+            BoolIf (quoteE t) (quoteE u) (quoteE v)
+        VNatural ->
+            Natural
+        VNaturalLit n ->
+            NaturalLit n
+        VNaturalFold a t u v ->
+            NaturalFold `qApp` a `qApp` t `qApp` u `qApp` v
+        VNaturalBuild t ->
+            NaturalBuild `qApp` t
+        VNaturalIsZero t ->
+            NaturalIsZero `qApp` t
+        VNaturalEven t ->
+            NaturalEven `qApp` t
+        VNaturalOdd t ->
+            NaturalOdd `qApp` t
+        VNaturalToInteger t ->
+            NaturalToInteger `qApp` t
+        VNaturalShow t ->
+            NaturalShow `qApp` t
+        VNaturalPlus t u ->
+            NaturalPlus (quoteE t) (quoteE u)
+        VNaturalTimes t u ->
+            NaturalTimes (quoteE t) (quoteE u)
+        VNaturalSubtract x y ->
+            NaturalSubtract `qApp` x `qApp` y
+        VInteger ->
+            Integer
+        VIntegerLit n ->
+            IntegerLit n
+        VIntegerShow t ->
+            IntegerShow `qApp` t
+        VIntegerToDouble t ->
+            IntegerToDouble `qApp` t
+        VDouble ->
+            Double
+        VDoubleLit n ->
+            DoubleLit n
+        VDoubleShow t ->
+            DoubleShow `qApp` t
+        VText ->
+            Text
+        VTextLit (VChunks xys z) ->
+            TextLit (Chunks (fmap (fmap quoteE) xys) z)
+        VTextAppend t u ->
+            TextAppend (quoteE t) (quoteE u)
+        VTextShow t ->
+            TextShow `qApp` t
+        VList t ->
+            List `qApp` t
+        VListLit ma ts ->
+            ListLit (fmap quoteE ma) (fmap quoteE ts)
+        VListAppend t u ->
+            ListAppend (quoteE t) (quoteE u)
+        VListBuild a t ->
+            ListBuild `qApp` a `qApp` t
+        VListFold a l t u v ->
+            ListFold `qApp` a `qApp` l `qApp` t `qApp` u `qApp` v
+        VListLength a t ->
+            ListLength `qApp` a `qApp` t
+        VListHead a t ->
+            ListHead `qApp` a `qApp` t
+        VListLast a t ->
+            ListLast `qApp` a `qApp` t
+        VListIndexed a t ->
+            ListIndexed `qApp` a `qApp` t
+        VListReverse a t ->
+            ListReverse `qApp` a `qApp` t
+        VOptional a ->
+            Optional `qApp` a
+        VSome t ->
+            Some (quoteE t)
+        VNone t ->
+            None `qApp` t
+        VOptionalFold a o t u v ->
+            OptionalFold `qApp` a `qApp` o `qApp` t `qApp` u `qApp` v
+        VOptionalBuild a t ->
+            OptionalBuild `qApp` a `qApp` t
+        VRecord m ->
+            Record (fmap quoteE m)
+        VRecordLit m ->
+            RecordLit (fmap quoteE m)
+        VUnion m ->
+            Union (fmap (fmap quoteE) m)
+        VCombine t u ->
+            Combine (quoteE t) (quoteE u)
+        VCombineTypes t u ->
+            CombineTypes (quoteE t) (quoteE u)
+        VPrefer t u ->
+            Prefer (quoteE t) (quoteE u)
+        VMerge t u ma ->
+            Merge (quoteE t) (quoteE u) (fmap quoteE ma)
+        VToMap t ma ->
+            ToMap (quoteE t) (fmap quoteE ma)
+        VField t k ->
+            Field (quoteE t) k
+        VProject t p ->
+            Project (quoteE t) (fmap quoteE p)
+        VAssert t ->
+            Assert (quoteE t)
+        VEquivalent t u ->
+            Equivalent (quoteE t) (quoteE u)
+        VInject m k Nothing ->
+            Field (Union (fmap (fmap quoteE) m)) k
+        VInject m k (Just t) ->
+            Field (Union (fmap (fmap quoteE) m)) k `qApp` t
+        VEmbed a ->
+            Embed a
+        VPrimVar ->
+            error errorMsg
+  where
+    fresh :: Text -> (Text, Val a)
+    fresh x = (x, VVar x (countNames x env))
+    {-# INLINE fresh #-}
+
+    freshClosure :: Closure a -> (Text, Val a, Closure a)
+    freshClosure closure@(Closure x _ _) = (x, snd (fresh x), closure)
+    {-# INLINE freshClosure #-}
 
     qVar :: Text -> Int -> Expr Void a
-    qVar !x !i = Var (V x (fromIntegral (countName' x env - i - 1)))
-    {-# inline qVar #-}
+    qVar !x !i = Var (V x (fromIntegral (countNames x env - i - 1)))
+    {-# INLINE qVar #-}
 
     quoteE :: Val a -> Expr Void a
     quoteE = quote env
-    {-# inline quoteE #-}
+    {-# INLINE quoteE #-}
 
     quoteBind :: Text -> Val a -> Expr Void a
-    quoteBind x = quote (NBind env x)
-    {-# inline quoteBind #-}
+    quoteBind x = quote (Bind env x)
+    {-# INLINE quoteBind #-}
 
     qApp :: Expr Void a -> Val a -> Expr Void a
     qApp t VPrimVar = t
     qApp t u        = App t (quoteE u)
-    {-# inline qApp #-}
-
-  in case t of
-    VConst k                      -> Const k
-    VVar x i                      -> qVar x i
-    VApp t u                      -> quoteE t `qApp` u
-    VLam a (freshCl -> (x, v, t)) -> Lam x (quoteE a) (quoteBind x (inst t v))
-    VHLam i t                     -> case i of
-                                       Typed (fresh -> (x, v)) a -> Lam x (quoteE a) (quoteBind x (t v))
-                                       Prim                      -> quote env (t VPrimVar)
-                                       NaturalFoldCl{}           -> quote env (t VPrimVar)
-                                       ListFoldCl{}              -> quote env (t VPrimVar)
-                                       OptionalFoldCl{}          -> quote env (t VPrimVar)
-                                       NaturalSubtractZero       -> App NaturalSubtract (NaturalLit 0)
-
-    VPi a (freshCl -> (x, v, b))  -> Pi x (quoteE a) (quoteBind x (inst b v))
-    VHPi (fresh -> (x, v)) a b    -> Pi x (quoteE a) (quoteBind x (b v))
-
-    VBool                         -> Bool
-    VBoolLit b                    -> BoolLit b
-    VBoolAnd t u                  -> BoolAnd (quoteE t) (quoteE u)
-    VBoolOr t u                   -> BoolOr (quoteE t) (quoteE u)
-    VBoolEQ t u                   -> BoolEQ (quoteE t) (quoteE u)
-    VBoolNE t u                   -> BoolNE (quoteE t) (quoteE u)
-    VBoolIf t u v                 -> BoolIf (quoteE t) (quoteE u) (quoteE v)
-
-    VNatural                      -> Natural
-    VNaturalLit n                 -> NaturalLit n
-    VNaturalFold a t u v          -> NaturalFold `qApp` a `qApp` t `qApp` u `qApp` v
-    VNaturalBuild t               -> NaturalBuild `qApp` t
-    VNaturalIsZero t              -> NaturalIsZero `qApp` t
-    VNaturalEven t                -> NaturalEven `qApp` t
-    VNaturalOdd t                 -> NaturalOdd `qApp` t
-    VNaturalToInteger t           -> NaturalToInteger `qApp` t
-    VNaturalShow t                -> NaturalShow `qApp` t
-    VNaturalPlus t u              -> NaturalPlus (quoteE t) (quoteE u)
-    VNaturalTimes t u             -> NaturalTimes (quoteE t) (quoteE u)
-    VNaturalSubtract x y          -> NaturalSubtract `qApp` x `qApp` y
-
-    VInteger                      -> Integer
-    VIntegerLit n                 -> IntegerLit n
-    VIntegerShow t                -> IntegerShow `qApp` t
-    VIntegerToDouble t            -> IntegerToDouble `qApp` t
-
-    VDouble                       -> Double
-    VDoubleLit n                  -> DoubleLit n
-    VDoubleShow t                 -> DoubleShow `qApp` t
-
-    VText                         -> Text
-    VTextLit (VChunks xys z)      -> TextLit (Chunks ((quoteE <$>) <$> xys) z)
-    VTextAppend t u               -> TextAppend (quoteE t) (quoteE u)
-    VTextShow t                   -> TextShow `qApp` t
-
-    VList t                       -> List `qApp` t
-    VListLit ma ts                -> ListLit (quoteE <$> ma) (quoteE <$> ts)
-    VListAppend t u               -> ListAppend (quoteE t) (quoteE u)
-    VListBuild a t                -> ListBuild `qApp` a `qApp` t
-    VListFold a l t u v           -> ListFold `qApp` a `qApp` l `qApp` t `qApp` u `qApp` v
-    VListLength a t               -> ListLength `qApp` a `qApp` t
-    VListHead a t                 -> ListHead `qApp` a `qApp` t
-    VListLast a t                 -> ListLast `qApp` a `qApp` t
-    VListIndexed a t              -> ListIndexed `qApp` a `qApp` t
-    VListReverse a t              -> ListReverse `qApp` a `qApp` t
-
-    VOptional a                   -> Optional `qApp` a
-    VSome t                       -> Some (quoteE t)
-    VNone t                       -> None `qApp` t
-    VOptionalFold a o t u v       -> OptionalFold `qApp` a `qApp` o `qApp` t `qApp` u `qApp` v
-    VOptionalBuild a t            -> OptionalBuild `qApp` a `qApp` t
-    VRecord m                     -> Record (quoteE <$> m)
-    VRecordLit m                  -> RecordLit (quoteE <$> m)
-    VUnion m                      -> Union ((quoteE <$>) <$> m)
-    VCombine t u                  -> Combine (quoteE t) (quoteE u)
-    VCombineTypes t u             -> CombineTypes (quoteE t) (quoteE u)
-    VPrefer t u                   -> Prefer (quoteE t) (quoteE u)
-    VMerge t u ma                 -> Merge (quoteE t) (quoteE u) (quoteE <$> ma)
-    VToMap t ma                   -> ToMap (quoteE t) (quoteE <$> ma)
-    VField t k                    -> Field (quoteE t) k
-    VProject t p                  -> Project (quoteE t) (fmap quoteE p)
-    VAssert t                     -> Assert (quoteE t)
-    VEquivalent t u               -> Equivalent (quoteE t) (quoteE u)
-    VInject m k Nothing           -> Field (Union ((quoteE <$>) <$> m)) k
-    VInject m k (Just t)          -> Field (Union ((quoteE <$>) <$> m)) k `qApp` t
-    VEmbed a                      -> Embed a
-    VPrimVar                      -> error errorMsg
-
--- Normalization
-----------------------------------------------------------------------------------------------------
+    {-# INLINE qApp #-}
 
 -- | Normalize an expression in an environment of values. Any variable pointing out of
 --   the environment is treated as opaque free variable.
-nf :: Eq a => Env a -> Expr s a -> Expr t a
-nf !env = coeExprVoid . quote (envNames env) . eval env . denote
+nf :: Eq a => Environment a -> Expr s a -> Expr t a
+nf !env = coeExprVoid . quote (envNames env) . eval env . Core.denote
+  where
+    coeExprVoid :: Expr Void a -> Expr s a
+    coeExprVoid = unsafeCoerce
+    {-# INLINE coeExprVoid #-}
 
--- | Normalize an expression in an empty environment.
-nfEmpty :: Eq a => Expr s a -> Expr t a
-nfEmpty = nf Empty
+{-| Reduce an expression to its normal form, performing beta reduction
 
--- Alpha-renaming
---------------------------------------------------------------------------------
+    `normalize` does not type-check the expression.  You may want to type-check
+    expressions before normalizing them since normalization can convert an
+    ill-typed expression into a well-typed expression.
 
--- | Rename all binders to "_".
+    `normalize` can also fail with `error` if you normalize an ill-typed
+    expression
+-}
+normalize :: Eq a => Expr s a -> Expr t a
+normalize = nf Empty
+
+{-| α-normalize an expression by renaming all bound variables to @\"_\"@ and
+    using De Bruijn indices to distinguish them
+
+>>> alphaNormalize (Lam "a" (Const Type) (Lam "b" (Const Type) (Lam "x" "a" (Lam "y" "b" "x"))))
+Lam "_" (Const Type) (Lam "_" (Const Type) (Lam "_" (Var (V "_" 1)) (Lam "_" (Var (V "_" 1)) (Var (V "_" 1)))))
+
+    α-normalization does not affect free variables:
+
+>>> alphaNormalize "x"
+Var (V "x" 0)
+
+-}
 alphaNormalize :: Expr s a -> Expr s a
-alphaNormalize = goEnv NEmpty where
+alphaNormalize = goEnv EmptyNames
+  where
+    goVar :: Names -> Text -> Int -> Expr s a
+    goVar e topX topI = go 0 e topI
+      where
+        go !acc (Bind env x) !i
+          | x == topX = if i == 0 then Var (V "_" acc) else go (acc + 1) env (i - 1)
+          | otherwise = go (acc + 1) env i
+        go acc EmptyNames i = Var (V topX i)
 
-  goVar :: Names -> Text -> Int -> Expr s a
-  goVar e topX topI = go 0 e topI where
-    go !acc (NBind env x) !i
-      | x == topX = if i == 0 then Var (V "_" acc) else go (acc + 1) env (i - 1)
-      | otherwise = go (acc + 1) env i
-    go acc NEmpty i = Var (V topX i)
-
-  goEnv :: Names -> Expr s a -> Expr s a
-  goEnv !e t = let
-
-    go                     = goEnv e
-    goBind x               = goEnv (NBind e x)
-    goChunks (Chunks ts x) = Chunks ((go <$>) <$> ts) x
-
-    in case t of
-      Const k          -> Const k
-      Var (V x i)      -> goVar e x i
-      Lam x t u        -> Lam "_" (go t) (goBind x u)
-      Pi x a b         -> Pi "_" (go a) (goBind x b)
-      App t u          -> App (go t) (go u)
-      Let (Binding src0 x src1 mA src2 a) b ->
-          Let (Binding src0 "_" src1 (adapt <$> mA) src2 (go a)) (goBind x b)
-        where
-          adapt (src3, _A) = (src3, go _A)
-      Annot t u        -> Annot (go t) (go u)
-      Bool             -> Bool
-      BoolLit b        -> BoolLit b
-      BoolAnd t u      -> BoolAnd (go t) (go u)
-      BoolOr t u       -> BoolOr  (go t) (go u)
-      BoolEQ t u       -> BoolEQ  (go t) (go u)
-      BoolNE t u       -> BoolNE  (go t) (go u)
-      BoolIf b t f     -> BoolIf  (go b) (go t) (go f)
-      Natural          -> Natural
-      NaturalLit n     -> NaturalLit n
-      NaturalFold      -> NaturalFold
-      NaturalBuild     -> NaturalBuild
-      NaturalIsZero    -> NaturalIsZero
-      NaturalEven      -> NaturalEven
-      NaturalOdd       -> NaturalOdd
-      NaturalToInteger -> NaturalToInteger
-      NaturalShow      -> NaturalShow
-      NaturalSubtract  -> NaturalSubtract
-      NaturalPlus t u  -> NaturalPlus  (go t) (go u)
-      NaturalTimes t u -> NaturalTimes (go t) (go u)
-      Integer          -> Integer
-      IntegerLit n     -> IntegerLit n
-      IntegerShow      -> IntegerShow
-      IntegerToDouble  -> IntegerToDouble
-      Double           -> Double
-      DoubleLit n      -> DoubleLit n
-      DoubleShow       -> DoubleShow
-      Text             -> Text
-      TextLit cs       -> TextLit (goChunks cs)
-      TextAppend t u   -> TextAppend (go t) (go u)
-      TextShow         -> TextShow
-      List             -> List
-      ListLit ma ts    -> ListLit (go <$> ma) (go <$> ts)
-      ListAppend t u   -> ListAppend (go t) (go u)
-      ListBuild        -> ListBuild
-      ListFold         -> ListFold
-      ListLength       -> ListLength
-      ListHead         -> ListHead
-      ListLast         -> ListLast
-      ListIndexed      -> ListIndexed
-      ListReverse      -> ListReverse
-      Optional         -> Optional
-      Some t           -> Some (go t)
-      None             -> None
-      OptionalFold     -> OptionalFold
-      OptionalBuild    -> OptionalBuild
-      Record kts       -> Record (go <$> kts)
-      RecordLit kts    -> RecordLit (go <$> kts)
-      Union kts        -> Union ((go <$>) <$> kts)
-      Combine t u      -> Combine (go t) (go u)
-      CombineTypes t u -> CombineTypes  (go t) (go u)
-      Prefer t u       -> Prefer (go t) (go u)
-      Merge x y ma     -> Merge (go x) (go y) (go <$> ma)
-      ToMap x ma       -> ToMap (go x) (go <$> ma)
-      Field t k        -> Field (go t) k
-      Project t ks     -> Project (go t) (go <$> ks)
-      Assert t         -> Assert (go t)
-      Equivalent t u   -> Equivalent (go t) (go u)
-      Note s e         -> Note s (go e)
-      ImportAlt t u    -> ImportAlt (go t) (go u)
-      Embed a          -> Embed a
+    goEnv :: Names -> Expr s a -> Expr s a
+    goEnv !e t =
+        case t of
+            Const k ->
+                Const k
+            Var (V x i) ->
+                goVar e x i
+            Lam x t u ->
+                Lam "_" (go t) (goBind x u)
+            Pi x a b ->
+                Pi "_" (go a) (goBind x b)
+            App t u ->
+                App (go t) (go u)
+            Let (Binding src0 x src1 mA src2 a) b ->
+                Let (Binding src0 "_" src1 (fmap (fmap go) mA) src2 (go a)) (goBind x b)
+            Annot t u ->
+                Annot (go t) (go u)
+            Bool ->
+                Bool
+            BoolLit b ->
+                BoolLit b
+            BoolAnd t u ->
+                BoolAnd (go t) (go u)
+            BoolOr t u ->
+                BoolOr  (go t) (go u)
+            BoolEQ t u ->
+                BoolEQ  (go t) (go u)
+            BoolNE t u ->
+                BoolNE  (go t) (go u)
+            BoolIf b t f ->
+                BoolIf  (go b) (go t) (go f)
+            Natural ->
+                Natural
+            NaturalLit n ->
+                NaturalLit n
+            NaturalFold ->
+                NaturalFold
+            NaturalBuild ->
+                NaturalBuild
+            NaturalIsZero ->
+                NaturalIsZero
+            NaturalEven ->
+                NaturalEven
+            NaturalOdd ->
+                NaturalOdd
+            NaturalToInteger ->
+                NaturalToInteger
+            NaturalShow ->
+                NaturalShow
+            NaturalSubtract ->
+                NaturalSubtract
+            NaturalPlus t u ->
+                NaturalPlus (go t) (go u)
+            NaturalTimes t u ->
+                NaturalTimes (go t) (go u)
+            Integer ->
+                Integer
+            IntegerLit n ->
+                IntegerLit n
+            IntegerShow ->
+                IntegerShow
+            IntegerToDouble ->
+                IntegerToDouble
+            Double ->
+                Double
+            DoubleLit n ->
+                DoubleLit n
+            DoubleShow ->
+                DoubleShow
+            Text ->
+                Text
+            TextLit cs ->
+                TextLit (goChunks cs)
+            TextAppend t u ->
+                TextAppend (go t) (go u)
+            TextShow ->
+                TextShow
+            List ->
+                List
+            ListLit ma ts ->
+                ListLit (fmap go ma) (fmap go ts)
+            ListAppend t u ->
+                ListAppend (go t) (go u)
+            ListBuild ->
+                ListBuild
+            ListFold ->
+                ListFold
+            ListLength ->
+                ListLength
+            ListHead ->
+                ListHead
+            ListLast ->
+                ListLast
+            ListIndexed ->
+                ListIndexed
+            ListReverse ->
+                ListReverse
+            Optional ->
+                Optional
+            Some t ->
+                Some (go t)
+            None ->
+                None
+            OptionalFold ->
+                OptionalFold
+            OptionalBuild ->
+                OptionalBuild
+            Record kts ->
+                Record (fmap go kts)
+            RecordLit kts ->
+                RecordLit (fmap go kts)
+            Union kts ->
+                Union (fmap (fmap go) kts)
+            Combine t u ->
+                Combine (go t) (go u)
+            CombineTypes t u ->
+                CombineTypes (go t) (go u)
+            Prefer t u ->
+                Prefer (go t) (go u)
+            Merge x y ma ->
+                Merge (go x) (go y) (fmap go ma)
+            ToMap x ma ->
+                ToMap (go x) (fmap go ma)
+            Field t k ->
+                Field (go t) k
+            Project t ks ->
+                Project (go t) (fmap go ks)
+            Assert t ->
+                Assert (go t)
+            Equivalent t u ->
+                Equivalent (go t) (go u)
+            Note s e ->
+                Note s (go e)
+            ImportAlt t u ->
+                ImportAlt (go t) (go u)
+            Embed a ->
+                Embed a
+      where
+        go                     = goEnv e
+        goBind x               = goEnv (Bind e x)
+        goChunks (Chunks ts x) = Chunks (fmap (fmap go) ts) x

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -941,8 +941,8 @@ quote !env !t0 =
     case t0 of
         VConst k ->
             Const k
-        VVar x i ->
-            qVar x i
+        VVar !x !i ->
+            Var (V x (fromIntegral (countNames x env - i - 1)))
         VApp t u ->
             quote env t `qApp` u
         VLam a (freshClosure -> (x, v, t)) ->
@@ -1090,10 +1090,6 @@ quote !env !t0 =
     freshClosure :: Closure a -> (Text, Val a, Closure a)
     freshClosure closure@(Closure x _ _) = (x, snd (fresh x), closure)
     {-# INLINE freshClosure #-}
-
-    qVar :: Text -> Int -> Expr Void a
-    qVar !x !i = Var (V x (fromIntegral (countNames x env - i - 1)))
-    {-# INLINE qVar #-}
 
     quoteBind :: Text -> Val a -> Expr Void a
     quoteBind x = quote (Bind env x)

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -36,11 +36,6 @@ module Dhall.Eval (
   , alphaNormalize
   ) where
 
-#if MIN_VERSION_base(4,8,0)
-#else
-import Control.Applicative (Applicative(..))
-#endif
-
 import Data.Foldable (foldr', toList)
 import Data.Semigroup (Semigroup(..))
 import Data.Sequence (Seq, ViewL(..), ViewR(..))

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -63,7 +63,7 @@ import Unsafe.Coerce (unsafeCoerce)
 
 import qualified Codec.Serialise as Serialise
 import qualified Data.Sequence   as Sequence
-import qualified Data.Set        as Set
+import qualified Data.Set
 import qualified Data.Text       as Text
 import qualified Dhall.Binary    as Binary
 import qualified Dhall.Core      as Core
@@ -356,7 +356,7 @@ vProjectByFields env t ks =
     VPrefer l r@(VRecordLit kvs) -> let
       ksSet = Dhall.Set.toSet ks
       kvs' = Map.restrictKeys kvs ksSet
-      ks' = Dhall.Set.fromSet (Set.difference ksSet (Map.keysSet kvs'))
+      ks' = Dhall.Set.fromSet (Data.Set.difference ksSet (Map.keysSet kvs'))
       in vPrefer env (vProjectByFields env l ks') (VRecordLit kvs')
     t -> VProject t (Left ks)
 

--- a/dhall/src/Dhall/Eval.hs-boot
+++ b/dhall/src/Dhall/Eval.hs-boot
@@ -3,6 +3,6 @@ module Dhall.Eval where
 
 import {-# SOURCE #-} Dhall.Core
 
-convEmpty      :: Eq a => Expr s a -> Expr t a -> Bool
-nfEmpty        :: Eq a => Expr s a -> Expr t a
-alphaNormalize :: Expr s a -> Expr s a
+judgmentallyEqual :: Eq a => Expr s a -> Expr t a -> Bool
+normalize         :: Eq a => Expr s a -> Expr t a
+alphaNormalize    :: Expr s a -> Expr s a


### PR DESCRIPTION
This updates the style of `Dhall.Eval` to match the stylistic
and naming conventions of the rest of the `dhall` package.