### PR TITLE
Add `--check` flag to `dhall {lint,freeze}`

### DIFF
--- a/dhall/src/Dhall/Format.hs
+++ b/dhall/src/Dhall/Format.hs
@@ -15,9 +15,9 @@ import Dhall.Pretty (CharacterSet(..), annToAnsiStyle)
 
 import Dhall.Util
     ( Censor
+    , CheckFailed(..)
     , Header(..)
     , Input(..)
-    , NotModified(..)
     , OutputMode(..)
     )
 
@@ -93,4 +93,4 @@ format (Format {..}) = do
 
                     let modified = "formatted"
 
-                    Control.Exception.throwIO NotModified{..}
+                    Control.Exception.throwIO CheckFailed{..}

--- a/dhall/src/Dhall/Format.hs
+++ b/dhall/src/Dhall/Format.hs
@@ -7,14 +7,19 @@
 module Dhall.Format
     ( -- * Format
       Format(..)
-    , FormatMode(..)
     , format
     ) where
 
-import Control.Exception (Exception)
 import Data.Monoid ((<>))
 import Dhall.Pretty (CharacterSet(..), annToAnsiStyle)
-import Dhall.Util (Censor, Input(..), Header(..))
+
+import Dhall.Util
+    ( Censor
+    , Header(..)
+    , Input(..)
+    , InputMode(..)
+    , NotModified(..)
+    )
 
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty.Terminal
@@ -27,30 +32,16 @@ import qualified System.AtomicWrite.Writer.LazyText        as AtomicWrite.LazyTe
 import qualified System.Console.ANSI
 import qualified System.IO
 
-data NotFormatted = NotFormatted
-    deriving (Exception)
-
-instance Show NotFormatted where
-    show _ = ""
-
 -- | Arguments to the `format` subcommand
 data Format = Format
     { characterSet :: CharacterSet
     , censor       :: Censor
-    , formatMode   :: FormatMode
+    , input        :: Input
+    , inputMode    :: InputMode
     }
 
-{-| The `format` subcommand can either `Modify` its input or simply `Check`
-    that the input is already formatted
--}
-data FormatMode
-    = Modify { inplace :: Input }
-    | Check  { path :: Input }
-
 -- | Implementation of the @dhall format@ subcommand
-format
-    :: Format
-    -> IO ()
+format :: Format -> IO ()
 format (Format {..}) = do
     let layoutHeaderAndExpr (Header header, expr) =
             Dhall.Pretty.layout
@@ -58,16 +49,16 @@ format (Format {..}) = do
                 <>  Dhall.Pretty.prettyCharacterSet characterSet expr 
                 <>  "\n")
 
-    let layoutInput input = do
+    let layoutInput = do
             headerAndExpr <- Dhall.Util.getExpressionAndHeader censor input
 
             return (layoutHeaderAndExpr headerAndExpr)
 
-    case formatMode of
-        Modify {..} -> do
-            docStream <- layoutInput inplace
+    case inputMode of
+        Modify -> do
+            docStream <- layoutInput
 
-            case inplace of
+            case input of
                 InputFile file -> do
                     AtomicWrite.LazyText.atomicWriteFile
                         file
@@ -82,13 +73,13 @@ format (Format {..}) = do
                             then (fmap annToAnsiStyle docStream)
                             else (Pretty.unAnnotateS docStream))
 
-        Check {..} -> do
-            originalText <- case path of
+        Check -> do
+            originalText <- case input of
                 InputFile file -> Data.Text.IO.readFile file
                 StandardInput  -> Data.Text.IO.getContents
 
-            docStream <- case path of
-                InputFile _    -> layoutInput path
+            docStream <- case input of
+                InputFile _    -> layoutInput
                 StandardInput  -> do
                     headerAndExpr <- Dhall.Util.getExpressionAndHeaderFromStdinText censor originalText
                     return (layoutHeaderAndExpr headerAndExpr)
@@ -97,4 +88,9 @@ format (Format {..}) = do
 
             if originalText == formattedText
                 then return ()
-                else Control.Exception.throwIO NotFormatted
+                else do
+                    let command = "format"
+
+                    let modified = "formatted"
+
+                    Control.Exception.throwIO NotModified{..}

