### PR TITLE
Group commands in CLI

### DIFF
--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -198,12 +198,11 @@ parseOptions =
         f True  = Censor
         f False = NoCensor
 
-subcommand' :: Bool -> Group -> String -> String -> Parser a -> Parser a
-subcommand' internal group name description parser =
+subcommand :: Group -> String -> String -> Parser a -> Parser a
+subcommand group name description parser =
     Options.Applicative.hsubparser
         (   Options.Applicative.command name parserInfo
         <>  Options.Applicative.metavar name
-        <>  if internal then Options.Applicative.internal else mempty
         <>  Options.Applicative.commandGroup (groupDescription group)
         )
   where
@@ -212,12 +211,6 @@ subcommand' internal group name description parser =
             (   Options.Applicative.fullDesc
             <>  Options.Applicative.progDesc description
             )
-
-subcommand :: Group -> String -> String -> Parser a -> Parser a
-subcommand = subcommand' False
-
-internalSubcommand :: Group -> String -> String -> Parser a -> Parser a
-internalSubcommand = subcommand' True
 
 parseMode :: Parser Mode
 parseMode =
@@ -296,7 +289,7 @@ parseMode =
             "version"
             "Display version"
             (pure Version)
-    <|> internalSubcommand
+    <|> subcommand
             Debugging
             "haskell-syntax-tree"
             "Output the parsed syntax tree (for debugging)"

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -222,10 +222,30 @@ internalSubcommand = subcommand' True
 parseMode :: Parser Mode
 parseMode =
         subcommand
-            Miscellaneous
-            "version"
-            "Display version"
-            (pure Version)
+            Manipulate
+            "format"
+            "Standard code formatter for the Dhall language"
+            (Format <$> parseInplace <*> parseCheck)
+    <|> subcommand
+            Manipulate
+            "freeze"
+            "Add integrity checks to remote import statements of an expression"
+            (Freeze <$> parseInplace <*> parseAllFlag <*> parseCacheFlag <*> parseCheck)
+    <|> subcommand
+            Manipulate
+            "lint"
+            "Improve Dhall code by using newer language features and removing dead code"
+            (Lint <$> parseInplace <*> parseCheck)
+    <|> subcommand
+            Generate
+            "text"
+            "Render a Dhall expression that evaluates to a Text literal"
+            (Text <$> parseFile)
+    <|> subcommand
+            Generate
+            "to-directory-tree"
+            "Convert nested records of Text literals into a directory tree"
+            (DirectoryTree <$> parseFile <*> parseDirectoryTreeOutput)
     <|> subcommand
             Interpret
             "resolve"
@@ -242,6 +262,16 @@ parseMode =
             "Normalize an expression"
             (Normalize <$> parseFile <*> parseAlpha)
     <|> subcommand
+            Convert
+            "encode"
+            "Encode a Dhall expression to binary"
+            (Encode <$> parseFile <*> parseJSONFlag)
+    <|> subcommand
+            Convert
+            "decode"
+            "Decode a Dhall expression from binary"
+            (Decode <$> parseFile <*> parseJSONFlag)
+    <|> subcommand
             Miscellaneous
             "repl"
             "Interpret expressions in a REPL"
@@ -257,45 +287,15 @@ parseMode =
             "Compute semantic hashes for Dhall expressions"
             (Hash <$> parseFile)
     <|> subcommand
-            Manipulate
-            "lint"
-            "Improve Dhall code by using newer language features and removing dead code"
-            (Lint <$> parseInplace <*> parseCheck)
-    <|> subcommand
             Miscellaneous
             "tags"
             "Generate etags file"
             (Tags <$> parseInput <*> parseTagsOutput <*> parseSuffixes <*> parseFollowSymlinks)
     <|> subcommand
-            Manipulate
-            "format"
-            "Standard code formatter for the Dhall language"
-            (Format <$> parseInplace <*> parseCheck)
-    <|> subcommand
-            Manipulate
-            "freeze"
-            "Add integrity checks to remote import statements of an expression"
-            (Freeze <$> parseInplace <*> parseAllFlag <*> parseCacheFlag <*> parseCheck)
-    <|> subcommand
-            Convert
-            "encode"
-            "Encode a Dhall expression to binary"
-            (Encode <$> parseFile <*> parseJSONFlag)
-    <|> subcommand
-            Convert
-            "decode"
-            "Decode a Dhall expression from binary"
-            (Decode <$> parseFile <*> parseJSONFlag)
-    <|> subcommand
-            Generate
-            "text"
-            "Render a Dhall expression that evaluates to a Text literal"
-            (Text <$> parseFile)
-    <|> subcommand
-            Generate
-            "to-directory-tree"
-            "Convert nested records of Text literals into a directory tree"
-            (DirectoryTree <$> parseFile <*> parseDirectoryTreeOutput)
+            Miscellaneous
+            "version"
+            "Display version"
+            (pure Version)
     <|> internalSubcommand
             Debugging
             "haskell-syntax-tree"

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -161,21 +161,21 @@ data ResolveMode
 
 -- | Groups of subcommands
 data Group
