### PR TITLE
Fix MustCombineARecord error message for `//`

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -902,13 +902,21 @@ infer typer = loop
 
             xLs' <- case _L' of
                 VRecord xLs' -> return xLs'
-                _            -> die (MustCombineARecord '⫽' l r)
+
+                _            -> do
+                    let _L'' = quote names _L'
+
+                    die (MustCombineARecord '⫽' l _L'')
 
             _R' <- loop ctx r
 
             xRs' <- case _R' of
                 VRecord xRs' -> return xRs'
-                _            -> die (MustCombineARecord '⫽' l r)
+
+                _            -> do
+                    let _R'' = quote names _R'
+
+                    die (MustCombineARecord '⫽' r _R'')
 
             return (VRecord (Dhall.Map.union xRs' xLs'))
 


### PR DESCRIPTION
For `{=} // 1`, we would previously report:

    You tried to combine the following value:

    ↳ {=}

    ... which is not a record, but is actually a:

    ↳ 1

Now we report:

    You tried to combine the following value:

    ↳ 1

    ... which is not a record, but is actually a:

    ↳ Natural

Fixes #1701.