### PR TITLE
Allow template-haskell-2.16

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -477,7 +477,7 @@ Library
         repline                     >= 0.2.1.0  && < 0.4 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
-        template-haskell            >= 2.11.1.0 && < 2.16,
+        template-haskell            >= 2.11.1.0 && < 2.17,
         text                        >= 0.11.1.0 && < 1.3 ,
         text-manipulate             >= 0.2.0.1  && < 0.3 ,
         th-lift-instances           >= 0.1.13   && < 0.2 ,

--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE DeriveTraversable  #-}
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE TypeFamilies       #-}
@@ -80,7 +81,6 @@ import qualified Data.List
 import qualified Data.Map
 import qualified Data.Set
 import qualified GHC.Exts
-import qualified Language.Haskell.TH.Syntax as Syntax
 import qualified Prelude
 
 {-| A `Map` that remembers the original ordering of keys
@@ -91,18 +91,12 @@ import qualified Prelude
     and also to improve performance
 -}
 data Map k v = Map (Data.Map.Map k v) (Keys k)
-    deriving (Data, Generic, NFData)
-
-instance (Data k, Data v, Lift k, Lift v, Ord k) => Lift (Map k v) where
-    lift = Syntax.liftData
+    deriving (Data, Generic, Lift, NFData)
 
 data Keys a
     = Sorted
     | Original [a]
-    deriving (Data, Generic, NFData)
-
-instance (Data a, Lift a) => Lift (Keys a) where
-    lift = Syntax.liftData
+    deriving (Data, Generic, Lift, NFData)
 
 instance (Ord k, Eq v) => Eq (Map k v) where
   m1 == m2 =

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveLift         #-}
 {-# LANGUAGE DeriveTraversable  #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedLists    #-}
@@ -101,7 +102,6 @@ import qualified Data.Text
 import qualified Data.Text.Prettyprint.Doc  as Pretty
 import qualified Dhall.Crypto
 import qualified Dhall.Optics               as Optics
-import qualified Language.Haskell.TH.Syntax as Syntax
 import qualified Network.URI                as URI
 
 {-| Constants for a pure type system
@@ -124,10 +124,7 @@ import qualified Network.URI                as URI
     Dhall is not a dependently typed language
 -}
 data Const = Type | Kind | Sort
-    deriving (Show, Eq, Ord, Data, Bounded, Enum, Generic, NFData)
-
-instance Lift Const where
-    lift = Syntax.liftData
+    deriving (Show, Eq, Ord, Data, Bounded, Enum, Generic, Lift, NFData)
 
 instance Pretty Const where
     pretty = Pretty.unAnnotate . prettyConst
@@ -165,10 +162,7 @@ instance Pretty Const where
     appear as a numeric suffix.
 -}
 data Var = V Text !Int
-    deriving (Data, Generic, Eq, Ord, Show, NFData)
-
-instance Lift Var where
-    lift = Syntax.liftData
+    deriving (Data, Generic, Eq, Ord, Show, Lift, NFData)
 
 instance IsString Var where
     fromString str = V (fromString str) 0
@@ -196,7 +190,7 @@ data Binding s a = Binding
     , annotation  :: Maybe (Maybe s, Expr s a)
     , bindingSrc2 :: Maybe s
     , value       :: Expr s a
-    } deriving (Data, Eq, Foldable, Functor, Generic, NFData, Ord, Show, Traversable)
+    } deriving (Data, Eq, Foldable, Functor, Generic, Lift, NFData, Ord, Show, Traversable)
 
 instance Bifunctor Binding where
     first k (Binding src0 a src1 b src2 c) =
@@ -214,7 +208,7 @@ makeBinding name = Binding Nothing name Nothing Nothing Nothing
 -- | This wrapper around 'Prelude.Double' exists for its 'Eq' instance which is
 -- defined via the binary encoding of Dhall @Double@s.
 newtype DhallDouble = DhallDouble { getDhallDouble :: Double }
-    deriving (Show, Data, NFData, Generic)
+    deriving (Show, Data, Lift, NFData, Generic)
 
 -- | This instance satisfies all the customary 'Eq' laws except substitutivity.
 --
@@ -245,10 +239,7 @@ instance Ord DhallDouble where
 
 -- | The body of an interpolated @Text@ literal
 data Chunks s a = Chunks [(Text, Expr s a)] Text
-    deriving (Functor, Foldable, Generic, Traversable, Show, Eq, Ord, Data, NFData)
-
-instance (Lift s, Lift a, Data s, Data a) => Lift (Chunks s a) where
-    lift = Syntax.liftData
+    deriving (Functor, Foldable, Generic, Traversable, Show, Eq, Ord, Data, Lift, NFData)
 
 instance Data.Semigroup.Semigroup (Chunks s a) where
     Chunks xysL zL <> Chunks         []    zR =
@@ -273,7 +264,7 @@ data PreferAnnotation s a
     | PreferFromWith (Expr s a)
       -- ^ Stores the original @with@ expression
     | PreferFromCompletion
-    deriving (Data, Eq, Foldable, Functor, Generic, NFData, Ord, Show, Traversable)
+    deriving (Data, Eq, Foldable, Functor, Generic, Lift, NFData, Ord, Show, Traversable)
 
 instance Bifunctor PreferAnnotation where
     first _  PreferFromSource      = PreferFromSource
@@ -480,7 +471,7 @@ data Expr s a
     | ImportAlt (Expr s a) (Expr s a)
     -- | > Embed import                             ~  import
     | Embed a
-    deriving (Foldable, Generic, Traversable, Show, Data, NFData)
+    deriving (Foldable, Generic, Traversable, Show, Data, Lift, NFData)
 -- NB: If you add a constructor to Expr, please also update the Arbitrary
 -- instance in Dhall.Test.QuickCheck.
 
@@ -496,9 +487,6 @@ deriving instance (Eq s, Eq a) => Eq (Expr s a)
 
 -- | Note that this 'Ord' instance inherits `DhallDouble`'s defects.
 deriving instance (Ord s, Ord a) => Ord (Expr s a)
-
-instance (Lift s, Lift a, Data s, Data a) => Lift (Expr s a) where
-    lift = Syntax.liftData
 
 -- This instance is hand-written due to the fact that deriving
 -- it does not give us an INLINABLE pragma. We annotate this fmap


### PR DESCRIPTION
This uses `-XDeriveLift` to address the missing liftTyped definitions.