### PR TITLE
Build against `QuickCheck-2.14.*`

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -620,7 +620,7 @@ Test-Suite tasty
         lens-family-core                               ,
         megaparsec                                     ,
         prettyprinter                                  ,
-        QuickCheck                >= 2.10     && < 2.14,
+        QuickCheck                >= 2.10     && < 2.15,
         quickcheck-instances      >= 0.3.12   && < 0.4 ,
         scientific                                     ,
         semigroups                                     ,


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/5271