### PR TITLE
Fix: `Text` values that represents boolean values in YAML 1.1 are quoted

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,3 +1,4 @@
 steps:
   - imports:
       align: group
+      pad_module_names: false

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,4 +1,4 @@
 steps:
   - imports:
       align: group
-      pad_module_names: false
+      pad_module_names: true

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,3 @@
+steps:
+  - imports:
+      align: group

--- a/dhall-json/src/Dhall/DhallToYaml/Main.hs
+++ b/dhall-json/src/Dhall/DhallToYaml/Main.hs
@@ -6,17 +6,17 @@
 module Dhall.DhallToYaml.Main (main) where
 
 import Control.Applicative (optional, (<|>))
-import Control.Exception (SomeException)
-import Data.ByteString (ByteString)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Dhall.JSON (parseConversion, parsePreservationAndOmission)
-import Dhall.JSON.Yaml (Options (..), parseDocuments, parseQuoted)
+import Control.Exception   (SomeException)
+import Data.ByteString     (ByteString)
+import Data.Monoid         ((<>))
+import Data.Text           (Text)
+import Dhall.JSON          (parseConversion, parsePreservationAndOmission)
+import Dhall.JSON.Yaml     (Options (..), parseDocuments, parseQuoted)
 import Options.Applicative (Parser, ParserInfo)
 
 import qualified Control.Exception
 import qualified Data.ByteString
-import qualified Data.Text.IO as Text.IO
+import qualified Data.Text.IO        as Text.IO
 import qualified Data.Version
 import qualified GHC.IO.Encoding
 import qualified Options.Applicative as Options

--- a/dhall-json/src/Dhall/DhallToYaml/Main.hs
+++ b/dhall-json/src/Dhall/DhallToYaml/Main.hs
@@ -5,14 +5,15 @@
 -}
 module Dhall.DhallToYaml.Main (main) where
 
-import Control.Applicative (optional, (<|>))
-import Control.Exception (SomeException)
-import Data.ByteString (ByteString)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Dhall.JSON (parsePreservationAndOmission, parseConversion)
-import Dhall.JSON.Yaml (Options(..), parseDocuments, parseQuoted)
-import Options.Applicative (Parser, ParserInfo)
+import           Control.Applicative (optional, (<|>))
+import           Control.Exception   (SomeException)
+import           Data.ByteString     (ByteString)
+import           Data.Monoid         ((<>))
+import           Data.Text           (Text)
+import           Dhall.JSON          (parseConversion,
+                                      parsePreservationAndOmission)
+import           Dhall.JSON.Yaml     (Options (..), parseDocuments, parseQuoted)
+import           Options.Applicative (Parser, ParserInfo)
 
 import qualified Control.Exception
 import qualified Data.ByteString
@@ -82,10 +83,10 @@ main version dhallToYaml = do
     maybeOptions <- Options.execParser parserInfo
 
     case maybeOptions of
-        Nothing -> do
+        Nothing ->
             putStrLn (Data.Version.showVersion version)
 
-        Just options@(Options {..}) -> do
+        Just options@Options{..} ->
             handle $ do
                 contents <- case file of
                     Nothing   -> Text.IO.getContents
@@ -93,7 +94,7 @@ main version dhallToYaml = do
 
                 let write =
                         case output of
-                            Nothing -> Data.ByteString.putStr
+                            Nothing    -> Data.ByteString.putStr
                             Just file_ -> Data.ByteString.writeFile file_
 
                 write =<< dhallToYaml options file contents

--- a/dhall-json/src/Dhall/DhallToYaml/Main.hs
+++ b/dhall-json/src/Dhall/DhallToYaml/Main.hs
@@ -5,19 +5,18 @@
 -}
 module Dhall.DhallToYaml.Main (main) where
 
