### PR TITLE
Fix lower bound on `dhall-json`

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -40,7 +40,7 @@ Library
         aeson-yaml                >= 1.0.6    && < 1.1 ,
         bytestring                               < 0.11,
         containers                                     ,
-        dhall                     >= 1.28.0   && < 1.31,
+        dhall                     >= 1.30.0   && < 1.31,
         exceptions                >= 0.8.3    && < 0.11,
         filepath                                 < 1.5 ,
         optparse-applicative      >= 0.14.0.0 && < 0.16,


### PR DESCRIPTION
https://github.com/dhall-lang/dhall-haskell/pull/1643 added a breaking
change to the shape of the `Combine` constructor which entailed a matching
change to `dhall-json`.  However, `dhall-json` didn't have its lower
bound updated to reflect that fact, leading to build failures if it
selects an older version of `dhall`.  This change fixes that.