### PR TITLE
Allow hashable-1.3

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -437,7 +437,7 @@ Library
         exceptions                  >= 0.8.3    && < 0.11,
         filepath                    >= 1.4      && < 1.5 ,
         haskeline                   >= 0.7.2.1  && < 0.8 ,
-        hashable                    >= 1.2      && < 1.3 ,
+        hashable                    >= 1.2      && < 1.4 ,
         lens-family-core            >= 1.0.0    && < 2.1 ,
         megaparsec                  >= 6.5.0    && < 7.1 ,
         memory                      >= 0.14     && < 0.16,


### PR DESCRIPTION
`dhall` uses `hashable` only to provide marshalling utils for `HashMap`s and `HashSet`s.