### PR TITLE
Fix: Ignore incorrect hashes and save new hash to cache

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -2,3 +2,4 @@ steps:
   - imports:
       align: group
       pad_module_names: true
+      long_list_align: multiline

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -538,13 +538,13 @@ loadImportWithSemanticCache
                     printWarning $
                         makeHashMismatchMessage semanticHash actualHash
                         <> "\n"
-                        <> "The interpreter has automatically fixed cached import\n"
-                    saveCacheToFile
+                        <> "The interpreter will attempt to fix the cached import\n"
+                    fetch
 
 
-        Nothing -> saveCacheToFile
+        Nothing -> fetch
     where
-        saveCacheToFile = do
+        fetch = do
             ImportSemantics { importSemantics } <- loadImportWithSemisemanticCache import_
 
             let variants = map (\version -> encodeExpression version (Dhall.Core.alphaNormalize importSemantics))

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -138,48 +138,36 @@ module Dhall.Import (
     , HashMismatch(..)
     ) where
 
-import           Control.Applicative                         (Alternative (..),
-                                                              liftA2)
-import           Control.Exception                           (Exception,
-                                                              IOException,
-                                                              SomeException,
-                                                              toException)
-import           Control.Monad                               (when)
-import           Control.Monad.Catch                         (MonadCatch (catch),
-                                                              handle, throwM)
-import           Control.Monad.IO.Class                      (MonadIO (..))
-import           Control.Monad.Trans.Class                   (lift)
-import           Control.Monad.Trans.State.Strict            (StateT)
-import           Data.ByteString                             (ByteString)
-import           Data.CaseInsensitive                        (CI)
-import           Data.List.NonEmpty                          (NonEmpty (..))
-import           Data.Semigroup                              (Semigroup (..))
-import           Data.Text                                   (Text)
-import           Data.Typeable                               (Typeable)
-import           Data.Void                                   (Void, absurd)
-import           Dhall.Binary                                (StandardVersion (..))
-import           Dhall.Syntax                                (Chunks (..),
-                                                              Directory (..),
-                                                              Expr (..),
-                                                              File (..),
-                                                              FilePrefix (..),
-                                                              Import (..),
-                                                              ImportHashed (..),
-                                                              ImportMode (..),
-                                                              ImportType (..),
-                                                              URL (..),
-                                                              bindingExprs)
-import           System.FilePath                             ((</>))
+import Control.Applicative              (Alternative (..), liftA2)
+import Control.Exception                (Exception, IOException, SomeException,
+                                         toException)
+import Control.Monad                    (when)
+import Control.Monad.Catch              (MonadCatch (catch), handle, throwM)
+import Control.Monad.IO.Class           (MonadIO (..))
+import Control.Monad.Trans.Class        (lift)
+import Control.Monad.Trans.State.Strict (StateT)
+import Data.ByteString                  (ByteString)
+import Data.CaseInsensitive             (CI)
+import Data.List.NonEmpty               (NonEmpty (..))
+import Data.Semigroup                   (Semigroup (..))
+import Data.Text                        (Text)
+import Data.Typeable                    (Typeable)
+import Data.Void                        (Void, absurd)
+import Dhall.Binary                     (StandardVersion (..))
+import Dhall.Syntax                     (Chunks (..), Directory (..), Expr (..),
+                                         File (..), FilePrefix (..),
+                                         Import (..), ImportHashed (..),
+                                         ImportMode (..), ImportType (..),
+                                         URL (..), bindingExprs)
+import System.FilePath                  ((</>))
 #ifdef WITH_HTTP
-import           Dhall.Import.HTTP
+import Dhall.Import.HTTP
 #endif
-import           Dhall.Import.Types
+import Dhall.Import.Types
 
