### PR TITLE
Fix pretty-printing precedence of `toMap`

### DIFF
--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -616,22 +616,6 @@ prettyCharacterSet characterSet expression =
             <>  prettyImportExpression b
             <>  space <> colon <> space
             <>  prettyApplicationExpression c
-    prettyAnnotatedExpression (Merge a b Nothing) =
-        Pretty.group (Pretty.flatAlt long short)
-      where
-        long =
-            Pretty.align
-                (   keyword "merge"
-                <>  Pretty.hardline
-                <>  Pretty.indent 2 (prettyImportExpression a)
-                <>  Pretty.hardline
-                <>  Pretty.indent 2 (prettyImportExpression b)
-                )
-
-        short = keyword "merge" <> space
-            <>  prettyImportExpression a
-            <>  " "
-            <>  prettyImportExpression b
     prettyAnnotatedExpression (ToMap a (Just b)) =
         Pretty.group (Pretty.flatAlt long short)
       where
@@ -843,17 +827,19 @@ prettyCharacterSet characterSet expression =
 
     prettyApplicationExpression :: Pretty a => Expr Src a -> Doc Ann
     prettyApplicationExpression a0 = case a0 of
-        App _ _   -> result
-        Some _    -> result
-        ToMap _ _ -> result
-        Note _ b  -> prettyApplicationExpression b
-        _         -> prettyImportExpression a0
+        App   {} -> result
+        Some  {} -> result
+        ToMap {} -> result
+        Merge {} -> result
+        Note _ b -> prettyApplicationExpression b
+        _        -> prettyImportExpression a0
       where
         result = enclose' "" "" " " "" (reverse (docs a0))
 
         docs (App  a b) = ( prettyImportExpression b, Pretty.indent 2 (prettyImportExpression b) ) : docs a
         docs (Some   a) = map duplicate [ prettyImportExpression a , builtin "Some" ]
         docs (ToMap a Nothing) = map duplicate [ prettyImportExpression a, keyword "toMap" ]
+        docs (Merge a b Nothing) = map duplicate [ prettyImportExpression b, prettyImportExpression a, keyword "merge" ]
         docs (Note _ b) = docs b
         docs         b  = map duplicate [ prettyImportExpression b ]
 

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -649,18 +649,6 @@ prettyCharacterSet characterSet expression =
             <>  prettyImportExpression a
             <>  space <> colon <> space
             <>  prettyApplicationExpression b
-    prettyAnnotatedExpression (ToMap a Nothing) =
-        Pretty.group (Pretty.flatAlt long short)
-      where
-        long =
-            Pretty.align
-                (   keyword "toMap"
-                <>  Pretty.hardline
-                <>  Pretty.indent 2 (prettyImportExpression a)
-                )
-
-        short = keyword "toMap" <> space
-            <>  prettyImportExpression a
     prettyAnnotatedExpression a0@(Annot _ _) =
         enclose'
             ""
@@ -855,15 +843,17 @@ prettyCharacterSet characterSet expression =
 
     prettyApplicationExpression :: Pretty a => Expr Src a -> Doc Ann
     prettyApplicationExpression a0 = case a0 of
-        App _ _  -> result
-        Some _   -> result
-        Note _ b -> prettyApplicationExpression b
-        _        -> prettyImportExpression a0
+        App _ _   -> result
+        Some _    -> result
+        ToMap _ _ -> result
+        Note _ b  -> prettyApplicationExpression b
+        _         -> prettyImportExpression a0
       where
         result = enclose' "" "" " " "" (reverse (docs a0))
 
         docs (App  a b) = ( prettyImportExpression b, Pretty.indent 2 (prettyImportExpression b) ) : docs a
         docs (Some   a) = map duplicate [ prettyImportExpression a , builtin "Some" ]
+        docs (ToMap a Nothing) = map duplicate [ prettyImportExpression a, keyword "toMap" ]
         docs (Note _ b) = docs b
         docs         b  = map duplicate [ prettyImportExpression b ]
 

--- a/dhall/tests/format/functionLikeA.dhall
+++ b/dhall/tests/format/functionLikeA.dhall
@@ -1,0 +1,6 @@
+{ example0 = merge a b + merge a b
+, example1 = (merge a b : T) + (merge a b : T)
+, example2 = toMap a + toMap a
+, example3 = (toMap a b : T) + (toMap a b : T)
+, example4 = Some a + Some a
+}

--- a/dhall/tests/format/functionLikeB.dhall
+++ b/dhall/tests/format/functionLikeB.dhall
@@ -1,0 +1,6 @@
+{ example0 = merge a b + merge a b
+, example1 = (merge a b : T) + (merge a b : T)
+, example2 = toMap a + toMap a
+, example3 = (toMap a b : T) + (toMap a b : T)
+, example4 = Some a + Some a
+}


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1358