### PR TITLE
Load italic and bold Lato fonts

### DIFF
--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -275,7 +275,7 @@ headContents title DocParams{..} =
     head_ $ do
         title_ $ toHtml title
         stylesheet $ relativeResourcesPath <> "index.css"
-        stylesheet "https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Lato&display=swap"
+        stylesheet "https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Lato:ital,wght@0,400;0,700;1,400&display=swap"
         script relativeResourcesPath
         meta_ [charset_ "UTF-8"]
 

--- a/dhall-docs/tasty/data/golden/IndexesExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/IndexesExample.dhall.html
@@ -4,7 +4,7 @@
     ><title
     >/IndexesExample.dhall</title
     ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
@@ -4,7 +4,7 @@
     ><title
     >/InvalidMarkdown.dhall</title
     ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
@@ -4,7 +4,7 @@
     ><title
     >/MarkdownExample.dhall</title
     ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/Pair.dhall.html
+++ b/dhall-docs/tasty/data/golden/Pair.dhall.html
@@ -4,7 +4,7 @@
     ><title
     >/Pair.dhall</title
     ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/a/b.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b.dhall.html
@@ -4,7 +4,7 @@
     ><title
     >/a/b.dhall</title
     ><link href="../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/a/b/c.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c.dhall.html
@@ -4,7 +4,7 @@
     ><title
     >/a/b/c.dhall</title
     ><link href="../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
@@ -4,7 +4,7 @@
     ><title
     >/a/b/c/a.dhall</title
     ><link href="../../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="../../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/a/b/c/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/index.html
@@ -4,7 +4,7 @@
     ><title
     >/a/b/c</title
     ><link href="../../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="../../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/a/b/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/index.html
@@ -4,7 +4,7 @@
     ><title
     >/a/b</title
     ><link href="../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/a/index.html
+++ b/dhall-docs/tasty/data/golden/a/index.html
@@ -4,7 +4,7 @@
     ><title
     >/a</title
     ><link href="../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
@@ -4,7 +4,7 @@
     ><title
     >/deep/nested/folder</title
     ><link href="../../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="../../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
@@ -4,7 +4,7 @@
     ><title
     >/deep/nested/folder/my-even.dhall</title
     ><link href="../../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="../../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -4,7 +4,7 @@
     ><title
     >/</title
     ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head

--- a/dhall-docs/tasty/data/golden/package.dhall.html
+++ b/dhall-docs/tasty/data/golden/package.dhall.html
@@ -4,7 +4,7 @@
     ><title
     >/package.dhall</title
     ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato&amp;display=swap"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head


### PR DESCRIPTION
Currently, `dhall-docs` loads the Fira Code and Lato fonts using [Google fonts' v2 API](https://developers.google.com/fonts/docs/css2), but only the regular Lato font is loaded.  Since `dhall-docs` supports markdown, italic and bold display should be expected but they currently don't display properly.  This PR adds the italic and bold versions of Lato to the fonts loaded.

Before:
![2020-07-11_15-23](https://user-images.githubusercontent.com/2049163/87234941-ff0a7500-c38a-11ea-994a-dc8712ba5c90.png)
After:
![2020-07-11_15-24](https://user-images.githubusercontent.com/2049163/87234942-00d43880-c38b-11ea-885d-0ef52b361691.png)


