### PR TITLE
Update Lift instances for compatibility with template-haskell-2.16

### DIFF
--- a/dhall/src/Dhall/Set.hs
+++ b/dhall/src/Dhall/Set.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
 
 -- | This module only exports ways of constructing a Set,
 -- retrieving List, Set, and Seq representations of the same data,
@@ -36,14 +37,13 @@ import Language.Haskell.TH.Syntax (Lift)
 import qualified Data.Set
 import qualified Data.Sequence
 import qualified Data.Foldable
-import qualified Language.Haskell.TH.Syntax as Syntax
 
 {-| This is a variation on @"Data.Set".`Data.Set.Set`@ that remembers the
     original order of elements.  This ensures that ordering is not lost when
     formatting Dhall code
 -}
 data Set a = Set (Data.Set.Set a) (Seq a)
-    deriving (Generic, Show, Data, NFData)
+    deriving (Generic, Show, Data, NFData, Lift)
 -- Invariant: In @Set set seq@, @toAscList set == sort (toList seq)@.
 
 instance Eq a => Eq (Set a) where
@@ -53,9 +53,6 @@ instance Eq a => Eq (Set a) where
 instance Ord a => Ord (Set a) where
     compare (Set _ x) (Set _ y) = compare x y
     {-# INLINABLE compare #-}
-
-instance (Data a, Lift a, Ord a) => Lift (Set a) where
-    lift = Syntax.liftData
 
 instance Foldable Set where
     foldMap f (Set _ x) = foldMap f x

--- a/dhall/src/Dhall/Src.hs
+++ b/dhall/src/Dhall/Src.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
@@ -18,7 +19,7 @@ import Data.Text (Text)
 import Data.Text.Prettyprint.Doc  (Pretty (..))
 import GHC.Generics (Generic)
 import Instances.TH.Lift ()
-import Language.Haskell.TH.Syntax (Lift, lift)
+import Language.Haskell.TH.Syntax (Lift(..))
 import Text.Megaparsec (SourcePos (SourcePos), mkPos, unPos)
 
 import {-# SOURCE #-} qualified Dhall.Util
@@ -36,8 +37,13 @@ data Src = Src
 
 
 instance Lift Src where
+#if MIN_VERSION_template_haskell(2,16,0)
+    liftTyped (Src (SourcePos a b c) (SourcePos d e f) g) =
+        [|| Src (SourcePos a (mkPos b') (mkPos c')) (SourcePos d (mkPos e') (mkPos f')) g ||]
+#else
     lift (Src (SourcePos a b c) (SourcePos d e f) g) =
         [| Src (SourcePos a (mkPos b') (mkPos c')) (SourcePos d (mkPos e') (mkPos f')) g |]
+#endif
       where
         b' = unPos b
         c' = unPos c


### PR DESCRIPTION
See
https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/8.10#lift-changes
for some background info.