### PR TITLE
Move RecordEncoder documentation

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -2471,6 +2471,12 @@ constructor :: Text -> Decoder a -> UnionDecoder a
 constructor key valueDecoder = UnionDecoder
     ( Data.Functor.Compose.Compose (Dhall.Map.singleton key valueDecoder) )
 
+-- | Infix 'divided'
+(>*<) :: Divisible f => f a -> f b -> f (a, b)
+(>*<) = divided
+
+infixr 5 >*<
+
 {-| The 'RecordEncoder' divisible (contravariant) functor allows you to build
     an 'Encoder' for a Dhall record.
 
@@ -2527,13 +2533,6 @@ injectProject =
 
 -}
 
--- | Infix 'divided'
-(>*<) :: Divisible f => f a -> f b -> f (a, b)
-(>*<) = divided
-
-infixr 5 >*<
-
--- | Intermediate type used for building a `ToDhall` instance for a record
 newtype RecordEncoder a
   = RecordEncoder (Dhall.Map.Map Text (Encoder a))
 


### PR DESCRIPTION
The documentation for how to use the Divisible instance to create a
RecordEncoder ended up in the "Miscellaneous" section. This made it very
hard to find, after some searching I ended up in the repository and
found out the documentation *was* included on the hackage page I was
trying to find it on.

I moved it to document the definition of the RecordEncoder newtype to
bring it in line with the RecordDecoder documentation.

(Note: The diff is slightly misleading but moving the (>*<) definition up is the same thing as moving the haddock comment down.)