### PR TITLE
Fix inferred type for record projection

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -1130,7 +1130,7 @@ infer typer = loop
 
                     let adapt = VRecord . Dhall.Map.fromList
 
-                    fmap adapt (traverse process (Dhall.Set.toList xs))
+                    fmap adapt (traverse process (Dhall.Set.toList (Dhall.Set.sort xs)))
 
                 _ -> do
                     let text =


### PR DESCRIPTION
This ensures that record projection correctly sorts the fields in the
inferred type

This fixes the regression test in
https://github.com/dhall-lang/dhall-lang/pull/750