### PR TITLE
Fix parser swallowing whitespace in Src annotations

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -327,7 +327,7 @@ parsers embedded = Parsers {..}
                 (sep, _) <- Text.Megaparsec.match nonemptyWhitespace
                 b <- importExpression_
                 return (sep, b)
-            return (foldl' app (f a) bs)
+            return (foldl app (f a) bs)
           where
             app a (sep, b)
                 | Note (Src left _ bytesL) _ <- a

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -327,7 +327,7 @@ parsers embedded = Parsers {..}
                 (sep, _) <- Text.Megaparsec.match nonemptyWhitespace
                 b <- importExpression_
                 return (sep, b)
-            return (foldl app (f a) bs)
+            return (foldl' app (f a) bs)
           where
             app a (sep, b)
                 | Note (Src left _ bytesL) _ <- a


### PR DESCRIPTION
The parser annotated application expressions incorrectly: whitespace
between function and argument was swallowed when constructing the Src
annotation. This bug resulted in strange behaviour in the hovering
functionality in dhall-lsp-server.

As an example, previously the Dhall expression `0 0` would be parsed as
```
Note (Src {..., srcText = "00"})
     (App (Note (Src {..., srcText = "0"}) (NaturalLit 0))
          (Note (Src {..., srcText = "0"}) (NaturalLit 0)))
```
while we now get
```
Note (Src {..., srcText = "0 0"})
     (App (Note (Src {..., srcText = "0"}) (NaturalLit 0))
          (Note (Src {..., srcText = "0"}) (NaturalLit 0)))
```
as expected.