### PR TITLE
WIP: Proposal to implement #1615 by abusing the type-checker

### DIFF
--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
@@ -3,8 +3,11 @@ module Dhall.LSP.Backend.Completion where
 import Data.List (foldl')
 import Data.Text (Text)
 import Data.Void (Void, absurd)
+import qualified Data.Set as Set
 import Dhall.Context (Context, insert)
 import Dhall.Context (empty, toList)
+import qualified Dhall.TypeCheck as Dhall
+import Dhall.LSP.Backend.Dhall (DhallError(..))
 import Dhall.LSP.Backend.Diagnostics (Position, positionToOffset)
 import Dhall.LSP.Backend.Parsing (holeExpr)
 import Dhall.Parser (Src, exprFromText)
@@ -152,6 +155,27 @@ contextToVariables ((name, _) : rest) =
   V name 0 : map (inc name) (contextToVariables rest)
  where inc x (V y i) | x == y = V x (i + 1)
                      | otherwise = V y i
+
+completeFromAnnotMismatch :: Expr Src Void -> Expr Src Void -> [Completion]
+-- Completing from record mismatch
+completeFromAnnotMismatch (Record annot) (Record literal) =
+  let present = Set.fromList $ map fst (Dhall.Map.toList literal)
+      toCompletion (name, typ) =
+          Completion (", " <> (Dhall.Pretty.escapeLabel True name)) (Just typ)
+  in map toCompletion $ filter (\(n, _) -> not (Set.member n present)) (Dhall.Map.toList annot)
+
+-- Catch-all for AnnotMismatch completion
+completeFromAnnotMismatch _ _ = []
+
+completeFromErrors :: DhallError -> [Completion]
+completeFromErrors (ErrorTypecheck Dhall.TypeError {typeMessage = msg}) =
+  let
+    fromAnnotation (Dhall.AnnotMismatch _ expr1 expr2) =
+      completeFromAnnotMismatch expr1 expr2
+    fromAnnotation _ = []
+  in
+    fromAnnotation msg
+completeFromErrors _ = []
 
 -- | Complete identifiers from the given completion context.
 completeFromContext :: CompletionContext -> [Completion]

--- a/dhall-lsp-server/tests/Main.hs
+++ b/dhall-lsp-server/tests/Main.hs
@@ -125,6 +125,15 @@ codeCompletionSpec fixtureDir =
           let firstItem = head cs
           _label firstItem `shouldBe` "bob"
           _detail firstItem `shouldBe` Just "Text"
+    it "suggests record labels even in error"
+      $ runSession "dhall-lsp-server" fullCaps fixtureDir
+      $ do
+        docId <- openDoc "TypedRecordError.dhall" "dhall"
+        cs <- getCompletions docId (Position {_line = 0, _character = 13})
+        liftIO $ do
+          let firstItem = head cs
+          _label firstItem `shouldBe` ", name"
+          _detail firstItem `shouldBe` Just "Text"
     it "suggests functions from imports"
       $ runSession "dhall-lsp-server" fullCaps fixtureDir
       $ do

--- a/dhall-lsp-server/tests/fixtures/completion/TypedRecordError.dhall
+++ b/dhall-lsp-server/tests/fixtures/completion/TypedRecordError.dhall
@@ -1,0 +1,1 @@
+{ result = 1 } : { result : Natural,  name : Text } 


### PR DESCRIPTION
I looked into a possibility of implementing the code-completion for record's labels and I woul like to know your opinion.

* I changed the parser to allow for empty labels, and now when I have annotated record, It will throw a type error instead of parse-error, when I start writing empty label. This is a terrible idea, because suddenly, you can have valid records `{ x = 1,}` of type `{``:Bool, x: Natural}`, but I didn't want to attempt to fix that glaring hole before I ask if the general attempt holds at least some water.
* now I can use the type-error in the completion handler when in the incomplete record.

What do you think? 

