### PR TITLE
Fix parsing of `Double` literal trailing whitespace

### DIFF
--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -134,8 +134,6 @@ import qualified Text.Parser.Combinators
 import Numeric.Natural (Natural)
 import Prelude hiding (const, pi)
 
-import qualified Text.Parser.Token
-
 -- | Returns `True` if the given `Int` is a valid Unicode codepoint
 validCodepoint :: Int -> Bool
 validCodepoint c =
@@ -191,7 +189,7 @@ signPrefix = (do
 doubleLiteral :: Parser Double
 doubleLiteral = (do
     sign <- signPrefix <|> pure id
-    a <- Text.Parser.Token.double
+    a <- Text.Megaparsec.Char.Lexer.float
     return (sign a) ) <?> "literal"
 
 {-| Parse a signed @Infinity@

--- a/dhall/tests/Dhall/Test/Regression.hs
+++ b/dhall/tests/Dhall/Test/Regression.hs
@@ -43,6 +43,7 @@ tests =
         , issue1131b
         , issue1341
         , issue1584
+        , issue1646
         , parsing0
         , typeChecking0
         , typeChecking1
@@ -186,6 +187,13 @@ issue1584 = Test.Tasty.HUnit.testCase "Issue #1584" (do
     -- This test ensures that we can parse variables with keyword prefixes
     -- (e.g. `ifX`)
     _ <- Util.code "./tests/regression/issue1584.dhall"
+    return () )
+
+issue1646 :: TestTree
+issue1646 = Test.Tasty.HUnit.testCase "Issue #1646" (do
+    -- This test ensures that the parser doesn't eagerly consume trailing
+    -- whitespace after a `Double`
+    _ <- Util.code "./tests/regression/issue1646.dhall"
     return () )
 
 parsing0 :: TestTree

--- a/dhall/tests/regression/issue1646.dhall
+++ b/dhall/tests/regression/issue1646.dhall
@@ -1,0 +1,1 @@
+let f = \(d : Double) -> \(i : Integer) -> {=} in f 3.1 -1


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1646