### PR TITLE
Generate Haskell datatype declarations from Dhall types

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -402,6 +402,7 @@ Extra-Source-Files:
     tests/regression/*.dhall
     tests/tags/*.dhall
     tests/tags/*.tags
+    tests/th/*.dhall
     tests/tutorial/*.dhall
 
 Source-Repository head
@@ -587,6 +588,7 @@ Test-Suite tasty
         Dhall.Test.QuickCheck
         Dhall.Test.Regression
         Dhall.Test.SemanticHash
+        Dhall.Test.TH
         Dhall.Test.Tutorial
         Dhall.Test.TypeInference
         Dhall.Test.Util

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -1225,7 +1225,7 @@ instance FromDhall (f (Result f)) => FromDhall (Result f) where
 -- >     \(Expr : Type)
 -- > ->  let ExprF =
 -- >           < LitF :
--- >               { _1 : Natural }
+-- >               Natural
 -- >           | AddF :
 -- >               { _1 : Expr, _2 : Expr }
 -- >           | MulF :
@@ -1233,7 +1233,7 @@ instance FromDhall (f (Result f)) => FromDhall (Result f) where
 -- >           >
 -- >
 -- >     in      \(Fix : ExprF -> Expr)
--- >         ->  let Lit = \(x : Natural) -> Fix (ExprF.LitF { _1 = x })
+-- >         ->  let Lit = \(x : Natural) -> Fix (ExprF.LitF x)
 -- >
 -- >             let Add =
 -- >                       \(x : Expr)
@@ -1291,7 +1291,6 @@ data InterpretOptions = InterpretOptions
     --   corresponding Dhall alternative names
     , singletonConstructors :: SingletonConstructors
     -- ^ Specify how to handle constructors with only one field.  The default is
-    --   `Wrapped` for backwards compatibility but will eventually be changed to
     --   `Smart`
     , inputNormalizer     :: Dhall.Core.ReifiedNormalizer Void
     -- ^ This is only used by the `FromDhall` instance for functions in order
@@ -1334,7 +1333,7 @@ defaultInterpretOptions = InterpretOptions
     , constructorModifier =
           id
     , singletonConstructors =
-          Wrapped
+          Smart
     , inputNormalizer =
           Dhall.Core.ReifiedNormalizer (const (pure Nothing))
     }

--- a/dhall/src/Dhall/TH.hs
+++ b/dhall/src/Dhall/TH.hs
@@ -202,19 +202,6 @@ toConstructor (constructorName, maybeAlternativeType) = do
 -- > 
 -- > deriving instance Generic   T
 -- > deriving instance FromDhall T
---
--- Carefully note that the generated Haskell type only corresponds to the Dhall
--- type when using the `Dhall.Smart` setting for the
--- `Dhall.singletonConstructors` field of `InterpretOptions`.  That setting
--- will eventually become the default, but until then you will need to
--- explicitly use the setting like this:
---
--- > let interpretOptions =
--- >         Dhall.defaultInterpretOptions
--- >             { Dhall.singletonConstructors = Dhall.Smart
--- >             }
--- >
--- > let decoder = Dhall.autoWith interpretOptions
 makeHaskellTypeFromUnion
     :: Text
     -- ^ Name of the generated Haskell type

--- a/dhall/src/Dhall/TH.hs
+++ b/dhall/src/Dhall/TH.hs
@@ -1,9 +1,47 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
-{-| This module provides `staticDhallExpression` which can be used to resolve
-    all of an expression’s imports at compile time, allowing one to reference
-    Dhall expressions from Haskell without having a runtime dependency on the
-    location of Dhall files.
+-- | Template Haskell utilities
+module Dhall.TH
+    ( -- * Template Haskell
+      staticDhallExpression
+    , makeHaskellType
+    ) where
+
+import Data.Text (Text)
+import Data.Text.Prettyprint.Doc (Pretty)
+import Dhall.Syntax (Expr(..))
+import Language.Haskell.TH.Quote (dataToExpQ) -- 7.10 compatibility.
+
+import Language.Haskell.TH.Syntax
+    ( Bang(..)
+    , Con(..)
+    , Dec(..)
+    , Exp(..)
+    , Q
+    , SourceStrictness(..)
+    , SourceUnpackedness(..)
+    , Type(..)
+    )
+
+import qualified Data.Text                               as Text
+import qualified Data.Text.Prettyprint.Doc.Render.String as Pretty
+import qualified Data.Typeable                           as Typeable
+import qualified Dhall
+import qualified Dhall.Map
+import qualified Dhall.Pretty
+import qualified Dhall.Util
+import qualified GHC.IO.Encoding
+import qualified Numeric.Natural
+import qualified System.IO
+import qualified Language.Haskell.TH.Syntax              as Syntax
+
+{-| This fully resolves, type checks, and normalizes the expression, so the
+    resulting AST is self-contained.
+
+    This can be used to resolve all of an expression’s imports at compile time,
+    allowing one to reference Dhall expressions from Haskell without having a
+    runtime dependency on the location of Dhall files.
 
     For example, given a file @".\/Some\/Type.dhall"@ containing
 
@@ -22,28 +60,196 @@
     at compile time with all imports resolved, making it easy to keep your Dhall
     configs and Haskell interpreters in sync.
 -}
-module Dhall.TH
-    ( -- * Template Haskell
-      staticDhallExpression
-    ) where
-
-import Data.Typeable
-import Language.Haskell.TH.Quote (dataToExpQ) -- 7.10 compatibility.
-import Language.Haskell.TH.Syntax
-
-import qualified Data.Text as Text
-import qualified Dhall
-import qualified GHC.IO.Encoding
-import qualified System.IO
-
--- | This fully resolves, type checks, and normalizes the expression, so the
---   resulting AST is self-contained.
-staticDhallExpression :: Text.Text -> Q Exp
+staticDhallExpression :: Text -> Q Exp
 staticDhallExpression text = do
-    runIO (GHC.IO.Encoding.setLocaleEncoding System.IO.utf8)
-    expression <- runIO (Dhall.inputExpr text)
-    dataToExpQ (\a -> liftText <$> cast a) expression
+    Syntax.runIO (GHC.IO.Encoding.setLocaleEncoding System.IO.utf8)
+
+    expression <- Syntax.runIO (Dhall.inputExpr text)
+
+    dataToExpQ (\a -> liftText <$> Typeable.cast a) expression
   where
     -- A workaround for a problem in TemplateHaskell (see
     -- https://stackoverflow.com/questions/38143464/cant-find-inerface-file-declaration-for-variable)
-    liftText = fmap (AppE (VarE 'Text.pack)) . lift . Text.unpack
+    liftText = fmap (AppE (VarE 'Text.pack)) . Syntax.lift . Text.unpack
+
+{-| Convert a Dhall type to a Haskell type that does not require any new
+    data declarations
+-}
+toSimpleHaskellType :: Pretty a => Expr s a -> Q Type
+toSimpleHaskellType dhallType =
+    case dhallType of
+        Bool -> do
+            return (ConT ''Bool)
+
+        Double -> do
+            return (ConT ''Double)
+
+        Integer -> do
+            return (ConT ''Integer)
+
+        Natural -> do
+            return (ConT ''Numeric.Natural.Natural)
+
+        Text -> do
+            return (ConT ''Text)
+
+        App List dhallElementType -> do
+            haskellElementType <- toSimpleHaskellType dhallElementType
+
+            return (AppT (ConT ''[]) haskellElementType)
+
+        App Optional dhallElementType -> do
+            haskellElementType <- toSimpleHaskellType dhallElementType
+
+            return (AppT (ConT ''Maybe) haskellElementType)
+
+        _ -> do
+            let document =
+                    "Dhall.TH.makeHaskellType: Unsupported simple type\n\
+                    \                                                                                \n\
+                    \Explanation: Not all Dhall alternative types can be converted to Haskell        \n\
+                    \constructor types.  Specifically, only the following simple Dhall types are     \n\
+                    \supported as an alternative type or a field of an alternative type:             \n\
+                    \                                                                                \n\
+                    \• ❰Bool❱                                                                        \n\
+                    \• ❰Double❱                                                                      \n\
+                    \• ❰Integer❱                                                                     \n\
+                    \• ❰Natural❱                                                                     \n\
+                    \• ❰Text❱                                                                        \n\
+                    \• ❰List a❱     (where ❰a❱ is also a simple type)                                \n\
+                    \• ❰Optional a❱ (where ❰a❱ is also a simple type)                                \n\
+                    \                                                                                \n\
+                    \The Haskell datatype generation logic encountered the following complex         \n\
+                    \Dhall type:                                                                     \n\
+                    \                                                                                \n\
+                    \ " <> Dhall.Util.insert dhallType <> "\n\
+                    \                                                                                \n\
+                    \... where a simpler type was expected."
+
+            let message = Pretty.renderString (Dhall.Pretty.layout document)
+
+            fail message
+
+-- | Convert a Dhall type to the corresponding Haskell constructor type
+toConstructor :: Pretty a => (Text, Maybe (Expr s a)) -> Q Con
+toConstructor (constructorName, maybeAlternativeType) = do
+    let name = Syntax.mkName (Text.unpack constructorName)
+
+    let bang = Bang NoSourceUnpackedness NoSourceStrictness
+
+    case maybeAlternativeType of
+        Just (Record kts) -> do
+            let process (key, dhallFieldType) = do
+                    haskellFieldType <- toSimpleHaskellType dhallFieldType
+
+                    return (Syntax.mkName (Text.unpack key), bang, haskellFieldType)
+
+            varBangTypes <- traverse process (Dhall.Map.toList kts)
+
+            return (RecC name varBangTypes)
+
+        Just dhallAlternativeType -> do
+            haskellAlternativeType <- toSimpleHaskellType dhallAlternativeType
+
+            return (NormalC name [ (bang, haskellAlternativeType) ])
+
+        Nothing -> do
+            return (NormalC name [])
+
+-- | Generate a Haskell datatype declaration from a Dhall type
+--
+-- This comes in handy if you need to keep a Dhall type and Haskell type in
+-- sync.  You make the Dhall type the source of truth and use Template Haskell
+-- to generate the matching Haskell type declaration from the Dhall type.
+--
+-- For example, this Template Haskell splice:
+--
+-- > Dhall.TH.makeHaskellType "T" "< A : { x : Bool } | B >"
+--
+-- ... generates this Haskell code:
+--
+-- > data T = A {x :: GHC.Types.Bool} | B
+--
+-- To add any desired instances (such as `Dhall.FromDhall`/`Dhall.ToDhall`),
+-- you can use the `StandaloneDeriving` language extension, like this:
+--
+-- > {-# LANGUAGE DeriveAnyClass     #-}
+-- > {-# LANGUAGE DeriveGeneric      #-}
+-- > {-# LANGUAGE OverloadedStrings  #-}
+-- > {-# LANGUAGE StandaloneDeriving #-}
+-- > {-# LANGUAGE TemplateHaskell    #-}
+-- >
+-- > Dhall.TH.makeHaskellType "T" "< A : { x : Bool } | B >"
+-- > 
+-- > deriving instance Generic   T
+-- > deriving instance FromDhall T
+--
+-- Carefully note that the generated Haskell type only corresponds to the Dhall
+-- type when using the `Dhall.Smart` setting for the
+-- `Dhall.singletonConstructors` field of `InterpretOptions`.  That setting
+-- will eventually become the default, but until then you will need to
+-- explicitly use the setting like this:
+--
+-- > let interpretOptions =
+-- >         Dhall.defaultInterpretOptions
+-- >             { Dhall.singletonConstructors = Dhall.Smart
+-- >             }
+-- >
+-- > let decoder = Dhall.autoWith interpretOptions
+
+makeHaskellType :: Text -> Text -> Q [Dec]
+makeHaskellType typeName text = do
+    Syntax.runIO (GHC.IO.Encoding.setLocaleEncoding System.IO.utf8)
+
+    expression <- Syntax.runIO (Dhall.inputExpr text)
+
+    case expression of
+        Union kts -> do
+            let name = Syntax.mkName (Text.unpack typeName)
+
+            constructors <- traverse toConstructor (Dhall.Map.toList kts )
+
+            let declaration = DataD [] name [] Nothing constructors []
+
+            return [ declaration ]
+
+        _ -> do
+            let document =
+                    "Dhall.TH.makeHaskellType: Unsupported Dhall type\n\
+                    \                                                                                \n\
+                    \Explanation: Not all Dhall types can be converted to Haskell datatype           \n\
+                    \declarations.  Specifically, only union types can be converted to Haskell types.\n\
+                    \                                                                                \n\
+                    \For example, this is a valid Dhall type:                                        \n\
+                    \                                                                                \n\
+                    \                                                                                \n\
+                    \    ┌─────────────────────────────────────────────────────────┐                 \n\
+                    \    │ Dhall.TH.makeHaskellType \"T\" \"< A : { x : Bool } | B >\" │                 \n\
+                    \    └─────────────────────────────────────────────────────────┘                 \n\
+                    \                                                                                \n\
+                    \                                                                                \n\
+                    \... which corresponds to this Haskell type declaration:                         \n\
+                    \                                                                                \n\
+                    \                                                                                \n\
+                    \    ┌──────────────────────────────────────┐                                    \n\
+                    \    │ data T = A {x :: GHC.Types.Bool} | B │                                    \n\
+                    \    └──────────────────────────────────────┘                                    \n\
+                    \                                                                                \n\
+                    \                                                                                \n\
+                    \... but the following Dhall type is rejected due to being a bare record type:   \n\
+                    \                                                                                \n\
+                    \                                                                                \n\
+                    \    ┌─────────────────────────────────────────────┐                             \n\
+                    \    │ Dhall.TH.makeHaskellType \"T\" \"{ x : Bool }\" │  Not valid due to not being \n\
+                    \    └─────────────────────────────────────────────┘  wrapped in a union         \n\
+                    \                                                                                \n\
+                    \                                                                                \n\
+                    \The Haskell datatype generation logic encountered the following Dhall type:     \n\
+                    \                                                                                \n\
+                    \ " <> Dhall.Util.insert expression <> "\n\
+                    \                                                                                \n\
+                    \... which is not a union type."
+
+            let message = Pretty.renderString (Dhall.Pretty.layout document)
+
+            fail message

--- a/dhall/tests/Dhall/Test/Dhall.hs
+++ b/dhall/tests/Dhall/Test/Dhall.hs
@@ -176,13 +176,13 @@ shouldHandleUnionsCorrectly :: TestTree
 shouldHandleUnionsCorrectly =
   testGroup "Handle union literals"
     [ "λ(x : < N0 : { _1 : Bool } | N1 : { _1 : Natural } | N2 : { _1 : Text } >) → x"
-        `shouldPassThrough` [ N0 True, N1 5, N2 "ABC" ]
+        `shouldPassThroughWrapped` [ N0 True, N1 5, N2 "ABC" ]
     , "λ(x : < E0 | E1 | E2 >) → x"
-        `shouldPassThrough` [ E0, E1, E2 ]
+        `shouldPassThroughWrapped` [ E0, E1, E2 ]
     , "λ(x : < R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >) → x"
-        `shouldPassThrough` [ R0 {}, R1 { a = () }, R2 { x = 1.0 }, R3 { a = (), b = () }, R4 { x = 1.0, y = 2.0 } ]
+        `shouldPassThroughWrapped` [ R0 {}, R1 { a = () }, R2 { x = 1.0 }, R3 { a = (), b = () }, R4 { x = 1.0, y = 2.0 } ]
     , "λ(x : < P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >) → x"
-        `shouldPassThrough` [ P0 , P1 (), P2 1.0, P3 () (), P4 1.0 2.0 ]
+        `shouldPassThroughWrapped` [ P0 , P1 (), P2 1.0, P3 () (), P4 1.0 2.0 ]
 
     , "λ(x : < N0 : Bool | N1 : Natural | N2 : Text >) → x"
         `shouldPassThroughSmart` [ N0 True, N1 5, N2 "ABC" ]
@@ -192,12 +192,12 @@ shouldHandleUnionsCorrectly =
         `shouldPassThroughSmart` [ P0 , P1 (), P2 1.0, P3 () (), P4 1.0 2.0 ]
 
     , "(< N0 : { _1 : Bool } | N1 : { _1 : Natural } | N2 : { _1 : Text } >).N0 { _1 = True }"
-        `shouldMarshalInto` N0 True
+        `shouldMarshalIntoWrapped` N0 True
     , "(< N0 : { _1 : Bool } | N1 : { _1 : Natural } | N2 : { _1 : Text } >).N1 { _1 = 5 }"
-        `shouldMarshalInto` N1 5
+        `shouldMarshalIntoWrapped` N1 5
     , "(< N0 : { _1 : Bool } | N1 : { _1 : Natural } | N2 : { _1 : Text } >).N2 { _1 = \"ABC\" }"
 
-        `shouldMarshalInto` N2 "ABC"
+        `shouldMarshalIntoWrapped` N2 "ABC"
 
     , "(< N0 : Bool | N1 : Natural | N2 : Text >).N0 True"
         `shouldMarshalIntoSmart` N0 True
@@ -206,20 +206,20 @@ shouldHandleUnionsCorrectly =
     , "(< N0 : Bool | N1 : Natural | N2 : Text >).N2 \"ABC\""
         `shouldMarshalIntoSmart` N2 "ABC"
 
-    , "(< E0 | E1 | E2>).E0" `shouldMarshalInto` E0
-    , "(< E0 | E1 | E2>).E1" `shouldMarshalInto` E1
-    , "(< E0 | E1 | E2>).E2" `shouldMarshalInto` E2
+    , "(< E0 | E1 | E2>).E0" `shouldMarshalIntoWrapped` E0
+    , "(< E0 | E1 | E2>).E1" `shouldMarshalIntoWrapped` E1
+    , "(< E0 | E1 | E2>).E2" `shouldMarshalIntoWrapped` E2
 
     , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R0"
-        `shouldMarshalInto` R0
+        `shouldMarshalIntoWrapped` R0
     , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R1 { a = {=} }"
-        `shouldMarshalInto` R1 { a = () }
+        `shouldMarshalIntoWrapped` R1 { a = () }
     , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R2 { x = 1.0 }"
-        `shouldMarshalInto` R2 { x = 1.0 }
+        `shouldMarshalIntoWrapped` R2 { x = 1.0 }
     , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R3 { a = {=}, b = {=} }"
-        `shouldMarshalInto` R3 { a = (), b = () }
+        `shouldMarshalIntoWrapped` R3 { a = (), b = () }
     , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
-        `shouldMarshalInto` R4 { x = 1.0, y = 2.0 }
+        `shouldMarshalIntoWrapped` R4 { x = 1.0, y = 2.0 }
 
     , "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R0"
         `shouldMarshalIntoSmart` R0
@@ -233,15 +233,15 @@ shouldHandleUnionsCorrectly =
         `shouldMarshalIntoSmart` R4 { x = 1.0, y = 2.0 }
 
     , "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
-        `shouldMarshalInto` P0
+        `shouldMarshalIntoWrapped` P0
     , "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P1 { _1 = {=} }"
-        `shouldMarshalInto` P1 ()
+        `shouldMarshalIntoWrapped` P1 ()
     , "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P2 { _1 = 1.0 }"
-        `shouldMarshalInto` P2 1.0
+        `shouldMarshalIntoWrapped` P2 1.0
     , "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P3 { _1 = {=}, _2 = {=} }"
-        `shouldMarshalInto` P3 () ()
+        `shouldMarshalIntoWrapped` P3 () ()
     , "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P4 { _1 = 1.0, _2 = 2.0 }"
-        `shouldMarshalInto` P4 1.0 2.0
+        `shouldMarshalIntoWrapped` P4 1.0 2.0
 
     , "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
         `shouldMarshalIntoSmart` P0
@@ -255,13 +255,13 @@ shouldHandleUnionsCorrectly =
         `shouldMarshalIntoSmart` P4 1.0 2.0
 
     , N0 True
-        `shouldEmbedAs`
+        `shouldEmbedAsWrapped`
         "(< N0 : { _1 : Bool } | N1 : { _1 : Natural } | N2 : { _1 : Text } >).N0 { _1 = True }"
     , N1 5
-        `shouldEmbedAs`
+        `shouldEmbedAsWrapped`
         "(< N0 : { _1 : Bool } | N1 : { _1 : Natural } | N2 : { _1 : Text } >).N1 { _1 = 5 }"
     , N2 "ABC"
-        `shouldEmbedAs`
+        `shouldEmbedAsWrapped`
         "(< N0 : { _1 : Bool } | N1 : { _1 : Natural } | N2 : { _1 : Text } >).N2 { _1 = \"ABC\" }"
 
     , N0 True
@@ -274,15 +274,15 @@ shouldHandleUnionsCorrectly =
         `shouldEmbedAsSmart`
         "(< N0 : Bool | N1 : Natural | N2 : Text >).N2 \"ABC\""
 
-    , E0 `shouldEmbedAs` "< E0 | E1 | E2 >.E0"
-    , E1 `shouldEmbedAs` "< E0 | E1 | E2 >.E1"
-    , E2 `shouldEmbedAs` "< E0 | E1 | E2 >.E2"
+    , E0 `shouldEmbedAsWrapped` "< E0 | E1 | E2 >.E0"
+    , E1 `shouldEmbedAsWrapped` "< E0 | E1 | E2 >.E1"
+    , E2 `shouldEmbedAsWrapped` "< E0 | E1 | E2 >.E2"
 
-    , R0 `shouldEmbedAs` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R0"
-    , R1 { a = () } `shouldEmbedAs` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R1 { a = {=} }"
-    , R2 { x = 1.0 } `shouldEmbedAs` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R2 { x = 1.0}"
-    , R3 { a = (), b = () } `shouldEmbedAs` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R3 { a = {=}, b = {=} }"
-    , R4 { x = 1.0, y = 2.0 } `shouldEmbedAs` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
+    , R0 `shouldEmbedAsWrapped` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R0"
+    , R1 { a = () } `shouldEmbedAsWrapped` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R1 { a = {=} }"
+    , R2 { x = 1.0 } `shouldEmbedAsWrapped` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R2 { x = 1.0}"
+    , R3 { a = (), b = () } `shouldEmbedAsWrapped` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R3 { a = {=}, b = {=} }"
+    , R4 { x = 1.0, y = 2.0 } `shouldEmbedAsWrapped` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
 
     , R0 `shouldEmbedAsSmart` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R0"
     , R1 { a = () } `shouldEmbedAsSmart` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R1 { a = {=} }"
@@ -290,11 +290,11 @@ shouldHandleUnionsCorrectly =
     , R3 { a = (), b = () } `shouldEmbedAsSmart` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R3 { a = {=}, b = {=} }"
     , R4 { x = 1.0, y = 2.0 } `shouldEmbedAsSmart` "< R0 | R1 : { a : {} } | R2 : { x : Double } | R3 : { a : {}, b : {} } | R4 : { x : Double, y : Double } >.R4 { x = 1.0, y = 2.0 }"
 
-    , P0 `shouldEmbedAs` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
-    , P1 () `shouldEmbedAs` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P1 { _1 = {=} }"
-    , P2 1.0 `shouldEmbedAs` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P2 { _1 = 1.0 }"
-    , P3 () () `shouldEmbedAs` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P3 { _1 = {=}, _2 = {=} }"
-    , P4 1.0 2.0 `shouldEmbedAs` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P4 { _1 = 1.0, _2 = 2.0 }"
+    , P0 `shouldEmbedAsWrapped` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
+    , P1 () `shouldEmbedAsWrapped` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P1 { _1 = {=} }"
+    , P2 1.0 `shouldEmbedAsWrapped` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P2 { _1 = 1.0 }"
+    , P3 () () `shouldEmbedAsWrapped` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P3 { _1 = {=}, _2 = {=} }"
+    , P4 1.0 2.0 `shouldEmbedAsWrapped` "< P0 | P1 : { _1 : {} } | P2 : { _1 : Double } | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P4 { _1 = 1.0, _2 = 2.0 }"
 
     , P0 `shouldEmbedAsSmart` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P0"
     , P1 () `shouldEmbedAsSmart` "< P0 | P1 | P2 : Double | P3 : { _1 : {}, _2 : {} } | P4 : { _1 : Double, _2 : Double } >.P1"
@@ -307,8 +307,12 @@ shouldHandleUnionsCorrectly =
         Dhall.defaultInterpretOptions
             { Dhall.singletonConstructors = Dhall.Smart }
 
-    code `shouldPassThrough` values = testCase "Pass through" $ do
-        f <- Dhall.input Dhall.auto code
+    wrappedOptions =
+        Dhall.defaultInterpretOptions
+            { Dhall.singletonConstructors = Dhall.Wrapped }
+
+    code `shouldPassThroughWrapped` values = testCase "Pass through" $ do
+        f <- Dhall.input (Dhall.autoWith wrappedOptions) code
 
         values @=? map f values
 
@@ -317,8 +321,8 @@ shouldHandleUnionsCorrectly =
 
         values @=? map f values
 
-    code `shouldMarshalInto` expectedValue = testCase "Marshal" $ do
-        actualValue <- Dhall.input Dhall.auto code
+    code `shouldMarshalIntoWrapped` expectedValue = testCase "Marshal" $ do
+        actualValue <- Dhall.input (Dhall.autoWith wrappedOptions) code
 
         expectedValue @=? actualValue
 
@@ -327,12 +331,12 @@ shouldHandleUnionsCorrectly =
 
         expectedValue @=? actualValue
 
-    value `shouldEmbedAs` expectedCode = testCase "ToDhall" $ do
+    value `shouldEmbedAsWrapped` expectedCode = testCase "ToDhall" $ do
         parsedExpression <- Dhall.Core.throws (Dhall.Parser.exprFromText "(test)" expectedCode)
 
         resolvedExpression <- Dhall.Import.assertNoImports parsedExpression
 
-        Dhall.Core.denote resolvedExpression @=? Dhall.embed Dhall.inject value
+        Dhall.Core.denote resolvedExpression @=? Dhall.embed (Dhall.injectWith wrappedOptions) value
 
     value `shouldEmbedAsSmart` expectedCode = testCase "ToDhall" $ do
         parsedExpression <- Dhall.Core.throws (Dhall.Parser.exprFromText "(test)" expectedCode)

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -14,6 +14,7 @@ import qualified Dhall.Test.Normalization
 import qualified Dhall.Test.Parser
 import qualified Dhall.Test.QuickCheck
 import qualified Dhall.Test.Regression
+import qualified Dhall.Test.TH
 import qualified Dhall.Test.Tutorial
 import qualified Dhall.Test.TypeInference
 import qualified GHC.IO.Encoding
@@ -57,6 +58,7 @@ getAllTests = do
                 , Dhall.Test.Tutorial.tests
                 , Dhall.Test.QuickCheck.tests
                 , Dhall.Test.Dhall.tests
+                , Dhall.Test.TH.tests
                 ]
 
     return testTree

--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -27,21 +27,14 @@ tests = Tasty.testGroup "Template Haskell" [ makeHaskellTypeFromUnion ]
 
 makeHaskellTypeFromUnion :: TestTree
 makeHaskellTypeFromUnion = Tasty.HUnit.testCase "makeHaskellTypeFromUnion" $ do
-    let interpretOptions =
-            Dhall.defaultInterpretOptions
-                { Dhall.singletonConstructors = Dhall.Smart
-                }
-
-    let decoder = Dhall.autoWith interpretOptions
-
-    t0 <- Dhall.input decoder "let T = ./tests/th/example.dhall in T.A { x = True, y = [ \"ABC\" ] }"
+    t0 <- Dhall.input Dhall.auto "let T = ./tests/th/example.dhall in T.A { x = True, y = [ \"ABC\" ] }"
 
     Tasty.HUnit.assertEqual "" t0 A{ x = True, y = [ "ABC" ] }
 
-    t1 <- Dhall.input decoder "let T = ./tests/th/example.dhall in T.B (Some [ 1 ])"
+    t1 <- Dhall.input Dhall.auto "let T = ./tests/th/example.dhall in T.B (Some [ 1 ])"
 
     Tasty.HUnit.assertEqual "" t1 (B (Just [ 1 ]))
 
-    t2 <- Dhall.input decoder "let T = ./tests/th/example.dhall in T.C"
+    t2 <- Dhall.input Dhall.auto "let T = ./tests/th/example.dhall in T.C"
 
     Tasty.HUnit.assertEqual "" t2 C

--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -15,7 +15,7 @@ import qualified Dhall.TH
 import qualified Test.Tasty       as Tasty
 import qualified Test.Tasty.HUnit as Tasty.HUnit
 
-Dhall.TH.makeHaskellType "T" "./tests/th/example.dhall"
+Dhall.TH.makeHaskellTypeFromUnion "T" "./tests/th/example.dhall"
 
 deriving instance Eq        T
 deriving instance Show      T
@@ -23,10 +23,10 @@ deriving instance Generic   T
 deriving instance FromDhall T
 
 tests :: TestTree
-tests = Tasty.testGroup "Template Haskell" [ makeHaskellType ]
+tests = Tasty.testGroup "Template Haskell" [ makeHaskellTypeFromUnion ]
 
-makeHaskellType :: TestTree
-makeHaskellType = Tasty.HUnit.testCase "makeHaskellType" $ do
+makeHaskellTypeFromUnion :: TestTree
+makeHaskellTypeFromUnion = Tasty.HUnit.testCase "makeHaskellTypeFromUnion" $ do
     let interpretOptions =
             Dhall.defaultInterpretOptions
                 { Dhall.singletonConstructors = Dhall.Smart

--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell    #-}
+
+module Dhall.Test.TH where
+
+import Dhall (FromDhall(..))
+import GHC.Generics
+import Test.Tasty (TestTree)
+
+import qualified Dhall
+import qualified Dhall.TH
+import qualified Test.Tasty       as Tasty
+import qualified Test.Tasty.HUnit as Tasty.HUnit
+
+Dhall.TH.makeHaskellType "T" "./tests/th/example.dhall"
+
+deriving instance Eq        T
+deriving instance Show      T
+deriving instance Generic   T
+deriving instance FromDhall T
+
+tests :: TestTree
+tests = Tasty.testGroup "Template Haskell" [ makeHaskellType ]
+
+makeHaskellType :: TestTree
+makeHaskellType = Tasty.HUnit.testCase "makeHaskellType" $ do
+    let interpretOptions =
+            Dhall.defaultInterpretOptions
+                { Dhall.singletonConstructors = Dhall.Smart
+                }
+
+    let decoder = Dhall.autoWith interpretOptions
+
+    t0 <- Dhall.input decoder "let T = ./tests/th/example.dhall in T.A { x = True, y = [ \"ABC\" ] }"
+
+    Tasty.HUnit.assertEqual "" t0 A{ x = True, y = [ "ABC" ] }
+
+    t1 <- Dhall.input decoder "let T = ./tests/th/example.dhall in T.B (Some [ 1 ])"
+
+    Tasty.HUnit.assertEqual "" t1 (B (Just [ 1 ]))
+
+    t2 <- Dhall.input decoder "let T = ./tests/th/example.dhall in T.C"
+
+    Tasty.HUnit.assertEqual "" t2 C

--- a/dhall/tests/recursive/expr0.dhall
+++ b/dhall/tests/recursive/expr0.dhall
@@ -1,20 +1,17 @@
   λ(Expr : Type)
 → let ExprF =
-        < LitF :
-            { _1 : Natural }
-        | AddF :
-            { _1 : Expr, _2 : Expr }
-        | MulF :
-            { _1 : Expr, _2 : Expr }
+        < LitF : Natural
+        | AddF : { _1 : Expr, _2 : Expr }
+        | MulF : { _1 : Expr, _2 : Expr }
         >
-  
+
   in    λ(Fix : ExprF → Expr)
-      → let Lit = λ(x : Natural) → Fix (ExprF.LitF { _1 = x })
-        
+      → let Lit = λ(x : Natural) → Fix (ExprF.LitF x)
+
         let Add =
               λ(x : Expr) → λ(y : Expr) → Fix (ExprF.AddF { _1 = x, _2 = y })
-        
+
         let Mul =
               λ(x : Expr) → λ(y : Expr) → Fix (ExprF.MulF { _1 = x, _2 = y })
-        
+
         in  Add (Mul (Lit 3) (Lit 7)) (Add (Lit 1) (Lit 2))

--- a/dhall/tests/recursive/expr1.dhall
+++ b/dhall/tests/recursive/expr1.dhall
@@ -1,18 +1,15 @@
   λ(a : Type)
 → let ExprF =
-        < LitF :
-            { _1 : Natural }
-        | AddF :
-            { _1 : a, _2 : a }
-        | MulF :
-            { _1 : a, _2 : a }
+        < LitF : Natural
+        | AddF : { _1 : a, _2 : a }
+        | MulF : { _1 : a, _2 : a }
         >
-  
+
   in    λ(a : ExprF → a)
-      → let Lit = λ(x : Natural) → a (ExprF.LitF { _1 = x })
-        
+      → let Lit = λ(x : Natural) → a (ExprF.LitF x)
+
         let Add = λ(x : a@1) → λ(y : a@1) → a (ExprF.AddF { _1 = x, _2 = y })
-        
+
         let Mul = λ(x : a@1) → λ(y : a@1) → a (ExprF.MulF { _1 = x, _2 = y })
-        
+
         in  Add (Mul (Lit 3) (Lit 7)) (Add (Lit 1) (Lit 2))

--- a/dhall/tests/th/example.dhall
+++ b/dhall/tests/th/example.dhall
@@ -1,0 +1,1 @@
+< A : { x : Bool, y : List Text } | B : Optional (List Natural) | C >

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -399,6 +399,11 @@ let
                           haskellPackagesNew.semigroups
                         ];
 
+                    managed =
+                      pkgsNew.haskell.lib.addBuildDepend
+                        haskellPackagesOld.managed
+                        haskellPackagesNew.semigroups;
+
                     megaparsec =
                       pkgsNew.haskell.lib.addBuildDepend
                         haskellPackagesOld.megaparsec
@@ -412,6 +417,11 @@ let
                       pkgsNew.haskell.lib.addBuildDepend
                         haskellPackagesOld.optparse-applicative
                         haskellPackagesNew.fail;
+
+                    optional-args =
+                      pkgsNew.haskell.lib.addBuildDepend
+                        haskellPackagesOld.optional-args
+                        haskellPackagesNew.semigroups;
 
                     parser-combinators =
                       pkgsNew.haskell.lib.addBuildDepend


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1616

This adds a new `Dhall.TH.makeHaskellType` utility which generates a
Haskell datatype declaration corresponding to a Dhall type.  This simplifies
keeping Haskell and Dhall code in sync with one another.