-import           Control.Applicative (optional, (<|>))
-import           Control.Exception   (SomeException)
-import           Data.ByteString     (ByteString)
-import           Data.Monoid         ((<>))
-import           Data.Text           (Text)
-import           Dhall.JSON          (parseConversion,
-                                      parsePreservationAndOmission)
-import           Dhall.JSON.Yaml     (Options (..), parseDocuments, parseQuoted)
-import           Options.Applicative (Parser, ParserInfo)
+import Control.Applicative (optional, (<|>))
+import Control.Exception (SomeException)
+import Data.ByteString (ByteString)
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import Dhall.JSON (parseConversion, parsePreservationAndOmission)
+import Dhall.JSON.Yaml (Options (..), parseDocuments, parseQuoted)
+import Options.Applicative (Parser, ParserInfo)
 
 import qualified Control.Exception
 import qualified Data.ByteString
-import qualified Data.Text.IO        as Text.IO
+import qualified Data.Text.IO as Text.IO
 import qualified Data.Version
 import qualified GHC.IO.Encoding
 import qualified Options.Applicative as Options

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -124,9 +124,9 @@
     the same record.  For example, this code:
 
 > let Example = < Left : { foo : Natural } | Right : { bar : Bool } >
-> 
+>
 > let Nesting = < Inline | Nested : Text >
