### PR TITLE
Improve error message for failed union extractions:

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -127,7 +127,7 @@ import Control.Exception (Exception)
 import Control.Monad.Trans.State.Strict
 import Control.Monad (guard)
 import Data.Coerce (coerce)
-import Data.Either.Validation (Validation(..), ealt, eitherToValidation, validationToEither)
+import Data.Either.Validation (Validation(..), eitherToValidation, validationToEither)
 import Data.Fix (Fix(..))
 import Data.Functor.Contravariant (Contravariant(..), (>$<), Op(..))
 import Data.Functor.Contravariant.Divisible (Divisible(..), divided)
@@ -1542,7 +1542,7 @@ instance (Constructor c, GenericFromDhall f, GenericFromDhall (g :+: h)) => Gene
 instance (GenericFromDhall (f :+: g), GenericFromDhall (h :+: i)) => GenericFromDhall ((f :+: g) :+: (h :+: i)) where
     genericAutoWithNormalizer inputNormalizer options = pure (Decoder {..})
       where
-        extract e = fmap L1 (extractL e) `ealt` fmap R1 (extractR e)
+        extract e = fmap L1 (extractL e) <> fmap R1 (extractR e)
 
         expected = Union (Dhall.Map.union ktsL ktsR)
 

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -135,9 +135,8 @@ import Data.Hashable (Hashable)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.HashMap.Strict (HashMap)
 import Data.Map (Map)
-import Data.Monoid ((<>))
 import Data.Scientific (Scientific)
-import Data.Semigroup (Semigroup)
+import Data.Semigroup (Semigroup(..))
 import Data.Sequence (Seq)
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Pretty)
@@ -166,7 +165,6 @@ import qualified Data.Map
 import qualified Data.Maybe
 import qualified Data.List
 import qualified Data.List.NonEmpty
-import qualified Data.Semigroup
 import qualified Data.Scientific
 import qualified Data.Sequence
 import qualified Data.Set


### PR DESCRIPTION
Related to https://github.com/dhall-lang/dhall-haskell/issues/1711

The derived `FromDhall` instance for unions used `ealt` to combine
results from the left and right "halves" of a union, and `ealt`
essentially prefers the last error if there is more than one.

This leads to confusing error messages when combining unions with
custom decoders.  For example, using the example from:

https://github.com/dhall-lang/dhall-haskell/issues/1711#issuecomment-605516095

... gives the following error message:

```
Error: Invalid Dhall.Decoder

Every Decoder must provide an extract function that succeeds if an expression
matches the expected type.  You provided a Decoder that disobeys this contract

The Decoder provided has the expected dhall type:

↳ < C | D >

and it couldn't extract a value from the well-typed expression:

↳ < A : List {} | B | C | D >.A [ {=}, {=} ]
```

... because the decoder splits the union into two smaller unions:

* `< A : List {} | B >`
* `< C | D >`

... and then tries to decode the union constructor using both smaller
unions.  Both halves fail, but in different ways:

* The first half fails due to Haskell-side validation for the expected
  `Set` that rejects the `List` since it contains duplicates

* The second half fails due the constructor not matching the union

... but only the error message for the former half is preserved.
(I'm oversimplifying a bit, but this is the basic idea)

After this change, both error messages are preserved and you now get:

```
Test.hs: Multiple errors were encountered during extraction:

Error: Failed extraction

The expression type-checked successfully but the transformation to the target
type failed with the following error:

One duplicate element in the list: ()

Error: Invalid Dhall.Decoder

Every Decoder must provide an extract function that succeeds if an expression
matches the expected type.  You provided a Decoder that disobeys this contract

The Decoder provided has the expected dhall type:

↳ < C | D >

and it couldn't extract a value from the well-typed expression:

↳ < A : List {} | B | C | D >.A [ {=}, {=} ]
```

It's still not ideal, but at least the error message that the user was
expecting is preserved, even if it is polluted by the error message for
the other half of the union.

To further improve the error message we'd need to refactor the
`ExtractError`s type to distinguish between union-decoding errors
and custom-decoder errors and give priority to the latter errors.