### PR TITLE
Expand website integrations list

### DIFF
--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -133,18 +133,10 @@
             </div>
           </li>
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="integrationsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              Integrations
+            <a class="nav-link dropdown-toggle" href="#" id="languagesDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Languages
             </a>
-            <div class="dropdown-menu" aria-labelledby="integrationsDropdown">
-              <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md"><img src = "./img/yaml-logo.png" height="20px" alt="YAML logo"><span>YAML</span></a>
-              <div class="dropdown-divider"></div>
-              <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md"><img src = "./img/json-logo.svg" height="32px" alt="JSON logo"><span>JSON</span></a>
-              <div class="dropdown-divider"></div>
-              <a class="nav-link" href="https://git.sr.ht/~singpolyma/dhall-xml-ruby"><img src = "./img/xml-logo.svg" height="32px" alt="XML logo"><span>XML</span></a>
-              <div class="dropdown-divider"></div>
-              <a class="nav-link" href="https://github.com/dhall-lang/dhall-kubernetes/blob/master/README.md"><img src = "./img/kubernetes-logo.svg" height="32px" alt="Kubernetes logo"><span>Kubernetes</span></a>
-              <div class="dropdown-divider"></div>
+            <div class="dropdown-menu" aria-labelledby="languagesDropdown">
               <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-bash/README.md"><img src = "./img/bash-logo.png" height="32px" alt="Bash logo"><span>Bash</span></a>
               <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://github.com/f-f/dhall-clj/blob/master/README.md"><img src = "./img/clojure-logo.svg" height="32px" alt="Clojure logo"><span>Clojure</span></a>
@@ -156,6 +148,32 @@
               <a class="nav-link" href="https://git.sr.ht/~singpolyma/dhall-ruby"><img src = "./img/ruby-logo.svg" height="32px" alt="Ruby logo"><span>Ruby</span></a>
               <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://github.com/Nadrieril/dhall-rust"><img src = "./img/rust-logo.svg" height="32px" alt="Rust logo"><span>Rust</span></a>
+            </div>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="formatsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Formats
+            </a>
+            <div class="dropdown-menu" aria-labelledby="formatsDropdown">
+              <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md"><img src = "./img/yaml-logo.png" height="20px" alt="YAML logo"><span>YAML</span></a>
+              <div class="dropdown-divider"></div>
+              <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md"><img src = "./img/json-logo.svg" height="32px" alt="JSON logo"><span>JSON</span></a>
+              <div class="dropdown-divider"></div>
+              <a class="nav-link" href="https://git.sr.ht/~singpolyma/dhall-xml-ruby"><img src = "./img/xml-logo.svg" height="32px" alt="XML logo"><span>XML</span></a>
+            </div>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="packagesDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Packages
+            </a>
+            <div class="dropdown-menu" aria-labelledby="packagesDropdown">
+              <a class="nav-link" href="https://github.com/EarnestResearch/dhall-packages/blob/master/kubernetes/argocd/Readme.md"><img src = "./img/argocd-logo.png" height="32px" alt="Argo CDlogo"><span>Argo CD</span></a>
+              <div class="dropdown-divider"></div>
+              <a class="nav-link" href="https://github.com/coralogix/dhall-kops/blob/master/README.md"><img src = "./img/kops-logo.svg" height="32px" alt="kops logo"><span>kops</span></a>
+              <div class="dropdown-divider"></div>
+              <a class="nav-link" href="https://github.com/dhall-lang/dhall-kubernetes/blob/master/README.md"><img src = "./img/kubernetes-logo.svg" height="32px" alt="Kubernetes logo"><span>Kubernetes</span></a>
+              <div class="dropdown-divider"></div>
+              <a class="nav-link" href="https://github.com/coralogix/dhall-prometheus-operator"><img src = "./img/prometheus-logo.svg" height="32px" alt="Prometheus logo"><span>Prometheus</span></a>
             </div>
           </li>
           <li class="nav-item">

--- a/dhall-try/index.html
+++ b/dhall-try/index.html
@@ -152,7 +152,7 @@
           </li>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="formatsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              Formats
