### PR TITLE
Bump aeson-yaml to 1.0.6.0; add 'hello world' yaml content

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -37,7 +37,7 @@ Library
         base                      >= 4.8.0.0  && < 5   ,
         aeson                     >= 1.0.0.0  && < 1.5 ,
         aeson-pretty                             < 0.9 ,
-        aeson-yaml                >= 1.0.5    && < 1.1 ,
+        aeson-yaml                >= 1.0.6    && < 1.1 ,
         bytestring                               < 0.11,
         containers                                     ,
         dhall                     >= 1.28.0   && < 1.31,

--- a/dhall-yaml/src/Dhall/Yaml.hs
+++ b/dhall-yaml/src/Dhall/Yaml.hs
@@ -17,6 +17,7 @@ import Data.ByteString.Lazy (toStrict)
 
 import qualified Data.Aeson
 import qualified Data.ByteString
+import qualified Data.Char as Char
 import qualified Data.Text as Text
 import qualified Data.Vector
 import qualified Data.YAML as Y
@@ -60,8 +61,17 @@ jsonToYaml json documents quoted =
     style (Y.SStr s)
         | "\n" `Text.isInfixOf` s =
             Right (YE.untagged, YE.Literal YE.Clip YE.IndentAuto, s)
-        | quoted =
+        | quoted || Text.all isNumberOrDateRelated s || isBoolString =
             Right (YE.untagged, YE.SingleQuoted, s)
+      where
+        isBoolString
+          | Text.length s > 5 = False
+          | otherwise =
+            case Text.toLower s of
+              "true" -> True
+              "false" -> True
+              _ -> False
+        isNumberOrDateRelated c = Char.isDigit c || c == '.' || c == 'e' || c == '-'
     style s =
         YS.schemaEncoderScalar Y.coreSchemaEncoder s
 

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -26,8 +26,7 @@ main = do
 testTree :: TestTree
 testTree =
     Test.Tasty.testGroup "dhall-yaml"
-        [ Test.Tasty.ExpectedFailure.ignoreTestBecause "#1516" $
-          testDhallToYaml
+        [ testDhallToYaml
             Dhall.JSON.Yaml.defaultOptions
             "./tasty/data/normal"
         , testDhallToYaml

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -14,7 +14,6 @@ import qualified Dhall.JSON.Yaml
 import qualified Dhall.Yaml
 import qualified GHC.IO.Encoding
 import qualified Test.Tasty
-import qualified Test.Tasty.ExpectedFailure
 import qualified Test.Tasty.HUnit
 
 main :: IO ()

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -26,7 +26,8 @@ main = do
 testTree :: TestTree
 testTree =
     Test.Tasty.testGroup "dhall-yaml"
-        [ testDhallToYaml
+        [ Test.Tasty.ExpectedFailure.ignoreTestBecause "#1516" $
+          testDhallToYaml
             Dhall.JSON.Yaml.defaultOptions
             "./tasty/data/normal"
         , testDhallToYaml
@@ -38,8 +39,7 @@ testTree =
         , testDhallToYaml
             Dhall.JSON.Yaml.defaultOptions
             "./tasty/data/emptyMap"
-        , Test.Tasty.ExpectedFailure.ignoreTestBecause "#1516" $
-          testDhallToYaml
+        , testDhallToYaml
             (Dhall.JSON.Yaml.defaultOptions { quoted = True })
             "./tasty/data/quoted"
         ]

--- a/dhall-yaml/tasty/data/normal.dhall
+++ b/dhall-yaml/tasty/data/normal.dhall
@@ -2,6 +2,7 @@
 , text = ./yaml.txt as Text
 , int_value = 1
 , bool_value = True
+, bool_string = "true"
 , yes = "y"
 , hello_world = "hello world"
 }

--- a/dhall-yaml/tasty/data/normal.dhall
+++ b/dhall-yaml/tasty/data/normal.dhall
@@ -3,4 +3,5 @@
 , int_value = 1
 , bool_value = True
 , yes = "y"
+, hello_world = "hello world"
 }

--- a/dhall-yaml/tasty/data/normal.yaml
+++ b/dhall-yaml/tasty/data/normal.yaml
@@ -1,7 +1,7 @@
 bool_value: true
 hello_world: hello world
 int_value: 1
-string_value: "2000-01-01"
+string_value: '2000-01-01'
 text: |
   Plain text
 yes: y

--- a/dhall-yaml/tasty/data/normal.yaml
+++ b/dhall-yaml/tasty/data/normal.yaml
@@ -1,4 +1,5 @@
 bool_value: true
+hello_world: hello world
 int_value: 1
 string_value: "2000-01-01"
 text: |

--- a/dhall-yaml/tasty/data/normal.yaml
+++ b/dhall-yaml/tasty/data/normal.yaml
@@ -1,3 +1,4 @@
+bool_string: 'true'
 bool_value: true
 hello_world: hello world
 int_value: 1

--- a/dhall-yaml/tasty/data/quoted.dhall
+++ b/dhall-yaml/tasty/data/quoted.dhall
@@ -2,6 +2,7 @@
 , text = ./yaml.txt as Text
 , int_value = 1
 , bool_value = True
+, bool_string = "true"
 , yes = "y"
 , hello_world = "hello world"
 }

