### PR TITLE
Auto-derive `Generic`/`FromDhall`/`ToDhall` with Template Haskell

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -628,6 +628,7 @@ Test-Suite tasty
         tasty-expected-failure                   < 0.12,
         tasty-hunit               >= 0.10     && < 0.11,
         tasty-quickcheck          >= 0.9.2    && < 0.11,
+        template-haskell                               ,
         text                      >= 0.11.1.0 && < 1.3 ,
         transformers                                   ,
         turtle                                   < 1.6 ,

--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -1,14 +1,13 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell    #-}
 
 module Dhall.Test.TH where
 
-import Dhall (FromDhall(..))
 import Dhall.TH (HaskellType(..))
-import GHC.Generics
 import Test.Tasty (TestTree)
 
 import qualified Dhall
@@ -18,25 +17,19 @@ import qualified Test.Tasty.HUnit as Tasty.HUnit
 
 Dhall.TH.makeHaskellTypeFromUnion "T" "./tests/th/example.dhall"
 
-deriving instance Eq        T
-deriving instance Show      T
-deriving instance Generic   T
-deriving instance FromDhall T
+deriving instance Eq   T
+deriving instance Show T
 
 Dhall.TH.makeHaskellTypes
     [ MultipleConstructors "Department" "./tests/th/Department.dhall"
     , SingleConstructor "Employee" "MakeEmployee" "./tests/th/Employee.dhall"
     ]
 
-deriving instance Eq        Department
-deriving instance Show      Department
-deriving instance Generic   Department
-deriving instance FromDhall Department
+deriving instance Eq   Department
+deriving instance Show Department
 
-deriving instance Eq        Employee
-deriving instance Show      Employee
-deriving instance Generic   Employee
-deriving instance FromDhall Employee
+deriving instance Eq   Employee
+deriving instance Show Employee
 
 tests :: TestTree
 tests = Tasty.testGroup "Template Haskell" [ makeHaskellTypeFromUnion ]

--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell    #-}
+
+#if MIN_VERSION_template_haskell(2,12,0)
+{-# LANGUAGE DerivingStrategies #-}
+#endif
 
 module Dhall.Test.TH where
 


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1679