### PR TITLE
Small optimizations around Dhall.Map and Dhall.Set

### DIFF
--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -619,14 +619,14 @@ eval !env t0 =
                 VListLit _ as ->
                     let a' =
                             if null as
-                            then Just (VList (VRecord (Map.fromList [("index", VNatural), ("value", a)])))
+                            then Just (VList (VRecord (Map.unorderedFromList [("index", VNatural), ("value", a)])))
                             else Nothing
 
                         as' =
                             Sequence.mapWithIndex
                                 (\i t ->
                                     VRecordLit
-                                        (Map.fromList
+                                        (Map.unorderedFromList
                                             [ ("index", VNaturalLit (fromIntegral i))
                                             , ("value", t)
                                             ]
@@ -701,17 +701,17 @@ eval !env t0 =
         ToMap x ma ->
             case (eval env x, fmap (eval env) ma) of
                 (VRecordLit m, ma'@(Just _)) | null m ->
-                    VListLit ma' (Sequence.empty)
+                    VListLit ma' Sequence.empty
                 (VRecordLit m, _) ->
                     let entry (k, v) =
                             VRecordLit
-                                (Map.fromList
+                                (Map.unorderedFromList
                                     [ ("mapKey", VTextLit $ VChunks [] k)
                                     , ("mapValue", v)
                                     ]
                                 )
 
-                        s = (Sequence.fromList . map entry . Map.toList) m
+                        s = (Sequence.fromList . map entry . Map.toAscList) m
 
                     in  VListLit Nothing s
                 (x', ma') ->
@@ -759,7 +759,7 @@ eqListBy f = go
 eqMapsBy :: Ord k => (v -> v -> Bool) -> Map k v -> Map k v -> Bool
 eqMapsBy f mL mR =
     Map.size mL == Map.size mR
-    && eqListBy eq (Map.toList mL) (Map.toList mR)
+    && eqListBy eq (Map.toAscList mL) (Map.toAscList mR)
   where
     eq (kL, vL) (kR, vR) = kL == kR && f vL vR
 {-# INLINE eqMapsBy #-}

--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -60,6 +60,7 @@ module Dhall.Map
 
       -- * Conversions
     , toList
+    , toAscList
     , toMap
     , keys
     , keysSet
@@ -125,6 +126,9 @@ instance Ord k => Foldable (Map k) where
 
   length m = size m
   {-# INLINABLE length #-}
+
+  null (Map m _) = null m
+  {-# INLINABLE null #-}
 
 instance Ord k => Traversable (Map k) where
   traverse f m = traverseWithKey (\_ v -> f v) m
@@ -653,6 +657,12 @@ toList :: Ord k => Map k v -> [(k, v)]
 toList (Map m Sorted)        = Data.Map.toList m
 toList (Map m (Original ks)) = fmap (\k -> (k, m Data.Map.! k)) ks
 {-# INLINABLE toList #-}
+
+{-| Convert a `Map` to a list of key-value pairs in ascending order of keys
+-}
+toAscList :: Map k v -> [(k, v)]
+toAscList (Map m _) = Data.Map.toAscList m
+{-# INLINABLE toAscList #-}
 
 {-| Convert a @"Dhall.Map".`Map`@ to a @"Data.Map".`Data.Map.Map`@
 

--- a/dhall/src/Dhall/Set.hs
+++ b/dhall/src/Dhall/Set.hs
@@ -10,6 +10,7 @@
 module Dhall.Set (
       Set(..)
     , toList
+    , toAscList
     , toSet
     , toSeq
     , fromList
@@ -57,6 +58,15 @@ instance Foldable Set where
     foldMap f (Set _ x) = foldMap f x
     {-# INLINABLE foldMap #-}
 
+    toList = Dhall.Set.toList
+    {-# INLINABLE toList #-}
+
+    null = Dhall.Set.null
+    {-# INLINABLE null #-}
+
+    length (Set s _) = Data.Set.size s
+    {-# INLINABLE length #-}
+
 -- | Convert to an unordered @"Data.Set".`Data.Set.Set`@
 toSet :: Set a -> Data.Set.Set a
 toSet (Set s _) = s
@@ -67,7 +77,11 @@ toSeq (Set _ xs) = xs
 
 -- | Convert a `Set` to a list, preserving the original order of the elements
 toList :: Set a -> [a]
-toList = Data.Foldable.toList
+toList (Set _ xs) = Data.Foldable.toList xs
+
+-- | Convert a `Set` to a list of ascending elements
+toAscList :: Set a -> [a]
+toAscList (Set s _) = Data.Set.toAscList s
 
 -- | Convert a list to a `Set`, remembering the element order
 fromList :: Ord a => [a] -> Set a
@@ -103,7 +117,7 @@ difference os (Set s _) =
 True
 -}
 sort :: Ord a => Set a -> Set a
-sort (Set s xs) = Set s (Data.Sequence.sort xs)
+sort (Set s _) = Set s (Data.Sequence.fromList (Data.Set.toList s))
 
 {-|
 >>> isSorted (fromList [2, 1])

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -684,7 +684,7 @@ infer typer = loop
                             VList a
                         ~>  VList
                                 (VRecord
-                                    (Dhall.Map.fromList
+                                    (Dhall.Map.unorderedFromList
                                         [ ("index", VNatural)
                                         , ("value", a       )
                                         ]
@@ -1084,7 +1084,7 @@ infer typer = loop
             let mapType _T' =
                     VList
                         (VRecord
-                            (Dhall.Map.fromList
+                            (Dhall.Map.unorderedFromList
                                 [("mapKey", VText), ("mapValue", _T')]
                             )
                         )
@@ -1150,9 +1150,9 @@ infer typer = loop
                                 Just _T' -> return (x, _T')
                                 Nothing  -> die (MissingField x _E'')
 
-                    let adapt = VRecord . Dhall.Map.fromList
+                    let adapt = VRecord . Dhall.Map.unorderedFromList
 
-                    fmap adapt (traverse process (Dhall.Set.toList (Dhall.Set.sort xs)))
+                    fmap adapt (traverse process (Dhall.Set.toAscList xs))
 
                 _ -> do
                     let text =


### PR DESCRIPTION
While looking at some core I noticed that `null` for Dhall.Map used
the default `foldr`-based definition. I fixed that and added a few
more small optimizations.