### PR TITLE
Use `subExpressions` to reduce internal boilerplate

### DIFF
--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -72,7 +72,6 @@ module Dhall.Core (
 
 import Control.Exception (Exception)
 import Control.Monad.IO.Class (MonadIO(..))
-import Data.Semigroup (Semigroup(..))
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc (Pretty)
 import Dhall.Normalize
@@ -92,29 +91,6 @@ import qualified Dhall.Syntax      as Syntax
 pretty :: Pretty a => a -> Text
 pretty = pretty_
 {-# INLINE pretty #-}
-
-_ERROR :: String
-_ERROR = "\ESC[1;31mError\ESC[0m"
-
-{-| Utility function used to throw internal errors that should never happen
-    (in theory) but that are not enforced by the type system
--}
-internalError :: Data.Text.Text -> forall b . b
-internalError text = error (unlines
-    [ _ERROR <> ": Compiler bug                                                        "
-    , "                                                                                "
-    , "Explanation: This error message means that there is a bug in the Dhall compiler."
-    , "You didn't do anything wrong, but if you would like to see this problem fixed   "
-    , "then you should report the bug at:                                              "
-    , "                                                                                "
-    , "https://github.com/dhall-lang/dhall-haskell/issues                              "
-    , "                                                                                "
-    , "Please include the following text in your bug report:                           "
-    , "                                                                                "
-    , "```                                                                             "
-    , Data.Text.unpack text <> "                                                       "
-    , "```                                                                             "
-    ] )
 
 {-| Escape a `Text` literal using Dhall's escaping rules
 

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -37,6 +37,7 @@ module Dhall.Syntax (
 
     -- ** Optics
     , subExpressions
+    , unsafeSubExpressions
     , chunkExprs
     , bindingExprs
 
@@ -68,6 +69,9 @@ module Dhall.Syntax (
 
     -- * Desugaring
     , desugarWith
+
+    -- * Utilities
+    , internalError
     ) where
 
 import Control.DeepSeq (NFData)
@@ -102,6 +106,7 @@ import qualified Data.Text
 import qualified Data.Text.Prettyprint.Doc  as Pretty
 import qualified Dhall.Crypto
 import qualified Dhall.Optics               as Optics
+import qualified Lens.Family                as Lens
 import qualified Network.URI                as URI
 
 {-| Constants for a pure type system
@@ -493,77 +498,10 @@ deriving instance (Ord s, Ord a) => Ord (Expr s a)
 -- implementation with this pragma below to allow GHC to, possibly,
 -- inline the implementation for performance improvements.
 instance Functor (Expr s) where
-  fmap _ (Const c) = Const c
-  fmap _ (Var v) = Var v
-  fmap f (Lam v e1 e2) = Lam v (fmap f e1) (fmap f e2)
-  fmap f (Pi v e1 e2) = Pi v (fmap f e1) (fmap f e2)
-  fmap f (App e1 e2) = App (fmap f e1) (fmap f e2)
-  fmap f (Let b e2) = Let (fmap f b) (fmap f e2)
-  fmap f (Annot e1 e2) = Annot (fmap f e1) (fmap f e2)
-  fmap _ Bool = Bool
-  fmap _ (BoolLit b) = BoolLit b
-  fmap f (BoolAnd e1 e2) = BoolAnd (fmap f e1) (fmap f e2)
-  fmap f (BoolOr e1 e2) = BoolOr (fmap f e1) (fmap f e2)
-  fmap f (BoolEQ e1 e2) = BoolEQ (fmap f e1) (fmap f e2)
-  fmap f (BoolNE e1 e2) = BoolNE (fmap f e1) (fmap f e2)
-  fmap f (BoolIf e1 e2 e3) = BoolIf (fmap f e1) (fmap f e2) (fmap f e3)
-  fmap _ Natural = Natural
-  fmap _ (NaturalLit n) = NaturalLit n
-  fmap _ NaturalFold = NaturalFold
-  fmap _ NaturalBuild = NaturalBuild
-  fmap _ NaturalIsZero = NaturalIsZero
-  fmap _ NaturalEven = NaturalEven
-  fmap _ NaturalOdd = NaturalOdd
-  fmap _ NaturalToInteger = NaturalToInteger
-  fmap _ NaturalShow = NaturalShow
-  fmap _ NaturalSubtract = NaturalSubtract
-  fmap f (NaturalPlus e1 e2) = NaturalPlus (fmap f e1) (fmap f e2)
-  fmap f (NaturalTimes e1 e2) = NaturalTimes (fmap f e1) (fmap f e2)
-  fmap _ Integer = Integer
-  fmap _ (IntegerLit i) = IntegerLit i
-  fmap _ IntegerClamp = IntegerClamp
-  fmap _ IntegerNegate = IntegerNegate
-  fmap _ IntegerShow = IntegerShow
-  fmap _ IntegerToDouble = IntegerToDouble
-  fmap _ Double = Double
-  fmap _ (DoubleLit d) = DoubleLit d
-  fmap _ DoubleShow = DoubleShow
-  fmap _ Text = Text
-  fmap f (TextLit cs) = TextLit (fmap f cs)
-  fmap f (TextAppend e1 e2) = TextAppend (fmap f e1) (fmap f e2)
-  fmap _ TextShow = TextShow
-  fmap _ List = List
-  fmap f (ListLit maybeE seqE) = ListLit (fmap (fmap f) maybeE) (fmap (fmap f) seqE)
-  fmap f (ListAppend e1 e2) = ListAppend (fmap f e1) (fmap f e2)
-  fmap _ ListBuild = ListBuild
-  fmap _ ListFold = ListFold
-  fmap _ ListLength = ListLength
-  fmap _ ListHead = ListHead
-  fmap _ ListLast = ListLast
-  fmap _ ListIndexed = ListIndexed
-  fmap _ ListReverse = ListReverse
-  fmap _ Optional = Optional
-  fmap f (Some e) = Some (fmap f e)
-  fmap _ None = None
-  fmap _ OptionalFold = OptionalFold
-  fmap _ OptionalBuild = OptionalBuild
-  fmap f (Record r) = Record (fmap (fmap f) r)
-  fmap f (RecordLit r) = RecordLit (fmap (fmap f) r)
-  fmap f (Union u) = Union (fmap (fmap (fmap f)) u)
-  fmap f (Combine m e1 e2) = Combine m (fmap f e1) (fmap f e2)
-  fmap f (CombineTypes e1 e2) = CombineTypes (fmap f e1) (fmap f e2)
-  fmap f (Prefer a e1 e2) = Prefer (fmap f a) (fmap f e1) (fmap f e2)
-  fmap f (RecordCompletion e1 e2) = RecordCompletion (fmap f e1) (fmap f e2)
-  fmap f (Merge e1 e2 maybeE) = Merge (fmap f e1) (fmap f e2) (fmap (fmap f) maybeE)
-  fmap f (ToMap e maybeE) = ToMap (fmap f e) (fmap (fmap f) maybeE)
-  fmap f (Field e1 v) = Field (fmap f e1) v
-  fmap f (Project e1 vs) = Project (fmap f e1) (fmap (fmap f) vs)
-  fmap f (Assert t) = Assert (fmap f t)
-  fmap f (Equivalent e1 e2) = Equivalent (fmap f e1) (fmap f e2)
-  fmap f (With e k v) = With (fmap f e) k (fmap f v)
-  fmap f (Note s e1) = Note s (fmap f e1)
-  fmap f (ImportAlt e1 e2) = ImportAlt (fmap f e1) (fmap f e2)
   fmap f (Embed a) = Embed (f a)
+  fmap f (Let b e2) = Let (fmap f b) (fmap f e2)
+  fmap f (Note s e1) = Note s (fmap f e1)
+  fmap f expression = Lens.over unsafeSubExpressions (fmap f) expression
   {-# INLINABLE fmap #-}
 
 instance Applicative (Expr s) where
@@ -574,160 +512,21 @@ instance Applicative (Expr s) where
 instance Monad (Expr s) where
     return = pure
 
-    Const a              >>= _ = Const a
-    Var a                >>= _ = Var a
-    Lam a b c            >>= k = Lam a (b >>= k) (c >>= k)
-    Pi  a b c            >>= k = Pi a (b >>= k) (c >>= k)
-    App a b              >>= k = App (a >>= k) (b >>= k)
-    Let a b              >>= k = Let (adapt0 a) (b >>= k)
+    Embed a    >>= k = k a
+    Let a b    >>= k = Let (adapt0 a) (b >>= k)
       where
         adapt0 (Binding src0 c src1 d src2 e) =
             Binding src0 c src1 (fmap adapt1 d) src2 (e >>= k)
 
         adapt1 (src3, f) = (src3, f >>= k)
-    Annot a b            >>= k = Annot (a >>= k) (b >>= k)
-    Bool                 >>= _ = Bool
-    BoolLit a            >>= _ = BoolLit a
-    BoolAnd a b          >>= k = BoolAnd (a >>= k) (b >>= k)
-    BoolOr  a b          >>= k = BoolOr  (a >>= k) (b >>= k)
-    BoolEQ  a b          >>= k = BoolEQ  (a >>= k) (b >>= k)
-    BoolNE  a b          >>= k = BoolNE  (a >>= k) (b >>= k)
-    BoolIf a b c         >>= k = BoolIf (a >>= k) (b >>= k) (c >>= k)
-    Natural              >>= _ = Natural
-    NaturalLit a         >>= _ = NaturalLit a
-    NaturalFold          >>= _ = NaturalFold
-    NaturalBuild         >>= _ = NaturalBuild
-    NaturalIsZero        >>= _ = NaturalIsZero
-    NaturalEven          >>= _ = NaturalEven
-    NaturalOdd           >>= _ = NaturalOdd
-    NaturalToInteger     >>= _ = NaturalToInteger
-    NaturalShow          >>= _ = NaturalShow
-    NaturalSubtract      >>= _ = NaturalSubtract
-    NaturalPlus  a b     >>= k = NaturalPlus  (a >>= k) (b >>= k)
-    NaturalTimes a b     >>= k = NaturalTimes (a >>= k) (b >>= k)
-    Integer              >>= _ = Integer
-    IntegerLit a         >>= _ = IntegerLit a
-    IntegerClamp         >>= _ = IntegerClamp
-    IntegerNegate        >>= _ = IntegerNegate
-    IntegerShow          >>= _ = IntegerShow
-    IntegerToDouble      >>= _ = IntegerToDouble
-    Double               >>= _ = Double
-    DoubleLit a          >>= _ = DoubleLit a
-    DoubleShow           >>= _ = DoubleShow
-    Text                 >>= _ = Text
-    TextLit (Chunks a b) >>= k = TextLit (Chunks (fmap (fmap (>>= k)) a) b)
-    TextAppend a b       >>= k = TextAppend (a >>= k) (b >>= k)
-    TextShow             >>= _ = TextShow
-    List                 >>= _ = List
-    ListLit a b          >>= k = ListLit (fmap (>>= k) a) (fmap (>>= k) b)
-    ListAppend a b       >>= k = ListAppend (a >>= k) (b >>= k)
-    ListBuild            >>= _ = ListBuild
-    ListFold             >>= _ = ListFold
-    ListLength           >>= _ = ListLength
-    ListHead             >>= _ = ListHead
-    ListLast             >>= _ = ListLast
-    ListIndexed          >>= _ = ListIndexed
-    ListReverse          >>= _ = ListReverse
-    Optional             >>= _ = Optional
-    Some a               >>= k = Some (a >>= k)
-    None                 >>= _ = None
-    OptionalFold         >>= _ = OptionalFold
-    OptionalBuild        >>= _ = OptionalBuild
-    Record    a          >>= k = Record (fmap (>>= k) a)
-    RecordLit a          >>= k = RecordLit (fmap (>>= k) a)
-    Union     a          >>= k = Union (fmap (fmap (>>= k)) a)
-    Combine a b c        >>= k = Combine a (b >>= k) (c >>= k)
-    CombineTypes a b     >>= k = CombineTypes (a >>= k) (b >>= k)
-    Prefer a b c         >>= k = Prefer a' (b >>= k) (c >>= k)
-      where
-        a' = case a of
-            PreferFromSource     -> PreferFromSource
-            PreferFromWith e     -> PreferFromWith (e >>= k)
-            PreferFromCompletion -> PreferFromCompletion
-    RecordCompletion a b >>= k = RecordCompletion (a >>= k) (b >>= k)
-    Merge a b c          >>= k = Merge (a >>= k) (b >>= k) (fmap (>>= k) c)
-    ToMap a b            >>= k = ToMap (a >>= k) (fmap (>>= k) b)
-    Field a b            >>= k = Field (a >>= k) b
-    Project a b          >>= k = Project (a >>= k) (fmap (>>= k) b)
-    Assert a             >>= k = Assert (a >>= k)
-    Equivalent a b       >>= k = Equivalent (a >>= k) (b >>= k)
-    With a b c           >>= k = With (a >>= k) b (c >>= k)
-    Note a b             >>= k = Note a (b >>= k)
-    ImportAlt a b        >>= k = ImportAlt (a >>= k) (b >>= k)
-    Embed a              >>= k = k a
+    Note a b   >>= k = Note a (b >>= k)
+    expression >>= k = Lens.over unsafeSubExpressions (>>= k) expression
 
 instance Bifunctor Expr where
-    first _ (Const a             ) = Const a
-    first _ (Var a               ) = Var a
-    first k (Lam a b c           ) = Lam a (first k b) (first k c)
-    first k (Pi a b c            ) = Pi a (first k b) (first k c)
-    first k (App a b             ) = App (first k a) (first k b)
-    first k (Let a b             ) = Let (first k a) (first k b)
-    first k (Annot a b           ) = Annot (first k a) (first k b)
-    first _  Bool                  = Bool
-    first _ (BoolLit a           ) = BoolLit a
-    first k (BoolAnd a b         ) = BoolAnd (first k a) (first k b)
-    first k (BoolOr a b          ) = BoolOr (first k a) (first k b)
-    first k (BoolEQ a b          ) = BoolEQ (first k a) (first k b)
-    first k (BoolNE a b          ) = BoolNE (first k a) (first k b)
-    first k (BoolIf a b c        ) = BoolIf (first k a) (first k b) (first k c)
-    first _  Natural               = Natural
-    first _ (NaturalLit a        ) = NaturalLit a
-    first _  NaturalFold           = NaturalFold
-    first _  NaturalBuild          = NaturalBuild
-    first _  NaturalIsZero         = NaturalIsZero
-    first _  NaturalEven           = NaturalEven
-    first _  NaturalOdd            = NaturalOdd
-    first _  NaturalToInteger      = NaturalToInteger
-    first _  NaturalShow           = NaturalShow
-    first _  NaturalSubtract       = NaturalSubtract
-    first k (NaturalPlus a b     ) = NaturalPlus (first k a) (first k b)
-    first k (NaturalTimes a b    ) = NaturalTimes (first k a) (first k b)
-    first _  Integer               = Integer
-    first _ (IntegerLit a        ) = IntegerLit a
-    first _  IntegerClamp          = IntegerClamp
-    first _  IntegerNegate         = IntegerNegate
-    first _  IntegerShow           = IntegerShow
-    first _  IntegerToDouble       = IntegerToDouble
-    first _  Double                = Double
-    first _ (DoubleLit a         ) = DoubleLit a
-    first _  DoubleShow            = DoubleShow
-    first _  Text                  = Text
-    first k (TextLit (Chunks a b)) = TextLit (Chunks (fmap (fmap (first k)) a) b)
-    first k (TextAppend a b      ) = TextAppend (first k a) (first k b)
-    first _  TextShow              = TextShow
-    first _  List                  = List
-    first k (ListLit a b         ) = ListLit (fmap (first k) a) (fmap (first k) b)
-    first k (ListAppend a b      ) = ListAppend (first k a) (first k b)
-    first _  ListBuild             = ListBuild
-    first _  ListFold              = ListFold
-    first _  ListLength            = ListLength
-    first _  ListHead              = ListHead
-    first _  ListLast              = ListLast
-    first _  ListIndexed           = ListIndexed
-    first _  ListReverse           = ListReverse
-    first _  Optional              = Optional
-    first k (Some a              ) = Some (first k a)
-    first _  None                  = None
-    first _  OptionalFold          = OptionalFold
-    first _  OptionalBuild         = OptionalBuild
-    first k (Record a            ) = Record (fmap (first k) a)
-    first k (RecordLit a         ) = RecordLit (fmap (first k) a)
-    first k (Union a             ) = Union (fmap (fmap (first k)) a)
-    first k (Combine a b c       ) = Combine a (first k b) (first k c)
-    first k (CombineTypes a b    ) = CombineTypes (first k a) (first k b)
-    first k (Prefer a b c        ) = Prefer (first k a) (first k b) (first k c)
-    first k (RecordCompletion a b) = RecordCompletion (first k a) (first k b)
-    first k (Merge a b c         ) = Merge (first k a) (first k b) (fmap (first k) c)
-    first k (ToMap a b           ) = ToMap (first k a) (fmap (first k) b)
-    first k (Field a b           ) = Field (first k a) b
-    first k (Assert a            ) = Assert (first k a)
-    first k (Equivalent a b      ) = Equivalent (first k a) (first k b)
-    first k (Project a b         ) = Project (first k a) (fmap (first k) b)
-    first k (With a b c          ) = With (first k a) b (first k c)
-    first k (Note a b            ) = Note (k a) (first k b)
-    first k (ImportAlt a b       ) = ImportAlt (first k a) (first k b)
-    first _ (Embed a             ) = Embed a
+    first k (Note a b  ) = Note (k a) (first k b)
+    first _ (Embed a   ) = Embed a
+    first k (Let a b   ) = Let (first k a) (first k b)
+    first k  expression  = Lens.over unsafeSubExpressions (first k) expression
 
     second = fmap
 
@@ -789,79 +588,104 @@ wrapInLets bs e = foldr Let e bs
 data MultiLet s a = MultiLet (NonEmpty (Binding s a)) (Expr s a)
 
 -- | A traversal over the immediate sub-expressions of an expression.
-subExpressions :: Applicative f => (Expr s a -> f (Expr s a)) -> Expr s a -> f (Expr s a)
-subExpressions _ (Const c) = pure (Const c)
-subExpressions _ (Var v) = pure (Var v)
-subExpressions f (Lam a b c) = Lam a <$> f b <*> f c
-subExpressions f (Pi a b c) = Pi a <$> f b <*> f c
-subExpressions f (App a b) = App <$> f a <*> f b
-subExpressions f (Let a b) = Let <$> bindingExprs f a <*> f b
-subExpressions f (Annot a b) = Annot <$> f a <*> f b
-subExpressions _ Bool = pure Bool
-subExpressions _ (BoolLit b) = pure (BoolLit b)
-subExpressions f (BoolAnd a b) = BoolAnd <$> f a <*> f b
-subExpressions f (BoolOr a b) = BoolOr <$> f a <*> f b
-subExpressions f (BoolEQ a b) = BoolEQ <$> f a <*> f b
-subExpressions f (BoolNE a b) = BoolNE <$> f a <*> f b
-subExpressions f (BoolIf a b c) = BoolIf <$> f a <*> f b <*> f c
-subExpressions _ Natural = pure Natural
-subExpressions _ (NaturalLit n) = pure (NaturalLit n)
-subExpressions _ NaturalFold = pure NaturalFold
-subExpressions _ NaturalBuild = pure NaturalBuild
-subExpressions _ NaturalIsZero = pure NaturalIsZero
-subExpressions _ NaturalEven = pure NaturalEven
-subExpressions _ NaturalOdd = pure NaturalOdd
-subExpressions _ NaturalToInteger = pure NaturalToInteger
-subExpressions _ NaturalShow = pure NaturalShow
-subExpressions _ NaturalSubtract = pure NaturalSubtract
-subExpressions f (NaturalPlus a b) = NaturalPlus <$> f a <*> f b
-subExpressions f (NaturalTimes a b) = NaturalTimes <$> f a <*> f b
-subExpressions _ Integer = pure Integer
-subExpressions _ (IntegerLit n) = pure (IntegerLit n)
-subExpressions _ IntegerClamp = pure IntegerClamp
-subExpressions _ IntegerNegate = pure IntegerNegate
-subExpressions _ IntegerShow = pure IntegerShow
-subExpressions _ IntegerToDouble = pure IntegerToDouble
-subExpressions _ Double = pure Double
-subExpressions _ (DoubleLit n) = pure (DoubleLit n)
-subExpressions _ DoubleShow = pure DoubleShow
-subExpressions _ Text = pure Text
-subExpressions f (TextLit chunks) =
-    TextLit <$> chunkExprs f chunks
-subExpressions f (TextAppend a b) = TextAppend <$> f a <*> f b
-subExpressions _ TextShow = pure TextShow
-subExpressions _ List = pure List
-subExpressions f (ListLit a b) = ListLit <$> traverse f a <*> traverse f b
-subExpressions f (ListAppend a b) = ListAppend <$> f a <*> f b
-subExpressions _ ListBuild = pure ListBuild
-subExpressions _ ListFold = pure ListFold
-subExpressions _ ListLength = pure ListLength
-subExpressions _ ListHead = pure ListHead
-subExpressions _ ListLast = pure ListLast
-subExpressions _ ListIndexed = pure ListIndexed
-subExpressions _ ListReverse = pure ListReverse
-subExpressions _ Optional = pure Optional
-subExpressions f (Some a) = Some <$> f a
-subExpressions _ None = pure None
-subExpressions _ OptionalFold = pure OptionalFold
-subExpressions _ OptionalBuild = pure OptionalBuild
-subExpressions f (Record a) = Record <$> traverse f a
-subExpressions f ( RecordLit a ) = RecordLit <$> traverse f a
-subExpressions f (Union a) = Union <$> traverse (traverse f) a
-subExpressions f (Combine a b c) = Combine a <$> f b <*> f c
-subExpressions f (CombineTypes a b) = CombineTypes <$> f a <*> f b
-subExpressions f (Prefer a b c) = Prefer <$> pure a <*> f b <*> f c
-subExpressions f (RecordCompletion a b) = RecordCompletion <$> f a <*> f b
-subExpressions f (Merge a b t) = Merge <$> f a <*> f b <*> traverse f t
-subExpressions f (ToMap a t) = ToMap <$> f a <*> traverse f t
-subExpressions f (Field a b) = Field <$> f a <*> pure b
-subExpressions f (Project a b) = Project <$> f a <*> traverse f b
-subExpressions f (Assert a) = Assert <$> f a
-subExpressions f (Equivalent a b) = Equivalent <$> f a <*> f b
-subExpressions f (With a b c) = With <$> f a <*> pure b <*> f c
-subExpressions f (Note a b) = Note a <$> f b
-subExpressions f (ImportAlt l r) = ImportAlt <$> f l <*> f r
+subExpressions
+    :: Applicative f => (Expr s a -> f (Expr s a)) -> Expr s a -> f (Expr s a)
 subExpressions _ (Embed a) = pure (Embed a)
+subExpressions f (Note a b) = Note a <$> f b
+subExpressions f (Let a b) = Let <$> bindingExprs f a <*> f b
+subExpressions f expression = unsafeSubExpressions f expression
+{-# INLINABLE subExpressions #-}
+
+{-| An internal utility used to implement transformations that require changing
+    one of the type variables of the `Expr` type
+
+    This utility only works because the implementation is partial, not
+    handling the `Let`, `Note`, or `Embed` cases, which needs to be handled by
+    the caller.
+-}
+unsafeSubExpressions
+    :: Applicative f => (Expr s a -> f (Expr t b)) -> Expr s a -> f (Expr t b)
+unsafeSubExpressions _ (Const c) = pure (Const c)
+unsafeSubExpressions _ (Var v) = pure (Var v)
+unsafeSubExpressions f (Lam a b c) = Lam a <$> f b <*> f c
+unsafeSubExpressions f (Pi a b c) = Pi a <$> f b <*> f c
+unsafeSubExpressions f (App a b) = App <$> f a <*> f b
+unsafeSubExpressions f (Annot a b) = Annot <$> f a <*> f b
+unsafeSubExpressions _ Bool = pure Bool
+unsafeSubExpressions _ (BoolLit b) = pure (BoolLit b)
+unsafeSubExpressions f (BoolAnd a b) = BoolAnd <$> f a <*> f b
+unsafeSubExpressions f (BoolOr a b) = BoolOr <$> f a <*> f b
+unsafeSubExpressions f (BoolEQ a b) = BoolEQ <$> f a <*> f b
+unsafeSubExpressions f (BoolNE a b) = BoolNE <$> f a <*> f b
+unsafeSubExpressions f (BoolIf a b c) = BoolIf <$> f a <*> f b <*> f c
+unsafeSubExpressions _ Natural = pure Natural
+unsafeSubExpressions _ (NaturalLit n) = pure (NaturalLit n)
+unsafeSubExpressions _ NaturalFold = pure NaturalFold
+unsafeSubExpressions _ NaturalBuild = pure NaturalBuild
+unsafeSubExpressions _ NaturalIsZero = pure NaturalIsZero
+unsafeSubExpressions _ NaturalEven = pure NaturalEven
+unsafeSubExpressions _ NaturalOdd = pure NaturalOdd
+unsafeSubExpressions _ NaturalToInteger = pure NaturalToInteger
+unsafeSubExpressions _ NaturalShow = pure NaturalShow
+unsafeSubExpressions _ NaturalSubtract = pure NaturalSubtract
+unsafeSubExpressions f (NaturalPlus a b) = NaturalPlus <$> f a <*> f b
+unsafeSubExpressions f (NaturalTimes a b) = NaturalTimes <$> f a <*> f b
+unsafeSubExpressions _ Integer = pure Integer
+unsafeSubExpressions _ (IntegerLit n) = pure (IntegerLit n)
+unsafeSubExpressions _ IntegerClamp = pure IntegerClamp
+unsafeSubExpressions _ IntegerNegate = pure IntegerNegate
+unsafeSubExpressions _ IntegerShow = pure IntegerShow
+unsafeSubExpressions _ IntegerToDouble = pure IntegerToDouble
+unsafeSubExpressions _ Double = pure Double
+unsafeSubExpressions _ (DoubleLit n) = pure (DoubleLit n)
+unsafeSubExpressions _ DoubleShow = pure DoubleShow
+unsafeSubExpressions _ Text = pure Text
+unsafeSubExpressions f (TextLit chunks) =
+    TextLit <$> chunkExprs f chunks
+unsafeSubExpressions f (TextAppend a b) = TextAppend <$> f a <*> f b
+unsafeSubExpressions _ TextShow = pure TextShow
+unsafeSubExpressions _ List = pure List
+unsafeSubExpressions f (ListLit a b) = ListLit <$> traverse f a <*> traverse f b
+unsafeSubExpressions f (ListAppend a b) = ListAppend <$> f a <*> f b
+unsafeSubExpressions _ ListBuild = pure ListBuild
+unsafeSubExpressions _ ListFold = pure ListFold
+unsafeSubExpressions _ ListLength = pure ListLength
+unsafeSubExpressions _ ListHead = pure ListHead
+unsafeSubExpressions _ ListLast = pure ListLast
+unsafeSubExpressions _ ListIndexed = pure ListIndexed
+unsafeSubExpressions _ ListReverse = pure ListReverse
+unsafeSubExpressions _ Optional = pure Optional
+unsafeSubExpressions f (Some a) = Some <$> f a
+unsafeSubExpressions _ None = pure None
+unsafeSubExpressions _ OptionalFold = pure OptionalFold
+unsafeSubExpressions _ OptionalBuild = pure OptionalBuild
+unsafeSubExpressions f (Record a) = Record <$> traverse f a
+unsafeSubExpressions f ( RecordLit a ) = RecordLit <$> traverse f a
+unsafeSubExpressions f (Union a) = Union <$> traverse (traverse f) a
+unsafeSubExpressions f (Combine a b c) = Combine a <$> f b <*> f c
+unsafeSubExpressions f (CombineTypes a b) = CombineTypes <$> f a <*> f b
+unsafeSubExpressions f (Prefer a b c) = Prefer <$> a' <*> f b <*> f c
+  where
+    a' = case a of
+        PreferFromSource     -> pure PreferFromSource
+        PreferFromWith d     -> PreferFromWith <$> f d
+        PreferFromCompletion -> pure PreferFromCompletion
+unsafeSubExpressions f (RecordCompletion a b) = RecordCompletion <$> f a <*> f b
+unsafeSubExpressions f (Merge a b t) = Merge <$> f a <*> f b <*> traverse f t
+unsafeSubExpressions f (ToMap a t) = ToMap <$> f a <*> traverse f t
+unsafeSubExpressions f (Field a b) = Field <$> f a <*> pure b
+unsafeSubExpressions f (Project a b) = Project <$> f a <*> traverse f b
+unsafeSubExpressions f (Assert a) = Assert <$> f a
+unsafeSubExpressions f (Equivalent a b) = Equivalent <$> f a <*> f b
+unsafeSubExpressions f (With a b c) = With <$> f a <*> pure b <*> f c
+unsafeSubExpressions f (ImportAlt l r) = ImportAlt <$> f l <*> f r
+unsafeSubExpressions _ (Let {}) = die
+unsafeSubExpressions _ (Note {}) = die
+unsafeSubExpressions _ (Embed {}) = die
+{-# INLINABLE unsafeSubExpressions #-}
+
+die :: a
+die = internalError "Dhall.Syntax.unsafeSubExpressions: Non-exhaustive pattern match"
 
 {-| Traverse over the immediate 'Expr' children in a 'Binding'.
 -}
@@ -877,6 +701,7 @@ bindingExprs f (Binding s0 n s1 t s2 v) =
     <*> traverse (traverse f) t
     <*> pure s2
     <*> f v
+{-# INLINABLE bindingExprs #-}
 
 -- | A traversal over the immediate sub-expressions in 'Chunks'.
 chunkExprs
@@ -885,6 +710,7 @@ chunkExprs
   -> Chunks s a -> f (Chunks t b)
 chunkExprs f (Chunks chunks final) =
   flip Chunks final <$> traverse (traverse f) chunks
+{-# INLINABLE chunkExprs #-}
 
 {-| Internal representation of a directory that stores the path components in
     reverse order
@@ -1092,87 +918,16 @@ pathCharacter c =
 
 -- | Remove all `Note` constructors from an `Expr` (i.e. de-`Note`)
 denote :: Expr s a -> Expr t a
-denote (Note _ b            ) = denote b
-denote (Const a             ) = Const a
-denote (Var a               ) = Var a
-denote (Lam a b c           ) = Lam a (denote b) (denote c)
-denote (Pi a b c            ) = Pi a (denote b) (denote c)
-denote (App a b             ) = App (denote a) (denote b)
-denote (Let a b             ) = Let (adapt0 a) (denote b)
+denote (Note _ b     ) = denote b
+denote (Let a b      ) = Let (adapt0 a) (denote b)
   where
     adapt0 (Binding _ c _ d _ e) =
         Binding Nothing c Nothing (fmap adapt1 d) Nothing (denote e)
 
     adapt1 (_, f) = (Nothing, denote f)
-denote (Annot a b           ) = Annot (denote a) (denote b)
-denote  Bool                  = Bool
-denote (BoolLit a           ) = BoolLit a
-denote (BoolAnd a b         ) = BoolAnd (denote a) (denote b)
-denote (BoolOr a b          ) = BoolOr (denote a) (denote b)
-denote (BoolEQ a b          ) = BoolEQ (denote a) (denote b)
-denote (BoolNE a b          ) = BoolNE (denote a) (denote b)
-denote (BoolIf a b c        ) = BoolIf (denote a) (denote b) (denote c)
-denote  Natural               = Natural
-denote (NaturalLit a        ) = NaturalLit a
-denote  NaturalFold           = NaturalFold
-denote  NaturalBuild          = NaturalBuild
-denote  NaturalIsZero         = NaturalIsZero
-denote  NaturalEven           = NaturalEven
-denote  NaturalOdd            = NaturalOdd
-denote  NaturalToInteger      = NaturalToInteger
-denote  NaturalShow           = NaturalShow
-denote  NaturalSubtract       = NaturalSubtract
-denote (NaturalPlus a b     ) = NaturalPlus (denote a) (denote b)
-denote (NaturalTimes a b    ) = NaturalTimes (denote a) (denote b)
-denote  Integer               = Integer
-denote (IntegerLit a        ) = IntegerLit a
-denote  IntegerClamp          = IntegerClamp
-denote  IntegerNegate         = IntegerNegate
-denote  IntegerShow           = IntegerShow
-denote  IntegerToDouble       = IntegerToDouble
-denote  Double                = Double
-denote (DoubleLit a         ) = DoubleLit a
-denote  DoubleShow            = DoubleShow
-denote  Text                  = Text
-denote (TextLit (Chunks a b)) = TextLit (Chunks (fmap (fmap denote) a) b)
-denote (TextAppend a b      ) = TextAppend (denote a) (denote b)
-denote  TextShow              = TextShow
-denote  List                  = List
-denote (ListLit a b         ) = ListLit (fmap denote a) (fmap denote b)
-denote (ListAppend a b      ) = ListAppend (denote a) (denote b)
-denote  ListBuild             = ListBuild
-denote  ListFold              = ListFold
-denote  ListLength            = ListLength
-denote  ListHead              = ListHead
-denote  ListLast              = ListLast
-denote  ListIndexed           = ListIndexed
-denote  ListReverse           = ListReverse
-denote  Optional              = Optional
-denote (Some a              ) = Some (denote a)
-denote  None                  = None
-denote  OptionalFold          = OptionalFold
-denote  OptionalBuild         = OptionalBuild
-denote (Record a            ) = Record (fmap denote a)
-denote (RecordLit a         ) = RecordLit (fmap denote a)
-denote (Union a             ) = Union (fmap (fmap denote) a)
-denote (Combine _ b c       ) = Combine Nothing (denote b) (denote c)
-denote (CombineTypes a b    ) = CombineTypes (denote a) (denote b)
-denote (Prefer a b c        ) = Prefer a' (denote b) (denote c)
-  where
-    a' = case a of
-        PreferFromSource     -> PreferFromSource
-        PreferFromWith e     -> PreferFromWith (denote e)
-        PreferFromCompletion -> PreferFromCompletion
-denote (RecordCompletion a b) = RecordCompletion (denote a) (denote b)
-denote (Merge a b c         ) = Merge (denote a) (denote b) (fmap denote c)
-denote (ToMap a b           ) = ToMap (denote a) (fmap denote b)
-denote (Field a b           ) = Field (denote a) b
-denote (Project a b         ) = Project (denote a) (fmap denote b)
-denote (Assert a            ) = Assert (denote a)
-denote (Equivalent a b      ) = Equivalent (denote a) (denote b)
-denote (With a b c          ) = With (denote a) b (denote c)
-denote (ImportAlt a b       ) = ImportAlt (denote a) (denote b)
-denote (Embed a             ) = Embed a
+denote (Embed a      ) = Embed a
+denote (Combine _ b c) = Combine Nothing (denote b) (denote c)
+denote  expression     = Lens.over unsafeSubExpressions denote expression
 
 -- | The \"opposite\" of `denote`, like @first absurd@ but faster
 renote :: Expr Void a -> Expr s a
@@ -1356,3 +1111,26 @@ desugarWith = Optics.rewriteOf subExpressions rewrite
                 )
             )
     rewrite _ = Nothing
+
+_ERROR :: String
+_ERROR = "\ESC[1;31mError\ESC[0m"
+
+{-| Utility function used to throw internal errors that should never happen
+    (in theory) but that are not enforced by the type system
+-}
+internalError :: Data.Text.Text -> forall b . b
+internalError text = error (unlines
+    [ _ERROR <> ": Compiler bug                                                        "
+    , "                                                                                "
+    , "Explanation: This error message means that there is a bug in the Dhall compiler."
+    , "You didn't do anything wrong, but if you would like to see this problem fixed   "
+    , "then you should report the bug at:                                              "
+    , "                                                                                "
+    , "https://github.com/dhall-lang/dhall-haskell/issues                              "
+    , "                                                                                "
+    , "Please include the following text in your bug report:                           "
+    , "                                                                                "
+    , "```                                                                             "
+    , Data.Text.unpack text <> "                                                       "
+    , "```                                                                             "
+    ] )

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -600,7 +600,7 @@ subExpressions f expression = unsafeSubExpressions f expression
     one of the type variables of the `Expr` type
 
     This utility only works because the implementation is partial, not
-    handling the `Let`, `Note`, or `Embed` cases, which needs to be handled by
+    handling the `Let`, `Note`, or `Embed` cases, which need to be handled by
     the caller.
 -}
 unsafeSubExpressions

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -679,13 +679,18 @@ unsafeSubExpressions f (Assert a) = Assert <$> f a
 unsafeSubExpressions f (Equivalent a b) = Equivalent <$> f a <*> f b
 unsafeSubExpressions f (With a b c) = With <$> f a <*> pure b <*> f c
 unsafeSubExpressions f (ImportAlt l r) = ImportAlt <$> f l <*> f r
-unsafeSubExpressions _ (Let {}) = die
-unsafeSubExpressions _ (Note {}) = die
-unsafeSubExpressions _ (Embed {}) = die
+unsafeSubExpressions _ (Let {}) = unhandledConstructor "Let"
+unsafeSubExpressions _ (Note {}) = unhandledConstructor "Note"
+unsafeSubExpressions _ (Embed {}) = unhandledConstructor "Embed"
 {-# INLINABLE unsafeSubExpressions #-}
 
-die :: a
-die = internalError "Dhall.Syntax.unsafeSubExpressions: Non-exhaustive pattern match"
+unhandledConstructor :: Text -> a
+unhandledConstructor constructor =
+    internalError
+        (   "Dhall.Syntax.unsafeSubExpressions: Unhandled "
+        <>  constructor
+        <>  " construtor"
+        )
 
 {-| Traverse over the immediate 'Expr' children in a 'Binding'.
 -}


### PR DESCRIPTION
To be precise, this adds a new `unsafeSubExpressions` utility, too,
and uses either `subExpressions` or `unsafeSubExpressions` to
reduce the boilerplate of several internal functions so that we don't
need to update the code in as many places whenever we extend the
abstract syntax tree.