### PR TITLE
Update website to use `dhall-json` for generating YAML

### DIFF
--- a/dhall-json/src/Dhall/Yaml.hs
+++ b/dhall-json/src/Dhall/Yaml.hs
@@ -7,7 +7,9 @@ module Dhall.Yaml
   , parseDocuments
   , parseQuoted
   , defaultOptions
-  , dhallToYaml ) where
+  , dhallToYaml
+  , jsonToYaml
+  ) where
 
 import Data.ByteString (ByteString)
 import Data.Monoid ((<>))

--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -314,20 +314,6 @@
       document.getElementById(tabId).classList.toggle("active");
     }
 
-    /* The Haskell yaml package doesn't support GHCJS, so we simulate the
-       dhall-to-yaml conversion in the browser in two steps:
-
-       * Convert Dhall to JSON using the `dhall-to-json` Haskell package
-         compiled with GHCJS
-       * Convert JSON to YAML using the `jsyaml` JavaScript package (this
-         function)
-    */
-    function jsonToYaml(json) {
-      let obj =JSON.parse(json);
-      let str = jsyaml.safeDump(obj);
-      return str;
-    }
-
     let example0 = `{- This is an example Dhall configuration file
 
    Can you spot the mistake?

--- a/dhall-try/src/Main.hs
+++ b/dhall-try/src/Main.hs
@@ -4,10 +4,10 @@ module Main where
 
 import qualified Control.Exception
 import qualified Data.Aeson.Encode.Pretty
-import qualified Data.Char
 import qualified Data.IORef
 import qualified Data.JSString
 import qualified Data.Text
+import qualified Data.Text.Encoding
 import qualified Data.Text.Lazy
 import qualified Data.Text.Lazy.Encoding
 import qualified Data.Text.Prettyprint.Doc             as Pretty
@@ -15,6 +15,7 @@ import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
 import qualified Dhall.Core
 import qualified Dhall.Import
 import qualified Dhall.JSON
+import qualified Dhall.Yaml
 import qualified Dhall.Parser
 import qualified Dhall.Pretty
 import qualified Dhall.TypeCheck
@@ -24,9 +25,6 @@ import Control.Exception (Exception, SomeException)
 import Data.JSString (JSString)
 import Data.Text (Text)
 import GHCJS.Foreign.Callback (Callback)
-
--- Work around the `yaml` package not working for GHCJS
-foreign import javascript unsafe "jsonToYaml($1)" jsonToYaml_ :: JSString -> JSString
 
 foreign import javascript unsafe "input.getValue()" getInput :: IO JSString
 
@@ -60,15 +58,6 @@ setMode Dhall = setMode_ "haskell"
 setMode Type  = setMode_ "haskell"
 setMode JSON  = setMode_ "javascript"
 setMode YAML  = setMode_ "yaml"
-
-jsonToYaml :: Text -> Text
-jsonToYaml =
-        Data.Text.dropWhileEnd Data.Char.isSpace
-    .   Data.Text.pack
-    .   Data.JSString.unpack
-    .   jsonToYaml_
-    .   Data.JSString.pack
-    .   Data.Text.unpack
 
 jsonConfig :: Data.Aeson.Encode.Pretty.Config
 jsonConfig =
@@ -144,12 +133,12 @@ main = do
                                               Left exception -> do
                                                   errOutput exception
                                               Right value -> do
-                                                  let jsonBytes = Data.Aeson.Encode.Pretty.encodePretty' jsonConfig value
-                                                  case Data.Text.Lazy.Encoding.decodeUtf8' jsonBytes of
+                                                  let yamlBytes = Dhall.Yaml.jsonToYaml value False False
+                                                  case Data.Text.Encoding.decodeUtf8' yamlBytes of
                                                       Left exception -> do
                                                           errOutput exception
-                                                      Right jsonText -> do
-                                                          setOutput (jsonToYaml (Data.Text.Lazy.toStrict jsonText))
+                                                      Right yamlText -> do
+                                                          setOutput yamlText
 
     interpret
 


### PR DESCRIPTION
Now that we depend on a pure Haskell implementation of YAML we can
use the `dhall-json` package for rendering YAML with GHCJS