+              File formats
             </a>
             <div class="dropdown-menu" aria-labelledby="formatsDropdown">
               <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md"><img src = "./img/yaml-logo.png" height="20px" alt="YAML logo"><span>YAML</span></a>

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -35,6 +35,12 @@ let
 
   overlayShared = pkgsNew: pkgsOld: {
     logo = {
+      argocd =
+        pkgsNew.fetchurl {
+          url    = "https://raw.githubusercontent.com/argoproj/argo-cd/master/docs/assets/argo.png";
+          sha256 = "0gvfd7y7ihqyz93by730w0f6kdfs8dlvxv45ydccih94rxj3j7ac";
+        };
+
       bash =
         pkgsNew.fetchurl {
           url    = "https://raw.githubusercontent.com/odb/official-bash-logo/master/assets/Logos/Icons/PNG/128x128.png";
@@ -81,6 +87,18 @@ let
           sha256 = "0g26j7vx34m46mwp93qgg3q5x8pfdq2j1ch0vxz5gj0nk3b8fxda";
         };
 
+      json =
+        pkgsNew.fetchurl {
+          url    = "https://upload.wikimedia.org/wikipedia/commons/c/c9/JSON_vector_logo.svg";
+          sha256 = "1hqd1qh35v9magjp3rbsw8wszk2wn3hkz981ir49z5cyf11jnx95";
+        };
+
+      kops =
+        pkgsNew.fetchurl {
+          url    = "https://raw.githubusercontent.com/kubernetes/kops/master/docs/img/logo-notext.svg";
+          sha256 = "0gdi0pcrmvmb23dy8zp7z1z980cmj5aqpp9yxrsyp4dsj7flay8r";
+        };
+
       kubernetes =
         pkgsNew.fetchurl {
           url    = "https://raw.githubusercontent.com/kubernetes/kubernetes/7839fe38620508eb0651930cb0e1acb8ea367842/logo/logo.svg";
@@ -93,10 +111,10 @@ let
           sha256 = "1hrz7wr7i0b2bips60ygacbkmdzv466lsbxi22hycg42kv4m0173";
         };
 
-      json =
+      prometheus =
         pkgsNew.fetchurl {
-          url    = "https://upload.wikimedia.org/wikipedia/commons/c/c9/JSON_vector_logo.svg";
-          sha256 = "1hqd1qh35v9magjp3rbsw8wszk2wn3hkz981ir49z5cyf11jnx95";
+          url    = "https://upload.wikimedia.org/wikipedia/commons/3/38/Prometheus_software_logo.svg";
+          sha256 = "19ff8l1kp3i3gxxbd5na9wbzxkpflcxw0lz2ysb1d6s4ybvr0fnb";
         };
 
       stackOverflow =
@@ -104,7 +122,6 @@ let
           url    = "https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-icon.svg";
           sha256 = "0i84h23ax197f3hwh0hqm6yjvvnpcjyhd6nkyy33z6x10dh8v4z3";
         };
-
 
       twitter = pkgsNew.callPackage ./twitterLogo.nix { };
 

--- a/nix/website.nix
+++ b/nix/website.nix
@@ -20,22 +20,25 @@ runCommand "try-dhall" {} ''
   ${coreutils}/bin/ln --symbolic ${npm.codemirror}/lib/node_modules/codemirror/mode/yaml/yaml.js $out/js
   ${coreutils}/bin/ln --symbolic ${npm.codemirror}/lib/node_modules/codemirror/lib/codemirror.css $out/css
   ${coreutils}/bin/ln --symbolic ${haskell.packages.ghcjs.dhall-try}/bin/dhall-try.jsexe/all.min.js $out/js
+  ${coreutils}/bin/ln --symbolic ${logo.argocd} $out/img/argocd-logo.png
   ${coreutils}/bin/ln --symbolic ${logo.bash} $out/img/bash-logo.png
   ${coreutils}/bin/ln --symbolic ${logo.clojure} $out/img/clojure-logo.svg
-  ${coreutils}/bin/ln --symbolic ${logo.ruby} $out/img/ruby-logo.svg
-  ${coreutils}/bin/ln --symbolic ${logo.rust} $out/img/rust-logo.svg
-  ${coreutils}/bin/ln --symbolic ${logo.discourse} $out/img/discourse-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.dhallLarge} $out/img/dhall-large-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.dhallSmall} $out/img/dhall-small-logo.svg
+  ${coreutils}/bin/ln --symbolic ${logo.discourse} $out/img/discourse-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.github}/PNG/GitHub-Mark-32px.png $out/img/github-logo.png
   ${coreutils}/bin/ln --symbolic ${logo.haskell} $out/img/haskell-logo.png
-  ${coreutils}/bin/ln --symbolic ${logo.kubernetes} $out/img/kubernetes-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.json} $out/img/json-logo.svg
+  ${coreutils}/bin/ln --symbolic ${logo.kops} $out/img/kops-logo.svg
+  ${coreutils}/bin/ln --symbolic ${logo.kubernetes} $out/img/kubernetes-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.nix} $out/img/nix-logo.png
+  ${coreutils}/bin/ln --symbolic ${logo.prometheus} $out/img/prometheus-logo.svg
+  ${coreutils}/bin/ln --symbolic ${logo.ruby} $out/img/ruby-logo.svg
+  ${coreutils}/bin/ln --symbolic ${logo.rust} $out/img/rust-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.stackOverflow} $out/img/stack-overflow-logo.svg
-  ${coreutils}/bin/ln --symbolic '${logo.twitter}/Twitter Logos/Twitter Logos/Twitter_Logo_Blue/Twitter_Logo_Blue.svg' $out/img/twitter-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.xml} $out/img/xml-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.yaml} $out/img/yaml-logo.png
+  ${coreutils}/bin/ln --symbolic '${logo.twitter}/Twitter Logos/Twitter Logos/Twitter_Logo_Blue/Twitter_Logo_Blue.svg' $out/img/twitter-logo.svg
   ${coreutils}/bin/mkdir $out/nix-support
   ${coreutils}/bin/echo "doc none $out/index.html" > $out/nix-support/hydra-build-products
 ''


### PR DESCRIPTION
This adds a few new integrations and splits them up into multiple
dropdown menus:

* Languages - Intended for language bindings
* Formats - Configuration file formats that Dhall interoperates with
* Packages - Notable Dhall packages to support various tools

Here is what the dropdowns currently look like:

![Screen Shot 2020-01-17 at 8 49 58 AM](https://user-images.githubusercontent.com/1313787/72630074-6ed10300-3906-11ea-8e6d-8a0f71f72f33.png)
![Screen Shot 2020-01-17 at 8 50 08 AM](https://user-images.githubusercontent.com/1313787/72630075-6ed10300-3906-11ea-8c0e-206e5c2fcaf7.png)
![Screen Shot 2020-01-17 at 8 50 14 AM](https://user-images.githubusercontent.com/1313787/72630076-6f699980-3906-11ea-8f07-bd01c4d4c0ca.png)

cc: @ari-becker @amarrella (let me know if I am missing any integrations you'd like me to mention)

I didn't include the Dhall packages for Argo Events and Argo Workflows yet because they are still missing `README`s