### PR TITLE
Fix `dhall {format,freeze,lint}` to not modify unchanged files

### DIFF
--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -181,6 +181,7 @@ getExpressionAndHeader censor =
 
 -- | Convenient utility for retrieving an expression along with its header from
 -- | text already read from STDIN (so it's not re-read)
-getExpressionAndHeaderFromStdinText :: Censor -> Text -> IO (Header, Expr Src Import)
+getExpressionAndHeaderFromStdinText
+    :: Censor -> Text -> IO (Header, Expr Src Import)
 getExpressionAndHeaderFromStdinText censor =
     get Dhall.Parser.exprAndHeaderFromText censor . StdinText


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1828

Surprisingly, getting this correct also simplified the code along
the way.