### PR TITLE
Don't include context in default output

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -4252,26 +4252,13 @@ instance (Eq a, Pretty s, Pretty a, ToTerm a) => Show (TypeError s a) where
 instance (Eq a, Pretty s, Pretty a, ToTerm a, Typeable s, Typeable a) => Exception (TypeError s a)
 
 instance (Eq a, Pretty s, Pretty a, ToTerm a) => Pretty (TypeError s a) where
-    pretty (TypeError ctx expr msg)
+    pretty (TypeError _ expr msg)
         = Pretty.unAnnotate
             (   "\n"
-            <>  (   if null (Dhall.Context.toList ctx)
-                    then ""
-                    else prettyContext ctx <> "\n\n"
-                )
             <>  shortTypeMessage msg <> "\n"
             <>  source
             )
       where
-        prettyKV (key, val) =
-            pretty key <> " : " <> Dhall.Util.snipDoc (pretty val)
-
-        prettyContext =
-                Pretty.vsep
-            .   map prettyKV
-            .   reverse
-            .   Dhall.Context.toList
-
         source = case expr of
             Note s _ -> pretty s
             _        -> mempty


### PR DESCRIPTION
The motivation for this is so that `dhall` can be made much faster on very
large projects like `dhall-kubernetes-charts` where vast majority of the time
is spent rendering the very large `Context` when type-checking fails, delaying
the user from getting to the actual error message.

The `Context` also gets in the way of the user noticing the (far more useful)
type diff, but the performance cost is the primary motivation for this change.

If the user wants the context they can still use the `--explain` flag.