### PR TITLE
Add `dhall-nix` support for shadowed variables

### DIFF
--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -32,6 +32,7 @@ Library
         data-fix                                < 0.3 ,
         dhall                     >= 1.31    && < 1.32,
         hnix                      >= 0.7     && < 0.8 ,
+        lens-family-core          >= 1.0.0   && < 2.2 ,
         neat-interpolation                      < 0.5 ,
         text                      >= 0.8.0.0 && < 1.3
     Exposed-Modules:

--- a/dhall-nix/release.nix
+++ b/dhall-nix/release.nix
@@ -122,7 +122,7 @@ in
           λ(r : { foo : Bool, bar : Text, baz : Natural }) → r.{ foo, bar }
         '';
         testShadow = dhallToNix ''
-          λ(x : Natural) → λ(y : Natural) → λ(x : Natural) → x@1
+          λ(x : Natural) → λ(x1 : Natural) → λ(x : Natural) → x@1
         '';
       in
         assert (testConst == {});

--- a/dhall-nix/release.nix
+++ b/dhall-nix/release.nix
@@ -122,7 +122,7 @@ in
           λ(r : { foo : Bool, bar : Text, baz : Natural }) → r.{ foo, bar }
         '';
         testShadow = dhallToNix ''
-          λ(x : Natural) → λ(x1 : Natural) → λ(x : Natural) → x@1
+          λ(x : Natural) → λ(x1 : Natural) → λ(x : Natural) → [ x, x1, x@1 ]
         '';
       in
         assert (testConst == {});
@@ -202,7 +202,7 @@ in
           foo = true;
           bar = "ABC";
         });
-        assert (testShadow 0 1 2 == 0);
+        assert (testShadow 0 1 2 == [ 2 1 0 ]);
         stdenv.mkDerivation {
           name = "tests-pass";
 

--- a/dhall-nix/release.nix
+++ b/dhall-nix/release.nix
@@ -1,99 +1,10 @@
 let
-  pinned = import ./pinnedNixpkgs.nix; in
-  inherit (pinned) nixpkgs;
+  shared = import ../nix/shared.nix { };
 
-  mass = function: names: haskellPackagesNew: haskellPackagesOld:
-    let
-      toNameValue = name: {
-        inherit name;
-
-        value = function haskellPackagesOld."${name}";
-      };
-
-    in
-      builtins.listToAttrs (map toNameValue names);
-
-  config = {
-    packageOverrides = pkgs: {
-      haskellPackages = pkgs.haskellPackages.override (old: {
-          overrides =
-            let
-              dontCheck =
-                mass pkgs.haskell.lib.dontCheck [
-                  "adjunctions"
-                  "base-orphans"
-                  "base64-bytestring"
-                  "cereal"
-                  "blaze-builder"
-                  "neat-interpolation"
-                  "pureMD5"
-                  "pem"
-                  "lens"
-                  "th-orphans"
-                  "mockery"
-                  "megaparsec"
-                  "lens-family-th"
-                  "network-uri"
-                  "interpolate"
-                  "http-types"
-                  "parsers"
-                  "dhall"
-                  "aeson"
-                  "half"
-                  "generic-deriving"
-                  "distributive"
-                  "deriving-compat"
-                  "monad-control"
-                  "logging-facade"
-                  "bifunctors"
-                  "exceptions"
-                  "cborg-json"
-                  "cryptohash-sha512"
-                  "Diff"
-                  "hashable"
-                  "hnix"
-                  "hnix-store-core"
-                  "optparse-generic"
-                  "serialise"
-                  "SHA"
-                  "these"
-                  "unordered-containers"
-                  "vector"
-                ];
-
-              extension = haskellPackagesNew: haskellPackagesOld: {
-                dhall-nix =
-                  pkgs.haskell.lib.failOnAllWarnings
-                    (pkgs.haskell.lib.justStaticExecutables
-                      haskellPackagesOld.dhall-nix
-                    );
-              };
-
-            in
-              pkgs.lib.fold
-                pkgs.lib.composeExtensions
-                (old.overrides or (_: _: {}))
-                [ (pkgs.haskell.lib.packagesFromDirectory { directory = ./nix; })
-                  dontCheck
-                  extension
-                ];
-        }
-      );
-    };
-  };
-
-  pkgs =
-    import nixpkgs { inherit config; };
-
-  inherit (pkgs) dhallToNix;
+  inherit (shared.pkgs) dhallToNix stdenv;
 
 in
-  { dhall-nix = pkgs.haskellPackages.dhall-nix;
-
-    shell = pkgs.haskellPackages.dhall-nix.env;
-
-    # Test that various Dhall to Nix conversions work
-    tests =
+  { tests =
       let
         testConst = dhallToNix "Type";
         testLam = dhallToNix "λ(x : Bool) → x";
@@ -210,6 +121,9 @@ in
         testProject = dhallToNix ''
           λ(r : { foo : Bool, bar : Text, baz : Natural }) → r.{ foo, bar }
         '';
+        testShadow = dhallToNix ''
+          λ(x : Natural) → λ(y : Natural) → λ(x : Natural) → x@1
+        '';
       in
         assert (testConst == {});
         assert (testLam true == true);
@@ -288,7 +202,8 @@ in
           foo = true;
           bar = "ABC";
         });
-        pkgs.stdenv.mkDerivation {
+        assert (testShadow 0 1 2 == 0);
+        stdenv.mkDerivation {
           name = "tests-pass";
 
           buildCommand = "touch $out";

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -81,7 +81,10 @@ successTest path = do
                 State.evalStateT (Test.Util.loadWith actualExpr) (Import.emptyStatus directoryString)
 
         let runTest = do
-                if Turtle.filename (Turtle.fromText path) == "hashFromCacheA.dhall"
+                if Turtle.filename (Turtle.fromText path) `elem`
+                     [ "hashFromCacheA.dhall"
+                     , "unit/asLocation/HashA.dhall"
+                     ]
                     then do
                         setCache
                         _ <- load

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -36,6 +36,10 @@ let
   overlayShared = pkgsNew: pkgsOld: {
     sdist = pkgsNew.callPackage ./sdist.nix { };
 
+    dhallToNix = pkgsOld.dhallToNix.override {
+      inherit (pkgsNew.haskell.packages."${compiler}") dhall-nix;
+    };
+
     haskell = pkgsOld.haskell // {
       packages = pkgsOld.haskell.packages // {
         "${compiler}" = pkgsOld.haskell.packages."${compiler}".override (old: {


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1761

This now renames variables to avoid conflicts, using as few renames as
possible.

I also dusted off the `dhall-nix/release.nix` test suite.  This test
suite still doesn't run in CI (since doing so would trigger a really
expensive evaluation-time build), but I ran it manually to test this
change.