### PR TITLE
Fix indentation for multiline Some-, toMap- and merge-expressions

### DIFF
--- a/dhall/tests/Dhall/Test/Format.hs
+++ b/dhall/tests/Dhall/Test/Format.hs
@@ -61,6 +61,10 @@ formatTest characterSet prefix =
         expectedText <- Text.IO.readFile outputFile
 
         let message =
-                "The formatted expression did not match the expected output"
+                   "The formatted expression did not match the expected output\n"
+                <> "Expected:\n\n" <> Text.unpack expectedText <> "\n\n"
+                <> "Actual:\n\n" <> Text.unpack actualText <> "\n\n"
+                <> "Expected (show): " <> show expectedText <> "\n"
+                <> "Actual   (show): " <> show actualText <> "\n"
 
-        Tasty.HUnit.assertEqual message expectedText actualText
+        Tasty.HUnit.assertBool message (actualText == expectedText)

--- a/dhall/tests/format/applicationMultilineA.dhall
+++ b/dhall/tests/format/applicationMultilineA.dhall
@@ -1,0 +1,5 @@
+{ app = ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff aaaaaaaaaaaaaaaaa
+, some = Some aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+, merge = merge aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+, toMap = toMap aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+}

--- a/dhall/tests/format/applicationMultilineB.dhall
+++ b/dhall/tests/format/applicationMultilineB.dhall
@@ -1,0 +1,14 @@
+{ app =
+    ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+      aaaaaaaaaaaaaaaaa
+, some =
+    Some
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+, merge =
+    merge
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+, toMap =
+    toMap
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+}

--- a/dhall/tests/format/largeRecordB.dhall
+++ b/dhall/tests/format/largeRecordB.dhall
@@ -34,15 +34,15 @@ in    defaults.Config
       , dark_room = Some False
       , disclose =
           Some
-          (   defaults.Disclose
-            ⫽ { inventory = Some { prompt = True, default = True }
-              , attributes = Some { prompt = True, default = False }
-              , monsters_killed = Some { prompt = False, default = True }
-              , monsters_genocided = Some { prompt = False, default = False }
-              , conduct = Some { prompt = False, default = False }
-              , dungeon_overview = Some { prompt = False, default = False }
-              }
-          )
+            (   defaults.Disclose
+              ⫽ { inventory = Some { prompt = True, default = True }
+                , attributes = Some { prompt = True, default = False }
+                , monsters_killed = Some { prompt = False, default = True }
+                , monsters_genocided = Some { prompt = False, default = False }
+                , conduct = Some { prompt = False, default = False }
+                , dungeon_overview = Some { prompt = False, default = False }
+                }
+            )
       , dogname = Some "Cujo"
       , extmenu = Some False
       , fixinv = Some True


### PR DESCRIPTION
The loss of indentation for toMap and merge was due to
75e6cc5ca7dccf4c8d5831f0aaa664fc3400f060. I have included Some for
consistency.

Fixes #1376.

Also improve format test failure messages