### PR TITLE
Use `Dhall.Eval` for type-checking

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -48,6 +48,7 @@ module Dhall.Core (
     , isNormalized
     , isNormalizedWith
     , denote
+    , renote
     , shallowDenote
     , freeIn
 
@@ -93,6 +94,7 @@ import Data.Sequence (Seq, ViewL(..), ViewR(..))
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty)
 import Data.Traversable
+import Data.Void (Void)
 import Dhall.Map (Map)
 import Dhall.Set (Set)
 import Dhall.Src (Src(..))
@@ -103,6 +105,7 @@ import Language.Haskell.TH.Syntax (Lift)
 import Lens.Family (over)
 import Numeric.Natural (Natural)
 import Prelude hiding (succ)
+import Unsafe.Coerce (unsafeCoerce)
 
 import qualified Control.Exception
 import qualified Control.Monad
@@ -1315,6 +1318,11 @@ denote (Assert a            ) = Assert (denote a)
 denote (Equivalent a b      ) = Equivalent (denote a) (denote b)
 denote (ImportAlt a b       ) = ImportAlt (denote a) (denote b)
 denote (Embed a             ) = Embed a
+
+-- | The \"opposite\" of `denote`, like @first absurd@ but faster
+renote :: Expr Void a -> Expr s a
+renote = unsafeCoerce
+{-# INLINE renote #-}
 
 shallowDenote :: Expr s a -> Expr s a
 shallowDenote (Note _ e) = shallowDenote e

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -40,11 +40,11 @@ module Dhall.Eval (
   , envNames
   , countNames
   , conv
+  , toVHPi
   , Closure(..)
   , Names(..)
   , Environment(..)
   , Val(..)
-  , pattern VAnyPi
   , (~>)
   ) where
 
@@ -140,14 +140,10 @@ data HLamInfo a
 pattern VPrim :: (Val a -> Val a) -> Val a
 pattern VPrim f = VHLam Prim f
 
-pattern VAnyPi :: Eq a => Text -> Val a -> (Val a -> Val a) -> Val a
-pattern VAnyPi x a b <-
-    (   let adapt e = case e of
-                VPi  a b@(Closure x _ _) -> Just (x, a, instantiate b)
-                VHPi x a b               -> Just (x, a, b            )
-                _                        -> Nothing
-         in  adapt -> Just (x, a, b)
-    )
+toVHPi :: Eq a => Val a -> Maybe (Text, Val a, Val a -> Val a)
+toVHPi (VPi a b@(Closure x _ _)) = Just (x, a, instantiate b)
+toVHPi (VHPi x a b             ) = Just (x, a, b)
+toVHPi  _                        = Nothing
 
 data Val a
     = VConst !Const

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -36,7 +36,6 @@ module Dhall.Eval (
   , alphaNormalize
   , eval
   , quote
-  , renote
   , envNames
   , countNames
   , conv
@@ -67,7 +66,6 @@ import Dhall.Map (Map)
 import Dhall.Set (Set)
 import GHC.Natural (Natural)
 import Prelude hiding (succ)
-import Unsafe.Coerce (unsafeCoerce)
 
 import qualified Codec.Serialise as Serialise
 import qualified Data.Sequence   as Sequence
@@ -1124,11 +1122,7 @@ quote !env !t0 =
 -- | Normalize an expression in an environment of values. Any variable pointing out of
 --   the environment is treated as opaque free variable.
 nf :: Eq a => Environment a -> Expr s a -> Expr t a
-nf !env = renote . quote (envNames env) . eval env . Core.denote
-
-renote :: Expr Void a -> Expr s a
-renote = unsafeCoerce
-{-# INLINE renote #-}
+nf !env = Core.renote . quote (envNames env) . eval env . Core.denote
 
 {-| Reduce an expression to its normal form, performing beta reduction
 

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -158,6 +158,20 @@ addTypeValue x t v (Ctx vs ts) = Ctx (Extend vs x v) (TypesBind ts x t)
 fresh :: Ctx a -> Text -> Val a
 fresh Ctx{..} x = VVar x (Eval.countNames x (Eval.envNames values))
 
+{-| `typeWithA` is implemented internally in terms of `infer` in order to speed
+    up equivalence checking.
+
+    Specifically, we extend the `Context` to become a `Ctx`, which can store 
+    the entire contents of a `let` expression (i.e. the type *and* the value
+    of the bound variable).  By storing this extra information in the `Ctx` we
+    no longer need to substitute `let` expressions at all (which is very
+    expensive!).
+
+    However, this means that we need to use `Dhall.Eval.conv` to perform
+    equivalence checking instead of `Dhall.Core.judgmentallyEqual` since
+    only `judgmentallyEqual` is unable to use the information stored in the
+    extended context for accurate equivalence checking.
+-}
 infer
     :: forall a s
     .  (Eq a, Pretty a)

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -114,7 +114,7 @@ typeWithA
     -> Expr s a
     -> Either (TypeError s a) (Expr s a)
 typeWithA tpa context expression =
-    fmap (Eval.renote . Eval.quote EmptyNames) (infer tpa ctx expression)
+    fmap (Dhall.Core.renote . Eval.quote EmptyNames) (infer tpa ctx expression)
   where
     ctx = contextToCtx context
 
@@ -136,7 +136,7 @@ ctxToContext (Ctx {..}) = loop types
       where
         ns = typesToNames ts
 
-        t' = Eval.renote (Eval.quote ns t)
+        t' = Dhall.Core.renote (Eval.quote ns t)
     loop TypesEmpty = Dhall.Context.empty
 
 typesToNames :: Types a -> Names
@@ -216,7 +216,7 @@ infer typer = loop
 
             let _B'' = quote (Bind (Eval.envNames values) x) _B'
 
-            tB' <- loop ctx' (Eval.renote _B'')
+            tB' <- loop ctx' (Dhall.Core.renote _B'')
 
             case tB' of
                 VConst _ -> return ()
@@ -1247,7 +1247,7 @@ infer typer = loop
 
         eval vs e = Eval.eval vs (Dhall.Core.denote e)
 
-        quote ns value = Eval.renote (Eval.quote ns value)
+        quote ns value = Dhall.Core.renote (Eval.quote ns value)
 
 {-| `typeOf` is the same as `typeWith` with an empty context, meaning that the
     expression must be closed (i.e. no free variables), otherwise type-checking

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -558,7 +558,15 @@ infer typer = loop
                                 else do
                                     let _T₀'' = quote names _T₀'
                                     let _T₁'' = quote names _T₁'
-                                    die (MismatchedListElements i _T₀'' t₁ _T₁'')
+
+                                    -- Carefully note that we don't use `die`
+                                    -- here so that the source span is narrowed
+                                    -- to just the offending element
+                                    let err = MismatchedListElements i _T₀'' t₁ _T₁''
+
+                                    let context = ctxToContext ctx
+
+                                    Left (TypeError context t₁ err)
 
                     traverseWithIndex_ process ts₁
 


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1306

The following comment describe how this works in depth:

https://github.com/dhall-lang/dhall-haskell/issues/1129#issuecomment-532928798

The short explanation is that we can substantially speed up type-checking
by not substituting `let` expressions and instead adding the bound variable
to the context.  This is the same as the type-checking "fast path" that
we had before adding dependent types, except this time it works even in the
presence of dependent types.

The main difference is that we add the `let`-bound type *and* value to the
context and use `Dhall.Eval.conv` to perform equivalence checking instead of
`Dhall.Core.judgmentallyEqual`.