### PR TITLE
Fix version numbers and update `cabal` version to 1.10

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -1,6 +1,6 @@
 Name: dhall-bash
 Version: 1.0.30
-Cabal-Version: >=1.8.0.2
+Cabal-Version: >=1.10
 Build-Type: Simple
 Tested-With: GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
@@ -37,6 +37,7 @@ Library
         text                      >= 0.2     && < 1.3
     Exposed-Modules: Dhall.Bash
     GHC-Options: -Wall
+    Default-Language: Haskell2010
 
 Executable dhall-to-bash
     Hs-Source-Dirs: exec
@@ -51,3 +52,4 @@ Executable dhall-to-bash
         optparse-generic >= 1.1.1    && < 1.4 ,
         text
     GHC-Options: -Wall
+    Default-Language: Haskell2010

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -1,6 +1,6 @@
 Name: dhall-json
-Version: 1.6.3
-Cabal-Version: >=1.8.0.2
+Version: 1.6.4
+Cabal-Version: >=1.10
 Build-Type: Simple
 Tested-With: GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
@@ -58,6 +58,7 @@ Library
     Other-Modules:
         Dhall.JSON.Util
     GHC-Options: -Wall
+    Default-Language: Haskell2010
 
 Executable dhall-to-json
     Hs-Source-Dirs: dhall-to-json
@@ -74,6 +75,7 @@ Executable dhall-to-json
     Other-Modules:
         Paths_dhall_json
     GHC-Options: -Wall
+    Default-Language: Haskell2010
 
 Executable dhall-to-yaml
     Hs-Source-Dirs: dhall-to-yaml
@@ -84,6 +86,7 @@ Executable dhall-to-yaml
     Other-Modules:
         Paths_dhall_json
     GHC-Options: -Wall
+    Default-Language: Haskell2010
 
 Executable json-to-dhall
     Hs-Source-Dirs: json-to-dhall
@@ -105,6 +108,7 @@ Executable json-to-dhall
     Other-Modules:
         Paths_dhall_json
     GHC-Options: -Wall
+    Default-Language: Haskell2010
 
 Test-Suite tasty
     Type: exitcode-stdio-1.0
@@ -120,3 +124,4 @@ Test-Suite tasty
         text              ,
         tasty-hunit >= 0.2
     GHC-Options: -Wall
+    Default-Language: Haskell2010

--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -1,6 +1,6 @@
 Name: dhall-nix
 Version: 1.1.14
-Cabal-Version: >=1.8.0.2
+Cabal-Version: >=1.10
 Build-Type: Simple
 Tested-With: GHC == 8.0.1
 License: BSD3
@@ -38,6 +38,7 @@ Library
     Exposed-Modules:
         Dhall.Nix
     GHC-Options: -Wall
+    Default-Language: Haskell2010
     if os(windows) || impl(eta)
         Buildable: False
         
@@ -56,5 +57,6 @@ Executable dhall-to-nix
         optparse-generic >= 1.1.1   && < 1.4,
         text
     GHC-Options: -Wall
+    Default-Language: Haskell2010
     if os(windows)
         Buildable: False

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -1,6 +1,6 @@
 Name: dhall-yaml
-Version: 1.0.3
-Cabal-Version: >=1.8.0.2
+Version: 1.1.0
+Cabal-Version: >=1.10
 Build-Type: Simple
 Tested-With: GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.1
 License: GPL-3
@@ -46,6 +46,7 @@ Library
         Dhall.Yaml
         Dhall.YamlToDhall
     GHC-Options: -Wall
+    Default-Language: Haskell2010
 
 Executable dhall-to-yaml-ng
     Hs-Source-Dirs: dhall-to-yaml-ng
@@ -57,6 +58,7 @@ Executable dhall-to-yaml-ng
     Other-Modules:
         Paths_dhall_yaml
     GHC-Options: -Wall
+    Default-Language: Haskell2010
 
 Executable yaml-to-dhall
     Hs-Source-Dirs: yaml-to-dhall
@@ -79,6 +81,7 @@ Executable yaml-to-dhall
     Other-Modules:
         Paths_dhall_yaml
     GHC-Options: -Wall
+    Default-Language: Haskell2010
 
 Test-Suite tasty
     Type: exitcode-stdio-1.0
@@ -95,3 +98,4 @@ Test-Suite tasty
         text                                    ,
         tasty-hunit            >= 0.2
     GHC-Options: -Wall
+    Default-Language: Haskell2010


### PR DESCRIPTION
I realized that I forgot to update the version numbers for `dhall-{json,yaml}`
as part of #1777 

Also, Hackage is starting to reject Haskell packages that have a
`Cabal-Version` with a minimum bound less than 1.10, which this
change fixes.