--- a/dhall/src/Dhall/Format.hs
+++ b/dhall/src/Dhall/Format.hs
@@ -17,8 +17,8 @@ import Dhall.Util
     ( Censor
     , Header(..)
     , Input(..)
-    , InputMode(..)
     , NotModified(..)
+    , OutputMode(..)
     )
 
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
@@ -37,7 +37,7 @@ data Format = Format
     { characterSet :: CharacterSet
     , censor       :: Censor
     , input        :: Input
-    , inputMode    :: InputMode
+    , outputMode   :: OutputMode
     }
 
 -- | Implementation of the @dhall format@ subcommand
@@ -54,8 +54,8 @@ format (Format {..}) = do
 
             return (layoutHeaderAndExpr headerAndExpr)
 
-    case inputMode of
-        Modify -> do
+    case outputMode of
+        Write -> do
             docStream <- layoutInput
 
             case input of

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -23,9 +23,9 @@ import Dhall.Pretty (CharacterSet)
 import Dhall.Syntax (Expr(..), Import(..), ImportHashed(..), ImportType(..))
 import Dhall.Util
     ( Censor
+    , CheckFailed(..)
     , Header(..)
     , Input(..)
-    , NotModified(..)
     , OutputMode(..)
     )
 import System.Console.ANSI (hSupportsANSI)
@@ -241,4 +241,4 @@ freeze inputMode input scope intent characterSet censor = do
 
                     let modified = "frozen"
 
-                    Exception.throwIO NotModified{..}
+                    Exception.throwIO CheckFailed{..}

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -230,9 +230,7 @@ freeze inputMode input scope intent characterSet censor = do
 
             let stream = Dhall.Pretty.layout doc
 
-            let unAnnotated = Pretty.unAnnotateS stream
-
-            let modifiedText = Pretty.renderStrict unAnnotated
+            let modifiedText = Pretty.Text.renderStrict stream
 
             if originalText == modifiedText
                 then return ()

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -15,25 +15,34 @@ module Dhall.Freeze
     , Intent(..)
     ) where
 
+import Data.Bifunctor (first)
 import Data.Monoid ((<>))
 import Data.Text
 import Dhall.Parser (Src)
 import Dhall.Pretty (CharacterSet)
 import Dhall.Syntax (Expr(..), Import(..), ImportHashed(..), ImportType(..))
-import Dhall.Util (Censor, Input(..))
+import Dhall.Util
+    ( Censor
+    , Header(..)
+    , Input(..)
+    , InputMode(..)
+    , NotModified(..)
+    )
 import System.Console.ANSI (hSupportsANSI)
 
-import qualified Control.Exception
+import qualified Control.Exception                         as Exception
 import qualified Control.Monad.Trans.State.Strict          as State
+import qualified Data.Text.IO                              as Text.IO
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty.Text
 import qualified Dhall.Core                                as Core
 import qualified Dhall.Import
 import qualified Dhall.Optics
+import qualified Dhall.Parser                              as Parser
 import qualified Dhall.Pretty
 import qualified Dhall.TypeCheck
-import qualified Dhall.Util
+import qualified Dhall.Util                                as Util
 import qualified System.AtomicWrite.Writer.LazyText        as AtomicWrite.LazyText
 import qualified System.FilePath
 import qualified System.IO
@@ -58,7 +67,7 @@ freezeImport directory import_ = do
     expression <- State.evalStateT (Dhall.Import.loadWith (Embed unprotectedImport)) status
 
     case Dhall.TypeCheck.typeOf expression of
-        Left  exception -> Control.Exception.throwIO exception
+        Left  exception -> Exception.throwIO exception
         Right _         -> return ()
 
     let normalizedExpression = Core.alphaNormalize (Core.normalize expression)
@@ -86,7 +95,7 @@ freezeRemoteImport directory import_ = do
         _         -> return import_
 
 writeExpr :: Input -> (Text, Expr Src Import) -> CharacterSet -> IO ()
-writeExpr inplace (header, expr) characterSet = do
+writeExpr input (header, expr) characterSet = do
     let doc =  Pretty.pretty header
             <> Dhall.Pretty.prettyCharacterSet characterSet expr
             <> "\n"
@@ -95,7 +104,7 @@ writeExpr inplace (header, expr) characterSet = do
 
     let unAnnotated = Pretty.unAnnotateS stream
 
-    case inplace of
+    case input of
         InputFile file ->
             AtomicWrite.LazyText.atomicWriteFile
                 file
@@ -129,19 +138,17 @@ data Intent
 
 -- | Implementation of the @dhall freeze@ subcommand
 freeze
-    :: Input
+    :: InputMode
+    -> Input
     -> Scope
     -> Intent
     -> CharacterSet
     -> Censor
     -> IO ()