-  = Manipulate
-  | Generate
-  | Interpret
-  | Convert
-  | Miscellaneous
-  | Debugging
+    = Manipulate
+    | Generate
+    | Interpret
+    | Convert
+    | Miscellaneous
+    | Debugging
 
 groupDescription :: Group -> String
 groupDescription group = case group of
-  Manipulate -> "Manipulate Dhall code"
-  Generate -> "Generate other formats from Dhall"
-  Interpret -> "Interpret Dhall"
-  Convert -> "Convert Dhall to and from its binary representation"
-  Miscellaneous -> "Miscellaneous"
-  Debugging -> "Debugging this interpreter"
+    Manipulate -> "Manipulate Dhall code"
+    Generate -> "Generate other formats from Dhall"
+    Interpret -> "Interpret Dhall"
+    Convert -> "Convert Dhall to and from its binary representation"
+    Miscellaneous -> "Miscellaneous"
+    Debugging -> "Debugging this interpreter"
 
 -- | `Parser` for the `Options` type
 parseOptions :: Parser Options


### PR DESCRIPTION
As mentioned in #1686, grouping commands should make using the CLI a bit easier. This PR changes the output from:

<details>
<summary>Old output of <code>dhall --help</code></summary>

```console
$ dhall --help
Usage: dhall ([version] | [resolve] | [type] | [normalize] | [repl] | [diff] |
             [hash] | [lint] | [tags] | [format] | [freeze] | [encode] |
             [decode] | [text] | [to-directory-tree] | [--file FILE]
             [--output FILE] [--annotate] [--alpha] [--no-cache] [--version])
             [--explain] [--plain] [--ascii] [--censor]
  Interpreter for the Dhall language

Available options:
  -h,--help                Show this help text
  --file FILE              Read expression from a file instead of standard input
  --output FILE            Write result to a file instead of standard output
  --annotate               Add a type annotation to the output
  --alpha                  α-normalize expression
  --no-cache               Handle protected imports as if the cache was empty
  --version                Display version
  --explain                Explain error messages in more detail
  --plain                  Disable syntax highlighting
  --ascii                  Format code using only ASCII syntax
  --censor                 Hide source code in error messages

Available commands:
  version                  Display version
  resolve                  Resolve an expression's imports
  type                     Infer an expression's type
  normalize                Normalize an expression
  repl                     Interpret expressions in a REPL
  diff                     Render the difference between the normal form of two
                           expressions
  hash                     Compute semantic hashes for Dhall expressions
  lint                     Improve Dhall code by using newer language features
                           and removing dead code
  tags                     Generate etags file
  format                   Standard code formatter for the Dhall language
  freeze                   Add integrity checks to remote import statements of
                           an expression
  encode                   Encode a Dhall expression to binary
  decode                   Decode a Dhall expression from binary
  text                     Render a Dhall expression that evaluates to a Text
                           literal
  to-directory-tree        Convert nested records of Text literals into a
                           directory tree
```
</details>

to:

<details>
<summary>New output of <code>dhall --help</code></summary>

```console
$ dhall --help
Usage: dhall ([format] | [freeze] | [lint] | [text] | [to-directory-tree] |
             [resolve] | [type] | [normalize] | [encode] | [decode] | [repl] |
             [diff] | [hash] | [tags] | [version] | [haskell-syntax-tree] |
             [--file FILE] [--output FILE] [--annotate] [--alpha] [--no-cache]
             [--version]) [--explain] [--plain] [--ascii] [--censor]
  Interpreter for the Dhall language

Available options:
  -h,--help                Show this help text
  --file FILE              Read expression from a file instead of standard input
  --output FILE            Write result to a file instead of standard output
  --annotate               Add a type annotation to the output
  --alpha                  α-normalize expression
  --no-cache               Handle protected imports as if the cache was empty
  --version                Display version
  --explain                Explain error messages in more detail
  --plain                  Disable syntax highlighting
  --ascii                  Format code using only ASCII syntax
  --censor                 Hide source code in error messages

Manipulate Dhall code
  format                   Standard code formatter for the Dhall language
  freeze                   Add integrity checks to remote import statements of
                           an expression
  lint                     Improve Dhall code by using newer language features
                           and removing dead code

Generate other formats from Dhall
  text                     Render a Dhall expression that evaluates to a Text
                           literal
  to-directory-tree        Convert nested records of Text literals into a
                           directory tree

Interpret Dhall
  resolve                  Resolve an expression's imports
  type                     Infer an expression's type
  normalize                Normalize an expression

Convert Dhall to and from its binary representation
  encode                   Encode a Dhall expression to binary
  decode                   Decode a Dhall expression from binary

Miscellaneous
  repl                     Interpret expressions in a REPL
  diff                     Render the difference between the normal form of two
                           expressions
  hash                     Compute semantic hashes for Dhall expressions
  tags                     Generate etags file
  version                  Display version

Debugging this interpreter
  haskell-syntax-tree      Output the parsed syntax tree (for debugging)
```
</details>

cc @sjakobi 