### PR TITLE
Allow haskell-lsp 0.17.

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -49,7 +49,7 @@ library
     , dhall                >= 1.26.0   && < 1.27
     , dhall-json           >= 1.4      && < 1.5
     , filepath             >= 1.4.2    && < 1.5
-    , haskell-lsp          >= 0.15.0.0 && < 0.16
+    , haskell-lsp          >= 0.15.0.0 && < 0.17
     , rope-utf16-splay     >= 0.3.1.0  && < 0.4
     , hslogger             >= 1.2.10   && < 1.4
     , lens                 >= 4.16.1   && < 4.19


### PR DESCRIPTION
This is related to #1249, since earlier versions don't support GHC
8.8.