### PR TITLE
Update release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,10 @@
 JOBSET=master
 
-function upload {
+function release {
   NAME="$1"
   VERSION="$2"
+
+  curl --location --output "${NAME}-${VERSION}-x86_64-linux.tar.bz2" "https://hydra.dhall-lang.org/job/dhall-haskell/${JOBSET}/tarball-${NAME}/latest/download/1/${NAME}.tar.bz2"
 
   curl --location --remote-name "https://hydra.dhall-lang.org/job/dhall-haskell/${JOBSET}/image-${NAME}/latest/download/1/docker-image-${NAME}.tar.gz"
 
@@ -10,8 +12,8 @@ function upload {
   skopeo copy --dest-creds=gabriel439:$(< dockerPassword.txt) "docker-archive:docker-image-${NAME}.tar.gz" "docker://dhallhaskell/${NAME}:${VERSION}"
 }
 
-upload dhall 1.26.0
-upload dhall-json 1.4.1
-upload dhall-bash 1.0.23
-upload dhall-nix 1.1.8
-upload dhall-lsp-server 1.0.1
+release dhall 1.26.1
+release dhall-json 1.4.1
+release dhall-bash 1.0.23
+release dhall-nix 1.1.8
+release dhall-lsp-server 1.0.1


### PR DESCRIPTION
With each new release I'm slowly automating more of the work I do for the
release process.  This change downloads the pre-built Linux binaries
and names them correctly for ease of upload to the release page.