### PR TITLE
Change formatting for functions and their types

### DIFF
--- a/dhall/tests/format/concatSepB.dhall
+++ b/dhall/tests/format/concatSepB.dhall
@@ -5,20 +5,20 @@ let Status = < Empty | NonEmpty : Text >
 
 let concatSep
     : ∀(separator : Text) → ∀(elements : List Text) → Text
-    =   λ(separator : Text)
-      → λ(elements : List Text)
-      → let status =
+    = λ(separator : Text) →
+      λ(elements : List Text) →
+        let status =
               List/fold
                 Text
                 elements
                 Status
-                (   λ(element : Text)
-                  → λ(status : Status)
-                  → merge
+                ( λ(element : Text) →
+                  λ(status : Status) →
+                    merge
                       { Empty = Status.NonEmpty element
                       , NonEmpty =
-                            λ(result : Text)
-                          → Status.NonEmpty (element ++ separator ++ result)
+                          λ(result : Text) →
+                            Status.NonEmpty (element ++ separator ++ result)
                       }
                       status
                 )

--- a/dhall/tests/format/ipfsB.dhall
+++ b/dhall/tests/format/ipfsB.dhall
@@ -20,14 +20,14 @@ let apiPort = k8s.IntOrString.Int 5001
 let gatewayPort = k8s.IntOrString.Int 8080
 
 let toRule =
-        λ ( args
-          : { host : Text
-            , path : Text
-            , serviceName : Text
-            , servicePort : k8s.IntOrString
-            }
-          )
-      → k8s.IngressRule::{
+      λ ( args
+        : { host : Text
+          , path : Text
+          , serviceName : Text
+          , servicePort : k8s.IntOrString
+          }
+        ) →
+        k8s.IngressRule::{
         , host = Some args.host
         , http = Some k8s.HTTPIngressRuleValue::{
           , paths =

--- a/dhall/tests/format/issue1400-2B.dhall
+++ b/dhall/tests/format/issue1400-2B.dhall
@@ -1,7 +1,7 @@
 let Tagged
     : Type → Type
-    =   λ(a : Type)
-      → { field : Text
+    = λ(a : Type) →
+        { field : Text
         , nesting :
               ./Nesting sha256:6284802edd41d5d725aa1ec7687e614e21ad1be7e14dd10996bfa9625105c335
             ? ./Nesting

--- a/dhall/tests/format/issue183B.dhall
+++ b/dhall/tests/format/issue183B.dhall
@@ -1,9 +1,9 @@
 let foo = 1
 
-in    λ(bar : Integer)
-    → let exposePort =
-              λ(portSpec : { ext : Integer, int : Integer })
-            → Integer/show portSpec.ext ++ ":" ++ Integer/show portSpec.int
+in  λ(bar : Integer) →
+      let exposePort =
+            λ(portSpec : { ext : Integer, int : Integer }) →
+              Integer/show portSpec.ext ++ ":" ++ Integer/show portSpec.int
 
       in  let exposeSamePort =
                 λ(port : Integer) → exposePort { ext = port, int = port }

--- a/dhall/tests/format/unicodeB.dhall
+++ b/dhall/tests/format/unicodeB.dhall
@@ -1,5 +1,5 @@
-  λ(isActive : Bool)
-→   { barLeftEnd = Some "┨"
+λ(isActive : Bool) →
+    { barLeftEnd = Some "┨"
     , barRightEnd = Some "┠"
     , separator = Some "┃"
     , alignment =

--- a/dhall/tests/lint/success/assertB.dhall
+++ b/dhall/tests/lint/success/assertB.dhall
@@ -3,9 +3,9 @@ let simpleAssert = assert : 1 + 1 ≡ 2
 let assertIn1Lam = λ(n : Natural) → assert : Natural/subtract 0 n ≡ n
 
 let assertIn2Lams =
-        λ(m : Natural)
-      → λ(n : Natural)
-      → assert : Natural/subtract m m ≡ Natural/subtract n n
+      λ(m : Natural) →
+      λ(n : Natural) →
+        assert : Natural/subtract m m ≡ Natural/subtract n n
 
 let assertInLetInLam = λ(m : Natural) → let n = m + 0 in assert : m ≡ n
 

--- a/dhall/tests/lint/success/multiletB.dhall
+++ b/dhall/tests/lint/success/multiletB.dhall
@@ -2,15 +2,15 @@
 
 let Person
     : Type
-    =   ∀(Person : Type)
-      → ∀(MakePerson : { children : List Person, name : Text } → Person)
-      → Person
+    = ∀(Person : Type) →
+      ∀(MakePerson : { children : List Person, name : Text } → Person) →
+        Person
 
 let example
     : Person
-    =   λ(Person : Type)
-      → λ(MakePerson : { children : List Person, name : Text } → Person)
-      → MakePerson
+    = λ(Person : Type) →
+      λ(MakePerson : { children : List Person, name : Text } → Person) →
+        MakePerson
           { children =
             [ MakePerson { children = [] : List Person, name = "Mary" }
             , MakePerson { children = [] : List Person, name = "Jane" }
@@ -22,11 +22,11 @@ let everybody
     : Person → List Text
     = let concat = http://prelude.dhall-lang.org/List/concat
 
-      in    λ(x : Person)
-          → x
+      in  λ(x : Person) →
+            x
               (List Text)
-              (   λ(p : { children : List (List Text), name : Text })
-                → [ p.name ] # concat Text p.children
+              ( λ(p : { children : List (List Text), name : Text }) →
+                  [ p.name ] # concat Text p.children
               )
 
 let result

--- a/dhall/tests/lint/success/optionalFoldBuildB.dhall
+++ b/dhall/tests/lint/success/optionalFoldBuildB.dhall
@@ -1,18 +1,18 @@
 { example0 =
-      λ(a : Type)
-    → λ(o : Optional a)
-    → λ(optional : Type)
-    → λ(some : a → optional)
-    → λ(none : optional)
-    → merge { Some = some, None = none } o
+    λ(a : Type) →
+    λ(o : Optional a) →
+    λ(optional : Type) →
+    λ(some : a → optional) →
+    λ(none : optional) →
+      merge { Some = some, None = none } o
 , example1 =
-      λ(a : Type)
-    → λ ( build
-        :   ∀(optional : Type)
-          → ∀(some : a → optional)
-          → ∀(none : optional)
-          → optional
-        )
-    → build (Optional a) (λ(x : a) → Some x) (None a)
+    λ(a : Type) →
+    λ ( build
+      : ∀(optional : Type) →
+        ∀(some : a → optional) →
+        ∀(none : optional) →
+          optional
+      ) →
+      build (Optional a) (λ(x : a) → Some x) (None a)
 , example2 = merge { Some = Natural/even, None = False } (Some 1)
 }

--- a/dhall/tests/regression/issue216a.dhall
+++ b/dhall/tests/regression/issue216a.dhall
@@ -1,5 +1,5 @@
 let GitHubProject : Type = { owner : Text, repo : Text } in
 let gitHubProject = \( github : GitHubProject ) ->
      let gitHubRoot = "https://github.com/${github.owner}/${github.repo}"
-	 in { bugReports = "${gitHubRoot}/issues"  }
+     in  { bugReports = "${gitHubRoot}/issues"  }
 in gitHubProject

--- a/dhall/tests/regression/issue216b.dhall
+++ b/dhall/tests/regression/issue216b.dhall
@@ -1,2 +1,2 @@
-  λ(github : { owner : Text, repo : Text })
-→ { bugReports = "https://github.com/${github.owner}/${github.repo}/issues" }
+λ(github : { owner : Text, repo : Text }) →
+  { bugReports = "https://github.com/${github.owner}/${github.repo}/issues" }


### PR DESCRIPTION
This is based on a suggestion from the functional programming
Slack

The basic difference is that now instead of this:

```dhall
  λ(x : A)
→ λ(y : B)
→ c
```

... we now do this:

```dhall
λ(x : A) →
λ(y : B) →
  c
```