### PR TITLE
Resolves #1408: Add more detail in `--explain` when `toMap` has the w…

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -3382,9 +3382,9 @@ prettyTypeMessage (MustMapARecord _expr0 _expr1) = ErrorMessages {..}
         \  using ❰toMap❱:                                                                \n\
         \                                                                                \n\
         \                                                                                \n\
-        \    ┌──────────┐                                                                \n\
-        \    │ toMap {} │                                                                \n\
-        \    └──────────┘                                                                \n\
+        \    ┌───────────────────────────────────────────────────────┐                   \n\
+        \    │ toMap {} : List { mapKey : Text, mapValue : Natural } │                   \n\
+        \    └───────────────────────────────────────────────────────┘                   \n\
         \            ⇧                                                                   \n\
         \            This should be ❰{=}❱ instead                                        \n"
 

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -3374,7 +3374,19 @@ prettyTypeMessage (MustMapARecord _expr0 _expr1) = ErrorMessages {..}
         \    └─────────────────────────────────────────────────────────────────────┘     \n\
         \                                                                                \n\
         \                                                                                \n\
-        \... but the argument to ❰toMap❱ must be a record and not some other type.       \n"
+        \... but the argument to ❰toMap❱ must be a record and not some other type.       \n\
+        \                                                                                \n\
+        \Some common reasons why you might get this error:                               \n\
+        \                                                                                \n\
+        \● You accidentally provide an empty record type instead of an empty record when \n\
+        \  using ❰toMap❱:                                                                \n\
+        \                                                                                \n\
+        \                                                                                \n\
+        \    ┌──────────┐                                                                \n\
+        \    │ toMap {} │                                                                \n\
+        \    └──────────┘                                                                \n\
+        \            ⇧                                                                   \n\
+        \            This should be ❰{=}❱ instead                                        \n"
 
 prettyTypeMessage (InvalidToMapRecordKind type_ kind) = ErrorMessages {..}
   where


### PR DESCRIPTION
…rong type.

Specifically, add common reason of using `{}` for record value.

For example,
``` shell
echo 'toMap {}' | ~/.local/bin/dhall
```

Outputs

```
Error: ❰toMap❱ expects a record value

Explanation: You can apply ❰toMap❱ to any homogenous record, like this:         
                                                                                
                                                                                
    ┌─────────────────────────────────────────────────────────────────────┐     
    │ let record = { one = 1, two = 2 }                                   │     
    │ in  toMap record : List { mapKey : Text, mapValue : Natural}        │     
    └─────────────────────────────────────────────────────────────────────┘     
                                                                                
                                                                                
... but the argument to ❰toMap❱ must be a record and not some other type.       
                                                                                
Some common reasons why you might get this error:                               
                                                                                
● You accidentally provide an empty record type instead of an empty record when 
  using ❰toMap❱:                                                                
                                                                                
                                                                                
    ┌───────────────────────────────────────────────────────┐                   
    │ toMap {} : List { mapKey : Text, mapValue : Natural } │                   
    └───────────────────────────────────────────────────────┘                   
            ⇧                                                                   
            This should be ❰{=}❱ instead                                        

────────────────────────────────────────────────────────────────────────────────

1│ toMap {}

(stdin):1:1
```