### PR TITLE
dhall-docs: filter non dhall file in generateDocs

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -120,6 +120,7 @@ Test-Suite tasty
     Main-Is: Main.hs
     Build-Depends:
         base                   ,
+        bytestring             ,
         containers             ,
         dhall-docs             ,
         HaXml        >= 1.25.5 ,

--- a/dhall-docs/tasty/Main.hs
+++ b/dhall-docs/tasty/Main.hs
@@ -4,6 +4,7 @@
 
 module Main (main) where
 
+import Data.ByteString (ByteString)
 import Data.Map.Strict (Map)
 import Data.Text       (Text)
 import Dhall.Docs.Core
@@ -11,6 +12,7 @@ import Path            (Dir, File, Path, Rel, (</>))
 import Test.Tasty      (TestTree)
 
 import qualified Control.Monad
+import qualified Data.ByteString
 import qualified Data.Map.Strict               as Map
 import qualified Data.Text
 import qualified Data.Text.IO                  as Text.IO
@@ -33,17 +35,17 @@ main = do
     let docsMap = Map.fromList docs
     Silver.defaultMain $ testTree docsMap
 
-getDirContents :: Path Rel Dir -> IO [(Path Rel File, Text)]
+getDirContents :: Path Rel Dir -> IO [(Path Rel File, ByteString)]
 getDirContents dataDir = do
     files <- snd <$> Path.IO.listDirRecurRel dataDir
     Control.Monad.forM files $ \file -> do
-        contents <- Text.IO.readFile $ Path.fromRelFile $ dataDir </> file
+        contents <- Data.ByteString.readFile $ Path.fromRelFile $ dataDir </> file
         return (file, contents)
 
 goldenDir :: Path Rel Dir
 goldenDir = $(Path.mkRelDir "./tasty/data/golden")
 
-getPackageContents :: IO [(Path Rel File, Text)]
+getPackageContents :: IO [(Path Rel File, ByteString)]
 getPackageContents = getDirContents $(Path.mkRelDir "./tasty/data/package")
 
 testTree :: Map (Path Rel File) Text -> TestTree

--- a/dhall-docs/tasty/data/package/InvalidUnicode.dhall
+++ b/dhall-docs/tasty/data/package/InvalidUnicode.dhall
@@ -1,0 +1,2 @@
+{- This file contains invalid unicode -}
+€

--- a/dhall-docs/tasty/data/package/ShouldBeIgnoredToo
+++ b/dhall-docs/tasty/data/package/ShouldBeIgnoredToo
@@ -1,0 +1,1 @@
+Should be ignored because this file has no .dhall extension


### PR DESCRIPTION
This change ensure dhall-docs doesn't halt with this exception
when running on a git project:
 .git/index: hGetContents: invalid argument (invalid byte sequence)

Fixes #1909