### PR TITLE
dhall-lsp-server.cabal: Register test dependency on executable

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -115,4 +115,5 @@ Test-Suite tests
         tasty             >= 0.11.2  && < 1.4  ,
         tasty-hspec       >= 1.1     && < 1.2  ,
         text              >= 0.11    && < 1.3
+    Build-Tool-Depends: dhall-lsp-server:dhall-lsp-server
     Default-Language: Haskell2010


### PR DESCRIPTION
cabal will now ensure that the dhall-lsp-server executable is
up-to-date before running the integration tests.

Documentation:

https://cabal.readthedocs.io/en/stable/developing-packages.html?highlight=build-tool-depends#pkg-field-build-tool-depends