### PR TITLE
Improve release script

### DIFF
--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -686,7 +686,7 @@ in
     shell-dhall            = pkgs.haskell.packages."${compiler}".dhall.env           ;
     shell-dhall-bash       = pkgs.haskell.packages."${compiler}".dhall-bash.env      ;
     shell-dhall-json       = pkgs.haskell.packages."${compiler}".dhall-json.env      ;
-    shell-dhall-lsp-server = (pkgs.haskell.lib.doCheck pkgs.haskell.packages."${compiler}".dhall-lsp-server).env;
+    shell-dhall-lsp-server = pkgs.haskell.packages."${compiler}".dhall-lsp-server.env;
     shell-dhall-nix        = pkgs.haskell.packages."${compiler}".dhall-nix.env       ;
     shell-dhall-try        = pkgs.haskell.packages."${compiler}".dhall-try.env       ;
     shell-dhall-yaml       = pkgs.haskell.packages."${compiler}".dhall-yaml.env      ;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,13 +1,15 @@
-set -x
+set -eux
 
 JOBSET=master
 
+. .travis-functions.sh
+
 function release {
   NAME="$1"
-  VERSION="$2"
+  VERSION="$(get_cabal_version "${NAME}")"
 
   pushd "${NAME}"
-  cabal v1-configure
+  cabal v1-configure --disable-tests --disable-benchmarks
   cabal v1-sdist
   cabal upload --publish "dist/${NAME}-${VERSION}.tar.gz"
   popd
@@ -20,9 +22,6 @@ function release {
   skopeo copy --dest-creds=gabriel439:$(< dockerPassword.txt) "docker-archive:docker-image-${NAME}.tar.gz" "docker://dhallhaskell/${NAME}:${VERSION}"
 }
 
-release dhall-lsp-server 1.0.3
-release dhall-json 1.6.0
-release dhall-yaml 1.0.0
-release dhall-bash 1.0.25
-release dhall-nix 1.1.10
-release dhall 1.28.0
+for package in dhall-lsp-server dhall-json dhall-yaml dhall-bash dhall-nix dhall; do
+  release "${package}"
+done


### PR DESCRIPTION
... to auto-detect package versions using the `get_cabal_version`
utility from `./travis-functions.sh`

This also fixes a few small issues I found along the way:

* Disable tests and benchmarks, which are not necessary for the release
  script

* Disable the explicit `doCheck` on the `nix-shell` for
  `dhall-lsp-server`, which was forcing test dependencies to be pulled
  in