### PR TITLE
Fix haddocks formatting for `Binding`

### DIFF
--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -182,7 +182,9 @@ instance Pretty Var where
 {- | Record the binding part of a @let@ expression.
 
 For example,
+
 > let {- A -} x {- B -} : {- C -} Bool = {- D -} True in x
+
 will be instantiated as follows:
 
 * @bindingSrc0@ corresponds to the @A@ comment.


### PR DESCRIPTION
Previously, the rendered haddocks looked a bit broken:

http://hackage.haskell.org/package/dhall-1.32.0/docs/Dhall-Core.html#t:Binding