### PR TITLE
Alphabetize exported packages in dhall-docs

### DIFF
--- a/dhall-docs/src/Dhall/Docs/Core.hs
+++ b/dhall-docs/src/Dhall/Docs/Core.hs
@@ -307,7 +307,7 @@ createIndexes packageName files = map toIndex dirToDirsAndFilesMapAssocs
         documentation to get more information.
     -}
     dirToDirsMap :: Map (Path Rel Dir) [Path Rel Dir]
-    dirToDirsMap = Map.map removeHereDir $ foldl go initialMap dirs
+    dirToDirsMap = Map.map removeHereDir $ foldr go initialMap dirs
       where
         -- > removeHeredir [$(mkRelDir "a"), $(mkRelDir ".")]
         --   [$(mkRelDir "a")]
@@ -323,8 +323,8 @@ createIndexes packageName files = map toIndex dirToDirsAndFilesMapAssocs
         initialMap :: Map (Path Rel Dir) [Path Rel Dir]
         initialMap = Map.fromList $ map (,[]) dirs
 
-        go :: Map (Path Rel Dir) [Path Rel Dir] -> Path Rel Dir -> Map (Path Rel Dir) [Path Rel Dir]
-        go dirMap d = Map.adjust ([d] <>) (key $ Path.parent d) dirMap
+        go :: Path Rel Dir -> Map (Path Rel Dir) [Path Rel Dir] -> Map (Path Rel Dir) [Path Rel Dir]
+        go d dirMap = Map.adjust ([d] <>) (key $ Path.parent d) dirMap
           where
             key :: Path Rel Dir -> Path Rel Dir
             key dir = if dir `Map.member` dirMap then dir else key $ Path.parent dir

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -92,8 +92,8 @@
       >Exported packages: </h3
       ><ul
         ><li
-          ><a href="deep/nested/folder/index.html"
-          >deep/nested/folder/</a></li
-        ><li
           ><a href="a/index.html"
-          >a/</a></li></ul></div></body></html>
+          >a/</a></li
+        ><li
+          ><a href="deep/nested/folder/index.html"
+          >deep/nested/folder/</a></li></ul></div></body></html>


### PR DESCRIPTION
Due to a `foldl` in `dirToDirsMap` (in `createIndexes`), exported packages were listed in reverse alphabetical order, which was unexpected behavior given that exported files were in alphabetical order.  Switching it to a `foldr` fixes the inconsistency.