### PR TITLE
Truncate `===...===` separator used in error messages

### DIFF
--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -69,7 +69,7 @@ snip text
 
     preview =
             Data.Text.unlines header
-        <>  separator <> "\n"
+        <>  Data.Text.take 80 separator <> "\n"
         <>  Data.Text.unlines footer
 
 {-| Like `snip`, but for `Doc`s


### PR DESCRIPTION
We use the `===...===` separator in error messages to truncate
expressions that are too large to display.  However, the separator
itself is sometimes too large to display, so we need to truncate
that, too!  :)