### PR TITLE
Use env where it works

### DIFF
--- a/dhall/benchmark/deep-nested-large-record/Main.hs
+++ b/dhall/benchmark/deep-nested-large-record/Main.hs
@@ -57,8 +57,11 @@ unionPerformance prelude = Gauge.whnf TypeCheck.typeOf expr
 
 main :: IO ()
 main = do
-  prelude <- Import.load (Core.Embed dhallPreludeImport)
   defaultMain
-    [ Gauge.bench "issue 412" (issue412 prelude)
-    , Gauge.bench "union performance" (unionPerformance prelude)
+    [ Gauge.env prelude $ \p ->
+      Gauge.bgroup "Prelude"
+        [ Gauge.bench "issue 412" (issue412 p)
+        , Gauge.bench "union performance" (unionPerformance p)
+        ]
     ]
+  where prelude = Import.load (Core.Embed dhallPreludeImport)

--- a/dhall/benchmark/parser/Main.hs
+++ b/dhall/benchmark/parser/Main.hs
@@ -83,15 +83,14 @@ benchNfExprFromText name expr =
 main :: IO ()
 main = do
     prelude <- loadPreludeFiles
-    issue108Text  <- TIO.readFile "benchmark/examples/issue108.dhall"
-    issue108Bytes <- Data.ByteString.Lazy.readFile "benchmark/examples/issue108.dhall.bin"
-    kubernetesExample <- Data.ByteString.Lazy.readFile "benchmark/examples/kubernetes.dhall.bin"
     defaultMain
-        [ bgroup "Issue #108"
-            [ benchExprFromText  "Text"   issue108Text
-            , benchExprFromBytes "Binary" issue108Bytes
-            ]
-        , benchExprFromBytes "Kubernetes/Binary" kubernetesExample
+        [ env issues $ \ ~(it, ib) ->
+            bgroup "Issue #108"
+                [ benchExprFromText  "Text"   it
+                , benchExprFromBytes "Binary" ib
+                ]
+        , env kubernetesExample $
+            benchExprFromBytes "Kubernetes/Binary"
         , benchExprFromText "Long variable names" (T.replicate 1000000 "x")
         , benchExprFromText "Large number of function arguments" (T.replicate 10000 "x ")
         , benchExprFromText "Long double-quoted strings" ("\"" <> T.replicate 1000000 "x" <> "\"")
@@ -101,7 +100,11 @@ main = do
         , benchExprFromText "Block comment" ("x {- " <> T.replicate 1000000 " " <> "-}")
         , benchExprFromText "Deeply nested parentheses" "((((((((((((((((x))))))))))))))))"
         , benchParser prelude
-        , env cpkgExample $ \e ->
-            benchNfExprFromText "CPkg/Text" e
+        , env cpkgExample $
+            benchNfExprFromText "CPkg/Text"
         ]
     where cpkgExample = TIO.readFile "benchmark/examples/cpkg.dhall"
+          issue108Text = TIO.readFile "benchmark/examples/issue108.dhall"
+          issue108Bytes = Data.ByteString.Lazy.readFile "benchmark/examples/issue108.dhall.bin"
+          issues = (,) <$> issue108Text <*> issue108Bytes
+          kubernetesExample = Data.ByteString.Lazy.readFile "benchmark/examples/kubernetes.dhall.bin"


### PR DESCRIPTION
This use [env](http://hackage.haskell.org/package/gauge-0.2.5/docs/Gauge-Benchmark.html#v:env) so that bits of memory are only alive while the appropriate benchmark is being run. This makes the benchmarks more independent from one another; otherwise the allocator/garbage collector interfere across benchmarks.

This doesn't work with `loadPrelude`; not quite sure why - perhaps the directory change? 