### PR TITLE
Fix typos

### DIFF
--- a/dhall-json/src/Dhall/JSONToDhall.hs
+++ b/dhall-json/src/Dhall/JSONToDhall.hs
@@ -349,7 +349,7 @@ App List Natural
 
 >>> typeCheckSchemaExpr id =<< resolveSchemaExpr "+1"
 *** Exception:
-Error: Schema expression is succesfully parsed but has Dhall type:
+Error: Schema expression is successfully parsed but has Dhall type:
 Integer
 Expected Dhall type: Type
 Parsed expression: +1
@@ -641,7 +641,7 @@ showCompileError format showValue = let prefix = red "\nError: "
     TypeError e -> show e
 
     BadDhallType t e -> prefix
-      <> "Schema expression is succesfully parsed but has Dhall type:\n"
+      <> "Schema expression is successfully parsed but has Dhall type:\n"
       <> showExpr t <> "\nExpected Dhall type: Type"
       <> "\nParsed expression: "
       <> showExpr e <> "\n"

--- a/dhall/tests/Dhall/Test/Dhall.hs
+++ b/dhall/tests/Dhall/Test/Dhall.hs
@@ -92,7 +92,7 @@ shouldShowDetailedTypeError = testCase "detailed TypeError" $ do
 
   case inputEx of
     Left ex -> assertEqual assertMsg expectedMsg (show ex)
-    Right _ -> fail "The extraction using a wrong type succeded"
+    Right _ -> fail "The extraction using a wrong type succeeded"
 
 -- https://github.com/dhall-lang/dhall-haskell/issues/915
 shouldHandleUnionLiteral :: TestTree

--- a/dhall/tests/Dhall/Test/Regression.hs
+++ b/dhall/tests/Dhall/Test/Regression.hs
@@ -193,7 +193,7 @@ parsing0 = Test.Tasty.HUnit.testCase "Parsing regression #0" (do
     -- Verify that parsing should not fail
     --
     -- In 267093f8cddf1c2f909f2d997c31fd0a7cb2440a I broke the parser when left
-    -- factoring the grammer by failing to handle the source tested by this
+    -- factoring the grammar by failing to handle the source tested by this
     -- regression test.  The root of the problem was that the parser was trying
     -- to parse `List ./Node` as `Field List "/Node"` instead of
     -- `App List (Embed (Path (File Homeless "./Node") Code))`.  The latter is


### PR DESCRIPTION
Should be non-semantic spelling fixes.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.