### PR TITLE
Annotate nested lets when parsing

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -209,8 +209,8 @@ parsers embedded = Parsers {..}
 
             -- A let binder is either followed by its 'payload', separated by
             -- `in` (e.g. `let a = 1 in b`), or it is followed immediately by
-            -- another let binder as part of a 'multi-let' (e.g. `let a = 1 let
-            -- b = 2 ... in c).
+            -- another let binder as part of a 'multi-let' (e.g.
+            -- `let a = 1 let b = 2 ... in c`).
             let payload = do
                     _in
 


### PR DESCRIPTION
Restores the 'informal invariant' that any parsed expression is wrapped
in a Src annotation. This fixes #1510, since the hover functionality in
the lsp server depended on these annotations.