### PR TITLE
dhall-lsp-server: Allow haskell-lsp-0.20, lens-4.19, lens-family-core-2.1

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -53,11 +53,11 @@ library
     , dhall                >= 1.29.0   && < 1.31
     , dhall-json           >= 1.4      && < 1.7
     , filepath             >= 1.4.2    && < 1.5
-    , haskell-lsp          >= 0.19.0.0 && < 0.20
+    , haskell-lsp          >= 0.19.0.0 && < 0.21
     , rope-utf16-splay     >= 0.3.1.0  && < 0.4
     , hslogger             >= 1.2.10   && < 1.4
-    , lens                 >= 4.16.1   && < 4.19
-    , lens-family-core     >= 1.2.2    && < 2.1
+    , lens                 >= 4.16.1   && < 4.20
+    , lens-family-core     >= 1.2.2    && < 2.2
     , megaparsec           >= 7.0.2    && < 8.1
     , mtl                  >= 2.2.2    && < 2.3
     , network-uri          >= 2.6.1.0  && < 2.7
@@ -115,7 +115,7 @@ Test-Suite tests
     GHC-Options: -Wall
     Build-Depends:
         base                                   ,
-        haskell-lsp-types >= 0.19.0  && < 0.20 ,
+        haskell-lsp-types >= 0.19.0  && < 0.21 ,
         lsp-test          >= 0.9     && < 0.11  ,
         tasty             >= 0.11.2  && < 1.3  ,
         tasty-hspec       >= 1.1     && < 1.2  ,


### PR DESCRIPTION
I've compiled `dhall-lsp-server` locally with the new versions.