-freeze inplace scope intent characterSet censor = do
-    let directory = case inplace of
+freeze inputMode input scope intent characterSet censor = do
+    let directory = case input of
             StandardInput  -> "."
             InputFile file -> System.FilePath.takeDirectory file
-
-    (Dhall.Util.Header header, parsedExpression) <-
-        Dhall.Util.getExpressionAndHeader censor inplace
 
     let freezeScope =
             case scope of
@@ -194,6 +201,44 @@ freeze inplace scope intent characterSet censor = do
                         cache
                         expression
 
-    frozenExpression <- rewrite parsedExpression
+    case inputMode of
+        Modify -> do
+            (Header header, parsedExpression) <- do
+                Util.getExpressionAndHeader censor input
 
-    writeExpr inplace (header, frozenExpression) characterSet
+            frozenExpression <- rewrite parsedExpression
+
+            writeExpr input (header, frozenExpression) characterSet
+
+        Check -> do
+            originalText <- case input of
+                InputFile file -> Text.IO.readFile file
+                StandardInput  -> Text.IO.getContents
+
+            let name = case input of
+                    InputFile file -> file
+                    StandardInput  -> "(stdin)"
+
+            (Header header, parsedExpression) <- do
+                Core.throws (first Parser.censor (Parser.exprAndHeaderFromText name originalText))
+
+            frozenExpression <- rewrite parsedExpression
+
+            let doc =  Pretty.pretty header
+                    <> Dhall.Pretty.prettyCharacterSet characterSet frozenExpression
+                    <> "\n"
+
+            let stream = Dhall.Pretty.layout doc
+
+            let unAnnotated = Pretty.unAnnotateS stream
+
+            let modifiedText = Pretty.renderStrict unAnnotated
+
+            if originalText == modifiedText
+                then return ()
+                else do
+                    let command = "freeze"
+
+                    let modified = "frozen"
+
+                    Exception.throwIO NotModified{..}

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -145,7 +145,7 @@ freeze
     -> CharacterSet
     -> Censor
     -> IO ()
-freeze inputMode input scope intent characterSet censor = do
+freeze outputMode input scope intent characterSet censor = do
     let directory = case input of
             StandardInput  -> "."
             InputFile file -> System.FilePath.takeDirectory file
@@ -201,7 +201,7 @@ freeze inputMode input scope intent characterSet censor = do
                         cache
                         expression
 
-    case inputMode of
+    case outputMode of
         Write -> do
             (Header header, parsedExpression) <- do
                 Util.getExpressionAndHeader censor input

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -25,8 +25,8 @@ import Dhall.Util
     ( Censor
     , Header(..)
     , Input(..)
-    , InputMode(..)
     , NotModified(..)
+    , OutputMode(..)
     )
 import System.Console.ANSI (hSupportsANSI)
 
@@ -138,7 +138,7 @@ data Intent
 
 -- | Implementation of the @dhall freeze@ subcommand
 freeze
-    :: InputMode
+    :: OutputMode
     -> Input
     -> Scope
     -> Intent
@@ -202,7 +202,7 @@ freeze inputMode input scope intent characterSet censor = do
                         expression
 
     case inputMode of
-        Modify -> do
+        Write -> do
             (Header header, parsedExpression) <- do
                 Util.getExpressionAndHeader censor input
 

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -50,9 +50,9 @@ import Dhall.Core
     )
 import Dhall.Util
     ( Censor(..)
+    , CheckFailed(..)
     , Header (..)
     , Input(..)
-    , NotModified(..)
     , OutputMode(..)
     , Output(..)
     )
@@ -753,7 +753,7 @@ command (Options {..}) = do
                         else do
                             let modified = "linted"
 
-                            Control.Exception.throwIO NotModified{ command = "lint", ..}
+                            Control.Exception.throwIO CheckFailed{ command = "lint", ..}
 
         Encode {..} -> do
             expression <- getExpression file

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -52,8 +52,8 @@ import Dhall.Util
     ( Censor(..)
     , Header (..)
     , Input(..)
-    , InputMode(..)
     , NotModified(..)
+    , OutputMode(..)
     , Output(..)
     )
 
@@ -137,11 +137,11 @@ data Mode
           }
     | Normalize { file :: Input , alpha :: Bool }
     | Repl
-    | Format { input :: Input, inputMode :: InputMode }
-    | Freeze { input :: Input, all_ :: Bool, cache :: Bool, inputMode :: InputMode }
+    | Format { input :: Input, outputMode :: OutputMode }
+    | Freeze { input :: Input, all_ :: Bool, cache :: Bool, outputMode :: OutputMode }
     | Hash { file :: Input }
     | Diff { expr1 :: Text, expr2 :: Text }
