### PR TITLE
Allow megaparsec-8

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-lsp-server ./dhall-nix
 
--- While hnix doesn't allow prettyprinter > 1.3
+-- TODO: Remove this once hnix has a compatible release:
 -- https://github.com/haskell-nix/hnix/issues/524
-allow-newer: hnix:prettyprinter
+allow-newer: hnix:prettyprinter, hnix:megaparsec

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -58,7 +58,7 @@ library
     , hslogger             >= 1.2.10   && < 1.4
     , lens                 >= 4.16.1   && < 4.19
     , lens-family-core     >= 1.2.3    && < 2.1
-    , megaparsec           >= 7.0.2    && < 7.1
+    , megaparsec           >= 7.0.2    && < 8.1
     , mtl                  >= 2.2.2    && < 2.3
     , network-uri          >= 2.6.1.0  && < 2.7
     , prettyprinter        >= 1.5.1    && < 1.6

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
@@ -139,9 +139,10 @@ getImportHash (Src left _ text) =
           return (Src begin end tokens)
 
 setSourcePos :: SourcePos -> Parser ()
-setSourcePos src = Megaparsec.updateParserState
-                     (\(Megaparsec.State s o (Megaparsec.PosState i o' _ t l)) ->
-                       Megaparsec.State s o (Megaparsec.PosState i o' src t l))
+setSourcePos src =
+  Megaparsec.updateParserState $ \state ->
+    let posState = (Megaparsec.statePosState state) { Megaparsec.pstateSourcePos = src }
+    in state { Megaparsec.statePosState = posState }
 
 getImportLink :: Src -> Src
 getImportLink src@(Src left _ text) =

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -439,7 +439,7 @@ Library
         haskeline                   >= 0.7.2.1  && < 0.8 ,
         hashable                    >= 1.2      && < 1.3 ,
         lens-family-core            >= 1.0.0    && < 2.1 ,
-        megaparsec                  >= 6.5.0    && < 7.1 ,
+        megaparsec                  >= 7        && < 8.1 ,
         memory                      >= 0.14     && < 0.16,
         mtl                         >= 2.2.1    && < 2.3 ,
         network-uri                 >= 2.6      && < 2.7 ,

--- a/dhall/src/Dhall/Parser.hs
+++ b/dhall/src/Dhall/Parser.hs
@@ -50,11 +50,7 @@ exprA = completeExpression
 
 -- | A parsing error
 data ParseError = ParseError {
-#if MIN_VERSION_megaparsec(7, 0, 0)
       unwrap :: Text.Megaparsec.ParseErrorBundle Text Void
-#else
-      unwrap :: Text.Megaparsec.ParseError Char Void
-#endif
     , input  :: Text
     }
 
@@ -78,11 +74,7 @@ censor parseError =
 
 instance Show ParseError where
     show (ParseError {..}) =
-#if MIN_VERSION_megaparsec(7, 0, 0)
       "\n\ESC[1;31mError\ESC[0m: Invalid input\n\n" <> Text.Megaparsec.errorBundlePretty unwrap
-#else
-      "\n\ESC[1;31mError\ESC[0m: Invalid input\n\n" <> Text.Megaparsec.parseErrorPretty unwrap
-#endif
 
 instance Exception ParseError
 

--- a/dhall/src/Dhall/Parser/Combinators.hs
+++ b/dhall/src/Dhall/Parser/Combinators.hs
@@ -29,9 +29,6 @@ import qualified Dhall.Map
 import qualified Dhall.Pretty
 import qualified Dhall.Set
 import qualified Text.Megaparsec
-#if !MIN_VERSION_megaparsec(7, 0, 0)
-import qualified Text.Megaparsec.Char as Text.Megaparsec (satisfy)
-#endif
 import qualified Text.Megaparsec.Char
 import qualified Text.Parser.Char
 import qualified Text.Parser.Combinators
@@ -126,9 +123,13 @@ instance MonadPlus Parser where
     -- {-# INLINE mplus #-}
 
 instance Text.Megaparsec.MonadParsec Void Text Parser where
+#if MIN_VERSION_megaparsec(8, 0, 0)
+    parseError e = Parser (Text.Megaparsec.parseError e)
+#else
     failure u e    = Parser (Text.Megaparsec.failure u e)
 
     fancyFailure e = Parser (Text.Megaparsec.fancyFailure e)
+#endif
 
     label l (Parser p) = Parser (Text.Megaparsec.label l p)
 
@@ -196,11 +197,7 @@ instance Text.Parser.Char.CharParsing Parser where
 
   notChar = Text.Megaparsec.Char.char
 
-#if MIN_VERSION_megaparsec(7, 0, 0)
   anyChar = Text.Megaparsec.anySingle
-#else
-  anyChar = Text.Megaparsec.Char.anyChar
-#endif
 
   string = fmap Data.Text.unpack . Text.Megaparsec.Char.string . fromString
 

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -32,9 +32,6 @@ import qualified Data.Text
 import qualified Data.Text.Encoding
 import qualified Dhall.Crypto
 import qualified Text.Megaparsec
-#if !MIN_VERSION_megaparsec(7, 0, 0)
-import qualified Text.Megaparsec.Char    as Text.Megaparsec
-#endif
 
 import Dhall.Parser.Combinators
 import Dhall.Parser.Token
@@ -43,31 +40,19 @@ import Dhall.Parser.Token
 getSourcePos :: Text.Megaparsec.MonadParsec e s m =>
                 m Text.Megaparsec.SourcePos
 getSourcePos =
-#if MIN_VERSION_megaparsec(7, 0, 0)
     Text.Megaparsec.getSourcePos
-#else
-    Text.Megaparsec.getPosition
-#endif
 {-# INLINE getSourcePos #-}
 
 -- | Get the current source offset (in tokens)
 getOffset :: Text.Megaparsec.MonadParsec e s m => m Int
-#if MIN_VERSION_megaparsec(7, 0, 0)
 getOffset = Text.Megaparsec.stateOffset <$> Text.Megaparsec.getParserState
-#else
-getOffset = Text.Megaparsec.stateTokensProcessed <$> Text.Megaparsec.getParserState
-#endif
 {-# INLINE getOffset #-}
 
 -- | Set the current source offset
 setOffset :: Text.Megaparsec.MonadParsec e s m => Int -> m ()
-#if MIN_VERSION_megaparsec(7, 0, 0)
-setOffset o = Text.Megaparsec.updateParserState $ \(Text.Megaparsec.State s _ pst) ->
-  Text.Megaparsec.State s o pst
-#else
-setOffset o = Text.Megaparsec.updateParserState $ \(Text.Megaparsec.State s p _ stw) ->
-  Text.Megaparsec.State s p o stw
-#endif
+setOffset o = Text.Megaparsec.updateParserState $ \state ->
+    state
+        { Text.Megaparsec.stateOffset = o }
 {-# INLINE setOffset #-}
 
 {-| Wrap a `Parser` to still match the same text but return only the `Src`

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,11 +25,12 @@ extra-deps:
   - aeson-yaml-1.0.5.0@sha256:5786f021c1e088d6a5aa259120ec5b1f22bb1757f4427c1a87e0513d00f17f31,1975
   - prettyprinter-1.5.1@sha256:fca87c3e2611d3499a0341a59857e9b424a23f31646e4737d535a18582284f96,5375
   - atomic-write-0.2.0.7@sha256:3b626dfbc288cd070f1ac31b1c15ddd49822a923778ffe21f92b2116ffc72dc3,4584
+  - megaparsec-8.0.0
 nix:
   packages:
     - ncurses
     - zlib
 
-# hnix doesn't allow prettyprinter >= 1.3
+# hnix-0.6.1 doesn't allow prettyprinter >= 1.3 and megaparsec >= 8
 # https://github.com/haskell-nix/hnix/issues/524
 allow-newer: true


### PR DESCRIPTION
This also officially removes support for megaparsec-6.5 – the build had been broken before though.