### PR TITLE
AppVeyor: Install stack without using Chocolatey

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 
-  - curl -sS -ostack.zip -L --insecure "https://github.com/commercialhaskell/stack/releases/download/v%STACK_VERSION%/stack-%STACK_VERSION%-windows-x86_64.zip"
+  - curl --silent --show-error --output stack.zip --location --insecure "https://github.com/commercialhaskell/stack/releases/download/v%STACK_VERSION%/stack-%STACK_VERSION%-windows-x86_64.zip"
   - 7z x stack.zip "%APPVEYOR_BUILD_FOLDER%\stack.exe"
   - cd %APPVEYOR_BUILD_FOLDER%
   - stack setup > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,6 @@ environment:
     - STACK_YAML: stack.yaml
     - STACK_YAML: stack-lts-6.yaml
 
-clone_folder: "c:\\dhall-haskell"
-
 install:
   # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ version: 1.0.{build}
 branches:
   only:
   - master
-  - /.*appveyor.*/
   - /\d*\.\d*\.\d*/
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,13 @@ environment:
     - STACK_YAML: stack-lts-6.yaml
 
 install:
-  - choco install -y haskell-stack --version %STACK_VERSION%
-  - stack setup > nul
+  # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+  - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+  - curl -sS -ostack.zip -L --insecure "https://github.com/commercialhaskell/stack/releases/download/v%STACK_VERSION%/stack-%STACK_VERSION%-windows-x86_64.zip"
+  - 7z x stack.zip "%APPVEYOR_BUILD_FOLDER%\stack.exe"
   - cd %APPVEYOR_BUILD_FOLDER%
+  - stack setup > nul
   - git submodule update --init --recursive
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 
-  - curl --silent --show-error --output stack.zip --location --insecure "https://github.com/commercialhaskell/stack/releases/download/v%STACK_VERSION%/stack-%STACK_VERSION%-windows-x86_64.zip"
+  - curl --silent --show-error --output stack.zip --location "https://github.com/commercialhaskell/stack/releases/download/v%STACK_VERSION%/stack-%STACK_VERSION%-windows-x86_64.zip"
   - 7z x stack.zip "%APPVEYOR_BUILD_FOLDER%\stack.exe"
   - cd %APPVEYOR_BUILD_FOLDER%
   - stack setup > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,14 @@ environment:
     - STACK_YAML: stack.yaml
     - STACK_YAML: stack-lts-6.yaml
 
+clone_folder: "c:\\dhall-haskell"
+
 install:
   # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 
   - curl --silent --show-error --output stack.zip --location "https://github.com/commercialhaskell/stack/releases/download/v%STACK_VERSION%/stack-%STACK_VERSION%-windows-x86_64.zip"
-  - 7z x stack.zip "%APPVEYOR_BUILD_FOLDER%\stack.exe"
-  - cd %APPVEYOR_BUILD_FOLDER%
+  - 7z x stack.zip stack.exe
   - stack setup > nul
   - git submodule update --init --recursive
 


### PR DESCRIPTION
Chocolatey is too unreliable.

Fixes https://github.com/dhall-lang/dhall-haskell/issues/1221.