### PR TITLE
Make encodeExpression polymorphic

### DIFF
--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -1178,7 +1178,7 @@ instance Serialise (Expr Void Import) where
     decode = decodeExpressionInternal decodeImport
 
 -- | Encode a Dhall expression as a CBOR-encoded `ByteString`
-encodeExpression :: Expr Void Import -> ByteString
+encodeExpression :: Serialise (Expr Void a) => Expr Void a -> ByteString
 encodeExpression = Serialise.serialise
 
 -- | Decode a Dhall expression from a CBOR `Term`

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -109,6 +109,9 @@ import qualified Dhall.Optics               as Optics
 import qualified Lens.Family                as Lens
 import qualified Network.URI                as URI
 
+-- $setup
+-- >>> import Dhall.Binary () -- For the orphan instance for `Serialise (Expr Void Import)`
+
 {-| Constants for a pure type system
 
     The axioms are:

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -14,7 +14,7 @@ import Data.Either (isRight)
 import Data.Either.Validation (Validation(..))
 import Data.Monoid ((<>))
 import Data.Void (Void)
-import Dhall (ToDhall(..), FromDhall(..), auto, extract, inject, embed, Vector)
+import Dhall (ToDhall(..), FromDhall(..), auto, extract, inject, embed, Vector, rawInput)
 import Dhall.Map (Map)
 import Dhall.Core
     ( Binding(..)
@@ -423,6 +423,22 @@ instance Arbitrary Var where
 
     shrink = genericShrink
 
+embedComposesWithBinaryEncode :: forall a. (ToDhall a, FromDhall a, Eq a, Typeable a, Arbitrary a, Show a)
+    => Proxy a
+    -> (String, Property, TestTree -> TestTree)
+embedComposesWithBinaryEncode p =
+    ( "Embed composes with encodeExpression for " ++ show (typeRep p)
+    , Test.QuickCheck.property (prop :: a -> Bool)
+    , adjustQuickCheckTests 1000
+    )
+  where
+    prop a = (fmap fromExpr . Dhall.Binary.decodeExpression . Dhall.Binary.encodeExpression . toExpr $ a) == Right (Just a)
+    toExpr :: a -> Expr Void Void
+    toExpr = Dhall.Core.denote . Dhall.embed inject
+
+    fromExpr :: Expr Void Void -> Maybe a
+    fromExpr = Dhall.rawInput auto
+
 binaryRoundtrip :: Expr () Import -> Property
 binaryRoundtrip expression =
         Dhall.Binary.decodeExpression (Dhall.Binary.encodeExpression denotedExpression)
@@ -547,6 +563,7 @@ tests =
           , Test.QuickCheck.property normalizingAnExpressionDoesntChangeItsInferredType
           , adjustQuickCheckTests 10000
           )
+        , embedComposesWithBinaryEncode (Proxy :: Proxy (Data.Map.Map Double Bool))
         , embedThenExtractIsIdentity (Proxy :: Proxy (Text.Text))
         , embedThenExtractIsIdentity (Proxy :: Proxy [Nat.Natural])
         , embedThenExtractIsIdentity (Proxy :: Proxy (Bool, Double))


### PR DESCRIPTION
We have serialize instances for Expr Void Import and Expr Void Void
but only values of type Expr Void Import could be binary encoded
without going through the serialize API directly. This change
relaxes that restriction