### PR TITLE
Fix #1884

### DIFF
--- a/dhall/src/Dhall/Parser/Combinators.hs
+++ b/dhall/src/Dhall/Parser/Combinators.hs
@@ -49,7 +49,7 @@ instance Show e => Show (SourcedException e) where
 
 -- | Doesn't force the 'Text' part
 laxSrcEq :: Src -> Src -> Bool
-laxSrcEq (Src p q _) (Src p' q' _) = eq p  p' && eq q q'
+laxSrcEq (Src p q _) (Src p' q' _) = eq p p' && eq q q'
   where
     -- Don't compare filename (which is FilePath = String)
     eq  :: Text.Megaparsec.SourcePos -> Text.Megaparsec.SourcePos -> Bool

--- a/dhall/tests/Dhall/Test/Regression.hs
+++ b/dhall/tests/Dhall/Test/Regression.hs
@@ -205,6 +205,13 @@ issue1732 = Test.Tasty.HUnit.testCase "Issue #1732" (do
     _ <- Util.code "./tests/regression/issue1732.dhall"
     return () )
 
+issue1884 :: TestTree
+issue1884 = Test.Tasty.HUnit.testCase "Issue #1884" (do
+    -- This test ensures that the parser allows a parenthesized application
+    -- expression as the first argument to a with expression
+    _ <- Util.code "./tests/regression/issue1884.dhall"
+    return () )
+
 parsing0 :: TestTree
 parsing0 = Test.Tasty.HUnit.testCase "Parsing regression #0" (do
     -- Verify that parsing should not fail

--- a/dhall/tests/regression/issue1884.dhall
+++ b/dhall/tests/regression/issue1884.dhall
@@ -1,0 +1,4 @@
+let Make = \(T: Type) -> { Type = { a: T },  default = {=} }
+
+in
+(Make Natural) with default = { a = 2 }


### PR DESCRIPTION
This is a refactored variation of #1889 that doesn't need `eqExprBySrc`.

Here, we try parsing the `with` expression _before_ attempting to parse a first operator expression.