-    | Lint { input :: Input, inputMode :: InputMode }
+    | Lint { input :: Input, outputMode :: OutputMode }
     | Tags
           { input :: Input
           , output :: Output
@@ -428,7 +428,7 @@ parseMode =
     parseCheck = fmap adapt switch
       where
         adapt True  = Check
-        adapt False = Modify
+        adapt False = Write
 
         switch =
             Options.Applicative.switch
@@ -696,7 +696,7 @@ command (Options {..}) = do
 
             let intent = if cache then Cache else Secure
 
-            Dhall.Freeze.freeze inputMode input scope intent characterSet censor
+            Dhall.Freeze.freeze outputMode input scope intent characterSet censor
 
         Hash {..} -> do
             expression <- getExpression file
@@ -712,8 +712,8 @@ command (Options {..}) = do
             Data.Text.IO.putStrLn (Dhall.Import.hashExpressionToCode normalizedExpression)
 
         Lint {..} -> do
-            case inputMode of
-                Modify -> do
+            case outputMode of
+                Write -> do
                     (Header header, expression) <- do
                         getExpressionAndHeader input
 

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -744,9 +744,9 @@ command (Options {..}) = do
                     let doc =   Pretty.pretty header
                             <>  Dhall.Pretty.prettyCharacterSet characterSet lintedExpression
 
-                    let stream = Pretty.unAnnotateS (Dhall.Pretty.layout doc)
+                    let stream = Dhall.Pretty.layout doc
 
-                    let modifiedText = Pretty.renderStrict stream <> "\n"
+                    let modifiedText = Pretty.Text.renderStrict stream <> "\n"
 
                     if originalText == modifiedText
                         then return ()

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -16,18 +16,30 @@ module Dhall.Main
     , parserInfoOptions
 
       -- * Execution
-    , command
+    , Dhall.Main.command
     , main
     ) where
 
 import Control.Applicative (optional, (<|>))
 import Control.Exception (Handler(..), SomeException)
 import Control.Monad (when)
+import Data.Bifunctor (first)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty)
 import Data.Void (Void)
+import Dhall.Freeze (Intent(..), Scope(..))
+import Dhall.Import (Imported(..), Depends(..), SemanticCacheMode(..), _semanticCacheMode)
+import Dhall.Parser (Src)
+import Dhall.Pretty (Ann, CharacterSet(..), annToAnsiStyle)
+import Dhall.TypeCheck (Censored(..), DetailedTypeError(..), TypeError)
+import Dhall.Version (dhallVersionString)
+import Options.Applicative (Parser, ParserInfo)
+import System.Exit (ExitCode, exitFailure)
+import System.IO (Handle)
+import Text.Dot ((.->.))
+
 import Dhall.Core
     ( Expr(Annot)
     , Import(..)
@@ -36,17 +48,14 @@ import Dhall.Core
     , URL(..)
     , pretty
     )
-import Dhall.Freeze (Intent(..), Scope(..))
-import Dhall.Import (Imported(..), Depends(..), SemanticCacheMode(..), _semanticCacheMode)
-import Dhall.Parser (Src)
-import Dhall.Pretty (Ann, CharacterSet(..), annToAnsiStyle)
-import Dhall.TypeCheck (Censored(..), DetailedTypeError(..), TypeError)
-import Dhall.Util (Censor(..), Header (..), Input(..), Output(..))
-import Dhall.Version (dhallVersionString)
-import Options.Applicative (Parser, ParserInfo)
-import System.Exit (ExitCode, exitFailure)
-import System.IO (Handle)
-import Text.Dot ((.->.))
+import Dhall.Util
+    ( Censor(..)
+    , Header (..)
+    , Input(..)
+    , InputMode(..)
+    , NotModified(..)
+    , Output(..)
+    )
 
 import qualified Codec.CBOR.JSON
 import qualified Codec.CBOR.Read
@@ -73,6 +82,7 @@ import qualified Dhall.Freeze
 import qualified Dhall.Import
 import qualified Dhall.Import.Types
 import qualified Dhall.Lint
+import qualified Dhall.Parser                              as Parser
 import qualified Dhall.Map
 import qualified Dhall.Tags
 import qualified Dhall.Pretty
@@ -127,11 +137,11 @@ data Mode
           }
     | Normalize { file :: Input , alpha :: Bool }
     | Repl
