### PR TITLE
Use `input` instead of `stdin` for error messages

### DIFF
--- a/dhall-bash/exec/Main.hs
+++ b/dhall-bash/exec/Main.hs
@@ -50,7 +50,7 @@ main = do
     (if unHelpful explain then Dhall.detailed else id) (handle (do
         inText <- Data.Text.IO.getContents
 
-        expr <- case Dhall.Parser.exprFromText "(stdin)" inText of
+        expr <- case Dhall.Parser.exprFromText "(input)" inText of
             Left  err  -> Control.Exception.throwIO err
             Right expr -> return expr
 

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -1147,7 +1147,7 @@ handleSpecialDoubles specialDoubleMode =
 
 >>> :set -XOverloadedStrings
 >>> import Core
->>> Dhall.JSON.codeToValue "(stdin)" "{ a = 1 }"
+>>> Dhall.JSON.codeToValue defaultConversion ForbidWithinJSON Nothing "{ a = 1 }"
 >>> Object (fromList [("a",Number 1.0)])
 -}
 codeToValue
@@ -1158,7 +1158,7 @@ codeToValue
   -> Text  -- ^ Input text.
   -> IO Value
 codeToValue conversion specialDoubleMode mFilePath code = do
-    parsedExpression <- Core.throws (Dhall.Parser.exprFromText (fromMaybe "(stdin)" mFilePath) code)
+    parsedExpression <- Core.throws (Dhall.Parser.exprFromText (fromMaybe "(input)" mFilePath) code)
 
     let rootDirectory = case mFilePath of
             Nothing -> "."

--- a/dhall-nix/exec/Main.hs
+++ b/dhall-nix/exec/Main.hs
@@ -44,7 +44,7 @@ main = handle (Dhall.detailed (do
 
     inText <- Data.Text.IO.getContents
 
-    expr <- case Dhall.Parser.exprFromText "(stdin)" inText of
+    expr <- case Dhall.Parser.exprFromText "(input)" inText of
         Left  err  -> Control.Exception.throwIO err
         Right expr -> return expr
 

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -217,7 +217,7 @@ freeze outputMode input scope intent characterSet censor = do
 
             let name = case input of
                     InputFile file -> file
-                    StandardInput  -> "(stdin)"
+                    StandardInput  -> "(input)"
 
             (Header header, parsedExpression) <- do
                 Core.throws (first Parser.censor (Parser.exprAndHeaderFromText name originalText))

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -761,7 +761,7 @@ command (Options {..}) = do
 
                     let name = case input of
                             InputFile file -> file
-                            StandardInput  -> "(stdin)"
+                            StandardInput  -> "(input)"
 
                     (Header header, expression) <- do
                         Dhall.Core.throws (first Parser.censor (Parser.exprAndHeaderFromText name originalText))

--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -130,7 +130,7 @@ parseAndLoad
   :: MonadIO m => String -> m ( Dhall.Expr Dhall.Src Void) 
 parseAndLoad src = do
   parsed <-
-    case Dhall.exprFromText "(stdin)" (Text.pack src <> "\n") of
+    case Dhall.exprFromText "(input)" (Text.pack src <> "\n") of
       Left e ->
         liftIO ( throwIO e )
 
@@ -222,7 +222,7 @@ separateEqual (str : strs)
 
 addBinding :: ( MonadFail m, MonadIO m, MonadState Env m ) => [String] -> m ()
 addBinding (k : "=" : srcs) = do
-  varName <- case Megaparsec.parse (unParser Parser.Token.label) "(stdin)" (Text.pack k) of
+  varName <- case Megaparsec.parse (unParser Parser.Token.label) "(input)" (Text.pack k) of
       Left   _      -> Fail.fail "Invalid variable name"
       Right varName -> return varName
 

--- a/dhall/src/Dhall/Tutorial.hs
+++ b/dhall/src/Dhall/Tutorial.hs
@@ -874,7 +874,7 @@ import Dhall
 -- > 
 -- > { foo = 1, bar = "ABC" } ∧ { foo = True }
 -- > 
--- > (stdin):1:1
+-- > (input):1:1
 --
 -- __Exercise__: Combine any record with the empty record.  What do you expect
 -- to happen?
@@ -941,7 +941,7 @@ import Dhall
 -- > <Ctrl-D>
 -- > Error: Invalid input
 -- > 
--- > (stdin):1:11:
+-- > (input):1:11:
 -- >   |
 -- > 1 | let twice (x : Text) = x ++ x in twice "ha"
 -- >   |           ^
@@ -1381,7 +1381,7 @@ import Dhall
 -- > 
 -- > 1│ ./test.dhall
 -- > 
--- > (stdin):1:1
+-- > (input):1:1
 --
 -- You can compare expressions that contain variables, too, which is equivalent
 -- to symbolic reasoning:
@@ -1410,7 +1410,7 @@ import Dhall
 -- > 
 -- > 1│                   assert : Natural/even (n + n) === True
 -- > 
--- > (stdin):1:19
+-- > (input):1:19
 --
 -- Here the interpreter is not smart enough to simplify @Natural/even (n + n)@
 -- to @True@ so the assertion fails.
@@ -1849,7 +1849,7 @@ import Dhall
 -- > 
 -- > +2 + +2
 -- > 
--- > (stdin):1:1
+-- > (input):1:1
 --
 -- In fact, there are no built-in functions for @Integer@s (or @Double@s) other
 -- than @Integer/show@ and @Double/show@.  As far as the language is concerned
@@ -1932,7 +1932,7 @@ import Dhall
 -- > 
 -- > Natural/equal 
 -- > 
--- > (stdin):1:1
+-- > (input):1:1
 --
 -- You will need to either:
 -- 

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -116,8 +116,8 @@ get parser censor input = do
     let name =
             case input of
                 Input_ (InputFile file) -> file
-                Input_ StandardInput    -> "(stdin)"
-                StdinText _             -> "(stdin)"
+                Input_ StandardInput    -> "(input)"
+                StdinText _             -> "(input)"
 
     let result = parser name inText
 


### PR DESCRIPTION
`stdin` is an abbreviation that might not be obvious to less experienced
programmers, so I thought `input` might be more clear