### PR TITLE
Add the `--preserveNull` flag and omit null fields by default on `dhall-to-yaml`

### DIFF
--- a/dhall-json/dhall-to-json/Main.hs
+++ b/dhall-json/dhall-to-json/Main.hs
@@ -41,7 +41,7 @@ parseOptions =
         (   Options
         <$> parseExplain
         <*> parsePretty
-        <*> Dhall.JSON.parseOmission
+        <*> Dhall.JSON.parsePreservationAndOmission
         <*> Dhall.JSON.parseConversion
         <*> parseApproximateSpecialDoubles
         <*> optional parseFile

--- a/dhall-json/dhall-to-yaml/Main.hs
+++ b/dhall-json/dhall-to-yaml/Main.hs
@@ -5,7 +5,7 @@ module Main where
 import Control.Applicative (optional, (<|>))
 import Control.Exception (SomeException)
 import Data.Monoid ((<>))
-import Dhall.JSON (parseNullPreservation, parseEmptyOmission, parseConversion)
+import Dhall.JSON (parsePreservationAndOmission, parseConversion)
 import Dhall.Yaml (Options(..), dhallToYaml, parseDocuments, parseQuoted)
 import Options.Applicative (Parser, ParserInfo)
 
@@ -24,10 +24,7 @@ parseOptions =
             Just
         <$> (   Options
             <$> parseExplain
-            <*> (    Dhall.JSON.parseNullPreservation
-                <|>  Dhall.JSON.parseEmptyOmission
-                <|>  pure id
-                )
+            <*> Dhall.JSON.parsePreservationAndOmission
             <*> parseDocuments
             <*> parseQuoted
             <*> Dhall.JSON.parseConversion

--- a/dhall-json/dhall-to-yaml/Main.hs
+++ b/dhall-json/dhall-to-yaml/Main.hs
@@ -5,7 +5,7 @@ module Main where
 import Control.Applicative (optional, (<|>))
 import Control.Exception (SomeException)
 import Data.Monoid ((<>))
-import Dhall.JSON (parseOmission, parseConversion)
+import Dhall.JSON (parseNullPreservation, parseEmptyOmission, parseConversion)
 import Dhall.Yaml (Options(..), dhallToYaml, parseDocuments, parseQuoted)
 import Options.Applicative (Parser, ParserInfo)
 
@@ -24,7 +24,10 @@ parseOptions =
             Just
         <$> (   Options
             <$> parseExplain
-            <*> Dhall.JSON.parseOmission
+            <*> (    Dhall.JSON.parseNullPreservation
+                <|>  Dhall.JSON.parseEmptyOmission
+                <|>  pure id
+                )
             <*> parseDocuments
             <*> parseQuoted
             <*> Dhall.JSON.parseConversion

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -175,7 +175,7 @@
 >       }
 >     ]
 
-    By default, the fields that are evaluated to @Null@ will be removed,
+    By default, the fields that are evaluated to @null@ will be removed,
     but here we're preserving them with the @--preserveNull@ flag.
 
 > $ dhall-to-json --preserveNull <<< './example.dhall'

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -197,8 +197,7 @@ module Dhall.JSON (
     , omitNull
     , omitEmpty
     , parseOmission
-    , parseEmptyOmission
-    , parseNullPreservation
+    , parsePreservationAndOmission
     , Conversion(..)
     , convertToHomogeneousMaps
     , parseConversion
@@ -625,17 +624,12 @@ parseOmission =
             (   Options.Applicative.long "omitNull"
             <>  Options.Applicative.help "Omit record fields that are null"
             )
-    <|> parseEmptyOmission
-    <|> pure id
-
--- | Parser for command-line options related to omitting empty fields
-parseEmptyOmission :: Parser (Value -> Value)
-parseEmptyOmission =
-        Options.Applicative.flag'
+    <|> Options.Applicative.flag'
             omitEmpty
             (   Options.Applicative.long "omitEmpty"
             <>  Options.Applicative.help "Omit record fields that are null or empty records"
             )
+    <|> pure id
 
 -- | Parser for command-line options related to preserving null fields.
 parseNullPreservation :: Parser (Value -> Value)
@@ -646,6 +640,10 @@ parseNullPreservation =
             (   Options.Applicative.long "preserveNull"
             <>  Options.Applicative.help "Preserve record fields that are null"
             )
+
+-- | Combines parsers for command-line options related to preserving & omitting null fields.
+parsePreservationAndOmission :: Parser (Value -> Value)
+parsePreservationAndOmission = parseNullPreservation <|> parseOmission <|> pure id
 
 {-| Specify whether or not to convert association lists of type
     @List { mapKey: Text, mapValue : v }@ to records

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -65,7 +65,7 @@
     Dhall @Optional@ values translate to @null@ if absent and the unwrapped
     value otherwise:
 
-> $ dhall-to-json <<< 'None Natural'
+> $ dhall-to-json --preserveNull <<< 'None Natural'
 > null
 > $ dhall-to-json <<< 'Some 1'
 > 1

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -197,6 +197,8 @@ module Dhall.JSON (
     , omitNull
     , omitEmpty
     , parseOmission
+    , parseEmptyOmission
+    , parseNullPreservation
     , Conversion(..)
     , convertToHomogeneousMaps
     , parseConversion
@@ -623,12 +625,27 @@ parseOmission =
             (   Options.Applicative.long "omitNull"
             <>  Options.Applicative.help "Omit record fields that are null"
             )
-    <|> Options.Applicative.flag'
+    <|> parseEmptyOmission
+    <|> pure id
+
+-- | Parser for command-line options related to omitting empty fields
+parseEmptyOmission :: Parser (Value -> Value)
+parseEmptyOmission =
+        Options.Applicative.flag'
             omitEmpty
             (   Options.Applicative.long "omitEmpty"
             <>  Options.Applicative.help "Omit record fields that are null or empty records"
             )
-    <|> pure id
+
+-- | Parser for command-line options related to preserving null fields.
+parseNullPreservation :: Parser (Value -> Value)
+parseNullPreservation =
+        Options.Applicative.flag
+            omitNull
+            id
+            (   Options.Applicative.long "preserveNull"
+            <>  Options.Applicative.help "Preserve record fields that are null"
+            )
 
 {-| Specify whether or not to convert association lists of type
     @List { mapKey: Text, mapValue : v }@ to records

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -65,7 +65,7 @@
     Dhall @Optional@ values translate to @null@ if absent and the unwrapped
     value otherwise:
 
-> $ dhall-to-json --preserveNull <<< 'None Natural'
+> $ dhall-to-json <<< 'None Natural'
 > null
 > $ dhall-to-json <<< 'Some 1'
 > 1
@@ -175,7 +175,10 @@
 >       }
 >     ]
 
-> $ dhall-to-json <<< './example.dhall'
+    By default, the fields that are evaluated to @Null@ will be removed,
+    but here we're preserving them with the @--preserveNull@ flag.
+
+> $ dhall-to-json --preserveNull <<< './example.dhall'
 > {
 >   "bar": [
 >     1,


### PR DESCRIPTION
Currently this is a breaking change because the `--omitNull` flag is removed, but it would seem a bit confusing to keep it and have two flags for the same purpose. Let me know if I should keep it.

```bash
$ dhall-to-yaml --preserveNull <<< '{ a = "dhall", b = None Natural, c = [ ] : List Text }'
a: dhall
b: null
c: []

$ dhall-to-yaml <<< '{ a = "dhall", b = None Natural, c = [ ] : List Text }'
a: dhall
c: []

$ dhall-to-yaml --omitEmpty <<< '{ a = "dhall", b = None Natural, c = [ ] : List Text }'
a: dhall
```
