### PR TITLE
Test that `dhall format` is idempotent

### DIFF
--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
@@ -128,7 +128,7 @@ parse = fmap snd . parseWithHeader
 
 -- | Parse a Dhall expression along with its "header", i.e. whitespace and
 --   comments prefixing the actual code.
-parseWithHeader :: Text -> Either DhallError (Text, Expr Src Dhall.Import)
+parseWithHeader :: Text -> Either DhallError (Dhall.Header, Expr Src Dhall.Import)
 parseWithHeader = first ErrorParse . Dhall.exprAndHeaderFromText ""
 
 -- | Resolve all imports in an expression.

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Formatting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Formatting.hs
@@ -1,6 +1,7 @@
 module Dhall.LSP.Backend.Formatting (formatExpr, formatExprWithHeader) where
 
 import Dhall.Core (Expr)
+import Dhall.Parser (Header(..))
 import Dhall.Pretty (CharacterSet(..), layoutOpts, prettyCharacterSet)
 import Dhall.Src (Src)
 
@@ -11,12 +12,12 @@ import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty
 
 -- | Pretty-print the given Dhall expression.
 formatExpr :: Pretty.Pretty b => Expr Src b -> Text
-formatExpr expr = formatExprWithHeader expr ""
+formatExpr expr = formatExprWithHeader expr (Header "")
 
 -- | Pretty-print the given Dhall expression, prepending the given a "header"
 --   (usually consisting of comments and whitespace).
-formatExprWithHeader :: Pretty.Pretty b => Expr Src b -> Text -> Text
-formatExprWithHeader expr header = Pretty.renderStrict
+formatExprWithHeader :: Pretty.Pretty b => Expr Src b -> Header -> Text
+formatExprWithHeader expr (Header header) = Pretty.renderStrict
   (Pretty.layoutSmart layoutOpts doc)
   where
     doc =

--- a/dhall/src/Dhall/Format.hs
+++ b/dhall/src/Dhall/Format.hs
@@ -55,7 +55,8 @@ format (Format {..}) =
         Modify {..} ->
             case inplace of
                 InputFile file -> do
-                    (header, expr) <- Dhall.Util.getExpressionAndHeader censor (InputFile file)
+                    (Dhall.Util.Header header, expr) <-
+                        Dhall.Util.getExpressionAndHeader censor (InputFile file)
 
                     let doc =   Pretty.pretty header
                             <>  Pretty.unAnnotate (Dhall.Pretty.prettyCharacterSet characterSet expr)
@@ -64,7 +65,8 @@ format (Format {..}) =
                     System.IO.withFile file System.IO.WriteMode (\handle -> do
                         Pretty.Terminal.renderIO handle (Pretty.layoutSmart layoutOpts doc))
                 StandardInput -> do
-                    (header, expr) <- Dhall.Util.getExpressionAndHeader censor StandardInput
+                    (Dhall.Util.Header header, expr) <-
+                        Dhall.Util.getExpressionAndHeader censor StandardInput
 
                     let doc =   Pretty.pretty header
                             <>  Dhall.Pretty.prettyCharacterSet characterSet expr
@@ -86,7 +88,8 @@ format (Format {..}) =
                 InputFile file -> Data.Text.IO.readFile file
                 StandardInput  -> Data.Text.IO.getContents
 
-            (header, expr) <- Dhall.Util.getExpressionAndHeader censor path
+            (Dhall.Util.Header header, expr) <-
+                Dhall.Util.getExpressionAndHeader censor path
 
             let doc =   Pretty.pretty header
                     <>  Pretty.unAnnotate (Dhall.Pretty.prettyCharacterSet characterSet expr)

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -145,7 +145,8 @@ freeze inplace scope intent characterSet censor = do
             StandardInput  -> "."
             InputFile file -> System.FilePath.takeDirectory file
 
