### PR TITLE
Move parser-pretty-printer note to D.Pretty.Internal

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -853,17 +853,6 @@ instance Monoid (Chunks s a) where
 instance IsString (Chunks s a) where
     fromString str = Chunks [] (fromString str)
 
-{-  There is a one-to-one correspondence between the builders in this section
-    and the sub-parsers in "Dhall.Parser".  Each builder is named after the
-    corresponding parser and the relationship between builders exactly matches
-    the relationship between parsers.  This leads to the nice emergent property
-    of automatically getting all the parentheses and precedences right.
-
-    This approach has one major disadvantage: you can get an infinite loop if
-    you add a new constructor to the syntax tree without adding a matching
-    case the corresponding builder.
--}
-
 -- | Generates a syntactically valid Dhall program
 instance Pretty a => Pretty (Expr s a) where
     pretty = Pretty.unAnnotate . prettyExpr

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -430,6 +430,17 @@ prettyVar :: Var -> Doc Ann
 prettyVar (V x 0) = label (Pretty.unAnnotate (prettyLabel x))
 prettyVar (V x n) = label (Pretty.unAnnotate (prettyLabel x <> "@" <> prettyInt n))
 
+{-  There is a close correspondence between the pretty-printers in 'prettyCharacterSet'
+    and the sub-parsers in 'Dhall.Parser.Expression.parsers'.  Most pretty-printers are
+    named after the corresponding parser and the relationship between pretty-printers
+    exactly matches the relationship between parsers.  This leads to the nice emergent
+    property of automatically getting all the parentheses and precedences right.
+
+    This approach has one major disadvantage: you can get an infinite loop if
+    you add a new constructor to the syntax tree without adding a matching
+    case the corresponding builder.
+-}
+
 {-| Pretty-print an 'Expr' using the given 'CharacterSet'.
 
 'prettyCharacterSet' largely ignores 'Note's. 'Note's do however matter for


### PR DESCRIPTION
I've toned it down a bit since the correspondence doesn't seem
to be as close anymore as it once was.

Fixes #1364.