### PR TITLE
feat(dhall-docs): Add content-addressed storage for documentation

### DIFF
--- a/dhall-docs/README.md
+++ b/dhall-docs/README.md
@@ -8,8 +8,8 @@ For installation or development instructions, see:
 
 ## Introduction
 
-This `dhall-docs` package provides a cli utility that takes a dhall package or file and outputs
-a HTML documentation of it.
+This `dhall-docs` package provides a cli utility that takes a dhall package or
+file and outputs a HTML documentation of it.
 
 ## Usage
 
@@ -19,12 +19,30 @@ The easiest usage is the following:
 dhall-docs --input ${PACKAGE-FOLDER}
 ```
 
-By default it will save the documentation of your package in `./docs`, but
-you can change that using the `--output` flag
+`dhall-docs` will store the documentation in
+`${XDG_DATA_HOME}/dhall-docs/${OUTPUT-HASH}-${PACKAGE-NAME}/`, where:
+
+* `$XDG_DATA_HOME` environment variable comes from the
+    [xdg](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+    specification. If it is not defined, `dhall-docs` will default to
+    `~/.local/share/`.
+* `OUTPUT-HASH` is the hash of the generated documentation. This is to make the
+    folder [content-addressable](https://es.wikipedia.org/wiki/Content_Addressed_Storage).
+    Also it avoids overwriting documentation folder when there was a change on
+    the way it was generated.
+* `PACKAGE-NAME` is the package name of your documentation. By default, it will
+    be the basename of the `--input` folder, but you can override it via
+    `--package-name`.
+
+After generating the documentation, `dhall-docs` will create a symlink to the
+documentation index at `./docs/index.html`. You can customize the location of
+that symlink using `--output-link` flag, like this:
 
 ```bash
