### PR TITLE
fix(parser): record fields should not include language keywords

### DIFF
--- a/dhall-json/tasty/data/missingList.dhall
+++ b/dhall-json/tasty/data/missingList.dhall
@@ -1,4 +1,4 @@
-{ missing = [] : List Text
+{ missingProp = [] : List Text
 , null = [] : List Text
 , present = ["some-stuff"]
 }

--- a/dhall-json/tasty/data/missingListSchema.dhall
+++ b/dhall-json/tasty/data/missingListSchema.dhall
@@ -1,1 +1,1 @@
-{present : List Text, null  : List Text, missing : List Text}
+{present : List Text, null  : List Text, missingProp : List Text}

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -844,7 +844,7 @@ parsers embedded = Parsers {..}
             _ <- optional (_bar *> whitespace)
 
             let unionTypeEntry = do
-                    a <- anyLabel
+                    a <- anyLabelOrSome
                     whitespace
                     b <- optional (_colon *> nonemptyWhitespace *> expression <* whitespace)
                     return (a, b)

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -7,16 +7,16 @@
 -- | Parsing Dhall expressions.
 module Dhall.Parser.Expression where
 
-import Control.Applicative (liftA2, Alternative(..), optional)
-import Data.ByteArray.Encoding (Base(..))
-import Data.Foldable (foldl')
-import Data.Functor (void)
-import Data.List.NonEmpty (NonEmpty(..))
-import Data.Semigroup (Semigroup(..))
-import Data.Text (Text)
+import Control.Applicative     (Alternative (..), liftA2, optional)
+import Data.ByteArray.Encoding (Base (..))
+import Data.Foldable           (foldl')
+import Data.Functor            (void)
+import Data.List.NonEmpty      (NonEmpty (..))
+import Data.Semigroup          (Semigroup (..))
+import Data.Text               (Text)
+import Dhall.Src               (Src (..))
 import Dhall.Syntax
-import Dhall.Src (Src(..))
-import Prelude hiding (const, pi)
+import Prelude                 hiding (const, pi)
 import Text.Parser.Combinators (choice, try, (<?>))
 
 import qualified Control.Monad
@@ -766,7 +766,7 @@ parsers embedded = Parsers {..}
 
     nonEmptyRecordTypeOrLiteral = do
             let nonEmptyRecordType = do
-                    a <- try (anyLabel <* whitespace <* _colon)
+                    a <- try (anyLabelOrSome <* whitespace <* _colon)
 
                     nonemptyWhitespace
 
@@ -779,7 +779,7 @@ parsers embedded = Parsers {..}
 
                         whitespace
 
-                        c <- anyLabel
+                        c <- anyLabelOrSome
 
                         whitespace
 
@@ -798,7 +798,7 @@ parsers embedded = Parsers {..}
                     return (Record m)
 
             let keysValue = do
-                    keys <- Combinators.NonEmpty.sepBy1 anyLabel (try (whitespace *> _dot) *> whitespace)
+                    keys <- Combinators.NonEmpty.sepBy1 anyLabelOrSome (try (whitespace *> _dot) *> whitespace)
 
                     let normalRecordEntry = do
                             try (whitespace *> _equal)

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -451,9 +451,9 @@ labels = do
     emptyLabels = pure Dhall.Set.empty
 
     nonEmptyLabels = do
-        x  <- anyLabel
+        x  <- anyLabelOrSome
         whitespace
-        xs <- many (do _comma; whitespace; l <- anyLabel; whitespace; return l)
+        xs <- many (do _comma; whitespace; l <- anyLabelOrSome; whitespace; return l)
         noDuplicates (x : xs)
 
 {-| Parse a label (e.g. a variable\/field\/alternative name)

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -108,16 +108,16 @@ module Dhall.Parser.Token (
     _with,
     ) where
 
-import           Dhall.Parser.Combinators
+import Dhall.Parser.Combinators
 
-import Control.Applicative (Alternative(..), optional)
-import Data.Bits ((.&.))
-import Data.Functor (void, ($>))
-import Data.Semigroup (Semigroup(..))
-import Data.Text (Text)
+import Control.Applicative     (Alternative (..), optional)
+import Data.Bits               ((.&.))
+import Data.Functor            (void, ($>))
+import Data.Semigroup          (Semigroup (..))
+import Data.Text               (Text)
+import Dhall.Set               (Set)
 import Dhall.Syntax
-import Dhall.Set (Set)
-import Prelude hiding (const, pi)
+import Prelude                 hiding (const, pi)
 import Text.Parser.Combinators (choice, try, (<?>))
 
 import qualified Control.Monad
@@ -133,11 +133,11 @@ import qualified Network.URI.Encode         as URI.Encode
 import qualified Text.Megaparsec
 import qualified Text.Megaparsec.Char.Lexer
 import qualified Text.Parser.Char
-import qualified Text.Parser.Token
 import qualified Text.Parser.Combinators
+import qualified Text.Parser.Token
 
 import Numeric.Natural (Natural)
-import Prelude hiding (const, pi)
+import Prelude         hiding (const, pi)
 
 -- | Returns `True` if the given `Int` is a valid Unicode codepoint
 validCodepoint :: Int -> Bool
@@ -407,13 +407,14 @@ blockCommentContinue = endOfComment <|> continue
         blockCommentContinue
 
 simpleLabel :: Bool -> Parser Text
-simpleLabel allowReserved = try (do
+simpleLabel allowReserved = try $ do
     c    <- Text.Parser.Char.satisfy headCharacter
     rest <- Dhall.Parser.Combinators.takeWhile tailCharacter
     let t = Data.Text.cons c rest
-    Control.Monad.guard (allowReserved || not (Data.HashSet.member t reservedIdentifiers))
-    return t )
-  where
+    let isNotAKeyword = not $ t `Data.HashSet.member` reservedKeywords
+    let isNotAReservedIdentifier = not $ t `Data.HashSet.member` reservedIdentifiers
+    Control.Monad.guard (isNotAKeyword && (allowReserved || isNotAReservedIdentifier))
+    return t
 
 headCharacter :: Char -> Bool
 headCharacter c = alpha c || c == '_'

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -14,6 +14,7 @@ module Dhall.Parser.Token (
     char,
     file_,
     label,
+    anyLabelOrSome,
     anyLabel,
     labels,
     httpRaw,
@@ -472,6 +473,14 @@ anyLabel :: Parser Text
 anyLabel = (do
     t <- backtickLabel <|> simpleLabel True
     return t ) <?> "any label"
+
+{-| Same as `anyLabel` except that `Some` is allowed
+
+    This corresponds to the @any-label-or-some@ rule in the official grammar
+-}
+
+anyLabelOrSome :: Parser Text
+anyLabelOrSome = try anyLabel <|> ("Some" <$ _Some)
 
 {-| Parse a valid Bash environment variable name
 

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -60,6 +60,7 @@ module Dhall.Syntax (
 
     -- * Reserved identifiers
     , reservedIdentifiers
+    , reservedKeywords
 
     -- * `Text` manipulation
     , toDoubleQuoted
@@ -74,40 +75,40 @@ module Dhall.Syntax (
     , internalError
     ) where
 
-import Control.DeepSeq (NFData)
-import Data.Bifunctor (Bifunctor(..))
-import Data.Bits (xor)
-import Data.Data (Data)
+import Control.DeepSeq            (NFData)
+import Data.Bifunctor             (Bifunctor (..))
+import Data.Bits                  (xor)
+import Data.Data                  (Data)
 import Data.Foldable
-import Data.HashSet (HashSet)
-import Data.List.NonEmpty (NonEmpty(..))
-import Data.String (IsString(..))
-import Data.Semigroup (Semigroup(..))
-import Data.Sequence (Seq)
-import Data.Text (Text)
-import Data.Text.Prettyprint.Doc (Doc, Pretty)
+import Data.HashSet               (HashSet)
+import Data.List.NonEmpty         (NonEmpty (..))
+import Data.Semigroup             (Semigroup (..))
+import Data.Sequence              (Seq)
+import Data.String                (IsString (..))
+import Data.Text                  (Text)
+import Data.Text.Prettyprint.Doc  (Doc, Pretty)
 import Data.Traversable
-import Data.Void (Void)
-import Dhall.Map (Map)
-import Dhall.Set (Set)
-import Dhall.Src (Src(..))
+import Data.Void                  (Void)
+import Dhall.Map                  (Map)
 import {-# SOURCE #-} Dhall.Pretty.Internal
-import GHC.Generics (Generic)
-import Instances.TH.Lift ()
+import Dhall.Set                  (Set)
+import Dhall.Src                  (Src (..))
+import GHC.Generics               (Generic)
+import Instances.TH.Lift          ()
 import Language.Haskell.TH.Syntax (Lift)
-import Numeric.Natural (Natural)
-import Prelude hiding (succ)
-import Unsafe.Coerce (unsafeCoerce)
+import Numeric.Natural            (Natural)
+import Prelude                    hiding (succ)
+import Unsafe.Coerce              (unsafeCoerce)
 
 import qualified Control.Monad
 import qualified Data.HashSet
-import qualified Data.List.NonEmpty         as NonEmpty
+import qualified Data.List.NonEmpty        as NonEmpty
 import qualified Data.Text
-import qualified Data.Text.Prettyprint.Doc  as Pretty
+import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Dhall.Crypto
-import qualified Dhall.Optics               as Optics
-import qualified Lens.Family                as Lens
-import qualified Network.URI                as URI
+import qualified Dhall.Optics              as Optics
+import qualified Lens.Family               as Lens
+import qualified Network.URI               as URI
 
 -- $setup
 -- >>> import Dhall.Binary () -- For the orphan instance for `Serialise (Expr Void Import)`
@@ -951,11 +952,11 @@ shallowDenote :: Expr s a -> Expr s a
 shallowDenote (Note _ e) = shallowDenote e
 shallowDenote         e  = e
 
--- | The set of reserved identifiers for the Dhall language
-reservedIdentifiers :: HashSet Text
-reservedIdentifiers =
+-- | The set of reserved keywords according to the `keyword` rule in the grammar
+reservedKeywords :: HashSet Text
+reservedKeywords =
     Data.HashSet.fromList
-        [ -- Keywords according to the `keyword` rule in the grammar
+        [
           "if"
         , "then"
         , "else"
@@ -972,9 +973,15 @@ reservedIdentifiers =
         , "assert"
         , "forall"
         , "with"
+        ]
 
-          -- Builtins according to the `builtin` rule in the grammar
-        , "Natural/fold"
+-- | The set of reserved identifiers for the Dhall language
+-- | Contains also all keywords from "reservedKeywords"
+reservedIdentifiers :: HashSet Text
+reservedIdentifiers = reservedKeywords <>
+    Data.HashSet.fromList
+        [ -- Builtins according to the `builtin` rule in the grammar
+          "Natural/fold"
         , "Natural/build"
         , "Natural/isZero"
         , "Natural/even"

--- a/dhall/tests/format/applicationMultilineA.dhall
+++ b/dhall/tests/format/applicationMultilineA.dhall
@@ -18,7 +18,7 @@
 , someList =
     Some
       [ aaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccc, dddddddddddddd ]
-, merge =
+, merge1 =
     merge
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/dhall/tests/format/applicationMultilineA.dhall
+++ b/dhall/tests/format/applicationMultilineA.dhall
@@ -27,7 +27,7 @@
       a
       b
       ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-, toMap =
+, toMap1 =
     toMap
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 }

--- a/dhall/tests/format/applicationMultilineB.dhall
+++ b/dhall/tests/format/applicationMultilineB.dhall
@@ -29,6 +29,6 @@
       a
       b
       ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-, toMap = toMap
+, toMap1 = toMap
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 }

--- a/dhall/tests/format/applicationMultilineB.dhall
+++ b/dhall/tests/format/applicationMultilineB.dhall
@@ -20,7 +20,7 @@
   , cccccccccccccccccccccccc
   , dddddddddddddd
   ]
-, merge =
+, merge1 =
     merge
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb


### PR DESCRIPTION
# Summary

Fixes #1750 

# Solution

Split `reservedKeywords` from `reservedIdentifiers`


Currently there are failing tests because [standard says that `Some` is a reserved keyword](https://github.com/dhall-lang/dhall-lang/issues/1012). Meanwhile, I'll have this PR as a draft