### PR TITLE
Give `dhall repl`'s turnstile an ASCII variant

### DIFF
--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -66,7 +66,7 @@ repl characterSet explain =
     io =
       evalStateT
         ( Repline.evalRepl
-            ( pure "⊢ " )
+            ( pure $ turnstile ++ " " )
             ( dontCrash . eval )
             options
             ( Just optionsPrefix )
@@ -75,6 +75,10 @@ repl characterSet explain =
         )
         (emptyEnv { characterSet, explain })
 
+    turnstile =
+      case characterSet of
+        Unicode -> "⊢"
+        ASCII   -> "|-"
 
 data Env = Env
   { envBindings      :: Dhall.Context.Context Binding


### PR DESCRIPTION
This makes `⊢` print as `|-` under `dhall --ascii repl`.