-    (header, parsedExpression) <- Dhall.Util.getExpressionAndHeader censor inplace
+    (Dhall.Util.Header header, parsedExpression) <-
+        Dhall.Util.getExpressionAndHeader censor inplace
 
     let freezeScope =
             case scope of

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -34,7 +34,7 @@ import Dhall.Import (Imported(..), Depends(..), SemanticCacheMode(..), _semantic
 import Dhall.Parser (Src)
 import Dhall.Pretty (Ann, CharacterSet(..), annToAnsiStyle, layoutOpts)
 import Dhall.TypeCheck (Censored(..), DetailedTypeError(..), TypeError)
-import Dhall.Util (Censor(..), Input(..), Output(..))
+import Dhall.Util (Censor(..), Header (..), Input(..), Output(..))
 import Dhall.Version (dhallVersionString)
 import Options.Applicative (Parser, ParserInfo)
 import System.Exit (ExitCode, exitFailure)
@@ -650,7 +650,7 @@ command (Options {..}) = do
             Data.Text.IO.putStrLn (Dhall.Import.hashExpressionToCode normalizedExpression)
 
         Lint {..} -> do
-            (header, expression) <- getExpressionAndHeader inplace
+            (Header header, expression) <- getExpressionAndHeader inplace
 
             case inplace of
                 InputFile file -> do

--- a/dhall/src/Dhall/Parser.hs
+++ b/dhall/src/Dhall/Parser.hs
@@ -13,6 +13,7 @@ module Dhall.Parser (
     , expr, exprA
 
     -- * Types
+    , Header(..)
     , Src(..)
     , SourcedException(..)
     , ParseError(..)
@@ -92,6 +93,13 @@ exprFromText
   -> Either ParseError (Expr Src Import)
 exprFromText delta text = fmap snd (exprAndHeaderFromText delta text)
 
+-- | A header corresponds to the leading comment at the top of a Dhall file.
+--
+-- It can use any combination of single line comments and/or multiline comments
+-- and must terminate in a newline.
+-- The header keeps the raw text unchanged (includes comment characters)
+newtype Header = Header Text
+
 {-| Like `exprFromText` but also returns the leading comments and whitespace
     (i.e. header) up to the last newline before the code begins
 
@@ -108,10 +116,10 @@ exprAndHeaderFromText
     :: String -- ^ User-friendly name describing the input expression,
               --   used in parsing error messages
     -> Text   -- ^ Input expression to parse
-    -> Either ParseError (Text, Expr Src Import)
+    -> Either ParseError (Header, Expr Src Import)
 exprAndHeaderFromText delta text = case result of
     Left errInfo   -> Left (ParseError { unwrap = errInfo, input = text })
-    Right (txt, r) -> Right (stripHeader txt, r)
+    Right (txt, r) -> Right (Header $ stripHeader txt, r)
   where
     parser = do
         (bytes, _) <- Text.Megaparsec.match whitespace

--- a/dhall/src/Dhall/Parser.hs
+++ b/dhall/src/Dhall/Parser.hs
@@ -100,7 +100,7 @@ exprFromText delta text = fmap snd (exprAndHeaderFromText delta text)
 -- trailing newlines
 newtype Header = Header Text deriving Show
 
--- Create a header with stripped of leading spaces and trailing newlines
+-- | Create a header with stripped leading spaces and trailing newlines
 createHeader :: Text -> Header
 createHeader =
     Header . Data.Text.dropWhile Data.Char.isSpace . Data.Text.dropWhileEnd (/= '\n')

--- a/dhall/src/Dhall/Parser.hs
+++ b/dhall/src/Dhall/Parser.hs
@@ -98,7 +98,7 @@ exprFromText delta text = fmap snd (exprAndHeaderFromText delta text)
 -- It can use any combination of single line comments and/or multiline comments
 -- and must terminate in a newline.
 -- The header keeps the raw text unchanged (includes comment characters)
-newtype Header = Header Text
+newtype Header = Header Text deriving Show
 
 {-| Like `exprFromText` but also returns the leading comments and whitespace
     (i.e. header) up to the last newline before the code begins

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -109,7 +109,7 @@ annToAnsiStyle Builtin  = Terminal.underlined
 annToAnsiStyle Operator = Terminal.bold <> Terminal.colorDull Terminal.Green
 
 -- | This type determines whether to render code as `ASCII` or `Unicode`
-data CharacterSet = ASCII | Unicode
+data CharacterSet = ASCII | Unicode deriving Show
 
 -- | Pretty print an expression
 prettyExpr :: Pretty a => Expr s a -> Doc Ann

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -12,6 +12,7 @@ module Dhall.Util
     , Output(..)
     , getExpression
     , getExpressionAndHeader
+    , Header(..)
     ) where
 
 import Data.Bifunctor (first)
@@ -20,7 +21,7 @@ import Data.String (IsString)
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty)
 import Dhall.Core (Expr, Import)
-import Dhall.Parser (ParseError)
+import Dhall.Parser (ParseError, Header(..))
 import Dhall.Pretty (Ann)
 import Dhall.Src (Src)
 
@@ -129,5 +130,5 @@ getExpression :: Censor -> Input -> IO (Expr Src Import)
 getExpression = get Dhall.Parser.exprFromText
 
 -- | Convenient utility for retrieving an expression along with its header
-getExpressionAndHeader :: Censor -> Input -> IO (Text, Expr Src Import)
+getExpressionAndHeader :: Censor -> Input -> IO (Header, Expr Src Import)
 getExpressionAndHeader = get Dhall.Parser.exprAndHeaderFromText

--- a/dhall/tests/Dhall/Test/Format.hs
+++ b/dhall/tests/Dhall/Test/Format.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
 
 module Dhall.Test.Format where
 
@@ -8,8 +7,6 @@ import Data.Text (Text)
 import Dhall.Parser (Header(..))
 import Dhall.Pretty (CharacterSet(..))
 import Test.Tasty (TestTree)
-import Test.Tasty.QuickCheck ((===))
-import Dhall.Test.QuickCheck () -- For Arbitrary instances
 
 import qualified Control.Monad                         as Monad
 import qualified Data.Text                             as Text
@@ -22,7 +19,6 @@ import qualified Dhall.Pretty                          as Pretty
 import qualified Dhall.Test.Util                       as Test.Util
 import qualified Test.Tasty                            as Tasty
 import qualified Test.Tasty.HUnit                      as Tasty.HUnit
-import qualified Test.Tasty.QuickCheck                 as Tasty.QuickCheck
 import qualified Turtle
 
 getTests :: IO TestTree
@@ -44,7 +40,6 @@ getTests = do
             Tasty.testGroup "format tests"
                 [ unicodeTests
                 , asciiTests
-                , idempotenceTest
                 ]
 
     return testTree
@@ -80,13 +75,3 @@ formatTest characterSet prefix =
                 <> "Actual   (show): " <> show actualText <> "\n"
 
         Tasty.HUnit.assertBool message (actualText == expectedText)
-
-idempotenceTest :: TestTree
-idempotenceTest =
-    Tasty.adjustOption (const $ Tasty.QuickCheck.QuickCheckMaxRatio 10000) $
-    Tasty.QuickCheck.testProperty
-        "Formatting should be idempotent"
-        $ \characterSet (format characterSet -> once) ->
-            case Parser.exprAndHeaderFromText mempty once of
-                Right (format characterSet -> twice) -> once === twice
-                Left _ -> Tasty.QuickCheck.discard

--- a/dhall/tests/Dhall/Test/Format.hs
+++ b/dhall/tests/Dhall/Test/Format.hs
@@ -8,7 +8,7 @@ import Data.Text (Text)
 import Dhall.Parser (Header(..))
 import Dhall.Pretty (CharacterSet(..))
 import Test.Tasty (TestTree)
-import Test.Tasty.QuickCheck ((===), property)
+import Test.Tasty.QuickCheck ((===))
 import Dhall.Test.QuickCheck () -- For Arbitrary instances
 
 import qualified Control.Monad                         as Monad
@@ -82,9 +82,11 @@ formatTest characterSet prefix =
         Tasty.HUnit.assertBool message (actualText == expectedText)
 
 idempotenceTest :: TestTree
-idempotenceTest = Tasty.QuickCheck.testProperty
-    "Formatting should be idempotent"
-    $ \characterSet (format characterSet -> once) ->
-        case Parser.exprAndHeaderFromText mempty once of
-            Right (format characterSet -> twice) -> once === twice
-            Left _ -> property Tasty.QuickCheck.Discard
+idempotenceTest =
+    Tasty.adjustOption (const $ Tasty.QuickCheck.QuickCheckMaxRatio 10000) $
+    Tasty.QuickCheck.testProperty
+        "Formatting should be idempotent"
+        $ \characterSet (format characterSet -> once) ->
+            case Parser.exprAndHeaderFromText mempty once of
+                Right (format characterSet -> twice) -> once === twice
+                Left _ -> Tasty.QuickCheck.discard

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -37,7 +37,7 @@ import Data.Functor.Identity (Identity(..))
 import Data.Typeable (Typeable, typeRep)
 import Data.Proxy (Proxy(..))
 import Dhall.Set (Set)
-import Dhall.Parser (Header(..))
+import Dhall.Parser (Header, createHeader)
 import Dhall.Pretty (CharacterSet(..))
 import Dhall.Src (Src(..))
 import Dhall.TypeCheck (Typer, TypeError)
@@ -164,7 +164,7 @@ instance Arbitrary Header where
         , newlines
         ]
 
-      pure . Header $ Text.unlines comments
+      pure . createHeader $ Text.unlines comments
 
     shrink = const [] -- TODO improve
 

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -545,13 +545,13 @@ tests =
         , ( "Formatting should be idempotent"
           , idempotenceTest
           , Test.Tasty.adjustOption (const $ QuickCheckTests 1) -- TODO Increase this!
-          . adjustQuickCheckMaxSize 10000 -- This test discards many cases
+          . adjustQuickCheckMaxRatio 10000 -- This test discards many cases
           )
         ]
 
