### PR TITLE
Add GHCJS build target

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,4 +15,6 @@ in
     ;
 
     inherit (shared_ghcjs) dhall-try;
+
+    dhall-ghcjs = shared_ghcjs.dhall;
   }


### PR DESCRIPTION
Related to https://github.com/dhall-lang/dhall-haskell/issues/1860

This is mainly for convenience in case people want to access the
GHCJS build product

This allows developers to obtain the GHCJS build product by running:

```bash
$ nix build --file ./default.nix dhall-ghcjs
```