-dhall-docs --input . --output ${OTHER_DIR}
+dhall-docs --input . --output-link ${OTHER_LINK}
 ```
+
+For more information about the tool, check the `--help` flag.
 
 ## Development
 

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -54,7 +54,7 @@ Library
         megaparsec           >= 7        && < 8.1 ,
         path                 >= 0.7.0    && < 0.8 ,
         path-io              >= 1.6.0    && < 1.7 ,
-        tar                  >= 0.5.1.1  && < 0.6 ,
+        tar                  >= 0.5.1.0  && < 0.6 ,
         text                 >= 0.11.1.0 && < 1.3 ,
         optparse-applicative >= 0.14.0.0 && < 0.16
     Exposed-Modules:

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -54,6 +54,7 @@ Library
         megaparsec           >= 7        && < 8.1 ,
         path                 >= 0.7.0    && < 0.8 ,
         path-io              >= 1.6.0    && < 1.7 ,
+        tar                  >= 0.5.1.1  && < 0.6 ,
         text                 >= 0.11.1.0 && < 1.3 ,
         optparse-applicative >= 0.14.0.0 && < 0.16
     Exposed-Modules:

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -45,6 +45,7 @@ Library
         base                 >= 4.9.1.0  && < 5   ,
         bytestring                          < 0.11,
         containers                                ,
+        directory            >= 1.3.0.0  && < 1.4 ,
         dhall                >= 1.32.0            ,
         file-embed           >= 0.0.10.0          ,
         filepath             >= 1.4      && < 1.5 ,
@@ -57,8 +58,10 @@ Library
         optparse-applicative >= 0.14.0.0 && < 0.16
     Exposed-Modules:
         Dhall.Docs
+        Dhall.Docs.Core
         Dhall.Docs.Html
         Dhall.Docs.Markdown
+        Dhall.Docs.Store
     Other-Modules:
         Dhall.Docs.Embedded
         Paths_dhall_docs

--- a/dhall-docs/src/Dhall/Docs.hs
+++ b/dhall-docs/src/Dhall/Docs.hs
@@ -18,6 +18,7 @@ module Dhall.Docs
 
 import Control.Applicative ((<|>))
 import Data.Monoid         ((<>))
+import Data.Text           (Text)
 import Data.Version        (showVersion)
 import Dhall.Docs.Core
 import Options.Applicative (Parser, ParserInfo)
@@ -111,9 +112,8 @@ defaultMain = \case
         Control.Monad.when outDirExists $ do
             isLink <- System.Directory.pathIsSymbolicLink docLink
             if isLink then System.Directory.removeFile docLink
-            else die $ "The specified --output-link (" <> docLink <> ") already "
-                    <> "exists and its not a symlink. The --output-link flag "
-                    <> "needs to either not exist or to be a symlink"
+            else die $ "The specified --output-link (" <> Data.Text.pack docLink
+                    <> ") already exists and its not a symlink."
 
         resolvedDocLink <- Path.IO.resolveDir' docLink
         let packageName = resolvePackageName resolvedPackageDir
@@ -121,9 +121,9 @@ defaultMain = \case
     Version ->
         putStrLn (showVersion Meta.version)
 
-die :: String -> IO a
+die :: Text -> IO a
 die e = do
-    Text.IO.hPutStrLn System.IO.stderr $ Data.Text.pack e
+    Text.IO.hPutStrLn System.IO.stderr e
 
     System.Exit.exitFailure
 

--- a/dhall-docs/src/Dhall/Docs.hs
+++ b/dhall-docs/src/Dhall/Docs.hs
@@ -113,7 +113,7 @@ defaultMain = \case
             isLink <- System.Directory.pathIsSymbolicLink docLink
             if isLink then System.Directory.removeFile docLink
             else die $ "The specified --output-link (" <> Data.Text.pack docLink
-                    <> ") already exists and its not a symlink."
+                    <> ") already exists and it's not a symlink."
 
         resolvedDocLink <- Path.IO.resolveDir' docLink
         let packageName = resolvePackageName resolvedPackageDir

--- a/dhall-docs/src/Dhall/Docs.hs
+++ b/dhall-docs/src/Dhall/Docs.hs
@@ -3,7 +3,6 @@
 -}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards     #-}
 {-# LANGUAGE RecordWildCards   #-}
 
 module Dhall.Docs
@@ -15,53 +14,30 @@ module Dhall.Docs
       -- * Execution
     , main
     , defaultMain
-    , getAllDhallFilesAndHeaders
-
-      -- * Miscelaneous
-    , saveHtml
-    , createIndexes
-    , resolveRelativePath
     ) where
 
 import Control.Applicative ((<|>))
 import Data.Monoid         ((<>))
-import Data.Text           (Text)
 import Data.Version        (showVersion)
-import Data.Void           (Void)
-import Dhall.Docs.Embedded
-import Dhall.Docs.Html
-import Dhall.Docs.Markdown
-import Dhall.Parser        (Header (..), ParseError (..), exprAndHeaderFromText)
+import Dhall.Docs.Core
 import Options.Applicative (Parser, ParserInfo)
-import Path                (Abs, Dir, File, Path, (</>))
-import Text.Megaparsec     (ParseErrorBundle (..))
+import Path                (Abs, Dir, Path)
 
 import qualified Control.Monad
-import qualified Data.ByteString
-import qualified Data.Map.Strict     as Map
-import qualified Data.Maybe
-import qualified Data.Text
-import qualified Data.Text.IO        as Text.IO
 import qualified GHC.IO.Encoding
-import qualified Lucid
 import qualified Options.Applicative
 import qualified Path
 import qualified Path.IO
 import qualified Paths_dhall_docs    as Meta
+import qualified System.Directory
 import qualified System.IO
-import qualified Text.Megaparsec
-
--- $setup
--- >>> :set -XQuasiQuotes
--- >>> import Path (absdir, absfile)
 
 -- | Command line options
 data Options
     = Options
         { packageDir :: FilePath         -- ^ Directory where your package resides
-        , outDir :: FilePath             -- ^ Directory where your documentation
-                                         --   will be placed
-        , packageNameResolver :: Path Abs Dir -> String
+        , docLink :: FilePath            -- ^ Link to the generated documentation
+        , resolvePackageName :: Path Abs Dir -> String
         }
     | Version
 
@@ -74,10 +50,10 @@ parseOptions =
        <> Options.Applicative.metavar "INPUT"
        <> Options.Applicative.help "Directory of your dhall package" )
     <*> Options.Applicative.strOption
-        ( Options.Applicative.long "output"
-       <> Options.Applicative.metavar "OUTPUT"
-       <> Options.Applicative.help "Directory where your docs will be generated"
-       <> Options.Applicative.value "docs" )
+        ( Options.Applicative.long "output-link"
+       <> Options.Applicative.metavar "OUTPUT-LINK"
+       <> Options.Applicative.help "Path for the link to the generated documentation"
+       <> Options.Applicative.value "./docs/index.html" )
     <*> parsePackageNameResolver
     ) <|> parseVersion
   where
@@ -117,199 +93,20 @@ parserInfoOptions =
         )
 
 
-{-| Fetches a list of all dhall files in a directory along with its `Header`.
-    This is not the same as finding all files that ends in @.dhall@,
-    but finds all files that successfully parses as a valid dhall file.
-
-    The reason it doesn't guide the search by its extension is because of the
-    dhall <https://prelude.dhall-lang.org Prelude>.
-    That package doesn't ends any of their files in @.dhall@.
--}
-getAllDhallFilesAndHeaders
-    :: Path Abs Dir -- ^ Base directory to do the search
-    -> IO [(Path Abs File, Header)]
-getAllDhallFilesAndHeaders baseDir = do
-    files <- filter hasDhallExtension . snd <$> Path.IO.listDirRecur baseDir
-    Data.Maybe.catMaybes <$> mapM readDhall files
-  where
-    hasDhallExtension :: Path Abs File -> Bool
-    hasDhallExtension absFile = case Path.splitExtension absFile of
-        Nothing -> False
-        Just (_, ext) -> ext == ".dhall"
-
-    readDhall :: Path Abs File -> IO (Maybe (Path Abs File, Header))
-    readDhall absFile = do
-        let filePath = Path.fromAbsFile absFile
-        contents <- Text.IO.readFile filePath
-        case exprAndHeaderFromText filePath contents of
-            Right (header, _) -> return $ Just (absFile, header)
-            Left ParseError{..} -> do
-                putStrLn $ showDhallParseError unwrap
-                return Nothing
-
-    showDhallParseError :: Text.Megaparsec.ParseErrorBundle Text Void -> String
-    showDhallParseError err =
-        "\n\ESC[1;33mWarning\ESC[0m: Invalid Input\n\n" <>
-        Text.Megaparsec.errorBundlePretty err <>
-        "... documentation won't be generated for this file"
-
-{-| Calculate the relative path needed to access files on the first argument
-    relative from the second argument.
-
-    The second argument needs to be a child of the first, otherwise it will
-    loop forever
-
-    Examples:
-
->>> resolveRelativePath [absdir|/a/b/c/|] [absdir|/a/b/c/d/e|]
-"../../"
->>> resolveRelativePath [absdir|/a/|] [absdir|/a/|]
-""
--}
-resolveRelativePath :: Path Abs Dir -> Path Abs Dir -> FilePath
-resolveRelativePath outDir currentDir =
-    if outDir == currentDir then ""
-    else "../" <> resolveRelativePath outDir (Path.parent currentDir)
-
-{-| Saves the HTML file from the input package to the output destination
--}
-saveHtml
-    :: Path Abs Dir         -- ^ Input package directory.
-                            --   Used to remove the prefix from all other dhall
-                            --   files in the package
-    -> Path Abs Dir         -- ^ Output directory
-    -> String               -- ^ Package name
-    -> Path Abs File        -- ^ Input file
-    -> Header               -- ^ Parsed header
-    -> IO (Path Abs File)   -- ^ Output path file
-saveHtml inputAbsDir outputAbsDir packageName absFile header = do
-    htmlOutputFile <- do
-        strippedPath <- Path.stripProperPrefix inputAbsDir absFile
-        strippedPathWithExt <- addHtmlExt strippedPath
-        return (outputAbsDir </> strippedPathWithExt)
-
-    let htmlOutputDir = Path.parent htmlOutputFile
-
-    Path.IO.ensureDir htmlOutputDir
-
-    let relativeResourcesPath = resolveRelativePath outputAbsDir htmlOutputDir
-
-    let strippedHeader = stripCommentSyntax header
-    headerAsHtml <- case markdownToHtml absFile strippedHeader of
-        Left err -> do
-            putStrLn $ markdownParseErrorAsWarning err
-            return $ Lucid.toHtml strippedHeader
-        Right html -> return html
-
-    Lucid.renderToFile (Path.fromAbsFile htmlOutputFile)
-        $ filePathHeaderToHtml absFile headerAsHtml DocParams {..}
-
-    return htmlOutputFile
-  where
-    addHtmlExt :: Path b File -> IO (Path b File)
-    addHtmlExt = Path.addExtension ".html"
-
-    markdownParseErrorAsWarning :: MarkdownParseError -> String
-    markdownParseErrorAsWarning MarkdownParseError{..} =
-        "\n\ESC[1;33mWarning\ESC[0m\n\n" <>
-        Text.Megaparsec.errorBundlePretty unwrap <>
-        "The original non-markdown text will be pasted in the documentation"
-
-    stripCommentSyntax :: Header -> Text
-    stripCommentSyntax (Header h)
-        | Just s <- Data.Text.stripPrefix "--" strippedHeader
-            = Data.Text.strip s
-        | Just commentPrefixStripped <- Data.Text.stripPrefix "{-" strippedHeader
-        , Just commentSuffixStripped <- Data.Text.stripSuffix "-}" commentPrefixStripped
-            = Data.Text.strip commentSuffixStripped
-        | otherwise = strippedHeader
-      where
-        strippedHeader = Data.Text.strip h
-
-
-{-| Create an index.html file on each folder available in the second argument
-    that lists all the contents on that folder.
-
-    For example,
-
-    @
-    createIndexes [absdir|/|]
-        [ [absfile|\/a\/b.txt|]
-        , [absfile|\/a\/c/b.txt|]
-        , [absfile|\/a\/c.txt"|]
-        ]
-    @
-
-    ... will create two index.html files:
-
-    1. @\/a\/index.html@, that will list the @\/a\/b.txt@ and
-    @\/a\/c.txt@ files
-    2. @\/a\/c\/index.html@ that will list the @\/a\/c\/b.txt@ file
-
--}
-createIndexes
-    :: Path Abs Dir    -- ^ Directory where index.html file will be saved. Used
-                       --   to link the css resources. It should be a prefix for
-                       --   each @Path Abs File@ on the second argument
-    -> [Path Abs File] -- ^ Html files generated by the tool
-    -> String          -- ^ Package name
-    -> IO ()
-createIndexes outputPath htmlFiles packageName = do
-    let toMap file = Map.singleton (Path.parent file) [file]
-    let filesGroupedByDir = Map.unionsWith (<>) $ map toMap htmlFiles
-
-    let listDirRel dir = do
-            dirs <- fst <$> Path.IO.listDir dir
-            mapM (Path.stripProperPrefix dir) dirs
-
-    let createIndex index files = do
-            indexFile <- Path.fromAbsFile . (index </>) <$> Path.parseRelFile "index.html"
-            indexTitle <-
-                if outputPath == index then return "package"
-                else Path.fromRelDir <$> Path.stripProperPrefix outputPath index
-            indexList <- Control.Monad.forM files $
-                fmap Path.filename . Path.stripProperPrefix outputPath
-            dirList <- listDirRel index
-
-            let relativeResourcesPath = resolveRelativePath outputPath index
-            Lucid.renderToFile indexFile $
-                indexToHtml
-                    indexTitle
-                    indexList
-                    dirList
-                    DocParams
-                        { relativeResourcesPath = relativeResourcesPath
-                        , packageName = packageName}
-
-    _ <- Map.traverseWithKey createIndex filesGroupedByDir
-    return ()
-
 -- | Default execution of @dhall-docs@ command
 defaultMain :: Options -> IO ()
 defaultMain = \case
     Options{..} -> do
         GHC.IO.Encoding.setLocaleEncoding System.IO.utf8
         resolvedPackageDir <- Path.IO.resolveDir' packageDir
-        resolvedOutDir <- Path.IO.resolveDir' outDir
 
-        let packageName = packageNameResolver resolvedPackageDir
+        outLinkExists <- System.Directory.doesFileExist docLink
+        Control.Monad.when outLinkExists $ System.Directory.removeFile docLink
 
-        dhallFilesAndHeaders <- getAllDhallFilesAndHeaders resolvedPackageDir
-        if null dhallFilesAndHeaders then
-            putStrLn $
-                "No documentation was generated because no file with .dhall " <>
-                "extension was found"
-        else do
-            generatedHtmlFiles <-
-                mapM (uncurry $ saveHtml resolvedPackageDir resolvedOutDir packageName)
-                    dhallFilesAndHeaders
-            createIndexes resolvedOutDir generatedHtmlFiles packageName
+        resolvedDocLink <- Path.IO.resolveFile' docLink
 
-            dataDir <- getDataDir
-            Path.IO.ensureDir resolvedOutDir
-            Control.Monad.forM_ dataDir $ \(filename, contents) -> do
-                let finalPath = Path.fromAbsFile $ resolvedOutDir </> filename
-                Data.ByteString.writeFile finalPath contents
+        let packageName = resolvePackageName resolvedPackageDir
+        generateDocs resolvedPackageDir resolvedDocLink packageName
     Version ->
         putStrLn (showVersion Meta.version)
 

--- a/dhall-docs/src/Dhall/Docs.hs
+++ b/dhall-docs/src/Dhall/Docs.hs
@@ -52,8 +52,13 @@ parseOptions =
     <*> Options.Applicative.strOption
         ( Options.Applicative.long "output-link"
        <> Options.Applicative.metavar "OUTPUT-LINK"
-       <> Options.Applicative.help "Path for the link to the generated documentation"
-       <> Options.Applicative.value "./docs/index.html" )
+       <> Options.Applicative.help
+            ( "Path to the link targeting the directory with the generated "
+           <> "documentation. If the path exists, is a directory or a symlink "
+           <> "to a directory, its overwritten with the target to the actual "
+           <> "documentation"
+            )
+       <> Options.Applicative.value "./docs" )
     <*> parsePackageNameResolver
     ) <|> parseVersion
   where
@@ -100,10 +105,10 @@ defaultMain = \case
         GHC.IO.Encoding.setLocaleEncoding System.IO.utf8
         resolvedPackageDir <- Path.IO.resolveDir' packageDir
 
-        outLinkExists <- System.Directory.doesFileExist docLink
+        outLinkExists <- System.Directory.doesDirectoryExist docLink
         Control.Monad.when outLinkExists $ System.Directory.removeFile docLink
 
-        resolvedDocLink <- Path.IO.resolveFile' docLink
+        resolvedDocLink <- Path.IO.resolveDir' docLink
 
         let packageName = resolvePackageName resolvedPackageDir
         generateDocs resolvedPackageDir resolvedDocLink packageName

--- a/dhall-docs/src/Dhall/Docs/Core.hs
+++ b/dhall-docs/src/Dhall/Docs/Core.hs
@@ -1,0 +1,239 @@
+-- | Contains all the functions that generate documentation
+
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# OPTIONS_GHC -Wno-unused-imports   #-}
+
+module Dhall.Docs.Core (generateDocs) where
+
+import Data.Monoid         ((<>))
+import Data.Text           (Text)
+import Data.Void           (Void)
+import Dhall.Docs.Embedded
+import Dhall.Docs.Html
+import Dhall.Docs.Markdown
+import Dhall.Docs.Store
+import Dhall.Parser        (Header (..), ParseError (..), exprAndHeaderFromText)
+import Path                (Abs, Dir, File, Path, Rel, (</>))
+import Text.Megaparsec     (ParseErrorBundle (..))
+
+import qualified Control.Applicative as Applicative
+import qualified Control.Monad
+import qualified Data.ByteString
+import qualified Data.Map.Strict     as Map
+import qualified Data.Maybe
+import qualified Data.Text
+import qualified Data.Text.IO        as Text.IO
+import qualified Lucid
+import qualified Path
+import qualified Path.IO
+import qualified Text.Megaparsec
+
+-- $setup
+-- >>> :set -XQuasiQuotes
+-- >>> import Path (absdir, absfile)
+
+
+{-| Fetches a list of all dhall files in a directory along with its `Header`.
+    This is not the same as finding all files that ends in @.dhall@,
+    but finds all files that successfully parses as a valid dhall file.
+
+    The reason it doesn't guide the search by its extension is because of the
+    dhall <https://prelude.dhall-lang.org Prelude>.
+    That package doesn't ends any of their files in @.dhall@.
+-}
+getAllDhallFilesAndHeaders
+    :: Path Abs Dir -- ^ Base directory to do the search
+    -> IO [(Path Abs File, Header)]
+getAllDhallFilesAndHeaders baseDir = do
+    files <- filter hasDhallExtension . snd <$> Path.IO.listDirRecur baseDir
+    Data.Maybe.catMaybes <$> mapM readDhall files
+  where
+    hasDhallExtension :: Path Abs File -> Bool
+    hasDhallExtension absFile = case Path.splitExtension absFile of
+        Nothing -> False
+        Just (_, ext) -> ext == ".dhall"
+
+    readDhall :: Path Abs File -> IO (Maybe (Path Abs File, Header))
+    readDhall absFile = do
+        let filePath = Path.fromAbsFile absFile
+        contents <- Text.IO.readFile filePath
+        case exprAndHeaderFromText filePath contents of
+            Right (header, _) -> return $ Just (absFile, header)
+            Left ParseError{..} -> do
+                putStrLn $ showDhallParseError unwrap
+                return Nothing
+
+    showDhallParseError :: Text.Megaparsec.ParseErrorBundle Text Void -> String
+    showDhallParseError err =
+        "\n\ESC[1;33mWarning\ESC[0m: Invalid Input\n\n" <>
+        Text.Megaparsec.errorBundlePretty err <>
+        "... documentation won't be generated for this file"
+
+{-| Calculate the relative path needed to access files on the first argument
+    relative from the second argument.
+
+    The second argument needs to be a child of the first, otherwise it will
+    loop forever
+
+    Examples:
+
+>>> resolveRelativePath [absdir|/a/b/c/|] [absdir|/a/b/c/d/e|]
+"../../"
+>>> resolveRelativePath [absdir|/a/|] [absdir|/a/|]
+""
+-}
+resolveRelativePath :: Path Abs Dir -> Path Abs Dir -> FilePath
+resolveRelativePath outDir currentDir =
+    if outDir == currentDir then ""
+    else "../" <> resolveRelativePath outDir (Path.parent currentDir)
+
+{-| Saves the HTML file from the input package to the output destination
+-}
+saveHtml
+    :: Path Abs Dir         -- ^ Input package directory.
+                            --   Used to remove the prefix from all other dhall
+                            --   files in the package
+    -> Path Abs Dir         -- ^ Output directory
+    -> String               -- ^ Package name
+    -> Path Abs File        -- ^ Input file
+    -> Header               -- ^ Parsed header
+    -> IO (Path Abs File)   -- ^ Output path file
+saveHtml inputAbsDir outputAbsDir packageName absFile header = do
+    htmlOutputFile <- do
+        strippedPath <- Path.stripProperPrefix inputAbsDir absFile
+        strippedPathWithExt <- addHtmlExt strippedPath
+        return (outputAbsDir </> strippedPathWithExt)
+
+    let htmlOutputDir = Path.parent htmlOutputFile
+
+    Path.IO.ensureDir htmlOutputDir
+
+    let relativeResourcesPath = resolveRelativePath outputAbsDir htmlOutputDir
+
+    let strippedHeader = stripCommentSyntax header
+    headerAsHtml <- case markdownToHtml absFile strippedHeader of
+        Left err -> do
+            putStrLn $ markdownParseErrorAsWarning err
+            return $ Lucid.toHtml strippedHeader
+        Right html -> return html
+
+    Lucid.renderToFile (Path.fromAbsFile htmlOutputFile)
+        $ filePathHeaderToHtml absFile headerAsHtml DocParams {..}
+
+    return htmlOutputFile
+  where
+    addHtmlExt :: Path b File -> IO (Path b File)
+    addHtmlExt = Path.addExtension ".html"
+
+    markdownParseErrorAsWarning :: MarkdownParseError -> String
+    markdownParseErrorAsWarning MarkdownParseError{..} =
+        "\n\ESC[1;33mWarning\ESC[0m\n\n" <>
+        Text.Megaparsec.errorBundlePretty unwrap <>
+        "The original non-markdown text will be pasted in the documentation"
+
+    stripCommentSyntax :: Header -> Text
+    stripCommentSyntax (Header h)
+        | Just s <- Data.Text.stripPrefix "--" strippedHeader
+            = Data.Text.strip s
+        | Just commentPrefixStripped <- Data.Text.stripPrefix "{-" strippedHeader
+        , Just commentSuffixStripped <- Data.Text.stripSuffix "-}" commentPrefixStripped
+            = Data.Text.strip commentSuffixStripped
+        | otherwise = strippedHeader
+      where
+        strippedHeader = Data.Text.strip h
+
+
+{-| Create an index.html file on each folder available in the second argument
+    that lists all the contents on that folder.
+
+    For example,
+
+    @
+    createIndexes [absdir|/|]
+        [ [absfile|\/a\/b.txt|]
+        , [absfile|\/a\/c/b.txt|]
+        , [absfile|\/a\/c.txt"|]
+        ]
+    @
+
+    ... will create two index.html files:
+
+    1. @\/a\/index.html@, that will list the @\/a\/b.txt@ and
+    @\/a\/c.txt@ files
+    2. @\/a\/c\/index.html@ that will list the @\/a\/c\/b.txt@ file
+
+-}
+createIndexes
+    :: Path Abs Dir    -- ^ Directory where index.html file will be saved. Used
+                       --   to link the css resources. It should be a prefix for
+                       --   each @Path Abs File@ on the second argument
+    -> [Path Abs File] -- ^ Html files generated by the tool
+    -> String          -- ^ Package name
+    -> IO ()
+createIndexes outputPath htmlFiles packageName = do
+    let toMap file = Map.singleton (Path.parent file) [file]
+    let filesGroupedByDir = Map.unionsWith (<>) $ map toMap htmlFiles
+
+    let listDirRel dir = do
+            dirs <- fst <$> Path.IO.listDir dir
+            mapM (Path.stripProperPrefix dir) dirs
+
+    let createIndex index files = do
+            indexFile <- Path.fromAbsFile . (index </>) <$> Path.parseRelFile "index.html"
+            indexTitle <-
+                if outputPath == index then return "package"
+                else Path.fromRelDir <$> Path.stripProperPrefix outputPath index
+            indexList <- Control.Monad.forM files $
+                fmap Path.filename . Path.stripProperPrefix outputPath
+            dirList <- listDirRel index
+
+            let relativeResourcesPath = resolveRelativePath outputPath index
+            Lucid.renderToFile indexFile $
+                indexToHtml
+                    indexTitle
+                    indexList
+                    dirList
+                    DocParams
+                        { relativeResourcesPath = relativeResourcesPath
+                        , packageName = packageName}
+
+    _ <- Map.traverseWithKey createIndex filesGroupedByDir
+    return ()
+
+-- | Generate all of the docs for a package
+generateDocs
+    :: Path Abs Dir  -- ^ Input directory
+    -> Path Abs File -- ^ Link to be created to the generated documentation
+    -> String        -- ^ Package name, used in some HTML titles
+    -> IO ()
+generateDocs inputDir outLink packageName = do
+
+    dhallFilesAndHeaders <- getAllDhallFilesAndHeaders inputDir
+    if null dhallFilesAndHeaders then
+        putStrLn $
+            "No documentation was generated because no file with .dhall " <>
+            "extension was found"
+    else Path.IO.withSystemTempDir "dhall-docs" $ \tempDir -> do
+        Path.IO.ensureDir tempDir
+        generatedHtmlFiles <-
+            mapM (uncurry $ saveHtml inputDir tempDir packageName)
+                dhallFilesAndHeaders
+        createIndexes tempDir generatedHtmlFiles packageName
+
+        dataDir <- getDataDir
+        Control.Monad.forM_ dataDir $ \(filename, contents) -> do
+            let finalPath = Path.fromAbsFile $ tempDir </> filename
+            Data.ByteString.writeFile finalPath contents
+
+        Path.IO.ensureDir $ Path.parent outLink
+
+        outputHash <- makeHashForDirectory tempDir
+        outDir <- Applicative.liftA2 (</>)
+                    getDocsHomeDirectory (Path.parseRelDir $ show outputHash <> "-" <> packageName)
+
+        Path.IO.copyDirRecur tempDir outDir
+        Path.IO.createFileLink (outDir </> $(Path.mkRelFile "index.html")) outLink

--- a/dhall-docs/src/Dhall/Docs/Core.hs
+++ b/dhall-docs/src/Dhall/Docs/Core.hs
@@ -2,10 +2,7 @@
 
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# OPTIONS_GHC -Wno-unused-imports   #-}
 
 module Dhall.Docs.Core (generateDocs) where
 
@@ -17,7 +14,7 @@ import Dhall.Docs.Html
 import Dhall.Docs.Markdown
 import Dhall.Docs.Store
 import Dhall.Parser        (Header (..), ParseError (..), exprAndHeaderFromText)
-import Path                (Abs, Dir, File, Path, Rel, (</>))
+import Path                (Abs, Dir, File, Path, (</>))
 import Text.Megaparsec     (ParseErrorBundle (..))
 
 import qualified Control.Applicative as Applicative
@@ -206,9 +203,9 @@ createIndexes outputPath htmlFiles packageName = do
 
 -- | Generate all of the docs for a package
 generateDocs
-    :: Path Abs Dir  -- ^ Input directory
-    -> Path Abs File -- ^ Link to be created to the generated documentation
-    -> String        -- ^ Package name, used in some HTML titles
+    :: Path Abs Dir -- ^ Input directory
+    -> Path Abs Dir -- ^ Link to be created to the generated documentation
+    -> String       -- ^ Package name, used in some HTML titles
     -> IO ()
 generateDocs inputDir outLink packageName = do
 
@@ -236,4 +233,4 @@ generateDocs inputDir outLink packageName = do
                     getDocsHomeDirectory (Path.parseRelDir $ show outputHash <> "-" <> packageName)
 
         Path.IO.copyDirRecur tempDir outDir
-        Path.IO.createFileLink (outDir </> $(Path.mkRelFile "index.html")) outLink
+        Path.IO.createDirLink outDir outLink

--- a/dhall-docs/src/Dhall/Docs/Store.hs
+++ b/dhall-docs/src/Dhall/Docs/Store.hs
@@ -1,0 +1,42 @@
+{-| Utilities to interact with the dhall-docs home directory
+-}
+module Dhall.Docs.Store (getDocsHomeDirectory, makeHashForDirectory) where
+
+import Data.Map.Strict (Map)
+import Dhall.Crypto    (SHA256Digest (..), sha256Hash)
+import Path            (Abs, Dir, File, Path)
+import Path.IO         (XdgDirectory (..))
+
+import qualified Data.ByteString
+import qualified Data.Map.Strict as Map
+import qualified Path
+import qualified Path.IO
+
+{-| Fetches the dhall-docs home directory. If @XDG_DATA_HOME@ env var is
+    defined, then @${XDG_DATA_HOME}/dhall-docs@ will be returned. Otherwise,
+    "${HOME}/.local/share/dhall-docs"
+-}
+getDocsHomeDirectory :: IO (Path Abs Dir)
+getDocsHomeDirectory = do
+    dir <- Path.IO.getXdgDir Path.IO.XdgData $ Path.parseRelDir "dhall-docs"
+    Path.IO.ensureDir dir
+    return dir
+
+{-| Compute the hash for a directory. It takes into account the hierarchy
+    structure of it and the contents of its files, but not the name of the
+    actual files.
+
+    This is done by computing the hash of each file and sorting them by its
+    absolute file name, and computing the hash of the concatenation of all
+    hashes.
+-}
+makeHashForDirectory :: Path Abs Dir -> IO SHA256Digest
+makeHashForDirectory dir = do
+    -- Builds a map so key order is preserved between several calls
+    hashes <- Map.elems <$> Path.IO.walkDirAccum Nothing go dir
+    return $ sha256Hash $ Data.ByteString.concat $ Prelude.map unSHA256Digest hashes
+  where
+    go :: (Path Abs Dir -> [Path Abs Dir] -> [Path Abs File] -> IO (Map (Path Abs File) SHA256Digest))
+    go _ _ files =
+        (Map.fromList . zip files) <$>
+            mapM (fmap sha256Hash . Data.ByteString.readFile . Path.fromAbsFile) files

--- a/dhall-docs/src/Dhall/Docs/Store.hs
+++ b/dhall-docs/src/Dhall/Docs/Store.hs
@@ -1,9 +1,13 @@
 {-| Utilities to interact with the dhall-docs home directory
 -}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+
 module Dhall.Docs.Store (getDocsHomeDirectory, makeHashForDirectory) where
 
 import Dhall.Crypto (SHA256Digest (..), sha256Hash)
-import Path         (Abs, Dir, Path)
+import Path         (Abs, Dir, Path, Rel)
 import Path.IO      (XdgDirectory (..))
 
 import qualified Codec.Archive.Tar       as Tar
@@ -19,7 +23,7 @@ import qualified Path.IO
 -}
 getDocsHomeDirectory :: IO (Path Abs Dir)
 getDocsHomeDirectory = do
-    dir <- Path.IO.getXdgDir Path.IO.XdgData $ Path.parseRelDir "dhall-docs"
+    dir <- Path.IO.getXdgDir Path.IO.XdgData $ Just $ [Path.reldir|dhall-docs|]
     Path.IO.ensureDir dir
     return dir
 

--- a/nix/dhall-docs-gen.nix
+++ b/nix/dhall-docs-gen.nix
@@ -1,4 +1,4 @@
-{ stdenv, dhall-docs, unzip, fetchurl }:
+{ stdenv, dhall-docs, unzip, fetchurl, tree }:
 
 stdenv.mkDerivation rec {
   name = "dhall-docs-artifacts";
@@ -8,12 +8,13 @@ stdenv.mkDerivation rec {
     sha256 = "8c46f81d6131bf5dac715a3f107d0a43f4e8decaadd7ed36fbc4375b5b32eeaf";
   };
 
-  buildInputs = [ dhall-docs unzip ];
+  buildInputs = [ dhall-docs unzip tree ];
 
   installPhase = ''
     mkdir -p $out/nix-support
     export XDG_DATA_HOME=$out/
     dhall-docs --input ./Prelude > $out/dhall-docs.log
+    tree $XDG_DATA_HOME/dhall-docs > $out/dhall-docs.log
     echo "report html $out/dhall-docs/5b8855b55ed149bcb1e6153c9c45c9be5d2c8e085b5bb3edf51398f326157b93-Prelude/" >> $out/nix-support/hydra-build-products
     echo "report log $out/dhall-docs.log" >> $out/nix-support/hydra-build-products
   '';

--- a/nix/dhall-docs-gen.nix
+++ b/nix/dhall-docs-gen.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/nix-support
     export XDG_DATA_HOME=$out/
     dhall-docs --input ./Prelude > $out/dhall-docs.log
-    echo "report html $out/dhall-docs/5b8855b55ed149bcb1e6153c9c45c9be5d2c8e085b5bb3edf51398f326157b93-Prelude" >> $out/nix-support/hydra-build-products
+    echo "report html $out/dhall-docs/5b8855b55ed149bcb1e6153c9c45c9be5d2c8e085b5bb3edf51398f326157b93-Prelude/" >> $out/nix-support/hydra-build-products
     echo "report log $out/dhall-docs.log" >> $out/nix-support/hydra-build-products
   '';
 }

--- a/nix/dhall-docs-gen.nix
+++ b/nix/dhall-docs-gen.nix
@@ -14,8 +14,9 @@ stdenv.mkDerivation rec {
     mkdir -p $out/nix-support
     export XDG_DATA_HOME=$out/
     dhall-docs --input ./Prelude > $out/dhall-docs.log
+    htmlDir=$(dirname $(readlink -f ./docs/index.html))
     tree $XDG_DATA_HOME/dhall-docs > $out/dhall-docs.log
-    echo "report html $out/dhall-docs/5b8855b55ed149bcb1e6153c9c45c9be5d2c8e085b5bb3edf51398f326157b93-Prelude/" >> $out/nix-support/hydra-build-products
+    echo "report html $htmlDir" >> $out/nix-support/hydra-build-products
     echo "report log $out/dhall-docs.log" >> $out/nix-support/hydra-build-products
   '';
 }

--- a/nix/dhall-docs-gen.nix
+++ b/nix/dhall-docs-gen.nix
@@ -12,8 +12,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/nix-support
-    dhall-docs --input ./Prelude --output $out/docs > $out/dhall-docs.log
-    echo "report html $out/docs" >> $out/nix-support/hydra-build-products
+    export XDG_DATA_HOME=$out/
+    dhall-docs --input ./Prelude > $out/dhall-docs.log
+    echo "report html $out/dhall-docs/5b8855b55ed149bcb1e6153c9c45c9be5d2c8e085b5bb3edf51398f326157b93-Prelude" >> $out/nix-support/hydra-build-products
     echo "report log $out/dhall-docs.log" >> $out/nix-support/hydra-build-products
   '';
 }

--- a/nix/dhall-docs-gen.nix
+++ b/nix/dhall-docs-gen.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/nix-support
     export XDG_DATA_HOME=$out/
-    dhall-docs --input ./Prelude > $out/dhall-docs.log
-    htmlDir=$(readlink -f ./docs)
+    dhall-docs --input ./Prelude --output-link ./dhall-docs > $out/dhall-docs.log
+    htmlDir=$(readlink -f ./dhall-docs)
     tree $XDG_DATA_HOME/dhall-docs > $out/dhall-docs.log
     echo "report html $htmlDir" >> $out/nix-support/hydra-build-products
     echo "report log $out/dhall-docs.log" >> $out/nix-support/hydra-build-products

--- a/nix/dhall-docs-gen.nix
+++ b/nix/dhall-docs-gen.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/nix-support
     export XDG_DATA_HOME=$out/
     dhall-docs --input ./Prelude > $out/dhall-docs.log
-    htmlDir=$(dirname $(readlink -f ./docs/index.html))
+    htmlDir=$(readlink -f ./docs)
     tree $XDG_DATA_HOME/dhall-docs > $out/dhall-docs.log
     echo "report html $htmlDir" >> $out/nix-support/hydra-build-products
     echo "report log $out/dhall-docs.log" >> $out/nix-support/hydra-build-products


### PR DESCRIPTION
Closes #1870 

## Known issues

- [x] If the symlink path already exists and it resolves to another symlink, the `resolveFile'` function of `path-io` resolves to the target of the symlink, and things break therefore.
- [x] I don't calculate the hash of the generated doc to use it as the name of the link. Do you have any idea (package that might help) to do so?
