### PR TITLE
Convert union alternatives to directory tree

### DIFF
--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -104,6 +104,9 @@ toDirectoryTree path expression = case expression of
     Some value -> do
         toDirectoryTree path value
 
+    App (Field (Union _) _) value -> do
+        toDirectoryTree path value
+
     App None _ -> do
         return ()
 
@@ -149,7 +152,9 @@ instance Show FilesystemError where
           \Explanation: Only a subset of Dhall expressions can be converted to a directory \n\
           \tree.  Specifically, record literals or maps can be converted to directories,   \n\
           \❰Text❱ literals can be converted to files, and ❰Optional❱ values are included if\n\
-          \❰Some❱ and omitted if ❰None❱.  No other type of value can be translated to a    \n\
+          \❰Some❱ and omitted if ❰None❱.  Values of union types can also be converted if   \n\
+          \they are an alternative which has a non-nullary constructor whose argument is of\n\
+          \an otherwise convertible type.  No other type of value can be translated to a   \n\
           \directory tree.                                                                 \n\
           \                                                                                \n\
           \For example, this is a valid expression that can be translated to a directory   \n\


### PR DESCRIPTION
This change adds the ability to convert union alternatives with non-nullary constructors of appropriate type into directory trees.

The commit message describes the details of the change, but my motivation here is that I'd like to build [s6-rc](https://skarnet.org/software/s6-rc/) service directories using Dhall as a source format. The `s6-rc` service directory format is described [here](https://skarnet.org/software/s6-rc/s6-rc-compile.html).

There are three types of `s6-rc` service directory: "longrun", "oneshot" and "bundle". I've modelled these as below (with some simplification and details omitted for brevity):

```dhall
let Longrun : Type
    = { run : Text
      , finish : Optional Text
      , down : Optional Text
      }

let Oneshot : Type
    = { up : Text
      , down : Optional Text
      }

let Bundle : Type
    = { contents : Text }
```
I've then defined a `Service` type, which is a sum type over the above types.

```dhall
let Service : Type = < L : Longrun | O : Oneshot | B : Bundle >
```
I'd like to be able to construct an expression of the `Service` type for each service in my database, and construct a record representing the database, e.g.:
```dhall
let networkUp = Service.O { {- oneshot definition... -} }
let httpd = Service.L { {- longrun definition... -} }
in { httpd = httpd, networkUp = networkUp }
```

At this point it would be really convenient to feed the record definition into `dhall to-directory-tree` in order to automatically generate the service database directory tree, however the union type means that (without the change in this commit) I need to convert the `Service` type into some suitable record type, with only (`Optional`) `Text` fields, and not all combinations of these fields may be valid.

Hence, it would be really useful for my case to be able to convert (appropriately-typed) union types into directory trees.