-    | Format { formatMode :: Dhall.Format.FormatMode }
-    | Freeze { inplace :: Input, all_ :: Bool, cache :: Bool }
+    | Format { input :: Input, inputMode :: InputMode }
+    | Freeze { input :: Input, all_ :: Bool, cache :: Bool, inputMode :: InputMode }
     | Hash { file :: Input }
     | Diff { expr1 :: Text, expr2 :: Text }
-    | Lint { inplace :: Input }
+    | Lint { input :: Input, inputMode :: InputMode }
     | Tags
           { input :: Input
           , output :: Output
@@ -224,7 +234,7 @@ parseMode =
     <|> subcommand
             "lint"
             "Improve Dhall code by using newer language features and removing dead code"
-            (Lint <$> parseInplace)
+            (Lint <$> parseInplace <*> parseCheck)
     <|> subcommand
             "tags"
             "Generate etags file"
@@ -232,11 +242,11 @@ parseMode =
     <|> subcommand
             "format"
             "Standard code formatter for the Dhall language"
-            (Format <$> parseFormatMode)
+            (Format <$> parseInplace <*> parseCheck)
     <|> subcommand
             "freeze"
             "Add integrity checks to remote import statements of an expression"
-            (Freeze <$> parseInplace <*> parseAllFlag <*> parseCacheFlag)
+            (Freeze <$> parseInplace <*> parseAllFlag <*> parseCacheFlag <*> parseCheck)
     <|> subcommand
             "encode"
             "Encode a Dhall expression to binary"
@@ -415,11 +425,16 @@ parseMode =
         <>  Options.Applicative.help "Add fallback unprotected imports when using integrity checks purely for caching purposes"
         )
 
-    parseCheck =
-        Options.Applicative.switch
-        (   Options.Applicative.long "check"
-        <>  Options.Applicative.help "Only check if the input is formatted"
-        )
+    parseCheck = fmap adapt switch
+      where
+        adapt True  = Check
+        adapt False = Modify
+
+        switch =
+            Options.Applicative.switch
+            (   Options.Applicative.long "check"
+            <>  Options.Applicative.help "Only check if the input is formatted"
+            )
 
     parseDirectoryTreeOutput =
         Options.Applicative.strOption
@@ -427,11 +442,6 @@ parseMode =
             <>  Options.Applicative.help "The destination path to create"
             <>  Options.Applicative.metavar "PATH"
             )
-
-    parseFormatMode = adapt <$> parseCheck <*> parseInplace
-      where
-        adapt True  path    = Dhall.Format.Check {..}
-        adapt False inplace = Dhall.Format.Modify {..}
 
 -- | `ParserInfo` for the `Options` type
 parserInfoOptions :: ParserInfo Options
@@ -686,7 +696,7 @@ command (Options {..}) = do
 
             let intent = if cache then Cache else Secure
 
-            Dhall.Freeze.freeze inplace scope intent characterSet censor
+            Dhall.Freeze.freeze inputMode input scope intent characterSet censor
 
         Hash {..} -> do
             expression <- getExpression file
@@ -702,17 +712,48 @@ command (Options {..}) = do
             Data.Text.IO.putStrLn (Dhall.Import.hashExpressionToCode normalizedExpression)
 
         Lint {..} -> do
-            (Header header, expression) <- getExpressionAndHeader inplace
+            case inputMode of
+                Modify -> do
+                    (Header header, expression) <- do
+                        getExpressionAndHeader input
 
-            let lintedExpression = Dhall.Lint.lint expression
+                    let lintedExpression = Dhall.Lint.lint expression
 
-            let doc =   Pretty.pretty header
-                    <>  Dhall.Pretty.prettyCharacterSet characterSet lintedExpression
+                    let doc =   Pretty.pretty header
+                            <>  Dhall.Pretty.prettyCharacterSet characterSet lintedExpression
 
-            case inplace of
-                InputFile file -> writeDocToFile file doc
+                    case input of
+                        InputFile file -> writeDocToFile file doc
 
