### PR TITLE
dhall-docs: add ascii characterset support

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -122,6 +122,7 @@ Test-Suite tasty
         base                   ,
         bytestring             ,
         containers             ,
+        dhall                  ,
         dhall-docs             ,
         HaXml        >= 1.25.5 ,
         path                   ,

--- a/dhall-docs/src/Dhall/Docs.hs
+++ b/dhall-docs/src/Dhall/Docs.hs
@@ -43,7 +43,7 @@ data Options
         { packageDir :: FilePath         -- ^ Directory where your package resides
         , docLink :: FilePath            -- ^ Link to the generated documentation
         , resolvePackageName :: Path Abs Dir -> Text
-        , ascii :: CharacterSet
+        , characterSet :: CharacterSet
         }
     | Version
 
@@ -131,7 +131,6 @@ defaultMain = \case
 
         resolvedDocLink <- Path.IO.resolveDir' docLink
         let packageName = resolvePackageName resolvedPackageDir
-        let characterSet = ascii
         generateDocs resolvedPackageDir resolvedDocLink packageName characterSet
     Version ->
         putStrLn (showVersion Meta.version)

--- a/dhall-docs/src/Dhall/Docs.hs
+++ b/dhall-docs/src/Dhall/Docs.hs
@@ -74,7 +74,7 @@ parseOptions =
             <>  Options.Applicative.help description
             )
 
-    parseAscii = fmap f (switch "ascii" "Format code using only ASCII syntax")
+    parseAscii = fmap f (switch "ascii" "Format rendered source code using only ASCII syntax")
       where
         f True  = ASCII
         f False = Unicode

--- a/dhall-docs/src/Dhall/Docs.hs
+++ b/dhall-docs/src/Dhall/Docs.hs
@@ -43,7 +43,7 @@ data Options
         { packageDir :: FilePath         -- ^ Directory where your package resides
         , docLink :: FilePath            -- ^ Link to the generated documentation
         , resolvePackageName :: Path Abs Dir -> Text
-        , ascii :: Bool
+        , ascii :: CharacterSet
         }
     | Version
 
@@ -65,7 +65,7 @@ parseOptions =
             )
        <> Options.Applicative.value "./docs" )
     <*> parsePackageNameResolver
-    <*> switch "ascii" "Format code using only ASCII syntax"
+    <*> parseAscii
     ) <|> parseVersion
   where
     switch name description =
@@ -73,6 +73,11 @@ parseOptions =
             (   Options.Applicative.long name
             <>  Options.Applicative.help description
             )
+
+    parseAscii = fmap f (switch "ascii" "Format code using only ASCII syntax")
+      where
+        f True  = ASCII
+        f False = Unicode
 
     parseVersion =
         Options.Applicative.flag'
@@ -126,9 +131,7 @@ defaultMain = \case
 
         resolvedDocLink <- Path.IO.resolveDir' docLink
         let packageName = resolvePackageName resolvedPackageDir
-        let characterSet = case ascii of
-                True  -> ASCII
-                False -> Unicode
+        let characterSet = ascii
         generateDocs resolvedPackageDir resolvedDocLink packageName characterSet
     Version ->
         putStrLn (showVersion Meta.version)

--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -20,8 +20,8 @@ module Dhall.Docs.Html
 import Data.Monoid  ((<>))
 import Data.Text    (Text)
 import Data.Void    (Void)
-import Dhall.Core   (Expr, Import)
-import Dhall.Pretty (Ann (..))
+import Dhall.Core   (Expr, Import, denote)
+import Dhall.Pretty (Ann (..), CharacterSet)
 import Dhall.Src    (Src)
 import Lucid
 import Path         (Dir, File, Path, Rel)
@@ -44,8 +44,8 @@ import qualified System.FilePath                                     as FilePath
 data ExprType = TypeAnnotation | FileContentsExpr
 
 
-exprToHtml :: ExprType -> Expr a Import -> Html ()
-exprToHtml exprType expr = pre_ $ renderTree prettyTree
+exprToHtml :: Dhall.Pretty.CharacterSet -> ExprType -> Expr a Import -> Html ()
+exprToHtml characterSet exprType expr = pre_ $ renderTree prettyTree
   where
     layout = case exprType of
         FileContentsExpr -> Dhall.Pretty.layout
@@ -53,7 +53,7 @@ exprToHtml exprType expr = pre_ $ renderTree prettyTree
 
     prettyTree = Pretty.treeForm
         $ layout
-        $ Dhall.Pretty.prettyExpr expr
+        $ Dhall.Pretty.prettyCharacterSet characterSet (denote expr)
 
     textSpaces :: Int -> Text
     textSpaces n = Data.Text.replicate n (Data.Text.singleton ' ')
@@ -95,6 +95,7 @@ data DocParams = DocParams
     { relativeResourcesPath :: FilePath -- ^ Relative resource path to the
                                         --   front-end files
     , packageName :: Text               -- ^ Name of the package
+    , characterSet :: CharacterSet      -- ^ Render code as `ASCII` or `Unicode`
     }
 
 -- | Generates an @`Html` ()@ with all the information about a dhall file
@@ -118,9 +119,9 @@ dhallFileToHtml filePath expr examples header params@DocParams{..} =
                 Control.Monad.unless (null examples) $ do
                     h3_ "Examples"
                     div_ [class_ "source-code code-examples"] $
-                        mapM_ (exprToHtml FileContentsExpr) examples
+                        mapM_ (exprToHtml characterSet FileContentsExpr) examples
                 h3_ "Source"
-                div_ [class_ "source-code"] $ exprToHtml FileContentsExpr expr
+                div_ [class_ "source-code"] $ exprToHtml characterSet FileContentsExpr expr
   where
     breadcrumb = relPathToBreadcrumb filePath
     htmlTitle = breadCrumbsToText breadcrumb
@@ -157,7 +158,7 @@ indexToHtml indexDir files dirs params@DocParams{..} = doctypehtml_ $ do
             a_ [href_ fileRef] $ toHtml itemText
             Data.Foldable.forM_ maybeType $ \typeExpr -> do
                 span_ [class_ "of-type-token"] ":"
-                span_ [class_ "dhall-type source-code"] $ exprToHtml TypeAnnotation typeExpr
+                span_ [class_ "dhall-type source-code"] $ exprToHtml characterSet TypeAnnotation typeExpr
 
 
     listDir :: Path Rel Dir -> Html ()

--- a/dhall-docs/tasty/Main.hs
+++ b/dhall-docs/tasty/Main.hs
@@ -7,6 +7,7 @@ module Main (main) where
 import Data.ByteString (ByteString)
 import Data.Map.Strict (Map)
 import Data.Text       (Text)
+import Dhall.Pretty    (CharacterSet(..))
 import Dhall.Docs.Core
 import Path            (Dir, File, Path, Rel, (</>))
 import Test.Tasty      (TestTree)
@@ -31,7 +32,7 @@ main = do
     GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
 
     input <- getPackageContents
-    let GeneratedDocs _ docs = generateDocsPure "test-package" input
+    let GeneratedDocs _ docs = generateDocsPure "test-package" Unicode input
     let docsMap = Map.fromList docs
     Silver.defaultMain $ testTree docsMap
 


### PR DESCRIPTION
This change adds a characterset operand and `--ascii` command line
argument to support ASCII output.