### PR TITLE
fix index in MismatchedListElements

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -588,7 +588,7 @@ infer typer = loop
                                     -- Carefully note that we don't use `die`
                                     -- here so that the source span is narrowed
                                     -- to just the offending element
-                                    let err = MismatchedListElements i _T₀'' t₁ _T₁''
+                                    let err = MismatchedListElements (i+1) _T₀'' t₁ _T₁''
 
                                     let context = ctxToContext ctx
 


### PR DESCRIPTION
If you run `dhall --explain` to explain a type error from a list with
mismatched elements, the index of the offending term was wrong.  For a
minimal example, you can run:

    dhall --explain <<<'[0, True]'

The problem is that `i` is an index into the tail of the list, not into
the whole list.  The fix is just to add one to it to correct for the
missing head.