### PR TITLE
(silly nitpick) Fix filename in example snippet

### DIFF
--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -486,7 +486,7 @@ in  {- Try generating 20 users instead of 10 -}
 
     input.setValue(example0);
 
-    h0.setValue(`-- ./example.dhall
+    h0.setValue(`-- ./company.dhall
 
 let Prelude =
       https://prelude.dhall-lang.org/v11.1.0/package.dhall sha256:99462c205117931c0919f155a6046aec140c70fb8876d208c7c77027ab19c2fa


### PR DESCRIPTION
In https://dhall-lang.org/ the snippets under `Don't Repeat Yourself` specify wrong filenames. 

<img width="598" alt="Screenshot 2020-01-10 at 23 14 12" src="https://user-images.githubusercontent.com/762126/72190152-20e86680-33ff-11ea-9fa0-426054794d72.png">
