### PR TITLE
Disable optimizations for Dhall.Test.QuickCheck

### DIFF
--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -8,6 +8,9 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
+-- Build without optimizations to prevent out-of-memory situations in Hydra CI
+{-# OPTIONS_GHC -O0 #-}
+
 module Dhall.Test.QuickCheck where
 
 import Data.Either (isRight)


### PR DESCRIPTION
…in order to prevent OOMs in Hydra CI.

This seems to reduce maximum residency when building with GHC 8.4.4 by
about 1.4GB while extending the test runtime by about 13%.