### PR TITLE
Move man/dhall.1 to data files

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -22,11 +22,12 @@ Description:
     .
     Read "Dhall.Tutorial" to learn how to use this library
 Category: Compiler
+Data-Files:
+    man/dhall.1
 Extra-Source-Files:
     benchmark/deep-nested-large-record/*.dhall
     benchmark/examples/*.dhall
     benchmark/examples/normalize/*.dhall
-    man/dhall.1
     CHANGELOG.md
     dhall-lang/Prelude/Bool/and
     dhall-lang/Prelude/Bool/build


### PR DESCRIPTION
This means that after running `cabal install dhall` (from e.g. hackage) the manpage will be installed to `share/...`. This is what `hlint` does, for instance. 