### PR TITLE
dhall-json: Don't normalize schema type before type-checking

### DIFF
--- a/dhall-json/src/Dhall/JSONToDhall.hs
+++ b/dhall-json/src/Dhall/JSONToDhall.hs
@@ -330,7 +330,7 @@ defaultConversion = Conversion
 -- | The 'Expr' type concretization used throughout this module
 type ExprX = Expr Src Void
 
--- | Parse schema code to a valid Dhall expression and check that its type is actually Type
+-- | Parse schema code and resolve imports
 resolveSchemaExpr :: Text  -- ^ type code (schema)
                   -> IO ExprX
 resolveSchemaExpr code = do
@@ -338,7 +338,7 @@ resolveSchemaExpr code = do
       case Dhall.Parser.exprFromText "\n\ESC[1;31mSCHEMA\ESC[0m" code of
         Left  err              -> throwIO err
         Right parsedExpression -> return parsedExpression
-    D.normalize <$> Dhall.Import.load parsedExpression -- IO
+    Dhall.Import.load parsedExpression
 
 {-| Check that the Dhall type expression actually has type 'Type'
 >>> :set -XOverloadedStrings


### PR DESCRIPTION
The normalization removed the source context on the expression,
which made the type error message harder to understand.

Fixes #1515.