-> 
+>
 > in  { field    = "name"
 >     , nesting  = Nesting.Inline
 >     , contents = Example.Left { foo = 2 }
@@ -143,9 +143,9 @@
     underneath a field named @nestedField@.  For example, this code:
 
 > let Example = < Left : { foo : Natural } | Right : { bar : Bool } >
-> 
+>
 > let Nesting = < Inline | Nested : Text >
-> 
+>
 > in  { field    = "name"
 >     , nesting  = Nesting.Nested "value"
 >     , contents = Example.Left { foo = 2 }
@@ -165,7 +165,7 @@
 
 > $ cat ./example.dhall
 > let JSON = https://prelude.dhall-lang.org/JSON/package.dhall
-> 
+>
 > in  JSON.object
 >     [ { mapKey = "foo", mapValue = JSON.null }
 >     , { mapKey =
@@ -212,21 +212,22 @@ module Dhall.JSON (
     , CompileError(..)
     ) where
 
-import Control.Applicative (empty, (<|>))
-import Control.Monad (guard)
-import Control.Exception (Exception, throwIO)
-import Data.Aeson (Value(..), ToJSON(..))
-import Data.Maybe (fromMaybe)
-import Data.Monoid ((<>), mempty)
-import Data.Text (Text)
-import Data.Text.Prettyprint.Doc (Pretty)
-import Data.Void (Void)
-import Dhall.Core (Binding(..), DhallDouble(..), Expr)
-import Dhall.Import (SemanticCacheMode(..))
-import Dhall.Map (Map)
-import Dhall.JSON.Util (pattern V)
-import Options.Applicative (Parser)
-import Prelude hiding (getContents)
+import           Control.Applicative                   (empty, (<|>))
+import           Control.Exception                     (Exception, throwIO)
+import           Control.Monad                         (guard)
+import           Data.Aeson                            (ToJSON (..), Value (..))
+import           Data.Maybe                            (fromMaybe)
+import           Data.Monoid                           (mempty, (<>))
+import           Data.Text                             (Text)
+import           Data.Text.Prettyprint.Doc             (Pretty)
+import           Data.Void                             (Void)
+import           Dhall.Core                            (Binding (..),
+                                                        DhallDouble (..), Expr)
+import           Dhall.Import                          (SemanticCacheMode (..))
+import           Dhall.JSON.Util                       (pattern V)
+import           Dhall.Map                             (Map)
+import           Options.Applicative                   (Parser)
+import           Prelude                               hiding (getContents)
 
 import qualified Data.Aeson                            as Aeson
 import qualified Data.Foldable                         as Foldable
@@ -412,7 +413,7 @@ dhallToJSON
     -> Either CompileError Value
 dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
   where
-    loop e = case e of 
+    loop e = case e of
         Core.BoolLit a -> return (toJSON a)
         Core.NaturalLit a -> return (toJSON a)
         Core.IntegerLit a -> return (toJSON a)
@@ -459,7 +460,7 @@ dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
                    , Just (alternativeName, mExpr) <- getContents contents -> do
                        contents' <- case mExpr of
                            Just expr -> loop expr
-                           Nothing -> return Aeson.Null
+                           Nothing   -> return Aeson.Null
 
                        let taggedValue =
                                Data.Map.fromList
@@ -637,7 +638,7 @@ omitNull (Bool bool) =
 omitNull Null =
     Null
 
-{-| Omit record fields that are @null@, arrays and records whose transitive 
+{-| Omit record fields that are @null@, arrays and records whose transitive
     fields are all null
 -}
 omitEmpty :: Value -> Value

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -212,32 +212,32 @@ module Dhall.JSON (
     , CompileError(..)
     ) where
 
-import Control.Applicative (empty, (<|>))
-import Control.Exception (Exception, throwIO)
-import Control.Monad (guard)
-import Data.Aeson (ToJSON (..), Value (..))
-import Data.Maybe (fromMaybe)
-import Data.Monoid (mempty, (<>))
-import Data.Text (Text)
+import Control.Applicative       (empty, (<|>))
+import Control.Exception         (Exception, throwIO)
+import Control.Monad             (guard)
+import Data.Aeson                (ToJSON (..), Value (..))
+import Data.Maybe                (fromMaybe)
+import Data.Monoid               (mempty, (<>))
+import Data.Text                 (Text)
 import Data.Text.Prettyprint.Doc (Pretty)
-import Data.Void (Void)
-import Dhall.Core (Binding (..), DhallDouble (..), Expr)
-import Dhall.Import (SemanticCacheMode (..))
-import Dhall.JSON.Util (pattern V)
-import Dhall.Map (Map)
-import Options.Applicative (Parser)
-import Prelude hiding (getContents)
+import Data.Void                 (Void)
+import Dhall.Core                (Binding (..), DhallDouble (..), Expr)
+import Dhall.Import              (SemanticCacheMode (..))
+import Dhall.JSON.Util           (pattern V)
+import Dhall.Map                 (Map)
+import Options.Applicative       (Parser)
+import Prelude                   hiding (getContents)
 
-import qualified Data.Aeson as Aeson
-import qualified Data.Foldable as Foldable
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Aeson                            as Aeson
+import qualified Data.Foldable                         as Foldable
+import qualified Data.HashMap.Strict                   as HashMap
 import qualified Data.List
 import qualified Data.Map
 import qualified Data.Ord
 import qualified Data.Text
 import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
-import qualified Data.Vector as Vector
-import qualified Dhall.Core as Core
+import qualified Data.Vector                           as Vector
+import qualified Dhall.Core                            as Core
 import qualified Dhall.Import
 import qualified Dhall.Map
 import qualified Dhall.Optics

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -212,33 +212,32 @@ module Dhall.JSON (
     , CompileError(..)
     ) where
 
-import           Control.Applicative                   (empty, (<|>))
-import           Control.Exception                     (Exception, throwIO)
-import           Control.Monad                         (guard)
-import           Data.Aeson                            (ToJSON (..), Value (..))
-import           Data.Maybe                            (fromMaybe)
-import           Data.Monoid                           (mempty, (<>))
-import           Data.Text                             (Text)
-import           Data.Text.Prettyprint.Doc             (Pretty)
-import           Data.Void                             (Void)
-import           Dhall.Core                            (Binding (..),
-                                                        DhallDouble (..), Expr)
-import           Dhall.Import                          (SemanticCacheMode (..))
-import           Dhall.JSON.Util                       (pattern V)
-import           Dhall.Map                             (Map)
-import           Options.Applicative                   (Parser)
-import           Prelude                               hiding (getContents)
+import Control.Applicative (empty, (<|>))
+import Control.Exception (Exception, throwIO)
+import Control.Monad (guard)
+import Data.Aeson (ToJSON (..), Value (..))
+import Data.Maybe (fromMaybe)
+import Data.Monoid (mempty, (<>))
+import Data.Text (Text)
+import Data.Text.Prettyprint.Doc (Pretty)
+import Data.Void (Void)
+import Dhall.Core (Binding (..), DhallDouble (..), Expr)
+import Dhall.Import (SemanticCacheMode (..))
+import Dhall.JSON.Util (pattern V)
+import Dhall.Map (Map)
+import Options.Applicative (Parser)
+import Prelude hiding (getContents)
 
-import qualified Data.Aeson                            as Aeson
-import qualified Data.Foldable                         as Foldable
-import qualified Data.HashMap.Strict                   as HashMap
+import qualified Data.Aeson as Aeson
+import qualified Data.Foldable as Foldable
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List
 import qualified Data.Map
 import qualified Data.Ord
 import qualified Data.Text
 import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
-import qualified Data.Vector                           as Vector
-import qualified Dhall.Core                            as Core
+import qualified Data.Vector as Vector
+import qualified Dhall.Core as Core
 import qualified Dhall.Import
 import qualified Dhall.Map
 import qualified Dhall.Optics

--- a/dhall-json/src/Dhall/JSON/Yaml.hs
+++ b/dhall-json/src/Dhall/JSON/Yaml.hs
@@ -15,10 +15,10 @@ module Dhall.JSON.Yaml
   , jsonToYaml
   ) where
 
-import Data.ByteString (ByteString)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Dhall.JSON (Conversion (..), SpecialDoubleMode (..))
+import Data.ByteString     (ByteString)
+import Data.Monoid         ((<>))
+import Data.Text           (Text)
+import Dhall.JSON          (Conversion (..), SpecialDoubleMode (..))
 import Options.Applicative (Parser)
 
 import qualified Data.Aeson

--- a/dhall-json/src/Dhall/JSON/Yaml.hs
+++ b/dhall-json/src/Dhall/JSON/Yaml.hs
@@ -15,11 +15,11 @@ module Dhall.JSON.Yaml
   , jsonToYaml
   ) where
 
-import Data.ByteString (ByteString)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Dhall.JSON (Conversion(..), SpecialDoubleMode(..))
-import Options.Applicative (Parser)
+import           Data.ByteString      (ByteString)
+import           Data.Monoid          ((<>))
+import           Data.Text            (Text)
+import           Dhall.JSON           (Conversion (..), SpecialDoubleMode (..))
+import           Options.Applicative  (Parser)
 
 import qualified Data.Aeson
 import qualified Data.Aeson.Yaml
@@ -63,7 +63,7 @@ parseQuoted =
             (   Options.Applicative.long "quoted"
             <>  Options.Applicative.help "Prevent from generating not quoted scalars"
             )
-                           
+
 {-| Convert a piece of Text carrying a Dhall inscription to an equivalent YAML ByteString
 -}
 dhallToYaml
@@ -73,7 +73,7 @@ dhallToYaml
   -> Text  -- ^ Input text.
   -> IO ByteString
 dhallToYaml Options{..} mFilePath code = do
-  
+
   let explaining = if explain then Dhall.detailed else id
 
   json <- omission <$> explaining (Dhall.JSON.codeToValue conversion UseYAMLEncoding mFilePath code)

--- a/dhall-json/src/Dhall/JSON/Yaml.hs
+++ b/dhall-json/src/Dhall/JSON/Yaml.hs
@@ -15,11 +15,11 @@ module Dhall.JSON.Yaml
   , jsonToYaml
   ) where
 
-import           Data.ByteString      (ByteString)
-import           Data.Monoid          ((<>))
-import           Data.Text            (Text)
-import           Dhall.JSON           (Conversion (..), SpecialDoubleMode (..))
-import           Options.Applicative  (Parser)
+import Data.ByteString (ByteString)
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import Dhall.JSON (Conversion (..), SpecialDoubleMode (..))
+import Options.Applicative (Parser)
 
 import qualified Data.Aeson
 import qualified Data.Aeson.Yaml

--- a/dhall-yaml/src/Dhall/Yaml.hs
+++ b/dhall-yaml/src/Dhall/Yaml.hs
@@ -51,7 +51,6 @@ jsonToYaml
     -> Bool
     -> ByteString
 jsonToYaml json documents quoted =
-  let encoder = Data.YAML.Aeson.encodeValue' schemaEncoder YT.UTF8 in
   case (documents, json) of
     (True, Data.Aeson.Array elems)
       -> Data.ByteString.intercalate "\n---\n"
@@ -73,3 +72,4 @@ jsonToYaml json documents quoted =
         YS.schemaEncoderScalar Y.coreSchemaEncoder s
 
     schemaEncoder = YS.setScalarStyle style Y.coreSchemaEncoder
+    encoder = Data.YAML.Aeson.encodeValue' schemaEncoder YT.UTF8

--- a/dhall-yaml/src/Dhall/Yaml.hs
+++ b/dhall-yaml/src/Dhall/Yaml.hs
@@ -9,22 +9,22 @@ module Dhall.Yaml
     , dhallToYaml
     ) where
 
-import Data.ByteString (ByteString)
+import Data.ByteString      (ByteString)
 import Data.ByteString.Lazy (toStrict)
-import Data.Text (Text)
-import Dhall.JSON (SpecialDoubleMode (..), codeToValue)
-import Dhall.JSON.Yaml (Options (..))
+import Data.Text            (Text)
+import Dhall.JSON           (SpecialDoubleMode (..), codeToValue)
+import Dhall.JSON.Yaml      (Options (..))
 
 import qualified Data.Aeson
 import qualified Data.ByteString
-import qualified Data.Char as Char
-import qualified Data.Text as Text
+import qualified Data.Char        as Char
+import qualified Data.Text        as Text
 import qualified Data.Vector
-import qualified Data.YAML as Y
+import qualified Data.YAML        as Y
 import qualified Data.YAML.Aeson
-import qualified Data.YAML.Event as YE
+import qualified Data.YAML.Event  as YE
 import qualified Data.YAML.Schema as YS
-import qualified Data.YAML.Token as YT
+import qualified Data.YAML.Token  as YT
 import qualified Dhall
 import qualified Dhall.JSON.Yaml
 

--- a/dhall-yaml/src/Dhall/Yaml.hs
+++ b/dhall-yaml/src/Dhall/Yaml.hs
@@ -52,12 +52,12 @@ jsonToYaml
     -> Bool
     -> ByteString
 jsonToYaml json documents quoted =
+  let encoder = Data.YAML.Aeson.encodeValue' schemaEncoder YT.UTF8 in
   case (documents, json) of
     (True, Data.Aeson.Array elems)
       -> Data.ByteString.intercalate "\n---\n"
-         $ fmap (Data.ByteString.Lazy.toStrict. (Data.YAML.Aeson.encodeValue' schemaEncoder YT.UTF8). (:[]))
-         $ Data.Vector.toList elems
-    _ -> Data.ByteString.Lazy.toStrict (Data.YAML.Aeson.encodeValue' schemaEncoder YT.UTF8 [json])
+         $ (Data.ByteString.Lazy.toStrict . encoder . (:[])) <$> Data.Vector.toList elems
+    _ -> Data.ByteString.Lazy.toStrict (encoder [json])
   where
     style (Y.SStr s)
         | "\n" `Text.isInfixOf` s =

--- a/dhall-yaml/src/Dhall/Yaml.hs
+++ b/dhall-yaml/src/Dhall/Yaml.hs
@@ -9,23 +9,22 @@ module Dhall.Yaml
     , dhallToYaml
     ) where
 
-import           Data.ByteString      (ByteString)
-import           Data.ByteString.Lazy (toStrict)
-import           Data.Text            (Text)
-import           Dhall.JSON           (SpecialDoubleMode (..), codeToValue)
-import           Dhall.JSON.Yaml      (Options (..))
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy (toStrict)
+import Data.Text (Text)
+import Dhall.JSON (SpecialDoubleMode (..), codeToValue)
+import Dhall.JSON.Yaml (Options (..))
 
 import qualified Data.Aeson
 import qualified Data.ByteString
-import qualified Data.Char            as Char
-import qualified Data.Text            as Text
+import qualified Data.Char as Char
+import qualified Data.Text as Text
 import qualified Data.Vector
-import qualified Data.YAML            as Y
+import qualified Data.YAML as Y
 import qualified Data.YAML.Aeson
-import qualified Data.YAML.Event      as YE
-import qualified Data.YAML.Schema     as YS
-import qualified Data.YAML.Token      as YT
-import qualified Debug.Trace
+import qualified Data.YAML.Event as YE
+import qualified Data.YAML.Schema as YS
+import qualified Data.YAML.Token as YT
 import qualified Dhall
 import qualified Dhall.JSON.Yaml
 

--- a/dhall-yaml/src/Dhall/Yaml.hs
+++ b/dhall-yaml/src/Dhall/Yaml.hs
@@ -66,7 +66,8 @@ jsonToYaml json documents quoted =
       where
         -- For backwards compatibility with YAML 1.1, we need to add the following to the set of boolean values:
         -- https://yaml.org/type/bool.html
-        isBoolString = Text.toLower s `elem` ["y", "yes", "n", "no", "true", "false", "on", "off"]
+        isBoolString = Text.length <= 5 &&
+                      Text.toLower s `elem` ["y", "yes", "n", "no", "true", "false", "on", "off"]
         isNumberOrDateRelated c = Char.isDigit c || c == '.' || c == 'e' || c == '-'
     style s =
         YS.schemaEncoderScalar Y.coreSchemaEncoder s

--- a/dhall-yaml/src/Dhall/Yaml.hs
+++ b/dhall-yaml/src/Dhall/Yaml.hs
@@ -66,7 +66,7 @@ jsonToYaml json documents quoted =
       where
         -- For backwards compatibility with YAML 1.1, we need to add the following to the set of boolean values:
         -- https://yaml.org/type/bool.html
-        isBoolString = Text.length <= 5 &&
+        isBoolString = Text.length s <= 5 &&
                       Text.toLower s `elem` ["y", "yes", "n", "no", "true", "false", "on", "off"]
         isNumberOrDateRelated c = Char.isDigit c || c == '.' || c == 'e' || c == '-'
     style s =

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -4,16 +4,16 @@
 
 module Main where
 
-import Data.Monoid ((<>))
+import Data.Monoid     ((<>))
 import Dhall.JSON.Yaml (Options (..))
-import Test.Tasty (TestTree)
+import Test.Tasty      (TestTree)
 
 import qualified Data.ByteString
 import qualified Data.Text.IO
 import qualified Dhall.Core
 import qualified Dhall.JSON.Yaml
 import qualified Dhall.Yaml
-import qualified Dhall.YamlToDhall as YamlToDhall
+import qualified Dhall.YamlToDhall          as YamlToDhall
 import qualified GHC.IO.Encoding
 import qualified Test.Tasty
 import qualified Test.Tasty.ExpectedFailure as Tasty.ExpectedFailure

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -68,15 +68,14 @@ testTree =
 testDhallToYaml :: Options -> String -> TestScope -> TestTree
 testDhallToYaml options prefix testScope =
     Test.Tasty.testGroup prefix (
-        let hsYamlTest = testCase Dhall.Yaml.dhallToYaml "HsYAML"
-            hsAesonYamlTest = testCase Dhall.JSON.Yaml.dhallToYaml "aeson-yaml"
-        in
         case testScope of
             SkipAesonYaml _ -> [hsYamlTest, Tasty.ExpectedFailure.expectFail hsAesonYamlTest]
             SkipHsYAML _ -> [hsAesonYamlTest, Tasty.ExpectedFailure.expectFail hsYamlTest]
             _ -> [hsYamlTest, hsAesonYamlTest]
     )
   where
+    hsYamlTest = testCase Dhall.Yaml.dhallToYaml "HsYAML"
+    hsAesonYamlTest = testCase Dhall.JSON.Yaml.dhallToYaml "aeson-yaml"
     testCase dhallToYaml s = Test.Tasty.HUnit.testCase s $ do
         let inputFile = prefix <> ".dhall"
         let outputFile = prefix <> ".yaml"

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
 module Main where
 
-import Data.Monoid ((<>))
-import Dhall.JSON.Yaml (Options(..))
-import Test.Tasty (TestTree)
+import           Data.Monoid       ((<>))
+import           Dhall.JSON.Yaml   (Options (..))
+import           Test.Tasty        (TestTree)
 
 import qualified Data.ByteString
 import qualified Data.Text.IO

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -16,6 +16,7 @@ import qualified Dhall.Yaml
 import qualified Dhall.YamlToDhall as YamlToDhall
 import qualified GHC.IO.Encoding
 import qualified Test.Tasty
+import qualified Test.Tasty.ExpectedFailure as Tasty.ExpectedFailure
 import qualified Test.Tasty.HUnit
 
 main :: IO ()
@@ -71,8 +72,8 @@ testDhallToYaml options prefix testScope =
             hsAesonYamlTest = testCase Dhall.JSON.Yaml.dhallToYaml "aeson-yaml"
         in
         case testScope of
-            SkipAesonYaml _ -> [hsYamlTest]
-            SkipHsYAML _ -> [hsAesonYamlTest]
+            SkipAesonYaml _ -> [hsYamlTest, Tasty.ExpectedFailure.expectFail hsAesonYamlTest]
+            SkipHsYAML _ -> [hsAesonYamlTest, Tasty.ExpectedFailure.expectFail hsYamlTest]
             _ -> [hsYamlTest, hsAesonYamlTest]
     )
   where

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -30,28 +30,48 @@ testTree =
         [ testDhallToYaml
             Dhall.JSON.Yaml.defaultOptions
             "./tasty/data/normal"
+            True
+            False
+        , testDhallToYaml
+            Dhall.JSON.Yaml.defaultOptions
+            "./tasty/data/normal-aeson"
+            False
+            True
         , testDhallToYaml
             Dhall.JSON.Yaml.defaultOptions
             "./tasty/data/special"
+            True
+            True
         , testDhallToYaml
             Dhall.JSON.Yaml.defaultOptions
             "./tasty/data/emptyList"
+            True
+            True
         , testDhallToYaml
             Dhall.JSON.Yaml.defaultOptions
             "./tasty/data/emptyMap"
+            True
+            True
         , testDhallToYaml
             (Dhall.JSON.Yaml.defaultOptions { quoted = True })
             "./tasty/data/quoted"
+            False
+            True
+        , testDhallToYaml
+            (Dhall.JSON.Yaml.defaultOptions)
+            "./tasty/data/boolean-quotes"
+            True
+            False
         , testYamlToDhall
             "./tasty/data/mergify"
         ]
 
-testDhallToYaml :: Options -> String -> TestTree
-testDhallToYaml options prefix =
-    Test.Tasty.testGroup prefix
-        [ testCase Dhall.Yaml.dhallToYaml "HsYAML"
-        , testCase Dhall.JSON.Yaml.dhallToYaml "aeson-yaml"
-        ]
+testDhallToYaml :: Options -> String -> Bool -> Bool -> TestTree
+testDhallToYaml options prefix testHsYaml testAesonYaml =
+    Test.Tasty.testGroup prefix (
+        [testCase Dhall.Yaml.dhallToYaml "HsYAML" | testHsYaml] <>
+        [testCase Dhall.JSON.Yaml.dhallToYaml "aeson-yaml" | testAesonYaml]
+    )
   where
     testCase dhallToYaml s = Test.Tasty.HUnit.testCase s $ do
         let inputFile = prefix <> ".dhall"

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -4,9 +4,9 @@
 
 module Main where
 
-import           Data.Monoid       ((<>))
-import           Dhall.JSON.Yaml   (Options (..))
-import           Test.Tasty        (TestTree)
+import Data.Monoid ((<>))
+import Dhall.JSON.Yaml (Options (..))
+import Test.Tasty (TestTree)
 
 import qualified Data.ByteString
 import qualified Data.Text.IO

--- a/dhall-yaml/tasty/data/boolean-quotes.dhall
+++ b/dhall-yaml/tasty/data/boolean-quotes.dhall
@@ -1,0 +1,7 @@
+{ y_quoted = "y"
+, yes_quoted = "yes"
+, n_quoted = "n"
+, no_quoted = "no"
+, on_quoted = "on"
+, off_quoted = "off"
+}

--- a/dhall-yaml/tasty/data/boolean-quotes.yaml
+++ b/dhall-yaml/tasty/data/boolean-quotes.yaml
@@ -1,0 +1,6 @@
+n_quoted: 'n'
+no_quoted: 'no'
+off_quoted: 'off'
+on_quoted: 'on'
+y_quoted: 'y'
+yes_quoted: 'yes'

--- a/dhall-yaml/tasty/data/normal-aeson.dhall
+++ b/dhall-yaml/tasty/data/normal-aeson.dhall
@@ -1,0 +1,8 @@
+{ string_value = "2000-01-01"
+, text = ./yaml.txt as Text
+, int_value = 1
+, bool_value = True
+, bool_string = "true"
+, yes = "y"
+, hello_world = "hello world"
+}

--- a/dhall-yaml/tasty/data/normal-aeson.yaml
+++ b/dhall-yaml/tasty/data/normal-aeson.yaml
@@ -1,0 +1,8 @@
+bool_string: 'true'
+bool_value: true
+hello_world: hello world
+int_value: 1
+string_value: '2000-01-01'
+text: |
+  Plain text
+yes: y

--- a/dhall-yaml/tasty/data/normal.yaml
+++ b/dhall-yaml/tasty/data/normal.yaml
@@ -5,4 +5,4 @@ int_value: 1
 string_value: '2000-01-01'
 text: |
   Plain text
-yes: y
+'yes': 'y'


### PR DESCRIPTION
Fixes #1785 

## Solution
The `Text` values that matches with the regex described on [Yaml 1.1](https://yaml.org/type/bool.html) specs are quoted so yaml 1.1 parsers doesn't parses them as boolean values

## Notes

`dhall-yaml` module uses HsYaml which let us set a custom encoding on each value, which fixes the issue for `dhall-to-yaml-ng` command.

Sadly, `dhall-json` source code for `dhall-to-yaml` command uses aeson-yaml, which doesn't provide a way to set custom encodings: only quoted or unquoted.

I suggest that `dhall-to-yaml` users that encounters this issue to use the `--quoted` flag to quote all key/values in yaml output or to move to `dhall-to-yaml-ng`

Another thing that should be noted is that not only values that match the boolean regex of specs are encoded, but also keys. So,

```dhall
{ yes = "hi" }
```
is encoded to

```yaml
'yes': hi
```