### PR TITLE
Update cborg-json to fix #1350

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -429,7 +429,7 @@ Library
         bytestring                                 < 0.11,
         case-insensitive                           < 1.3 ,
         cborg                       >= 0.2.0.0  && < 0.3 ,
-        cborg-json                                 < 0.3 ,
+        cborg-json                  >= 0.2.2.0  && < 0.3 ,
         containers                  >= 0.5.0.0  && < 0.7 ,
         contravariant                              < 1.6 ,
         data-fix                                   < 0.3 ,

--- a/nix/cborg-json.nix
+++ b/nix/cborg-json.nix
@@ -1,13 +1,18 @@
-{ mkDerivation, aeson, aeson-pretty, base, cborg, scientific
-, stdenv, text, unordered-containers, vector
+{ mkDerivation, aeson, aeson-pretty, base, bytestring, cborg
+, criterion, deepseq, directory, process, scientific, stdenv, text
+, unordered-containers, vector, zlib
 }:
 mkDerivation {
   pname = "cborg-json";
-  version = "0.2.1.0";
-  sha256 = "3fb6b54e6ddd322880689fb461f7911aca45b9758482c9f9949619c7d7b52006";
+  version = "0.2.2.0";
+  sha256 = "ab68a2457cb71a76699d7a8df07a880ea70c51d2c1a891b12669ca9ccfa7517b";
   libraryHaskellDepends = [
     aeson aeson-pretty base cborg scientific text unordered-containers
     vector
+  ];
+  benchmarkHaskellDepends = [
+    aeson base bytestring cborg criterion deepseq directory process
+    zlib
   ];
   homepage = "https://github.com/well-typed/cborg";
   description = "A library for encoding JSON as CBOR";

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -20,7 +20,7 @@ extra-deps:
 - cabal-doctest-1.0.6
 - case-insensitive-1.2.1.0
 - cborg-0.2.1.0
-- cborg-json-0.2.1.0
+- cborg-json-0.2.2.0
 - contravariant-1.5.2
 - cryptonite-0.24
 - data-fix-0.2.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,6 +26,7 @@ extra-deps:
   - prettyprinter-1.5.1@sha256:fca87c3e2611d3499a0341a59857e9b424a23f31646e4737d535a18582284f96,5375
   - atomic-write-0.2.0.7@sha256:3b626dfbc288cd070f1ac31b1c15ddd49822a923778ffe21f92b2116ffc72dc3,4584
   - megaparsec-8.0.0
+  - cborg-json-0.2.2.0
 nix:
   packages:
     - ncurses


### PR DESCRIPTION
CBOR values that are unrepresentable in JSON, are encoded as `null`,
e.g.

    $ echo 'Infinity' | dhall encode --json
    null