### PR TITLE
Fix `asLocation/Hash` test

### DIFF
--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -494,6 +494,10 @@ loadImportWithSemanticCache
     loadImportWithSemisemanticCache import_
 
 loadImportWithSemanticCache
+  import_@(Chained (Import _ Location)) = do
+    loadImportWithSemisemanticCache import_
+
+loadImportWithSemanticCache
   import_@(Chained (Import (ImportHashed (Just semanticHash) _) _)) = do
     Status { .. } <- State.get
     mCached <-

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -62,9 +62,7 @@ successTest path = do
 
     let directoryString = FilePath.takeDirectory pathString
 
-    let expectedFailures =
-            [ importDirectory </> "success/unit/asLocation/HashA.dhall"
-            ]
+    let expectedFailures = []
 
     Test.Util.testCase path expectedFailures (do
 


### PR DESCRIPTION
This fixes Dhall's import resolution logic to not use the cache when
resolving `as Location` import, as the standard requires