### PR TITLE
Improve formatting of multi-line literals

### DIFF
--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -1092,7 +1092,7 @@ prettyCharacterSet characterSet expression =
         | anyText (== '\n') =
             if not (null a) || anyText (/= '\n')
             then long
-            else Pretty.flatAlt long short
+            else Pretty.group (Pretty.flatAlt long short)
         | otherwise =
             short
       where

--- a/dhall/tests/format/multilineArgumentA.dhall
+++ b/dhall/tests/format/multilineArgumentA.dhall
@@ -1,0 +1,1 @@
+fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff xxxxxxxxxxxxxxxx "\n"

--- a/dhall/tests/format/multilineArgumentB.dhall
+++ b/dhall/tests/format/multilineArgumentB.dhall
@@ -1,0 +1,3 @@
+fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  xxxxxxxxxxxxxxxx
+  "\n"


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1566

This changes multi-line literals so that they can be formatted independently
of their surrounding expression