### PR TITLE
Fix numeric parsing for GHCJS

### DIFF
--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -123,13 +123,16 @@ import qualified Control.Monad
 import qualified Data.Char                  as Char
 import qualified Data.Foldable
 import qualified Data.HashSet
+import qualified Data.List                  as List
 import qualified Data.List.NonEmpty
+import qualified Data.Scientific            as Scientific
 import qualified Data.Text
 import qualified Dhall.Set
 import qualified Network.URI.Encode         as URI.Encode
 import qualified Text.Megaparsec
 import qualified Text.Megaparsec.Char.Lexer
 import qualified Text.Parser.Char
+import qualified Text.Parser.Token
 import qualified Text.Parser.Combinators
 
 import Numeric.Natural (Natural)
@@ -190,8 +193,43 @@ signPrefix = (do
 doubleLiteral :: Parser Double
 doubleLiteral = (do
     sign <- signPrefix <|> pure id
-    a <- Text.Megaparsec.Char.Lexer.float
-    return (sign a) ) <?> "literal"
+
+    x <- Text.Parser.Token.decimal
+
+    let alternative0 = do
+            y <- fraction
+
+            e <- exponent' <|> pure 1
+
+            return ((fromInteger x + y) * e)
+
+    let alternative1 = do
+            expo <- exponent'
+
+            return (fromInteger x * expo)
+
+    n <- alternative0 <|> alternative1
+
+    return (sign (Scientific.toRealFloat n)) ) <?> "literal"
+  where
+    fraction = do
+        _ <- Text.Parser.Char.char '.'
+
+        digits <- some Text.Parser.Char.digit
+
+        let snoc y d =
+              y + Scientific.scientific (fromIntegral (Char.digitToInt d)) (Scientific.base10Exponent y - 1)
+
+        return (List.foldl' snoc 0 digits)
+
+    exponent' = do
+        _ <- Text.Parser.Char.oneOf "eE"
+
+        sign <- signPrefix <|> pure id
+
+        x <- Text.Parser.Token.decimal
+
+        return (Scientific.scientific 1 (fromInteger (sign x)))
 
 {-| Parse a signed @Infinity@
 

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -192,6 +192,21 @@ signPrefix = (do
 -}
 doubleLiteral :: Parser Double
 doubleLiteral = (do
+    -- We don't use `Text.Parser.Token.double` since that consumes trailing
+    -- whitespace and there is no whitespace-free alternative.  See:
+    --
+    -- * https://github.com/dhall-lang/dhall-haskell/pull/1646
+    -- * https://github.com/dhall-lang/dhall-haskell/pull/1647
+    --
+    -- We also don't use `Text.Megaparsec.Char.Lexer.float` because that
+    -- transitively depends on `Data.Char.toTitle` which is broken on older
+    -- versions of GHCJS that we still support.  See:
+    --
+    -- * https://github.com/dhall-lang/dhall-haskell/pull/1681
+    -- * https://github.com/ghcjs/ghcjs-base/issues/62
+    --
+    -- Also, hand-writing the parser code for `Double` literals helps to better
+    -- ensure that we follow the standard exactly as written.
     sign <- signPrefix <|> pure id
 
     x <- Text.Parser.Token.decimal

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -195,15 +195,15 @@ doubleLiteral = (do
     -- We don't use `Text.Parser.Token.double` since that consumes trailing
     -- whitespace and there is no whitespace-free alternative.  See:
     --
-    -- * https://github.com/dhall-lang/dhall-haskell/pull/1646
-    -- * https://github.com/dhall-lang/dhall-haskell/pull/1647
+    -- https://github.com/dhall-lang/dhall-haskell/pull/1646
+    -- https://github.com/dhall-lang/dhall-haskell/pull/1647
     --
     -- We also don't use `Text.Megaparsec.Char.Lexer.float` because that
     -- transitively depends on `Data.Char.toTitle` which is broken on older
     -- versions of GHCJS that we still support.  See:
     --
-    -- * https://github.com/dhall-lang/dhall-haskell/pull/1681
-    -- * https://github.com/ghcjs/ghcjs-base/issues/62
+    -- https://github.com/dhall-lang/dhall-haskell/pull/1681
+    -- https://github.com/ghcjs/ghcjs-base/issues/62
     --
     -- Also, hand-writing the parser code for `Double` literals helps to better
     -- ensure that we follow the standard exactly as written.


### PR DESCRIPTION
The fix from #1647 broke GHCJS support for Dhall.  Specifically, any Dhall
code containing numeric literals would fail to parse when using GHCJS.

The consequence of this is that the final example from the online demo
currently does not work because it uses at least one number.

The root cause was this issue:

https://github.com/ghcjs/ghcjs-base/issues/62

The change to use `Text.Megaparsec.Char.Lexer.float` triggered the above
problem, because `float` depended transitively on `Data.Char.toTitle` which
was not working for the version of GHCJS that we currently build against.

The fix is to reimplement the logic for parsing double literals by
following the standard grammar instead of reusing an existing utility.
However, I cribbed quite a bit from the existing logic for
`Text.Parser.Char.double` along the way.