### PR TITLE
Improve parsing error message

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -407,8 +407,7 @@ parsers embedded = Parsers {..}
             alternative07 = do
                 try (_merge *> nonemptyWhitespace)
                 a <- importExpression_
-                nonemptyWhitespace
-                b <- importExpression_ <?> "second argument to ❰merge❱"
+                b <- (nonemptyWhitespace *> importExpression_) <?> "second argument to ❰merge❱"
                 return (Merge a b Nothing)
 
             alternative08 = do


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1655

This suggests the better error message for `merge`'s second argument even when
the trailing whitespace is not yet present