-                StandardInput -> renderDoc System.IO.stdout doc
+                        StandardInput -> renderDoc System.IO.stdout doc
+
+                Check -> do
+                    originalText <- case input of
+                        InputFile file -> Data.Text.IO.readFile file
+                        StandardInput  -> Data.Text.IO.getContents
+
+                    let name = case input of
+                            InputFile file -> file
+                            StandardInput  -> "(stdin)"
+
+                    (Header header, expression) <- do
+                        Dhall.Core.throws (first Parser.censor (Parser.exprAndHeaderFromText name originalText))
+
+                    let lintedExpression = Dhall.Lint.lint expression
+
+                    let doc =   Pretty.pretty header
+                            <>  Dhall.Pretty.prettyCharacterSet characterSet lintedExpression
+
+                    let stream = Pretty.unAnnotateS (Dhall.Pretty.layout doc)
+
+                    let modifiedText = Pretty.renderStrict stream <> "\n"
+
+                    if originalText == modifiedText
+                        then return ()
+                        else do
+                            let modified = "linted"
+
+                            Control.Exception.throwIO NotModified{ command = "lint", ..}
 
         Encode {..} -> do
             expression <- getExpression file
@@ -813,4 +854,5 @@ command (Options {..}) = do
 main :: IO ()
 main = do
     options <- Options.Applicative.execParser parserInfoOptions
-    command options
+
+    Dhall.Main.command options

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -162,9 +162,9 @@ instance Show CheckFailed where
     show CheckFailed{..} =
          _ERROR <> ": ❰dhall " <> command_ <> " --check❱ failed\n\
         \\n\
-        \You ran ❰dhall " <> command_ <> " --check❱ command, but the input appears to\n\
-        \have not been " <> modified_ <> " before, or was changed since the last time the\n\
-        \input was " <> modified_ <> ".\n"
+        \You ran ❰dhall " <> command_ <> " --check❱, but the input appears to have not\n\
+        \been " <> modified_ <> " before, or was changed since the last time the input\n\
+        \was " <> modified_ <> ".\n"
       where
         modified_ = Data.Text.unpack modified
 

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -17,7 +17,7 @@ module Dhall.Util
     , getExpressionAndHeader
     , getExpressionAndHeaderFromStdinText
     , Header(..)
-    , NotModified(..)
+    , CheckFailed(..)
     ) where
 
 import Control.Exception (Exception(..))
@@ -155,12 +155,12 @@ data Output = StandardOutput | OutputFile FilePath
 data OutputMode = Write | Check
 
 -- | Exception thrown when the @--check@ flag to a command-line subcommand fails
-data NotModified = NotModified { command :: Text, modified :: Text }
+data CheckFailed = CheckFailed { command :: Text, modified :: Text }
     deriving (Exception)
 
-instance Show NotModified where
-    show NotModified{..} =
-         _ERROR <> ": Expression is not fully " <> modified_ <> "\n\
+instance Show CheckFailed where
+    show CheckFailed{..} =
+         _ERROR <> ": ❰dhall " <> command_ <> " --check❱ failed\n\
         \\n\
         \You ran ❰dhall " <> command_ <> " --check❱ command, but the input appears to\n\
         \have not been " <> modified_ <> " before, or was changed since the last time the\n\

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -11,7 +11,7 @@ module Dhall.Util
     , _ERROR
     , Censor(..)
     , Input(..)
-    , InputMode(..)
+    , OutputMode(..)
     , Output(..)
     , getExpression
     , getExpressionAndHeader
@@ -148,11 +148,11 @@ data InputOrTextFromStdin = Input_ Input | StdinText Text
 -- | Path to output
 data Output = StandardOutput | OutputFile FilePath
 
-{-| Some command-line subcommands can either `Modify` their input or `Check`
+{-| Some command-line subcommands can either `Write` their input or `Check`
     that the input has already been modified.  This type is shared between them
     to record that choice.
 -}
-data InputMode = Modify | Check
+data OutputMode = Write | Check
 
 -- | Exception thrown when the @--check@ flag to a command-line subcommand fails
 data NotModified = NotModified { command :: Text, modified :: Text }

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -163,7 +163,7 @@ instance Show NotModified where
          _ERROR <> ": Expression is not fully " <> modified_ <> "\n\
         \\n\
         \You ran ❰dhall " <> command_ <> " --check❱ command, but the input appears to\n\
-        \have not been " <> modified_ <> " before, or was chaned since the last time the\n\
+        \have not been " <> modified_ <> " before, or was changed since the last time the\n\
         \input was " <> modified_ <> ".\n"
       where
         modified_ = Data.Text.unpack modified


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1629

The main changes here are:

*  Transposing `FormatMode` from (conceptually) `Either FilePath FilePath` to `(Bool, FilePath)`
* Generalizing `FormatMode` and `NotFormatted` to be usable for linting and freezing, too
* Improving the error message if `--check` fails (which was previously blank)