-adjustQuickCheckMaxSize :: Int -> TestTree -> TestTree
-adjustQuickCheckMaxSize maxSize =
-    Test.Tasty.adjustOption (max $ Test.Tasty.QuickCheck.QuickCheckMaxSize maxSize)
+adjustQuickCheckMaxRatio :: Int -> TestTree -> TestTree
+adjustQuickCheckMaxRatio maxSize =
+    Test.Tasty.adjustOption (max $ Test.Tasty.QuickCheck.QuickCheckMaxRatio maxSize)
 
 adjustQuickCheckTests :: Int -> TestTree -> TestTree
 adjustQuickCheckTests nTests =

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -13,6 +13,7 @@ module Dhall.Test.QuickCheck where
 import Codec.Serialise (DeserialiseFailure(..))
 import Data.Either (isRight)
 import Data.Either.Validation (Validation(..))
+import Data.Monoid ((<>))
 import Dhall (ToDhall(..), FromDhall(..), auto, extract, inject, embed, Vector)
 import Dhall.Map (Map)
 import Dhall.Core


### PR DESCRIPTION
Closes #1421 

I am not too sure what kind of expression we expect `dhall format` to handle. Should `dhall format` be able to format code that doesn't type check?

Issue #1421 suggested using the `Arbitrary` instance for `Src` (which in turn uses the `Arbitrary` instance for `Text`) but this resulted in too many parse error we have to discard. I am now using the `Arbitrary` instance for `Expr s a` which seem much more reasonable.

This PR currently doesn't pass this new formatting test. However I am still opening it in order to discuss whether the test is too strict and to find out if anyone has any ideas for how to solve these remaining idempotency issues.