### PR TITLE
Fix assert equal order for semantichash test

### DIFF
--- a/dhall/tests/Dhall/Test/SemanticHash.hs
+++ b/dhall/tests/Dhall/Test/SemanticHash.hs
@@ -45,4 +45,4 @@ hashTest prefix =
 
         let message = "The hash did not match the expected hash."
 
-        Tasty.HUnit.assertEqual message actualHash expectedHash
+        Tasty.HUnit.assertEqual message expectedHash actualHash


### PR DESCRIPTION
This change fixes assert order so that expected and actual value
are correctly represented.