### PR TITLE
Fix formatting of multi-argument function applications

### DIFF
--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -838,19 +838,22 @@ prettyCharacterSet characterSet expression =
         prettyApplicationExpression a0
 
     prettyApplicationExpression :: Pretty a => Expr Src a -> Doc Ann
-    prettyApplicationExpression = \case
-        App a b           -> f (prettyApplicationExpression a) [b]
-        Some a            -> f (builtin "Some") [a]
-        ToMap a Nothing   -> f (keyword "toMap") [a]
-        Merge a b Nothing -> f (keyword "merge") [a, b]
-        Note _ b          -> prettyApplicationExpression b
-        e                 -> prettyImportExpression e
+    prettyApplicationExpression = go []
       where
-        f a bs =
+        go args = \case
+            App a b           -> go (b : args) a
+            Some a            -> app (builtin "Some") (a : args)
+            Merge a b Nothing -> app (keyword "merge") (a : b : args)
+            ToMap a Nothing   -> app (keyword "toMap") (a : args)
+            Note _ b          -> go args b
+            e | null args     -> prettyImportExpression e -- just a performance optimization
+              | otherwise     -> app (prettyImportExpression e) args
+
+        app f args =
             enclose'
                 "" "" " " ""
-                ( duplicate a
-                : map (fmap (Pretty.indent 2) . duplicate . prettyImportExpression) bs
+                ( duplicate f
+                : map (fmap (Pretty.indent 2) . duplicate . prettyImportExpression) args
                 )
 
     prettyImportExpression :: Pretty a => Expr Src a -> Doc Ann

--- a/dhall/tests/format/applicationMultilineA.dhall
+++ b/dhall/tests/format/applicationMultilineA.dhall
@@ -1,5 +1,30 @@
-{ app = ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff aaaaaaaaaaaaaaaaa
-, some = Some aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-, merge = merge aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-, toMap = toMap aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+{ app =
+    ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+      aaaaaaaaaaaaaaaaa
+, app2 =
+    f
+      a
+      b
+      cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+, app3 =
+    f
+      a
+      b
+      c
+      dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+, some =
+    Some
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+, merge =
+    merge
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+, merge3 =
+    merge
+      a
+      b
+      ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+, toMap =
+    toMap
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 }

--- a/dhall/tests/format/applicationMultilineB.dhall
+++ b/dhall/tests/format/applicationMultilineB.dhall
@@ -1,6 +1,17 @@
 { app =
     ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
       aaaaaaaaaaaaaaaaa
+, app2 =
+    f
+      a
+      b
+      cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+, app3 =
+    f
+      a
+      b
+      c
+      dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 , some =
     Some
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -8,6 +19,11 @@
     merge
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+, merge3 =
+    merge
+      a
+      b
+      ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 , toMap =
     toMap
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/dhall/tests/format/concatSepA.dhall
+++ b/dhall/tests/format/concatSepA.dhall
@@ -1,0 +1,30 @@
+{-
+Concatenate a `List` of `Text` values with a separator in between each value
+-}
+let Status = < Empty | NonEmpty : Text >
+
+let concatSep
+    : ∀(separator : Text) → ∀(elements : List Text) → Text
+    =   λ(separator : Text)
+      → λ(elements : List Text)
+      → let status =
+              List/fold Text elements Status
+                (   λ(element : Text)
+                  → λ(status : Status)
+                  → merge
+                      { Empty = Status.NonEmpty element
+                      , NonEmpty =
+                            λ(result : Text)
+                          → Status.NonEmpty (element ++ separator ++ result)
+                      }
+                      status
+                )
+                Status.Empty
+        
+        in  merge { Empty = "", NonEmpty = λ(result : Text) → result } status
+
+let example0 = assert : concatSep ", " [ "ABC", "DEF", "GHI" ] ≡ "ABC, DEF, GHI"
+
+let example1 = assert : concatSep ", " ([] : List Text) ≡ ""
+
+in  concatSep

--- a/dhall/tests/format/concatSepB.dhall
+++ b/dhall/tests/format/concatSepB.dhall
@@ -1,0 +1,33 @@
+{-
+Concatenate a `List` of `Text` values with a separator in between each value
+-}
+let Status = < Empty | NonEmpty : Text >
+
+let concatSep
+    : ∀(separator : Text) → ∀(elements : List Text) → Text
+    =   λ(separator : Text)
+      → λ(elements : List Text)
+      → let status =
+              List/fold
+                Text
+                elements
+                Status
+                (   λ(element : Text)
+                  → λ(status : Status)
+                  → merge
+                      { Empty = Status.NonEmpty element
+                      , NonEmpty =
+                            λ(result : Text)
+                          → Status.NonEmpty (element ++ separator ++ result)
+                      }
+                      status
+                )
+                Status.Empty
+        
+        in  merge { Empty = "", NonEmpty = λ(result : Text) → result } status
+
+let example0 = assert : concatSep ", " [ "ABC", "DEF", "GHI" ] ≡ "ABC, DEF, GHI"
+
+let example1 = assert : concatSep ", " ([] : List Text) ≡ ""
+
+in  concatSep


### PR DESCRIPTION
merge-expressions with additional arguments are also formatted with
consistent indentation for all arguments. E.g.

    merge
      { x = Natural/even }
      < x >.x
      1111111111111111111111111111111111111111111111111111111111

This fixes a small regression introduced in https://github.com/dhall-lang/dhall-haskell/commit/7634ee740b96979bc13706afa98db5c209580c2c.