### PR TITLE
Small formatting fixes

### DIFF
--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -1074,7 +1074,20 @@ prettyCharacterSet characterSet expression =
             <>  separator
             <>  case shallowDenote val of
                     Some val' ->
-                            " Some"
+                            " " <> builtin "Some"
+                        <>  case shallowDenote val' of
+                                RecordCompletion _T r ->
+                                    completion _T r
+                                ListLit _ xs
+                                    | not (null xs) ->
+                                            Pretty.hardline
+                                        <>  "  "
+                                        <>  prettyExpression val'
+                                _ ->    Pretty.hardline
+                                    <>  "    "
+                                    <>  prettyImportExpression val'
+                    ToMap val' Nothing ->
+                            " " <> keyword "toMap"
                         <>  case shallowDenote val' of
                                 RecordCompletion _T r ->
                                     completion _T r

--- a/dhall/tests/format/applicationMultilineA.dhall
+++ b/dhall/tests/format/applicationMultilineA.dhall
@@ -15,6 +15,9 @@
 , some =
     Some
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+, someList =
+    Some
+      [ aaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccc, dddddddddddddd ]
 , merge =
     merge
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/dhall/tests/format/applicationMultilineB.dhall
+++ b/dhall/tests/format/applicationMultilineB.dhall
@@ -14,6 +14,12 @@
       dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 , some = Some
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+, someList = Some
+  [ aaaaaaaaaaaaaaaaaaaaaaaaaa
+  , bbbbbbbbbbbbbbbbbbbb
+  , cccccccccccccccccccccccc
+  , dddddddddddddd
+  ]
 , merge =
     merge
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -23,7 +29,6 @@
       a
       b
       ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-, toMap =
-    toMap
-      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+, toMap = toMap
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 }


### PR DESCRIPTION
* Lists wrapped in a `Some` will now be dedented the same as if they had not
  been wrapped

* `toMap` is now formatted the same as `Some`

* `Some` inside a field is correctly highlighted