### PR TITLE
(small) nix/shared.nix: pull cabal2nix from non-static pkgs

### DIFF
--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -294,6 +294,8 @@ let
   };
 
   overlayStaticLinux = pkgsNew: pkgsOld: {
+    cabal2nix = pkgs.cabal2nix;
+
     cabal_patched_src = pkgsNew.fetchFromGitHub {
       owner = "nh2";
       repo = "cabal";

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -201,6 +201,15 @@ let
   };
 
   overlayCabal2nix = pkgsNew: pkgsOld: {
+
+    # we only reference git repositories with cabal2nix
+    nix-prefetch-scripts = pkgsOld.nix-prefetch-scripts.override {
+      mercurial = null;
+      bazaar = null;
+      cvs = null;
+      subversion = null;
+    };
+
     haskellPackages = pkgsOld.haskellPackages.override (old: {
         overrides =
           let


### PR DESCRIPTION
See commit messages, this strips quite some build time from the static binaries.

Actually, what I forgot to mention in the commit message, building cabal2nix statically without using the custom binary cache is not possible because the tests of pyopenssl in that version are flaky in that nixpkgs version, so this came out of looking into that.