### PR TITLE
Different with-http CPP check; fix remote imports in GHCJS

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -429,6 +429,9 @@ Library
       Build-Depends: semigroups == 0.18.*
       Build-Depends: transformers == 0.4.2.*
       Build-Depends: fail == 4.9.*
+    if flag(with-http)
+      CPP-Options:
+        -DWITH_HTTP
     if impl(ghcjs)
       Hs-Source-Dirs: ghcjs-src
       Build-Depends:

--- a/dhall/doctest/Main.hs
+++ b/dhall/doctest/Main.hs
@@ -25,7 +25,8 @@ main = do
         writeFile "file1" "./file2"
 
         Test.DocTest.doctest
-            [ "--fast"
+            [ "-DWITH_HTTP"
+            , "--fast"
             , "-i" <> (prefix </> "src")
             , "-i" <> (prefix </> "ghc-src")
             , prefix </> "src/Dhall.hs"

--- a/dhall/ghc-src/Dhall/Import/HTTP.hs
+++ b/dhall/ghc-src/Dhall/Import/HTTP.hs
@@ -258,12 +258,10 @@ corsCompliant _ _ _ = return ()
 
 type HTTPHeader = Network.HTTP.Types.Header
 
-fetchFromHttpUrl
-    :: Manager
-    -> URL
-    -> Maybe [HTTPHeader]
-    -> StateT Status IO Text.Text
-fetchFromHttpUrl manager childURL mheaders = do
+fetchFromHttpUrl :: URL -> Maybe [HTTPHeader] -> StateT Status IO Text.Text
+fetchFromHttpUrl childURL mheaders = do
+    manager <- liftIO $ newManager
+
     let childURLString = Text.unpack (renderURL childURL)
 
     request <- liftIO (HTTP.parseUrlThrow childURLString)

--- a/dhall/ghcjs-src/Dhall/Import/HTTP.hs
+++ b/dhall/ghcjs-src/Dhall/Import/HTTP.hs
@@ -17,11 +17,10 @@ import Dhall.URL (renderURL)
 import Dhall.Import.Types
 
 fetchFromHttpUrl
-    :: a
-    -> URL
+    :: URL
     -> Maybe [(CI ByteString, ByteString)]
     -> StateT Status IO Text.Text
-fetchFromHttpUrl _ childURL Nothing = do
+fetchFromHttpUrl childURL Nothing = do
     let childURLText = renderURL childURL
 
     let childURLString = Text.unpack childURLText
@@ -35,5 +34,5 @@ fetchFromHttpUrl _ childURL Nothing = do
         _   -> fail (childURLString <> " returned a non-200 status code: " <> show statusCode)
 
     return body
-fetchFromHttpUrl _ _ _ = do
+fetchFromHttpUrl _ _ = do
     fail "Dhall does not yet support custom headers when built using GHCJS"


### PR DESCRIPTION
I submitted https://github.com/dhall-lang/dhall-haskell/pull/1311 before studying `Import.hs` carefully enough, and my GHCJS build worked perfectly (with local imports, doh!) so I didn't notice.

Since I removed the GHCJS dependency on http-client, the CPP check for `MIN_VERSION_http_client` no longer works. I noticed the existence of `-DWITH_HTTP` in the tasty test suite and added that at the library level. (I think it's clearer too.)

Also, fortunately, `Manager` is not actually needed in Import.hs, just the check for `WITH_HTTP`.