--- a/dhall-yaml/tasty/data/quoted.dhall
+++ b/dhall-yaml/tasty/data/quoted.dhall
@@ -3,4 +3,5 @@
 , int_value = 1
 , bool_value = True
 , yes = "y"
+, hello_world = "hello world"
 }

--- a/dhall-yaml/tasty/data/quoted.yaml
+++ b/dhall-yaml/tasty/data/quoted.yaml
@@ -1,3 +1,4 @@
+'bool_string': 'true'
 'bool_value': true
 'hello_world': 'hello world'
 'int_value': 1

--- a/dhall-yaml/tasty/data/quoted.yaml
+++ b/dhall-yaml/tasty/data/quoted.yaml
@@ -1,4 +1,5 @@
 'bool_value': true
+'hello_world': 'hello world'
 'int_value': 1
 'string_value': '2000-01-01'
 'text': |

--- a/nix/aeson-yaml.nix
+++ b/nix/aeson-yaml.nix
@@ -4,8 +4,8 @@
 }:
 mkDerivation {
   pname = "aeson-yaml";
-  version = "1.0.5.0";
-  sha256 = "e3c49b52b7000dcfe0a227af2e3a70aa7fd97f5c577156ad659470b17127a533";
+  version = "1.0.6.0";
+  sha256 = "feac4e3706601ec65e4bc8a71c0e95c36383426f7b286b09d3f673429f24359b";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,7 +22,7 @@ extra-deps:
   - HsYAML-aeson-0.2.0.0@sha256:04796abfc01cffded83f37a10e6edba4f0c0a15d45bef44fc5bb4313d9c87757,1791
   - ordered-containers-0.2.2@sha256:ebf2be3f592d9cf148ea6b8375f8af97148d44f82d8d04476899285e965afdbf,810
   - lsp-test-0.10.0.0
-  - aeson-yaml-1.0.5.0@sha256:5786f021c1e088d6a5aa259120ec5b1f22bb1757f4427c1a87e0513d00f17f31,1975
+  - aeson-yaml-1.0.6.0@sha256:bdf6d67265d9a3e251122fa53d2f0f19e0b9865d928e5d6efb77d4754ca3f6cb,1975
   - prettyprinter-1.6.0
   - atomic-write-0.2.0.7@sha256:3b626dfbc288cd070f1ac31b1c15ddd49822a923778ffe21f92b2116ffc72dc3,4584
   - megaparsec-8.0.0


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1516: '2020-02-27' is now single-quoted by both aeson-yaml and HsYAML.

Fixes https://github.com/dhall-lang/dhall-haskell/issues/1617: "hello world" is no longer quoted.

HsYAML was single-quoting when `quoted` was True and double-quoting otherwise. Changed its behavior so it will single-quote strings containing dates and bools in both cases.