### PR TITLE
Require dhall 1.32.0+ for dhall-json 1.6.4

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -41,7 +41,7 @@ Library
         aeson-yaml                >= 1.0.6    && < 1.1 ,
         bytestring                               < 0.11,
         containers                                     ,
-        dhall                     >= 1.31.0   && < 1.33,
+        dhall                     >= 1.32.0   && < 1.33,
         exceptions                >= 0.8.3    && < 0.11,
         filepath                                 < 1.5 ,
         optparse-applicative      >= 0.14.0.0 && < 0.16,


### PR DESCRIPTION
dhall-json 1.6.4 does not build with e.g. dhall 1.31.1:

```
[5 of 5] Compiling Dhall.JSONToDhall ( src/Dhall/JSONToDhall.hs, dist/build/Dhall/JSONToDhall.dyn_o )

src/Dhall/JSONToDhall.hs:793:45: error:
    Not in scope: ‘Lint.useToMap’
    Module ‘Dhall.Lint’ does not export ‘useToMap’.
    |
793 |     fmap (Optics.rewriteOf D.subExpressions Lint.useToMap) . loop (D.alphaNormalize (D.normalize expressionType))
    |                                             ^^^^^^^^^^^^^
```