### PR TITLE
Prevent potential CoC abuse

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+appearance, race, religion, political belief or sexual identity and orientation.
 
 ## Our Standards
 


### PR DESCRIPTION
I believe I speak for everyone when I take "harassment-free experience," as delineated in this CoC, to include harassment based on political beliefs (conservative, liberal, libertarian, etc.) as well. This PR explicitly includes it, to prevent any potential abuse of the otherwise excellent CoC.

For reference, compare with [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/) which already handles this, viz.:

> Our communities welcome and support people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, **political belief**, religion, and mental and physical ability.

(emphasis mine)