### PR TITLE
Improve error message for incorrect let type annotation

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -298,7 +298,7 @@ infer typer = loop
                         else do
                             let _A₀'' = quote names _A₀'
                             let _A₁'' = quote names _A₁'
-                            die (AnnotMismatch a₀ _A₀'' _A₁'')
+                            Left (TypeError context a₀ (AnnotMismatch a₀ _A₀'' _A₁''))
 
                     return (addTypeValue x _A₀' a₀' ctx)
 
@@ -599,8 +599,6 @@ infer typer = loop
                                     -- here so that the source span is narrowed
                                     -- to just the offending element
                                     let err = MismatchedListElements (i+1) _T₀'' t₁ _T₁''
-
-                                    let context = ctxToContext ctx
 
                                     Left (TypeError context t₁ err)
 
@@ -1277,8 +1275,8 @@ infer typer = loop
             return (eval values (typer p))
       where
         die err = Left (TypeError context expression err)
-          where
-            context = ctxToContext ctx
+
+        context = ctxToContext ctx
 
         names = typesToNames types
 


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1694

This returns the right-hand-side of the binding as the
expression for the error message, which improves the source span