### PR TITLE
Handle --version consistently

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -41,6 +41,8 @@ Library
 Executable dhall-to-bash
     Hs-Source-Dirs: exec
     Main-Is: Main.hs
+    Other-Modules:
+        Paths_dhall_bash
     Build-Depends:
         base                                  ,
         bytestring                            ,

--- a/dhall-bash/exec/Main.hs
+++ b/dhall-bash/exec/Main.hs
@@ -15,6 +15,7 @@ import System.Exit (ExitCode(..))
 import qualified Control.Exception
 import qualified Data.ByteString
 import qualified Data.Text.IO
+import qualified Data.Version
 import qualified Dhall
 import qualified Dhall.Bash
 import qualified Dhall.Import
@@ -22,6 +23,7 @@ import qualified Dhall.Parser
 import qualified Dhall.TypeCheck
 import qualified GHC.IO.Encoding
 import qualified Options.Generic
+import qualified Paths_dhall_bash
 import qualified System.Exit
 import qualified System.IO
 
@@ -30,12 +32,20 @@ data Options = Options
         <?> "Explain error messages in detail"
     , declare :: Maybe ByteString
         <?> "Declare the given variable as a statement instead of an expression"
+    , version :: Bool
+        <?> "Display version"
     } deriving (Generic, ParseRecord)
 
 main :: IO ()
 main = do
     GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
     Options {..} <- Options.Generic.getRecord "Compile Dhall to Bash"
+
+    if unHelpful version
+        then do
+            putStrLn (Data.Version.showVersion Paths_dhall_bash.version)
+            System.Exit.exitSuccess
+        else return ()
 
     (if unHelpful explain then Dhall.detailed else id) (handle (do
         inText <- Data.Text.IO.getContents

--- a/dhall-lsp-server/app/Main.hs
+++ b/dhall-lsp-server/app/Main.hs
@@ -20,6 +20,7 @@ import qualified Paths_dhall_lsp_server
 data Options = Options {
     command :: Mode
   , logFile :: Maybe FilePath
+  , version :: Bool
 }
 
 -- | The mode in which to run @dhall-lsp-server@
@@ -27,11 +28,16 @@ data Mode = Version | LSPServer
 
 parseOptions :: Parser Options
 parseOptions =
-  Options <$> parseMode <*> Options.Applicative.optional parseLogFile
+  Options <$> parseMode <*> Options.Applicative.optional parseLogFile <*> parseVersion
   where
     parseLogFile = Options.Applicative.strOption
       (Options.Applicative.long "log" <> Options.Applicative.help
         "If present writes debug output to the specified file"
+      )
+
+    parseVersion = Options.Applicative.switch
+      (  Options.Applicative.long "version"
+      <> Options.Applicative.help "Display version"
       )
 
 
@@ -57,9 +63,14 @@ parserInfoOptions = Options.Applicative.info
   )
 
 runCommand :: Options -> IO ()
-runCommand Options {..} = case command of
-  Version -> putStrLn (Data.Version.showVersion Paths_dhall_lsp_server.version)
-  LSPServer -> Dhall.LSP.Server.run logFile
+runCommand Options {..} = do
+  if version
+    then printVersion
+    else case command of
+      Version -> printVersion
+      LSPServer -> Dhall.LSP.Server.run logFile
+  where
+    printVersion = putStrLn (Data.Version.showVersion Paths_dhall_lsp_server.version)
 
 -- | Entry point for the @dhall-lsp-server@ executable
 main :: IO ()

--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -43,6 +43,8 @@ Library
 Executable dhall-to-nix
     Hs-Source-Dirs: exec
     Main-Is: Main.hs
+    Other-Modules:
+        Paths_dhall_nix
     Build-Depends:
         base                                ,
         dhall                               ,

--- a/dhall-nix/exec/Main.hs
+++ b/dhall-nix/exec/Main.hs
@@ -1,12 +1,19 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeOperators     #-}
 
 module Main where
 
 import Control.Exception (SomeException)
+import Options.Generic (Generic, ParseRecord, type (<?>)(..))
 import System.Exit (ExitCode(..))
 
 import qualified Control.Exception
 import qualified Data.Text.IO
+import qualified Data.Version
 import qualified Dhall
 import qualified Dhall.Import
 import qualified Dhall.Nix
@@ -15,13 +22,25 @@ import qualified Dhall.TypeCheck
 import qualified GHC.IO.Encoding
 import qualified Nix.Pretty
 import qualified Options.Generic
+import qualified Paths_dhall_nix
 import qualified System.Exit
 import qualified System.IO
+
+data Options = Options
+    { version :: Bool
+        <?> "Display version"
+    } deriving (Generic, ParseRecord)
 
 main :: IO ()
 main = handle (Dhall.detailed (do
     GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
-    () <- Options.Generic.getRecord "Compile Dhall to Nix"
+    Options{..} <- Options.Generic.getRecord "Compile Dhall to Nix"
+
+    if unHelpful version
+        then do
+            putStrLn (Data.Version.showVersion Paths_dhall_nix.version)
+            System.Exit.exitSuccess
+        else return ()
 
     inText <- Data.Text.IO.getContents
 

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -92,6 +92,7 @@ data Mode
           , annotate :: Bool
           , alpha :: Bool
           , semanticCacheMode :: SemanticCacheMode
+          , version :: Bool
           }
     | Version
     | Resolve { file :: Input, resolveMode :: Maybe ResolveMode }
@@ -201,7 +202,13 @@ parseMode =
             "text"
             "Render a Dhall expression that evaluates to a Text literal"
             (Text <$> parseFile)
-    <|> (Default <$> parseFile <*> parseAnnotate <*> parseAlpha <*> parseSemanticCacheMode)
+    <|> (   Default
+        <$> parseFile
+        <*> parseAnnotate
+        <*> parseAlpha
+        <*> parseSemanticCacheMode
+        <*> parseVersion
+        )
   where
     argument =
             fmap Data.Text.pack
@@ -238,6 +245,12 @@ parseMode =
             (   Options.Applicative.long "no-cache"
             <>  Options.Applicative.help
                   "Handle protected imports as if the cache was empty"
+            )
+
+    parseVersion =
+        Options.Applicative.switch
+            (   Options.Applicative.long "version"
+            <>  Options.Applicative.help "Display version"
             )
 
     parseResolveMode =
@@ -394,6 +407,12 @@ command (Options {..}) = do
             putStrLn dhallVersionString
 
         Default {..} -> do
+            if version
+                then do
+                    putStrLn dhallVersionString
+                    Exit.exitSuccess
+                else return ()
+
             expression <- getExpression file
 
             resolvedExpression <-


### PR DESCRIPTION
#1199 had addressed this for the `dhall-json` executables. This PR takes care of the rest.

Fixes #1331.