### PR TITLE
Make sure `dhall-nix` is included in releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
   - tar -jcvf $(mk_release_name dhall-json) bin/dhall-to-json bin/dhall-to-yaml bin/json-to-dhall bin/yaml-to-dhall
   - tar -jcvf $(mk_release_name dhall-bash) bin/dhall-to-bash
   - tar -jcvf $(mk_release_name dhall-lsp-server) bin/dhall-lsp-server
+  - tar -jcvf $(mk_release_name dhall-nix) bin/dhall-to-nix
   - mkdir -p uploads
   - mv *.tar.bz2 uploads/
 


### PR DESCRIPTION
Saw on Slack that the Darwin release was missing for `dhall-to-nix`, and from what I've dug up it looks like this should fix that.