### PR TITLE
Dhall version

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -508,6 +508,8 @@ Library
         Dhall.Import.Types,
         Dhall.Eval,
         Paths_dhall
+    Autogen-Modules:
+        Paths_dhall
     if flag(with-http)
       Other-Modules:
         Dhall.Import.HTTP

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -497,6 +497,7 @@ Library
         Dhall.Tutorial,
         Dhall.TypeCheck,
         Dhall.Util
+        Dhall.Version
     if !flag(cross)
         Exposed-Modules:
             Dhall.TH

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -69,7 +69,6 @@ import qualified Dhall.TypeCheck
 import qualified Dhall.Util
 import qualified GHC.IO.Encoding
 import qualified Options.Applicative
-import qualified Paths_dhall as Meta
 import qualified System.Console.ANSI
 import qualified System.Exit                               as Exit
 import qualified System.IO

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -26,7 +26,6 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty)
-import Data.Version (showVersion)
 import Dhall.Core (Expr(Annot), Import, pretty)
 import Dhall.Freeze (Intent(..), Scope(..))
 import Dhall.Import (Imported(..), Depends(..), SemanticCacheMode(..))
@@ -34,6 +33,7 @@ import Dhall.Parser (Src)
 import Dhall.Pretty (Ann, CharacterSet(..), annToAnsiStyle, layoutOpts)
 import Dhall.TypeCheck (DetailedTypeError(..), TypeError, X)
 import Dhall.Util (Censor(..), Input(..))
+import Dhall.Version (dhallVersionString)
 import Options.Applicative (Parser, ParserInfo)
 import System.Exit (ExitCode, exitFailure)
 import System.IO (Handle)
@@ -392,7 +392,7 @@ command (Options {..}) = do
 
     handle $ case mode of
         Version -> do
-            putStrLn (showVersion Meta.version)
+            putStrLn dhallVersionString
 
         Default {..} -> do
             expression <- getExpression file

--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -22,7 +22,6 @@ import Data.List ( isPrefixOf, nub )
 import Data.Maybe ( mapMaybe )
 import Data.Semigroup ((<>))
 import Data.Text ( Text )
-import Data.Version (showVersion)
 import Dhall.Context (Context)
 import Dhall.Import (hashExpressionToCode)
 import Dhall.Src (Src)
@@ -49,7 +48,7 @@ import qualified Dhall.Import as Dhall
 import qualified Dhall.Map as Map
 import qualified Dhall.Parser as Dhall
 import qualified Dhall.TypeCheck as Dhall
-import qualified Paths_dhall as Meta
+import qualified Dhall.Version as Meta
 import qualified System.Console.ANSI
 import qualified System.Console.Haskeline.Completion as Haskeline
 import qualified System.Console.Haskeline.MonadException as Haskeline
@@ -573,7 +572,7 @@ completeFunc reversedPrev word
 
 greeter :: MonadIO m => m ()
 greeter =
-  let version = showVersion Meta.version
+  let version = Meta.dhallVersionString
       message = "Welcome to the Dhall v" <> version <> " REPL! Type :help for more information."
   in liftIO (putStrLn message)
 

--- a/dhall/src/Dhall/Version.hs
+++ b/dhall/src/Dhall/Version.hs
@@ -1,0 +1,12 @@
+module Dhall.Version ( dhallVersion
+                     , dhallVersionString
+                     ) where
+
+import qualified Data.Version as V
+import qualified Paths_dhall  as P
+
+dhallVersion :: V.Version
+dhallVersion = P.version
+
+dhallVersionString :: String
+dhallVersionString = V.showVersion dhallVersion


### PR DESCRIPTION
This adds an exposed module `Dhall.Version`, which I can use downstream.

I also used it internally.