-import           Dhall.Parser                                (ParseError (..),
-                                                              Parser (..),
-                                                              SourcedException (..),
-                                                              Src (..))
-import           Lens.Family.State.Strict                    (zoom)
+import Dhall.Parser             (ParseError (..), Parser (..),
+                                 SourcedException (..), Src (..))
+import Lens.Family.State.Strict (zoom)
 
 import qualified Codec.CBOR.Encoding                         as Encoding
 import qualified Codec.CBOR.Write                            as Write

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -535,8 +535,11 @@ loadImportWithSemanticCache
 
                     return (ImportSemantics {..})
                 else do
-                    printWarning $ makeHashMismatchMessage semanticHash actualHash
-                    saveCacheToFile -- TODO: here we should show a warning that caches doesn't match
+                    printWarning $
+                        makeHashMismatchMessage semanticHash actualHash
+                        <> "\n"
+                        <> "Interpreter has automatically fixed cached import"
+                    saveCacheToFile
 
 
         Nothing -> saveCacheToFile

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -538,7 +538,7 @@ loadImportWithSemanticCache
                     printWarning $
                         makeHashMismatchMessage semanticHash actualHash
                         <> "\n"
-                        <> "Interpreter has automatically fixed cached import"
+                        <> "The interpreter has automatically fixed cached import\n"
                     saveCacheToFile
 
 

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1054,7 +1054,7 @@ loadWith expr₀ = case expr₀ of
 load :: Expr Src Import -> IO (Expr Src Void)
 load = loadRelativeTo "." UseSemanticCache
 
-printWarning :: (MonadCatch m, Alternative m, MonadIO m) => String -> m ()
+printWarning :: (MonadIO m) => String -> m ()
 printWarning message = do
     let warning =
                 "\n"

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -139,8 +139,12 @@ module Dhall.Import (
     ) where
 
 import Control.Applicative              (Alternative (..), liftA2)
-import Control.Exception                (Exception, IOException, SomeException,
-                                         toException)
+import Control.Exception
+    ( Exception
+    , IOException
+    , SomeException
+    , toException
+    )
 import Control.Monad                    (when)
 import Control.Monad.Catch              (MonadCatch (catch), handle, throwM)
 import Control.Monad.IO.Class           (MonadIO (..))
@@ -154,19 +158,33 @@ import Data.Text                        (Text)
 import Data.Typeable                    (Typeable)
 import Data.Void                        (Void, absurd)
 import Dhall.Binary                     (StandardVersion (..))
-import Dhall.Syntax                     (Chunks (..), Directory (..), Expr (..),
-                                         File (..), FilePrefix (..),
-                                         Import (..), ImportHashed (..),
-                                         ImportMode (..), ImportType (..),
-                                         URL (..), bindingExprs)
-import System.FilePath                  ((</>))
+
+import Dhall.Syntax
+    ( Chunks (..)
+    , Directory (..)
+    , Expr (..)
+    , File (..)
+    , FilePrefix (..)
+    , Import (..)
+    , ImportHashed (..)
+    , ImportMode (..)
+    , ImportType (..)
+    , URL (..)
+    , bindingExprs
+    )
+
+import System.FilePath ((</>))
 #ifdef WITH_HTTP
 import Dhall.Import.HTTP
 #endif
 import Dhall.Import.Types
 
-import Dhall.Parser             (ParseError (..), Parser (..),
-                                 SourcedException (..), Src (..))
+import Dhall.Parser
+    ( ParseError (..)
+    , Parser (..)
+    , SourcedException (..)
+    , Src (..)
+    )
 import Lens.Family.State.Strict (zoom)
 
 import qualified Codec.CBOR.Encoding                         as Encoding

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -3,13 +3,13 @@
 module Dhall.Test.Import where
 
 import Control.Exception (SomeException)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Dhall.Import (MissingImports(..))
-import Dhall.Parser (SourcedException(..))
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath, (</>))
+import Data.Monoid       ((<>))
+import Data.Text         (Text)
+import Dhall.Import      (MissingImports (..))
+import Dhall.Parser      (SourcedException (..))
+import Prelude           hiding (FilePath)
+import Test.Tasty        (TestTree)
+import Turtle            (FilePath, (</>))
 
 import qualified Control.Exception                as Exception
 import qualified Control.Monad                    as Monad
