### PR TITLE
Support template haskell for multiple datatypes

### DIFF
--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -7,6 +7,7 @@
 module Dhall.Test.TH where
 
 import Dhall (FromDhall(..))
+import Dhall.TH (HaskellType(..))
 import GHC.Generics
 import Test.Tasty (TestTree)
 
@@ -21,6 +22,21 @@ deriving instance Eq        T
 deriving instance Show      T
 deriving instance Generic   T
 deriving instance FromDhall T
+
+Dhall.TH.makeHaskellTypes
+    [ MultipleConstructors "Department" "./tests/th/Department.dhall"
+    , SingleConstructor "Employee" "MakeEmployee" "./tests/th/Employee.dhall"
+    ]
+
+deriving instance Eq        Department
+deriving instance Show      Department
+deriving instance Generic   Department
+deriving instance FromDhall Department
+
+deriving instance Eq        Employee
+deriving instance Show      Employee
+deriving instance Generic   Employee
+deriving instance FromDhall Employee
 
 tests :: TestTree
 tests = Tasty.testGroup "Template Haskell" [ makeHaskellTypeFromUnion ]
@@ -38,3 +54,7 @@ makeHaskellTypeFromUnion = Tasty.HUnit.testCase "makeHaskellTypeFromUnion" $ do
     t2 <- Dhall.input Dhall.auto "let T = ./tests/th/example.dhall in T.C"
 
     Tasty.HUnit.assertEqual "" t2 C
+
+    employee <- Dhall.input Dhall.auto "let Department = ./tests/th/Department.dhall in { name = \"John\", department = Department.Marketing }"
+
+    Tasty.HUnit.assertEqual "" employee MakeEmployee{ name = "John", department = Marketing }

--- a/dhall/tests/th/Department.dhall
+++ b/dhall/tests/th/Department.dhall
@@ -1,0 +1,1 @@
+< Sales | Engineering | Marketing >

--- a/dhall/tests/th/Employee.dhall
+++ b/dhall/tests/th/Employee.dhall
@@ -1,0 +1,1 @@
+{ name : Text, department : ./Department.dhall }


### PR DESCRIPTION
Inspired by this discussion: https://discourse.dhall-lang.org/t/makehaskelltypefromunion-and-fields-with-sum-types/150

This adds a new `makeHaskellTypes` utility which can generate multiple
types which can refer to each other.  The trick is that the type
compares nested Dhall types against top-level ones and replaces them
with Haskell datatype references when the types are judgmentally
equivalent.