### PR TITLE
WIP: Make whitespace after "missing" optional

### DIFF
--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -1101,7 +1101,9 @@ _equivalent = do
 
 -- | Parse the @missing@ keyword
 _missing :: Parser ()
-_missing = keyword "missing"
+_missing = do
+    _ <- Text.Parser.Char.text "missing"
+    whitespace
 
 -- | Parse the @?@ symbol
 _importAlt :: Parser ()

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -329,15 +329,17 @@ blockCommentContinue = endOfComment <|> continue
 
 simpleLabel :: Bool -> Parser Text
 simpleLabel allowReserved = try (do
-    c    <- Text.Parser.Char.satisfy headCharacter
-    rest <- Dhall.Parser.Combinators.takeWhile tailCharacter
+    c    <- Text.Parser.Char.satisfy simpleLabelFirstChar
+    rest <- Dhall.Parser.Combinators.takeWhile simpleLabelNextChar
     let text = Data.Text.cons c rest
     Control.Monad.guard (allowReserved || not (Data.HashSet.member text reservedIdentifiers))
     return text )
-  where
-    headCharacter c = alpha c || c == '_'
 
-    tailCharacter c = alphaNum c || c == '_' || c == '-' || c == '/'
+simpleLabelFirstChar ::Char -> Bool
+simpleLabelFirstChar c = alpha c || c == '_'
+
+simpleLabelNextChar :: Char -> Bool
+simpleLabelNextChar c = alphaNum c || c == '_' || c == '-' || c == '/'
 
 backtickLabel :: Parser Text
 backtickLabel = do
@@ -1103,6 +1105,7 @@ _equivalent = do
 _missing :: Parser ()
 _missing = do
     _ <- Text.Parser.Char.text "missing"
+    _ <- Text.Megaparsec.notFollowedBy (Text.Megaparsec.satisfy simpleLabelFirstChar)
     whitespace
 
 -- | Parse the @?@ symbol

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -1148,6 +1148,8 @@ reservedIdentifiers =
         , "else"
         , "as"
         , "using"
+        , "missing"
+        , "assert"
         , "Natural"
         , "Natural/fold"
         , "Natural/build"


### PR DESCRIPTION
Also add "missing" to the reserved identifiers, together
with "assert" (see https://github.com/dhall-lang/dhall-lang/pull/785)

This passes the test added in https://github.com/dhall-lang/dhall-lang/pull/788.

Closes #1454.