@@ -62,7 +62,7 @@ successTest path = do
 
     let directoryString = FilePath.takeDirectory pathString
 
-    let expectedFailures = []
+    let expectedFailures = ["unit/IgnorePoisonedCacheA.dhall"]
 
     Test.Util.testCase path expectedFailures (do
 

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -62,7 +62,7 @@ successTest path = do
 
     let directoryString = FilePath.takeDirectory pathString
 
-    let expectedFailures = ["unit/IgnorePoisonedCacheA.dhall"]
+    let expectedFailures = []
 
     Test.Util.testCase path expectedFailures (do
 
@@ -78,11 +78,11 @@ successTest path = do
         let load =
                 State.evalStateT (Test.Util.loadWith actualExpr) (Import.emptyStatus directoryString)
 
-        let runTest = do
+        let runTest =
                 if Turtle.filename (Turtle.fromText path) `elem`
                      [ "hashFromCacheA.dhall"
                      , "unit/asLocation/HashA.dhall"
-                     ]
+                     , "unit/IgnorePoisonedCacheA.dhall"]
                     then do
                         setCache
                         _ <- load

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -78,11 +78,14 @@ successTest path = do
         let load =
                 State.evalStateT (Test.Util.loadWith actualExpr) (Import.emptyStatus directoryString)
 
+        let usesCache = [ "hashFromCacheA.dhall"
+                        , "unit/asLocation/HashA.dhall"
+                        , "unit/IgnorePoisonedCacheA.dhall"]
+
+        let endsIn path' = not $ null $ Turtle.match (Turtle.ends path') path
+
         let runTest =
-                if Turtle.filename (Turtle.fromText path) `elem`
-                     [ "hashFromCacheA.dhall"
-                     , "unit/asLocation/HashA.dhall"
-                     , "unit/IgnorePoisonedCacheA.dhall"]
+                if any endsIn usesCache
                     then do
                         setCache
                         _ <- load


### PR DESCRIPTION
Fixes #1790 

```bash
# First time download
$ echo 'https://prelude.dhall-lang.org/v16.0.0/JSON/Type sha256:40edbc9371979426df63e064333b02689b969c4cfbbccfa481216d2d1a6e9759' | dhall
∀(JSON : Type) →
∀ ( json
  : { array : List JSON → JSON
    , bool : Bool → JSON
    , double : Double → JSON
    , integer : Integer → JSON
    , null : JSON
    , object : List { mapKey : Text, mapValue : JSON } → JSON
    , string : Text → JSON
    }
  ) →
  JSON

# Corrupting cache
$ echo 'bla' > ~/.cache/dhall/122040edbc9371979426df63e064333b02689b969c4cfbbccfa481216d2d1a6e9759

# Second time download detects hashes changes and raises a warning
$ echo 'https://prelude.dhall-lang.org/v16.0.0/JSON/Type sha256:40edbc9371979426df63e064333b02689b969c4cfbbccfa481216d2d1a6e9759' | dhall

Warning: Import integrity check failed

Expected hash:

↳ 40edbc9371979426df63e064333b02689b969c4cfbbccfa481216d2d1a6e9759

Actual hash:

↳ 00e3261a6e0d79c329445acd540fb2b07187a0dcf6017065c8814010283ac67f

Interpreter has automatically fixed cached import
∀(JSON : Type) →
∀ ( json
  : { array : List JSON → JSON
    , bool : Bool → JSON
    , double : Double → JSON
    , integer : Integer → JSON
    , null : JSON
    , object : List { mapKey : Text, mapValue : JSON } → JSON
    , string : Text → JSON
    }
  ) →
  JSON
```
What I don't know is how to write tests for this yet