### PR TITLE
Format haskell files with stylish-haskell and hlint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ stack*.yaml.lock
 .vscode
 docs
 result
+report.html

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,88 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Warnings currently triggered by your code
+- ignore: {name: "Redundant $"}
+- ignore: {name: "Use fewer imports"}
+- ignore: {name: "Redundant bracket"}
+- ignore: {name: "Move brackets to avoid $"}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Reduce duplication"}
+- ignore: {name: "Use when"}
+- ignore: {name: "Use const"}
+- ignore: {name: "Avoid lambda"}
+- ignore: {name: "Redundant return"}
+- ignore: {name: "Redundant irrefutable pattern"}
+- ignore: {name: "Use if"}
+- ignore: {name: "Use unless"}
+- ignore: {name: "Use record patterns"}
+- ignore: {name: "Use &&&"}
+- ignore: {name: "Use newtype instead of data"}
+- ignore: {name: "Use second"}
+- ignore: {name: "Use $>"}
+- ignore: {name: "Use guards"}
+- ignore: {name: "Parse error"}
+- ignore: {name: "Use ***"}
+- ignore: {name: "Use first"}
+- ignore: {name: "Use ."}
+- ignore: {name: "Use list comprehension"}
+- ignore: {name: "Use fromMaybe"}
+
+
+# Specify additional command line arguments
+#
+- arguments: [--color, --cpp-simple]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/dhall-bash/src/Dhall/Bash.hs
+++ b/dhall-bash/src/Dhall/Bash.hs
@@ -101,12 +101,12 @@ module Dhall.Bash (
     ) where
 
 import Control.Exception (Exception)
-import Data.Bifunctor (first)
+import Data.Bifunctor    (first)
 import Data.ByteString
-import Data.Monoid ((<>))
-import Data.Typeable (Typeable)
-import Data.Void (Void, absurd)
-import Dhall.Core (Expr(..), Chunks(..))
+import Data.Monoid       ((<>))
+import Data.Typeable     (Typeable)
+import Data.Void         (Void, absurd)
+import Dhall.Core        (Chunks (..), Expr (..))
 
 import qualified Data.Foldable
 import qualified Data.Text
@@ -227,9 +227,9 @@ dhallToStatement expr0 var0 = go (Dhall.Core.normalize expr0)
 
     adapt (UnsupportedExpression e) = UnsupportedSubexpression e
 
-    go (BoolLit a) = do
+    go (BoolLit a) =
         go (TextLit (if a then "true" else "false"))
-    go (NaturalLit a) = do
+    go (NaturalLit a) =
         go (IntegerLit (fromIntegral a))
     go (IntegerLit a) = do
         e <- first adapt (dhallToExpression (IntegerLit a))
@@ -268,9 +268,9 @@ dhallToStatement expr0 var0 = go (Dhall.Core.normalize expr0)
         e <- first adapt (dhallToExpression (Field (Union m) k))
         let bytes = "declare -r " <> var <> "=" <> e
         return bytes
-    go (Embed   x) = do
+    go (Embed   x) =
         absurd x
-    go (Note  _ e) = do
+    go (Note  _ e) =
         go e
 
     -- Use an exhaustive pattern match here so that we don't forget to handle
@@ -352,11 +352,11 @@ dhallToExpression
     -- ^ Bash expression or compile failure
 dhallToExpression expr0 = go (Dhall.Core.normalize expr0)
   where
-    go (BoolLit a) = do
+    go (BoolLit a) =
         go (TextLit (if a then "true" else "false"))
-    go (NaturalLit a) = do
+    go (NaturalLit a) =
         go (IntegerLit (fromIntegral a))
-    go (IntegerLit a) = do
+    go (IntegerLit a) =
         go (TextLit (Chunks [] (Data.Text.pack (show a))))
     go (TextLit (Chunks [] a)) = do
         let bytes = Data.Text.Encoding.encodeUtf8 a

--- a/dhall-docs/src/Dhall/Docs/Embedded.hs
+++ b/dhall-docs/src/Dhall/Docs/Embedded.hs
@@ -29,7 +29,7 @@ import qualified Path.IO
 
 getDataDir :: IO [(Path Rel File, ByteString)]
 #if defined(EMBED)
-getDataDir = return $(embedDir "src/Dhall/data") >>= mapM f
+getDataDir = mapM f $(embedDir "src/Dhall/data")
   where
     f :: (FilePath, ByteString) -> IO (Path Rel File, ByteString)
     f (filePath, contents) = (,contents) <$> Path.parseRelFile filePath

--- a/dhall-json/dhall-to-json/Main.hs
+++ b/dhall-json/dhall-to-json/Main.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Main where
 
-import Control.Applicative ((<|>), optional)
-import Control.Exception (SomeException)
-import Data.Aeson (Value)
-import Data.Monoid ((<>))
-import Data.Version (showVersion)
-import Dhall.JSON (Conversion, SpecialDoubleMode(..))
+import Control.Applicative (optional, (<|>))
+import Control.Exception   (SomeException)
+import Data.Aeson          (Value)
+import Data.Monoid         ((<>))
+import Data.Version        (showVersion)
+import Dhall.JSON          (Conversion, SpecialDoubleMode (..))
 import Options.Applicative (Parser, ParserInfo)
 
 import qualified Control.Exception
@@ -117,10 +117,10 @@ main = do
     options <- Options.execParser parserInfo
 
     case options of
-        Version -> do
+        Version ->
             putStrLn (showVersion Meta.version)
 
-        Options {..} -> do
+        Options {..} ->
             handle $ do
                 let config = Data.Aeson.Encode.Pretty.Config
                                { Data.Aeson.Encode.Pretty.confIndent = Data.Aeson.Encode.Pretty.Spaces 2

--- a/dhall-json/json-to-dhall/Main.hs
+++ b/dhall-json/json-to-dhall/Main.hs
@@ -1,20 +1,18 @@
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE PatternGuards       #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Main where
 
 import Control.Applicative (optional, (<|>))
-import Control.Exception (SomeException, throwIO)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Data.Version (showVersion)
+import Control.Exception   (SomeException, throwIO)
+import Data.Monoid         ((<>))
+import Data.Text           (Text)
+import Data.Version        (showVersion)
 import Dhall.JSONToDhall
-import Dhall.Pretty (CharacterSet(..))
+import Dhall.Pretty        (CharacterSet (..))
 import Options.Applicative (Parser, ParserInfo)
 
 import qualified Control.Exception
@@ -24,14 +22,14 @@ import qualified Data.Text.IO                              as Text.IO
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty.Terminal
 import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty.Text
+import qualified Dhall.Core
+import qualified Dhall.Pretty
 import qualified GHC.IO.Encoding
 import qualified Options.Applicative                       as Options
+import qualified Paths_dhall_json                          as Meta
 import qualified System.Console.ANSI                       as ANSI
 import qualified System.Exit
 import qualified System.IO                                 as IO
-import qualified Dhall.Core
-import qualified Dhall.Pretty
-import qualified Paths_dhall_json                          as Meta
 
 -- ---------------
 -- Command options
@@ -188,7 +186,7 @@ main = do
                         Text.IO.hPutStrLn h ""
 
     case options of
-        Version -> do
+        Version ->
             putStrLn (showVersion Meta.version)
 
         Default{..} -> do

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -246,9 +246,9 @@ import qualified Dhall.Parser
 import qualified Dhall.Pretty
 import qualified Dhall.TypeCheck
 import qualified Dhall.Util
+import qualified Lens.Family                           as Lens
 import qualified Options.Applicative
 import qualified System.FilePath
-import qualified Lens.Family as Lens
 
 {-| This is the exception type for errors that might arise when translating
     Dhall to JSON

--- a/dhall-json/src/Dhall/JSONToDhall.hs
+++ b/dhall-json/src/Dhall/JSONToDhall.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE PatternGuards       #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedLists     #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PatternGuards       #-}
 {-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns        #-}
 

--- a/dhall-json/tasty/Main.hs
+++ b/dhall-json/tasty/Main.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedLists   #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Main where
 
@@ -77,7 +76,7 @@ testDhallToJSON prefix = Test.Tasty.HUnit.testCase prefix $ do
 
     text <- Data.Text.IO.readFile inputFile
 
-    parsedExpression <- do
+    parsedExpression <-
         Core.throws (Dhall.Parser.exprFromText inputFile text)
 
     resolvedExpression <- Dhall.Import.load parsedExpression
@@ -87,7 +86,7 @@ testDhallToJSON prefix = Test.Tasty.HUnit.testCase prefix $ do
     let convertedExpression =
             Dhall.JSON.convertToHomogeneousMaps Dhall.JSON.defaultConversion resolvedExpression
 
-    actualValue <- do
+    actualValue <-
         Core.throws (Dhall.JSON.dhallToJSON convertedExpression)
 
     bytes <- Data.ByteString.Lazy.readFile outputFile
@@ -121,12 +120,12 @@ testCustomConversionJSONToDhall infer conv prefix =
 
     _ <- Core.throws (Dhall.TypeCheck.typeOf schema)
 
-    actualExpression <- do
+    actualExpression <-
         Core.throws (JSONToDhall.dhallFromJSON conv schema value)
 
     outputText <- Data.Text.IO.readFile outputFile
 
-    parsedExpression <- do
+    parsedExpression <-
         Core.throws (Dhall.Parser.exprFromText outputFile outputText)
 
     resolvedExpression <- Dhall.Import.load parsedExpression

--- a/dhall-lsp-server/app/Main.hs
+++ b/dhall-lsp-server/app/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {-| This module contains the top-level entrypoint and options parsing for the
     @dhall-lsp-server@ executable
 -}
@@ -7,15 +8,15 @@ module Main
   )
 where
 
-import Options.Applicative (Parser, ParserInfo)
-import qualified Options.Applicative
 import Control.Applicative ((<|>))
-import Data.Monoid ((<>))
+import Data.Monoid         ((<>))
+import Options.Applicative (Parser, ParserInfo)
 
 import qualified Data.Version
 import qualified Dhall.LSP.Server
-import qualified Paths_dhall_lsp_server
 import qualified GHC.IO.Encoding
+import qualified Options.Applicative
+import qualified Paths_dhall_lsp_server
 
 -- | Top-level program options
 data Options = Options {
@@ -64,7 +65,7 @@ parserInfoOptions = Options.Applicative.info
   )
 
 runCommand :: Options -> IO ()
-runCommand Options {..} = do
+runCommand Options {..} =
   if version
     then printVersion
     else case command of

--- a/dhall-lsp-server/doctest/Main.hs
+++ b/dhall-lsp-server/doctest/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Data.Monoid ((<>))
+import Data.Monoid     ((<>))
 import System.FilePath ((</>))
 
 import qualified GHC.IO.Encoding

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
@@ -18,31 +18,35 @@ module Dhall.LSP.Backend.Dhall (
   normalize
  ) where
 
+import Dhall.Core   (Expr)
 import Dhall.Parser (Src)
-import Dhall.Core (Expr)
 
-import qualified Dhall.Core as Dhall
-import qualified Dhall.Import as Dhall
-import qualified Dhall.Parser as Dhall
-import qualified Dhall.TypeCheck as Dhall
-
-import qualified Data.Graph as Graph
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
-import qualified Dhall.Map
-import qualified Network.URI as URI
-import qualified Language.Haskell.LSP.Types as LSP.Types
-import qualified Data.Text as Text
-
-import Data.List.NonEmpty (NonEmpty((:|)))
-import Data.Text (Text)
-import Data.Void (Void)
-import System.FilePath (splitDirectories, takeFileName, takeDirectory)
-import Lens.Family (view, set)
-import Control.Exception (SomeException, catch)
+import Control.Exception                (SomeException, catch)
 import Control.Monad.Trans.State.Strict (runStateT)
-import Network.URI (URI)
-import Data.Bifunctor (first)
+import Data.Bifunctor                   (first)
+import Data.List.NonEmpty               (NonEmpty ((:|)))
+import Data.Text                        (Text)
+import Data.Void                        (Void)
+import Lens.Family                      (set, view)
+import Network.URI                      (URI)
+import System.FilePath
+    ( splitDirectories
+    , takeDirectory
+    , takeFileName
+    )
+
+import qualified Data.Graph                 as Graph
+import qualified Data.Map.Strict            as Map
+import qualified Data.Set                   as Set
+import qualified Data.Text                  as Text
+import qualified Dhall.Core                 as Dhall
+import qualified Dhall.Import               as Dhall
+import qualified Dhall.Map
+import qualified Dhall.Parser               as Dhall
+import qualified Dhall.TypeCheck            as Dhall
+import qualified Language.Haskell.LSP.Types as LSP.Types
+import qualified Network.URI                as URI
+
 
 -- | A @FileIdentifier@ represents either a local file or a remote url.
 newtype FileIdentifier = FileIdentifier Dhall.Chained
@@ -104,7 +108,7 @@ invalidate (FileIdentifier chained) (Cache dependencies cache) =
 
     -- compute the reverse dependencies, i.e. the imports reachable in the transposed graph
     reachableImports import_ =
-      map (\(i,_,_) -> i) . map importFromVertex . concat $
+      (map ((\ (i, _, _) -> i) . importFromVertex) . concat) $
         do vertex <- vertexFromImport import_
            return (Graph.reachable graph vertex)
 

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Diagnostics.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Diagnostics.hs
@@ -16,22 +16,26 @@ module Dhall.LSP.Backend.Diagnostics
   )
 where
 
-import Dhall.Parser (SourcedException(..), Src(..), unwrap)
-import Dhall.TypeCheck (DetailedTypeError(..), ErrorMessages(..), TypeError(..))
-import Dhall.Core (Expr(Note, Embed), subExpressions)
+import Dhall.Core      (Expr (Embed, Note), subExpressions)
+import Dhall.Parser    (SourcedException (..), Src (..), unwrap)
+import Dhall.TypeCheck
+    ( DetailedTypeError (..)
+    , ErrorMessages (..)
+    , TypeError (..)
+    )
 
-import Dhall.LSP.Util
 import Dhall.LSP.Backend.Dhall
 import Dhall.LSP.Backend.Parsing (getImportLink)
+import Dhall.LSP.Util
 
-import Control.Lens (toListOf)
+import Control.Lens               (toListOf)
 import Control.Monad.Trans.Writer (Writer, execWriter, tell)
-import Data.Monoid ((<>))
-import Data.Text (Text)
+import Data.Monoid                ((<>))
+import Data.Text                  (Text)
 
+import qualified Data.List.NonEmpty                    as NonEmpty
 import qualified Data.Text                             as Text
 import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty.Text
-import qualified Data.List.NonEmpty                    as NonEmpty
 import qualified Dhall.Pretty
 import qualified Dhall.TypeCheck                       as TypeCheck
 import qualified Text.Megaparsec                       as Megaparsec

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Formatting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Formatting.hs
@@ -1,15 +1,15 @@
 module Dhall.LSP.Backend.Formatting (formatExpr, formatExprWithHeader) where
 
-import Dhall.Core (Expr)
-import Dhall.Pretty (CharacterSet(..))
-import Dhall.Parser (Header(..))
-import qualified Dhall.Pretty
-import Dhall.Src (Src)
+import Data.Monoid  ((<>))
+import Data.Text    (Text)
+import Dhall.Core   (Expr)
+import Dhall.Parser (Header (..))
+import Dhall.Pretty (CharacterSet (..))
+import Dhall.Src    (Src)
 
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import qualified Data.Text.Prettyprint.Doc                 as Pretty
-import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty
+import qualified Data.Text.Prettyprint.Doc             as Pretty
+import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
+import qualified Dhall.Pretty
 
 -- | Pretty-print the given Dhall expression.
 formatExpr :: Pretty.Pretty b => CharacterSet -> Expr Src b -> Text

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Linting.hs
@@ -7,18 +7,23 @@ module Dhall.LSP.Backend.Linting
   )
 where
 
-import Control.Lens (universeOf)
-import Data.Maybe (maybeToList)
-import Data.Monoid ((<>))
-import Data.Text (Text)
+import Control.Lens                  (universeOf)
+import Data.Maybe                    (maybeToList)
+import Data.Monoid                   ((<>))
+import Data.Text                     (Text)
+import Dhall.Core
+    ( Binding (..)
+    , Expr (..)
+    , Import
+    , MultiLet (..)
+    )
 import Dhall.LSP.Backend.Diagnostics
-import Dhall.Parser (Src)
-import Dhall.Core (Expr(..), Binding(..), MultiLet(..), Import)
+import Dhall.Parser                  (Src)
 
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Maybe         as Maybe
 import qualified Dhall.Core         as Core
 import qualified Dhall.Lint         as Lint
-import qualified Data.List.NonEmpty as NonEmpty
 
 data Suggestion = Suggestion {
     range :: Range,

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/ToJSON.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/ToJSON.hs
@@ -1,13 +1,12 @@
 module Dhall.LSP.Backend.ToJSON (CompileError, toJSON) where
 
-import Dhall.JSON as Dhall
-import qualified Data.Aeson.Encode.Pretty as Aeson
-
+import Data.ByteString.Lazy    (toStrict)
+import Data.Text               (Text)
+import Data.Text.Encoding      (decodeUtf8)
+import Dhall.JSON              as Dhall
 import Dhall.LSP.Backend.Dhall
 
-import Data.Text (Text)
-import Data.Text.Encoding (decodeUtf8)
-import Data.ByteString.Lazy (toStrict)
+import qualified Data.Aeson.Encode.Pretty as Aeson
 
 -- | Try to convert a given Dhall expression to JSON.
 toJSON :: WellTyped -> Either CompileError Text

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -1,24 +1,31 @@
+{-# LANGUAGE RecordWildCards #-}
+
 {-| This is the entry point for the LSP server. -}
 module Dhall.LSP.Server(run) where
 
-import           Control.Concurrent.MVar
-import           Control.Lens ((^.))
-import           Data.Aeson (fromJSON, Result(Success))
-import           Data.Default
-import qualified Language.Haskell.LSP.Control as LSP.Control
-import qualified Language.Haskell.LSP.Core as LSP.Core
-
-import qualified Language.Haskell.LSP.Types as J
-import qualified Language.Haskell.LSP.Types.Lens as J
-
-import Data.Text (Text)
-import qualified System.Log.Logger
-
+import Control.Concurrent.MVar
+import Control.Lens            ((^.))
+import Data.Aeson              (Result (Success), fromJSON)
+import Data.Default
+import Data.Text               (Text)
+import Dhall.LSP.Handlers
+    ( completionHandler
+    , didOpenTextDocumentNotificationHandler
+    , didSaveTextDocumentNotificationHandler
+    , documentFormattingHandler
+    , documentLinkHandler
+    , executeCommandHandler
+    , hoverHandler
+    , nullHandler
+    , wrapHandler
+    )
 import Dhall.LSP.State
-import Dhall.LSP.Handlers (nullHandler, wrapHandler, hoverHandler,
-  didOpenTextDocumentNotificationHandler, didSaveTextDocumentNotificationHandler,
-  executeCommandHandler, documentFormattingHandler, documentLinkHandler,
-  completionHandler)
+
+import qualified Language.Haskell.LSP.Control    as LSP.Control
+import qualified Language.Haskell.LSP.Core       as LSP.Core
+import qualified Language.Haskell.LSP.Types      as J
+import qualified Language.Haskell.LSP.Types.Lens as J
+import qualified System.Log.Logger
 
 -- | The main entry point for the LSP server.
 run :: Maybe FilePath -> IO ()

--- a/dhall-lsp-server/src/Dhall/LSP/State.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/State.hs
@@ -1,20 +1,29 @@
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+
 module Dhall.LSP.State where
 
-import qualified Language.Haskell.LSP.Core as LSP
-import qualified Language.Haskell.LSP.Messages as LSP
-import qualified Language.Haskell.LSP.Types as J
-
-import Control.Lens.TH (makeLenses)
-import Lens.Family (LensLike')
-import Data.Aeson (FromJSON(..), withObject, (.:), (.:?), (.!=))
-import Data.Map.Strict (Map, empty)
-import Data.Default (Default(def))
-import Data.Dynamic (Dynamic)
-import Dhall.LSP.Backend.Dhall (DhallError, Cache, emptyCache)
-import Data.Text (Text)
-import Control.Monad.Trans.Except (ExceptT)
+import Control.Lens.TH                  (makeLenses)
+import Control.Monad.Trans.Except       (ExceptT)
 import Control.Monad.Trans.State.Strict (StateT)
+import Data.Aeson
+    ( FromJSON (..)
+    , withObject
+    , (.!=)
+    , (.:)
+    , (.:?)
+    )
+import Data.Default                     (Default (def))
+import Data.Dynamic                     (Dynamic)
+import Data.Map.Strict                  (Map, empty)
+import Data.Text                        (Text)
+import Dhall.LSP.Backend.Dhall          (Cache, DhallError, emptyCache)
+import Lens.Family                      (LensLike')
+
+import qualified Language.Haskell.LSP.Core     as LSP
+import qualified Language.Haskell.LSP.Messages as LSP
+import qualified Language.Haskell.LSP.Types    as J
+
 
 -- Inside a handler we have access to the ServerState. The exception layer
 -- allows us to fail gracefully, displaying a message to the user via the

--- a/dhall-lsp-server/src/Dhall/LSP/Util.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Util.hs
@@ -7,8 +7,8 @@ module Dhall.LSP.Util (
   unlines'
 ) where
 
-import Data.Text
 import Data.List.NonEmpty
+import Data.Text
 
 -- | Shorthand for @pack . show@. Useful since we are mostly working with Text
 --   rather than String.

--- a/dhall-lsp-server/tests/Main.hs
+++ b/dhall-lsp-server/tests/Main.hs
@@ -1,23 +1,24 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
-import Control.Monad.IO.Class (liftIO)
-import Data.Maybe (fromJust)
-import qualified Data.Text as T
-import qualified GHC.IO.Encoding
+import Control.Monad.IO.Class     (liftIO)
+import Data.Maybe                 (fromJust)
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
-  ( CompletionItem(..)
-  , Diagnostic(..)
-  , DiagnosticSeverity(..)
-  , Hover(..)
-  , HoverContents(..)
-  , MarkupContent(..)
-  , Position(..)
-  , Range(..)
-  )
+    ( CompletionItem (..)
+    , Diagnostic (..)
+    , DiagnosticSeverity (..)
+    , Hover (..)
+    , HoverContents (..)
+    , MarkupContent (..)
+    , Position (..)
+    , Range (..)
+    )
 import Test.Tasty
 import Test.Tasty.Hspec
+
+import qualified Data.Text       as T
+import qualified GHC.IO.Encoding
 
 baseDir :: FilePath -> FilePath
 baseDir d = "tests/fixtures/" <> d

--- a/dhall-nix/src/Dhall/Nix.hs
+++ b/dhall-nix/src/Dhall/Nix.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE OverloadedLists    #-}
-{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE QuasiQuotes        #-}
+{-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
 {-| This library only exports a single `dhallToNix` function for translating a
@@ -92,35 +92,35 @@ module Dhall.Nix (
     ) where
 
 import Control.Exception (Exception)
-import Data.Foldable (toList)
-import Data.Fix (Fix(..))
-import Data.Text (Text)
-import Data.Traversable (for)
-import Data.Typeable (Typeable)
-import Data.Void (Void, absurd)
+import Data.Fix          (Fix (..))
+import Data.Foldable     (toList)
+import Data.Text         (Text)
+import Data.Traversable  (for)
+import Data.Typeable     (Typeable)
+import Data.Void         (Void, absurd)
 import Dhall.Core
-    ( Binding(..)
-    , Chunks(..)
-    , DhallDouble(..)
-    , Expr(..)
-    , MultiLet(..)
-    , PreferAnnotation(..)
-    , Var(..)
+    ( Binding (..)
+    , Chunks (..)
+    , DhallDouble (..)
+    , Expr (..)
+    , MultiLet (..)
+    , PreferAnnotation (..)
+    , Var (..)
     )
-import Lens.Family (toListOf)
-import Nix.Atoms (NAtom(..))
+import Lens.Family       (toListOf)
+import Nix.Atoms         (NAtom (..))
 import Nix.Expr
-    ( Antiquoted(..)
-    , Binding(..)
-    , NBinaryOp(..)
-    , NExprF(..)
-    , NKeyName(..)
-    , NRecordType(..)
-    , NString(..)
-    , Params(..)
-    , (@@)
-    , (==>)
+    ( Antiquoted (..)
+    , Binding (..)
+    , NBinaryOp (..)
+    , NExprF (..)
+    , NKeyName (..)
+    , NRecordType (..)
+    , NString (..)
+    , Params (..)
     , ($+)
+    , (==>)
+    , (@@)
     )
 
 import qualified Data.Text
@@ -283,7 +283,7 @@ dhallToNix e =
         (x' , a') <- rename (x, a)
 
         return (Let Binding{ variable = x', .. } a')
-    renameShadowed _ = do
+    renameShadowed _ =
         Nothing
 
     -- Even higher-level utility that renames all shadowed references
@@ -298,7 +298,7 @@ dhallToNix e =
         return (Fix (NAbs (Param a) c'))
     loop (Pi _ _ _) = return untranslatable
     -- None needs a type to convert to an Optional
-    loop (App None _) = do
+    loop (App None _) =
       return (Fix (NConstant NNull))
     loop (App (Field (Union kts) k) v) = do
         v' <- loop v
@@ -381,7 +381,7 @@ dhallToNix e =
         let e7 = Fix (NBinary NLte "n" (Fix (NConstant (NInt 0))))
         let e8 = Fix (NAbs "n" (Fix (NBinary NApp "naturalOdd" (Fix (NIf e7 e6 "n")))))
         return (Fix (NLet [e5] e8))
-    loop NaturalShow = do
+    loop NaturalShow =
         return "toString"
     loop NaturalSubtract = do
         let e0 = NamedVar ["z"] (Fix (NBinary NMinus "y" "x")) Nix.nullPos
@@ -391,7 +391,7 @@ dhallToNix e =
         let e4 = Fix (NIf e1 e2 e3)
         let e5 = Fix (NLet [e0] e4)
         return (Fix (NAbs "x" (Fix (NAbs "y" e5))))
-    loop NaturalToInteger = do
+    loop NaturalToInteger =
         return (Fix (NAbs "n" "n"))
     loop (NaturalPlus a b) = do
         a' <- loop a
@@ -418,11 +418,11 @@ dhallToNix e =
         let e2 = Fix (NBinary NLte (Fix (NConstant (NInt 0))) "x")
         let e3 = Fix (NAbs "x" (Fix (NIf e2 e1 e0)))
         return e3
-    loop IntegerToDouble = do
+    loop IntegerToDouble =
         return (Fix (NAbs "x" "x"))
     loop Double = return untranslatable
     loop (DoubleLit (DhallDouble n)) = return (Fix (NConstant (NFloat (realToFrac n))))
-    loop DoubleShow = do
+    loop DoubleShow =
         return "toString"
     loop Text = return untranslatable
     loop (TextLit (Chunks abs_ c)) = do
@@ -592,7 +592,7 @@ dhallToNix e =
         b' <- loop b
         c' <- loop c
         return (Fix (NBinary NUpdate b' c'))
-    loop (RecordCompletion a b) = do
+    loop (RecordCompletion a b) =
         loop (Annot (Prefer PreferFromCompletion (Field a "default") b) (Field a "Type"))
     loop (Field (Union kts) k) =
         case Dhall.Map.lookup k kts of
@@ -621,13 +621,13 @@ dhallToNix e =
         a' <- loop a
         let b' = fmap StaticKey (toList b)
         return (Fix (NSet NNonRecursive [Inherit (Just a') b' Nix.nullPos]))
-    loop (Project _ (Right _)) = do
+    loop (Project _ (Right _)) =
         Left CannotProjectByType
-    loop (Assert _) = do
+    loop (Assert _) =
         return untranslatable
-    loop (Equivalent _ _) = do
+    loop (Equivalent _ _) =
         return untranslatable
-    loop a@With{} = do
+    loop a@With{} =
         loop (Dhall.Core.desugarWith a)
     loop (ImportAlt a _) = loop a
     loop (Note _ b) = loop b

--- a/dhall-nixpkgs/Main.hs
+++ b/dhall-nixpkgs/Main.hs
@@ -4,9 +4,9 @@
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE OverloadedStrings     #-}
 
 {-| @dhall-to-nixpkgs@ is essentially the Dhall analog of @cabal2nix@.
 
@@ -69,37 +69,37 @@
 
 module Main where
 
-import Control.Applicative (empty, optional, (<|>))
-import Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.Morph (hoist)
-import Control.Monad.Trans.Class (lift)
+import Control.Applicative              (empty, optional, (<|>))
+import Control.Monad.IO.Class           (MonadIO (..))
+import Control.Monad.Morph              (hoist)
+import Control.Monad.Trans.Class        (lift)
 import Control.Monad.Trans.State.Strict (StateT)
-import Data.Aeson (FromJSON)
-import Data.Fix (Fix)
-import Data.List.NonEmpty (NonEmpty(..))
-import Data.Text (Text)
-import Data.Void (Void)
-import Dhall.Import (Status(..), stack)
-import Dhall.Parser (Src)
-import GHC.Generics (Generic)
-import Lens.Family.State.Strict (zoom)
-import Network.URI (URI(..), URIAuth(..))
-import Nix.Expr.Shorthands ((@@), (@.))
-import Nix.Expr.Types (NExpr)
-import Options.Applicative (Parser, ParserInfo)
-import Prelude hiding (FilePath)
-import System.Exit (ExitCode(..))
-import Text.Megaparsec (Parsec)
-import Turtle (FilePath, Shell, fp, (</>))
+import Data.Aeson                       (FromJSON)
+import Data.Fix                         (Fix)
+import Data.List.NonEmpty               (NonEmpty (..))
+import Data.Text                        (Text)
+import Data.Void                        (Void)
+import Dhall.Import                     (Status (..), stack)
+import Dhall.Parser                     (Src)
+import GHC.Generics                     (Generic)
+import Lens.Family.State.Strict         (zoom)
+import Network.URI                      (URI (..), URIAuth (..))
+import Nix.Expr.Shorthands              ((@.), (@@))
+import Nix.Expr.Types                   (NExpr)
+import Options.Applicative              (Parser, ParserInfo)
+import Prelude                          hiding (FilePath)
+import System.Exit                      (ExitCode (..))
+import Text.Megaparsec                  (Parsec)
+import Turtle                           (FilePath, Shell, fp, (</>))
 
 import Dhall.Core
-    ( Expr(..)
-    , File(..)
-    , Import(..)
-    , ImportHashed(..)
-    , ImportMode(..)
-    , ImportType(..)
-    , URL(..)
+    ( Expr (..)
+    , File (..)
+    , Import (..)
+    , ImportHashed (..)
+    , ImportMode (..)
+    , ImportType (..)
+    , URL (..)
     )
 
 import qualified Control.Foldl                         as Foldl

--- a/dhall-try/src/Main.hs
+++ b/dhall-try/src/Main.hs
@@ -21,9 +21,9 @@ import qualified Dhall.Pretty
 import qualified Dhall.TypeCheck
 import qualified GHCJS.Foreign.Callback
 
-import Control.Exception (Exception, SomeException)
-import Data.JSString (JSString)
-import Data.Text (Text)
+import Control.Exception      (Exception, SomeException)
+import Data.JSString          (JSString)
+import Data.Text              (Text)
 import GHCJS.Foreign.Callback (Callback)
 
 foreign import javascript unsafe "input.getValue()" getInput :: IO JSString
@@ -93,16 +93,16 @@ main = do
             let inputText   = Data.Text.pack inputString
 
             case Dhall.Parser.exprFromText "(input)" inputText of
-                Left exception -> do
+                Left exception ->
                     errOutput exception
                 Right parsedExpression -> do
                   eitherResolvedExpression <- Control.Exception.try (Dhall.Import.load parsedExpression)
                   case eitherResolvedExpression of
-                      Left exception -> do
+                      Left exception ->
                           errOutput (exception :: SomeException)
-                      Right resolvedExpression -> do
+                      Right resolvedExpression ->
                           case Dhall.TypeCheck.typeOf resolvedExpression of
-                              Left exception -> do
+                              Left exception ->
                                   errOutput exception
                               Right inferredType -> do
                                   mode <- Data.IORef.readIORef modeRef
@@ -120,30 +120,30 @@ main = do
 
                                           setOutput typeText
 
-                                      JSON -> do
+                                      JSON ->
                                           case Dhall.JSON.dhallToJSON resolvedExpression of
-                                              Left exception -> do
+                                              Left exception ->
                                                   errOutput exception
                                               Right value -> do
                                                   let jsonBytes = Data.Aeson.Encode.Pretty.encodePretty' jsonConfig value
                                                   case Data.Text.Lazy.Encoding.decodeUtf8' jsonBytes of
-                                                      Left exception -> do
+                                                      Left exception ->
                                                           errOutput exception
-                                                      Right jsonText -> do
+                                                      Right jsonText ->
                                                           setOutput (Data.Text.Lazy.toStrict jsonText)
-                                      YAML -> do
+                                      YAML ->
                                           case Dhall.JSON.dhallToJSON resolvedExpression of
-                                              Left exception -> do
+                                              Left exception ->
                                                   errOutput exception
                                               Right value -> do
                                                   let yamlBytes = Dhall.JSON.Yaml.jsonToYaml value False False
                                                   case Data.Text.Encoding.decodeUtf8' yamlBytes of
-                                                      Left exception -> do
+                                                      Left exception ->
                                                           errOutput exception
-                                                      Right yamlText -> do
+                                                      Right yamlText ->
                                                           setOutput yamlText
 
-                                      Hash -> do
+                                      Hash ->
                                           setOutput (Dhall.Import.hashExpressionToCode (Dhall.Core.alphaNormalize (Dhall.Core.normalize resolvedExpression)))
 
     interpret

--- a/dhall-yaml/src/Dhall/YamlToDhall.hs
+++ b/dhall-yaml/src/Dhall/YamlToDhall.hs
@@ -9,25 +9,26 @@ module Dhall.YamlToDhall
   ) where
 
 import Control.Exception (Exception, throwIO)
-import Data.Aeson (Value)
-import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS8
-import Data.Text (Text)
-import Data.Void (Void)
-import qualified Data.YAML.Aeson
-import Dhall.Core (Expr)
+import Data.Aeson        (Value)
+import Data.ByteString   (ByteString)
+import Data.Text         (Text)
+import Data.Void         (Void)
+import Dhall.Core        (Expr)
 import Dhall.JSONToDhall
-  ( CompileError(..)
-  , Conversion(..)
-  , defaultConversion
-  , dhallFromJSON
-  , inferSchema
-  , resolveSchemaExpr
-  , schemaToDhallType
-  , showCompileError
-  , typeCheckSchemaExpr
-  )
-import Dhall.Src (Src)
+    ( CompileError (..)
+    , Conversion (..)
+    , defaultConversion
+    , dhallFromJSON
+    , inferSchema
+    , resolveSchemaExpr
+    , schemaToDhallType
+    , showCompileError
+    , typeCheckSchemaExpr
+    )
+import Dhall.Src         (Src)
+
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.YAML.Aeson
 
 -- | Options to parametrize conversion
 data Options = Options
@@ -52,7 +53,7 @@ dhallFromYaml :: Options -> ByteString -> IO (Expr Src Void)
 dhallFromYaml Options{..} yaml = do
   value <- either (throwIO . userError) pure (yamlToJson yaml)
 
-  finalSchema <- do
+  finalSchema <-
       case schema of
           Just text -> resolveSchemaExpr text
           Nothing   -> return (schemaToDhallType (inferSchema value))

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 
 module Main where
 

--- a/dhall-yaml/yaml-to-dhall/Main.hs
+++ b/dhall-yaml/yaml-to-dhall/Main.hs
@@ -1,21 +1,19 @@
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE PatternGuards       #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Main where
 
 import Control.Applicative (optional, (<|>))
-import Control.Exception (SomeException)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Data.Version (showVersion)
-import Dhall.JSONToDhall (Conversion, parseConversion)
-import Dhall.Pretty (CharacterSet(..))
-import Dhall.YamlToDhall (Options(..), dhallFromYaml)
+import Control.Exception   (SomeException)
+import Data.Monoid         ((<>))
+import Data.Text           (Text)
+import Data.Version        (showVersion)
+import Dhall.JSONToDhall   (Conversion, parseConversion)
+import Dhall.Pretty        (CharacterSet (..))
+import Dhall.YamlToDhall   (Options (..), dhallFromYaml)
 import Options.Applicative (Parser, ParserInfo)
 
 import qualified Control.Exception
@@ -28,10 +26,10 @@ import qualified Dhall.Pretty
 import qualified Dhall.YamlToDhall                         as YamlToDhall
 import qualified GHC.IO.Encoding
 import qualified Options.Applicative                       as Options
+import qualified Paths_dhall_yaml                          as Meta
 import qualified System.Console.ANSI                       as ANSI
 import qualified System.Exit
 import qualified System.IO                                 as IO
-import qualified Paths_dhall_yaml                          as Meta
 
 -- ---------------
 -- Command options
@@ -172,7 +170,7 @@ main = do
                         Text.IO.hPutStrLn h ""
 
     case options of
-        Version -> do
+        Version ->
             putStrLn (showVersion Meta.version)
 
         Default{..} -> do

--- a/dhall/benchmark/deep-nested-large-record/Main.hs
+++ b/dhall/benchmark/deep-nested-large-record/Main.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import Gauge(defaultMain)
+import Gauge (defaultMain)
 
-import qualified Data.Sequence as Seq
-import qualified Dhall.Core as Core
-import qualified Dhall.Import as Import
+import qualified Data.Sequence   as Seq
+import qualified Dhall.Core      as Core
+import qualified Dhall.Import    as Import
 import qualified Dhall.TypeCheck as TypeCheck
 import qualified Gauge
 
@@ -56,7 +56,7 @@ unionPerformance prelude = Gauge.whnf TypeCheck.typeOf expr
             "x"
 
 main :: IO ()
-main = do
+main =
   defaultMain
     [ Gauge.env prelude $ \p ->
       Gauge.bgroup "Prelude"

--- a/dhall/benchmark/parser/Main.hs
+++ b/dhall/benchmark/parser/Main.hs
@@ -4,22 +4,22 @@
 module Main where
 
 import Control.Exception (throw)
-import Control.Monad (forM)
-import Data.Map (Map, foldrWithKey, singleton, unions)
-import Data.Monoid ((<>))
-import Data.Void (Void)
-import Gauge (defaultMain, bgroup, bench, env, nf, whnf, nfIO)
+import Control.Monad     (forM)
+import Data.Map          (Map, foldrWithKey, singleton, unions)
+import Data.Monoid       ((<>))
+import Data.Void         (Void)
+import Gauge             (bench, bgroup, defaultMain, env, nf, nfIO, whnf)
 
 import System.Directory
 
 import qualified Codec.Serialise
-import qualified Gauge
 import qualified Data.ByteString.Lazy
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import qualified Data.Text            as T
+import qualified Data.Text.IO         as TIO
 import qualified Dhall.Binary
-import qualified Dhall.Core as Dhall
-import qualified Dhall.Parser as Dhall
+import qualified Dhall.Core           as Dhall
+import qualified Dhall.Parser         as Dhall
+import qualified Gauge
 
 #if MIN_VERSION_directory(1,2,3)
 #else
@@ -71,7 +71,7 @@ benchExprFromBytes
     :: String -> Data.ByteString.Lazy.ByteString -> Gauge.Benchmark
 benchExprFromBytes name bytes = bench name (nf f bytes)
   where
-    f bytes = do
+    f bytes =
         case Dhall.Binary.decodeExpression bytes of
             Left  exception  -> error (show exception)
             Right expression -> expression :: Dhall.Expr Void Dhall.Import

--- a/dhall/doctest/Main.hs
+++ b/dhall/doctest/Main.hs
@@ -2,19 +2,19 @@
 
 module Main where
 
-import Data.Monoid ((<>))
+import Data.Monoid     ((<>))
 import System.FilePath ((</>))
 
 import qualified GHC.IO.Encoding
 import qualified System.Directory
 import qualified System.IO
-import qualified Test.Mockery.Directory
 import qualified Test.DocTest
+import qualified Test.Mockery.Directory
 
 main :: IO ()
 main = do
-   
-    GHC.IO.Encoding.setLocaleEncoding System.IO.utf8 
+
+    GHC.IO.Encoding.setLocaleEncoding System.IO.utf8
     pwd    <- System.Directory.getCurrentDirectory
     prefix <- System.Directory.makeAbsolute pwd
 

--- a/dhall/ghc-src/Dhall/Crypto.hs
+++ b/dhall/ghc-src/Dhall/Crypto.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {-| This module provides implementations of cryptographic utilities that only
@@ -11,12 +11,12 @@ module Dhall.Crypto (
     , sha256Hash
     ) where
 
-import Control.DeepSeq (NFData)
-import Crypto.Hash (SHA256)
-import Data.ByteArray (ByteArrayAccess, convert)
-import Data.ByteArray.Encoding (Base(Base16), convertToBase)
-import Data.ByteString (ByteString)
-import GHC.Generics (Generic)
+import Control.DeepSeq         (NFData)
+import Crypto.Hash             (SHA256)
+import Data.ByteArray          (ByteArrayAccess, convert)
+import Data.ByteArray.Encoding (Base (Base16), convertToBase)
+import Data.ByteString         (ByteString)
+import GHC.Generics            (Generic)
 
 import qualified Crypto.Hash
 import qualified Data.ByteString.Char8 as ByteString.Char8

--- a/dhall/ghc-src/Dhall/Import/HTTP.hs
+++ b/dhall/ghc-src/Dhall/Import/HTTP.hs
@@ -6,44 +6,44 @@ module Dhall.Import.HTTP
     ( fetchFromHttpUrl
     ) where
 
-import Control.Exception (Exception)
-import Control.Monad.IO.Class (MonadIO(..))
+import Control.Exception                (Exception)
+import Control.Monad.IO.Class           (MonadIO (..))
 import Control.Monad.Trans.State.Strict (StateT)
-import Data.ByteString (ByteString)
-import Data.CaseInsensitive (CI)
-import Data.Dynamic (toDyn)
-import Data.Semigroup ((<>))
-
+import Data.ByteString                  (ByteString)
+import Data.CaseInsensitive             (CI)
+import Data.Dynamic                     (toDyn)
+import Data.Semigroup                   ((<>))
 import Dhall.Core
-    ( Import(..)
-    , ImportHashed(..)
-    , ImportType(..)
-    , Scheme(..)
-    , URL(..)
+    ( Import (..)
+    , ImportHashed (..)
+    , ImportType (..)
+    , Scheme (..)
+    , URL (..)
     )
-import Dhall.URL (renderURL)
-
-import qualified Control.Monad.Trans.State.Strict as State
-import qualified Data.Text                        as Text
-import qualified Data.Text.Encoding
-import qualified Dhall.Util
-
 import Dhall.Import.Types
+import Dhall.URL                        (renderURL)
 
-import qualified Control.Exception
-import qualified Data.List.NonEmpty               as NonEmpty
-import qualified Data.Text.Lazy
-import qualified Data.Text.Lazy.Encoding
 
 #if MIN_VERSION_http_client(0,5,0)
 import Network.HTTP.Client
-    (HttpException(..), HttpExceptionContent(..), Manager)
+    ( HttpException (..)
+    , HttpExceptionContent (..)
+    , Manager
+    )
 #else
-import Network.HTTP.Client (HttpException(..), Manager)
+import Network.HTTP.Client (HttpException (..), Manager)
 #endif
 
-import qualified Network.HTTP.Client                     as HTTP
-import qualified Network.HTTP.Client.TLS                 as HTTP
+import qualified Control.Exception
+import qualified Control.Monad.Trans.State.Strict as State
+import qualified Data.List.NonEmpty               as NonEmpty
+import qualified Data.Text                        as Text
+import qualified Data.Text.Encoding
+import qualified Data.Text.Lazy
+import qualified Data.Text.Lazy.Encoding
+import qualified Dhall.Util
+import qualified Network.HTTP.Client              as HTTP
+import qualified Network.HTTP.Client.TLS          as HTTP
 import qualified Network.HTTP.Types
 
 mkPrettyHttpException :: String -> HttpException -> PrettyHttpException
@@ -190,7 +190,7 @@ newManager = do
 
             return manager
 
-        Just manager -> do
+        Just manager ->
             return manager
 
 data NotCORSCompliant = NotCORSCompliant

--- a/dhall/ghcjs-src/Dhall/Import/HTTP.hs
+++ b/dhall/ghcjs-src/Dhall/Import/HTTP.hs
@@ -1,24 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 
 module Dhall.Import.HTTP
     ( fetchFromHttpUrl
     , Manager
     ) where
 
-import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.IO.Class           (MonadIO (..))
 import Control.Monad.Trans.State.Strict (StateT)
-import Data.ByteString (ByteString)
-import Data.CaseInsensitive (CI)
-import Data.Semigroup ((<>))
+import Data.ByteString                  (ByteString)
+import Data.CaseInsensitive             (CI)
+import Data.Semigroup                   ((<>))
+import Data.Void                        (Void)
+import Dhall.Core                       (URL (..))
+import Dhall.Import.Types
+import Dhall.URL                        (renderURL)
 
-import qualified Data.Text as Text
+import qualified Data.Text      as Text
 import qualified JavaScript.XHR
 
-import Data.Void (Void)
-import Dhall.Core (URL(..))
-import Dhall.URL (renderURL)
-import Dhall.Import.Types
 
 {-| The GHCJS implementation does not require a `Manager`
 
@@ -46,5 +45,5 @@ fetchFromHttpUrl childURL Nothing = do
         _   -> fail (childURLString <> " returned a non-200 status code: " <> show statusCode)
 
     return body
-fetchFromHttpUrl _ _ = do
+fetchFromHttpUrl _ _ =
     fail "Dhall does not yet support custom headers when built using GHCJS"

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -2,9 +2,8 @@
 {-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE DefaultSignatures          #-}
 {-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE MultiWayIf                 #-}
@@ -13,10 +12,9 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
-{-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
 {-| Please read the "Dhall.Tutorial" module, which contains a tutorial explaining
@@ -132,38 +130,48 @@ module Dhall
     , Generic
     ) where
 
-import Control.Applicative (empty, liftA2, Alternative)
-import Control.Exception (Exception)
+import Control.Applicative                  (Alternative, empty, liftA2)
+import Control.Exception                    (Exception)
+import Control.Monad                        (guard)
 import Control.Monad.Trans.State.Strict
-import Control.Monad (guard)
-import Data.Coerce (coerce)
-import Data.Either.Validation (Validation(..), eitherToValidation, validationToEither)
-import Data.Fix (Fix(..))
-import Data.Functor.Contravariant (Contravariant(..), (>$<), Op(..))
-import Data.Functor.Contravariant.Divisible (Divisible(..), divided)
-import Data.Hashable (Hashable)
-import Data.List.NonEmpty (NonEmpty (..))
-import Data.HashMap.Strict (HashMap)
-import Data.Map (Map)
-import Data.Monoid ((<>))
-import Data.Scientific (Scientific)
-import Data.Semigroup (Semigroup)
-import Data.Sequence (Seq)
-import Data.Text (Text)
-import Data.Text.Prettyprint.Doc (Pretty)
-import Data.Typeable (Typeable, Proxy(..))
-import Data.Vector (Vector)
-import Data.Void (Void)
-import Data.Word (Word8, Word16, Word32, Word64)
-import Dhall.Syntax (Expr(..), Chunks(..), DhallDouble(..), RecordField(..), Var(..))
-import Dhall.Import (Imported(..))
-import Dhall.Parser (Src(..))
-import Dhall.TypeCheck (DetailedTypeError(..), TypeError)
+import Data.Coerce                          (coerce)
+import Data.Either.Validation
+    ( Validation (..)
+    , eitherToValidation
+    , validationToEither
+    )
+import Data.Fix                             (Fix (..))
+import Data.Functor.Contravariant           (Contravariant (..), Op (..), (>$<))
+import Data.Functor.Contravariant.Divisible (Divisible (..), divided)
+import Data.Hashable                        (Hashable)
+import Data.HashMap.Strict                  (HashMap)
+import Data.List.NonEmpty                   (NonEmpty (..))
+import Data.Map                             (Map)
+import Data.Monoid                          ((<>))
+import Data.Scientific                      (Scientific)
+import Data.Semigroup                       (Semigroup)
+import Data.Sequence                        (Seq)
+import Data.Text                            (Text)
+import Data.Text.Prettyprint.Doc            (Pretty)
+import Data.Typeable                        (Proxy (..), Typeable)
+import Data.Vector                          (Vector)
+import Data.Void                            (Void)
+import Data.Word                            (Word16, Word32, Word64, Word8)
+import Dhall.Import                         (Imported (..))
+import Dhall.Parser                         (Src (..))
+import Dhall.Syntax
+    ( Chunks (..)
+    , DhallDouble (..)
+    , Expr (..)
+    , RecordField (..)
+    , Var (..)
+    )
+import Dhall.TypeCheck                      (DetailedTypeError (..), TypeError)
 import GHC.Generics
-import Lens.Family (LensLike', view)
-import Numeric.Natural (Natural)
-import Prelude hiding (maybe, sequence)
-import System.FilePath (takeDirectory)
+import Lens.Family                          (LensLike', view)
+import Numeric.Natural                      (Natural)
+import Prelude                              hiding (maybe, sequence)
+import System.FilePath                      (takeDirectory)
 
 import qualified Control.Applicative
 import qualified Control.Exception
@@ -171,23 +179,23 @@ import qualified Control.Monad.Trans.State.Strict as State
 import qualified Data.Foldable
 import qualified Data.Functor.Compose
 import qualified Data.Functor.Product
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Map
-import qualified Data.Maybe
+import qualified Data.HashMap.Strict              as HashMap
+import qualified Data.HashSet
 import qualified Data.List
 import qualified Data.List.NonEmpty
-import qualified Data.Semigroup
+import qualified Data.Map
+import qualified Data.Maybe
 import qualified Data.Scientific
+import qualified Data.Semigroup
 import qualified Data.Sequence
 import qualified Data.Set
-import qualified Data.HashSet
 import qualified Data.Text
 import qualified Data.Text.IO
 import qualified Data.Text.Lazy
 import qualified Data.Vector
 import qualified Data.Void
 import qualified Dhall.Context
-import qualified Dhall.Core as Core
+import qualified Dhall.Core                       as Core
 import qualified Dhall.Import
 import qualified Dhall.Map
 import qualified Dhall.Parser
@@ -621,7 +629,7 @@ rawInput
     -- ^ a closed form Dhall program, which evaluates to the expected type
     -> f a
     -- ^ The decoded value in Haskell
-rawInput (Decoder {..}) expr = do
+rawInput (Decoder {..}) expr =
     case extract (Core.normalize expr) of
         Success x  -> pure x
         Failure _e -> empty

--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE BangPatterns       #-}
-{-# LANGUAGE FlexibleContexts   #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE RecordWildCards    #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -24,45 +24,45 @@ module Dhall.Binary
     , DecodingFailure(..)
     ) where
 
-import Codec.CBOR.Decoding (Decoder, TokenType(..))
-import Codec.CBOR.Encoding (Encoding)
-import Codec.Serialise (Serialise(encode, decode))
-import Control.Applicative (empty, (<|>))
-import Control.Exception (Exception)
+import Codec.CBOR.Decoding  (Decoder, TokenType (..))
+import Codec.CBOR.Encoding  (Encoding)
+import Codec.Serialise      (Serialise (decode, encode))
+import Control.Applicative  (empty, (<|>))
+import Control.Exception    (Exception)
 import Data.ByteString.Lazy (ByteString)
 import Dhall.Syntax
-    ( Binding(..)
-    , Chunks(..)
-    , Const(..)
-    , Directory(..)
-    , DhallDouble(..)
-    , Expr(..)
-    , File(..)
-    , FilePrefix(..)
-    , Import(..)
-    , ImportHashed(..)
-    , ImportMode(..)
-    , ImportType(..)
-    , MultiLet(..)
-    , PreferAnnotation(..)
+    ( Binding (..)
+    , Chunks (..)
+    , Const (..)
+    , DhallDouble (..)
+    , Directory (..)
+    , Expr (..)
+    , File (..)
+    , FilePrefix (..)
+    , Import (..)
+    , ImportHashed (..)
+    , ImportMode (..)
+    , ImportType (..)
+    , MultiLet (..)
+    , PreferAnnotation (..)
     , RecordField (..)
-    , Scheme(..)
-    , URL(..)
-    , Var(..)
+    , Scheme (..)
+    , URL (..)
+    , Var (..)
     )
 
 import Data.Foldable (toList)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Data.Void (Void, absurd)
-import GHC.Float (double2Float, float2Double)
-import Numeric.Half (fromHalf, toHalf)
+import Data.Monoid   ((<>))
+import Data.Text     (Text)
+import Data.Void     (Void, absurd)
+import GHC.Float     (double2Float, float2Double)
+import Numeric.Half  (fromHalf, toHalf)
 
 import qualified Codec.CBOR.ByteArray
-import qualified Codec.CBOR.Decoding  as Decoding
-import qualified Codec.CBOR.Encoding  as Encoding
-import qualified Codec.CBOR.Read      as Read
-import qualified Codec.Serialise      as Serialise
+import qualified Codec.CBOR.Decoding   as Decoding
+import qualified Codec.CBOR.Encoding   as Encoding
+import qualified Codec.CBOR.Read       as Read
+import qualified Codec.Serialise       as Serialise
 import qualified Data.ByteArray
 import qualified Data.ByteString
 import qualified Data.ByteString.Lazy
@@ -71,8 +71,8 @@ import qualified Data.Sequence
 import qualified Dhall.Crypto
 import qualified Dhall.Map
 import qualified Dhall.Set
-import qualified Dhall.Syntax         as Syntax
-import qualified Text.Printf          as Printf
+import qualified Dhall.Syntax          as Syntax
+import qualified Text.Printf           as Printf
 
 {-| Supported version strings
 
@@ -228,7 +228,7 @@ decodeExpressionInternal decodeEmbed = go
 
                                 return (Var (V x n))
 
-                            _ -> do
+                            _ ->
                                 die ("Unexpected token type for variable index: " <> show tokenType₂)
 
                     TypeUInt -> do
@@ -250,7 +250,7 @@ decodeExpressionInternal decodeEmbed = go
                                     then die "Non-standard encoding of a function with no arguments"
                                     else loop nArgs f
 
-                            1 -> do
+                            1 ->
                                 case len of
                                     3 -> do
                                         _A <- go
@@ -272,10 +272,10 @@ decodeExpressionInternal decodeEmbed = go
 
                                         return (Lam x _A b)
 
-                                    _ -> do
+                                    _ ->
                                         die ("Incorrect number of tokens used to encode a λ expression: " <> show len)
 
-                            2 -> do
+                            2 ->
                                 case len of
                                     3 -> do
                                         _A <- go
@@ -297,7 +297,7 @@ decodeExpressionInternal decodeEmbed = go
 
                                         return (Pi x _A _B)
 
-                                    _ -> do
+                                    _ ->
                                         die ("Incorrect number of tokens used to encode a ∀ expression: " <> show len)
 
                             3 -> do
@@ -326,7 +326,7 @@ decodeExpressionInternal decodeEmbed = go
 
                                 return (op l r)
 
-                            4 -> do
+                            4 ->
                                 case len of
                                     2 -> do
                                         _T <- go
@@ -352,7 +352,7 @@ decodeExpressionInternal decodeEmbed = go
                                 u <- go
 
                                 case len of
-                                    3 -> do
+                                    3 ->
                                         return (Merge t u Nothing)
 
                                     4 -> do
@@ -360,7 +360,7 @@ decodeExpressionInternal decodeEmbed = go
 
                                         return (Merge t u (Just _T))
 
-                                    _ -> do
+                                    _ ->
                                         die ("Incorrect number of tokens used to encode a `merge` expression: " <> show len)
 
                             7 -> do
@@ -413,7 +413,7 @@ decodeExpressionInternal decodeEmbed = go
                                                 x <- Decoding.decodeString
                                                 return (Left (Dhall.Set.fromList [x]))
 
-                                            _ -> do
+                                            _ ->
                                                 die ("Unexpected token type for projection: " <> show tokenType₂)
 
                                     _ -> do
@@ -473,7 +473,7 @@ decodeExpressionInternal decodeEmbed = go
                                         !n <- fromIntegral <$> Decoding.decodeInteger
                                         return (NaturalLit n)
 
-                                    _ -> do
+                                    _ ->
                                         die ("Unexpected token type for Natural literal: " <> show tokenType₂)
 
                             16 -> do
@@ -503,7 +503,7 @@ decodeExpressionInternal decodeEmbed = go
                                         n <- Decoding.decodeInteger
                                         return (IntegerLit n)
 
-                                    _ -> do
+                                    _ ->
                                         die ("Unexpected token type for Integer literal: " <> show tokenType₂)
 
                             18 -> do
@@ -523,7 +523,7 @@ decodeExpressionInternal decodeEmbed = go
 
                                 return (Assert t)
 
-                            24 -> do
+                            24 ->
                                 fmap Embed (decodeEmbed len)
 
                             25 -> do
@@ -562,7 +562,7 @@ decodeExpressionInternal decodeEmbed = go
                                 t <- go
 
                                 mT <- case len of
-                                    2 -> do
+                                    2 ->
                                         return Nothing
 
                                     3 -> do
@@ -570,7 +570,7 @@ decodeExpressionInternal decodeEmbed = go
 
                                         return (Just _T)
 
-                                    _ -> do
+                                    _ ->
                                         die ("Incorrect number of tokens used to encode a type annotation: " <> show len)
 
                                 return (ToMap t mT)
@@ -580,13 +580,13 @@ decodeExpressionInternal decodeEmbed = go
 
                                 return (ListLit (Just _T) empty)
 
-                            _ -> do
+                            _ ->
                                 die ("Unexpected tag: " <> show tag)
 
-                    _ -> do
+                    _ ->
                         die ("Unexpected tag type: " <> show tokenType₁)
 
-            _ -> do
+            _ ->
                 die ("Unexpected initial token: " <> show tokenType₀)
 
 encodeExpressionInternal :: (a -> Encoding) -> Expr Void a -> Encoding
@@ -1007,7 +1007,7 @@ decodeImport len = do
                 Nothing     -> die ("Invalid sha256 digest: " <> show bytes)
                 Just digest -> return (Just digest)
 
-        _ -> do
+        _ ->
             die ("Unexpected hash token: " <> show tokenType₀)
 
     m <- Decoding.decodeWord
@@ -1043,7 +1043,7 @@ decodeImport len = do
                 TypeNull -> do
                     Decoding.decodeNull
                     return Nothing
-                _ -> do
+                _ ->
                     fmap Just Decoding.decodeString
 
             let components = reverse paths
@@ -1227,7 +1227,7 @@ decodeWith55799Tag decoder = do
                 else return ()
 
             decoder
-        _ -> do
+        _ ->
             decoder
 
 {-| This indicates that a given CBOR-encoded `ByteString` did not correspond to

--- a/dhall/src/Dhall/Context.hs
+++ b/dhall/src/Dhall/Context.hs
@@ -13,7 +13,7 @@ module Dhall.Context (
     ) where
 
 import Data.Text (Text)
-import Prelude hiding (lookup)
+import Prelude   hiding (lookup)
 
 {-| A @(Context a)@ associates `Text` labels with values of type @a@.  Each
     `Text` label can correspond to multiple values of type @a@

--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RankNTypes         #-}
-{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE RankNTypes      #-}
+{-# LANGUAGE RecordWildCards #-}
 
 {-| This module contains the core calculus for the Dhall language.
 
@@ -73,17 +73,16 @@ module Dhall.Core (
     , Syntax.desugarWith
     ) where
 
-import Control.Exception (Exception)
-import Control.Monad.IO.Class (MonadIO(..))
-import Data.Text (Text)
+import Control.Exception         (Exception)
+import Control.Monad.IO.Class    (MonadIO (..))
+import Data.Text                 (Text)
 import Data.Text.Prettyprint.Doc (Pretty)
 import Dhall.Normalize
-import Dhall.Src (Src(..))
-import Dhall.Syntax
 import Dhall.Pretty.Internal
-import Instances.TH.Lift ()
-import Lens.Family (over)
-import Prelude hiding (succ)
+import Dhall.Src                 (Src (..))
+import Dhall.Syntax
+import Instances.TH.Lift         ()
+import Lens.Family               (over)
 
 import qualified Control.Exception
 import qualified Data.Text

--- a/dhall/src/Dhall/Deriving.hs
+++ b/dhall/src/Dhall/Deriving.hs
@@ -77,12 +77,12 @@ module Dhall.Deriving
 
   ) where
 
-import Data.Proxy (Proxy (..))
+import Data.Proxy   (Proxy (..))
 import Dhall
 import GHC.Generics (Generic (Rep))
-import GHC.TypeLits (Symbol, KnownSymbol, symbolVal)
+import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 
-import qualified Data.Text as Text
+import qualified Data.Text            as Text
 import qualified Data.Text.Manipulate as Case
 
 -- | Intended for use on @deriving via@ clauses for types with a
@@ -219,8 +219,8 @@ instance ToSingletonConstructors Smart where
 --   matches @prefix@, or the entire @text@ otherwise
 dropPrefix :: Text -> (Text -> Text)
 dropPrefix prefix text = case Text.stripPrefix prefix text of
-  Just stripped -> stripped
-  Nothing       -> text
+  Nothing -> text
+  Just e -> e
 
 -- * InterpretOptions setters
 

--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -16,20 +16,28 @@ module Dhall.Diff (
     , diff
     ) where
 
-import Data.Foldable (fold, toList)
-import Data.List.NonEmpty (NonEmpty(..))
-import Data.Monoid (Any(..))
-import Data.Semigroup hiding (diff)
-import Data.Sequence (Seq)
-import Data.String (IsString(..))
-import Data.Text (Text)
+import Data.Foldable             (fold, toList)
+import Data.List.NonEmpty        (NonEmpty (..))
+import Data.Monoid               (Any (..))
+import Data.Semigroup            hiding (diff)
+import Data.Sequence             (Seq)
+import Data.String               (IsString (..))
+import Data.Text                 (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty)
-import Data.Void (Void)
-import Dhall.Syntax (Binding(..), Chunks (..), Const(..), DhallDouble(..), Expr(..), RecordField(..), Var(..))
-import Dhall.Map (Map)
-import Dhall.Set (Set)
-import Dhall.Pretty.Internal (Ann)
-import Numeric.Natural (Natural)
+import Data.Void                 (Void)
+import Dhall.Map                 (Map)
+import Dhall.Pretty.Internal     (Ann)
+import Dhall.Set                 (Set)
+import Dhall.Syntax
+    ( Binding (..)
+    , Chunks (..)
+    , Const (..)
+    , DhallDouble (..)
+    , Expr (..)
+    , RecordField (..)
+    , Var (..)
+    )
+import Numeric.Natural           (Natural)
 
 import qualified Data.Algorithm.Diff       as Algo.Diff
 import qualified Data.List.NonEmpty

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -14,7 +14,7 @@ import Control.Applicative (empty)
 import Control.Exception   (Exception)
 import Data.Monoid         ((<>))
 import Data.Void           (Void)
-import Dhall.Syntax        (Chunks (..), Expr (..), RecordField(..))
+import Dhall.Syntax        (Chunks (..), Expr (..), RecordField (..))
 import System.FilePath     ((</>))
 
 import qualified Control.Exception                       as Exception

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -1,16 +1,15 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE PatternSynonyms     #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE BangPatterns         #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE PatternSynonyms      #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE ViewPatterns         #-}
 
 {-# OPTIONS_GHC -O #-}
 
@@ -52,34 +51,34 @@ module Dhall.Eval (
   , textShow
   ) where
 
-import Data.Foldable (foldr', toList)
-import Data.Semigroup (Semigroup(..))
-import Data.Sequence (Seq, ViewL(..), ViewR(..))
-import Data.Text (Text)
-import Data.Void (Void)
-import Dhall.Map (Map)
-import Dhall.Set (Set)
-import GHC.Natural (Natural)
-import Prelude hiding (succ)
+import Data.Foldable  (foldr', toList)
+import Data.Semigroup (Semigroup (..))
+import Data.Sequence  (Seq, ViewL (..), ViewR (..))
+import Data.Text      (Text)
+import Data.Void      (Void)
+import Dhall.Map      (Map)
+import Dhall.Set      (Set)
+import GHC.Natural    (Natural)
+import Prelude        hiding (succ)
 
 import Dhall.Syntax
-  ( Binding(..)
-  , Expr(..)
-  , Chunks(..)
-  , Const(..)
-  , DhallDouble(..)
-  , PreferAnnotation(..)
-  , RecordField (..)
-  , Var(..)
-  )
+    ( Binding (..)
+    , Chunks (..)
+    , Const (..)
+    , DhallDouble (..)
+    , Expr (..)
+    , PreferAnnotation (..)
+    , RecordField (..)
+    , Var (..)
+    )
 
 import qualified Data.Char
-import qualified Data.Sequence   as Sequence
+import qualified Data.Sequence as Sequence
 import qualified Data.Set
-import qualified Data.Text       as Text
-import qualified Dhall.Syntax    as Syntax
-import qualified Dhall.Map       as Map
+import qualified Data.Text     as Text
+import qualified Dhall.Map     as Map
 import qualified Dhall.Set
+import qualified Dhall.Syntax  as Syntax
 import qualified Text.Printf
 
 data Environment a
@@ -262,7 +261,7 @@ vVar env0 (V x i0) = go env0 i0
         | otherwise =
             go env i
     go Empty i =
-        VVar x (0 - i - 1)
+        VVar x (negate i - 1)
 
 vApp :: Eq a => Val a -> Val a -> Val a
 vApp !t !u =

--- a/dhall/src/Dhall/Format.hs
+++ b/dhall/src/Dhall/Format.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
@@ -11,29 +10,29 @@ module Dhall.Format
     ) where
 
 import Data.Foldable (for_)
-import Data.Monoid ((<>))
-import Dhall.Pretty (CharacterSet(..), annToAnsiStyle)
+import Data.Monoid   ((<>))
+import Dhall.Pretty  (CharacterSet (..), annToAnsiStyle)
 
 import Dhall.Util
     ( Censor
-    , CheckFailed(..)
-    , Header(..)
-    , OutputMode(..)
-    , PossiblyTransitiveInput(..)
-    , Transitivity(..)
+    , CheckFailed (..)
+    , Header (..)
+    , OutputMode (..)
+    , PossiblyTransitiveInput (..)
+    , Transitivity (..)
     )
 
+import qualified Control.Exception
+import qualified Data.Text.IO
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty.Terminal
 import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty.Text
-import qualified Control.Exception
-import qualified Data.Text.IO
 import qualified Dhall.Import
 import qualified Dhall.Pretty
 import qualified Dhall.Util
 import qualified System.AtomicWrite.Writer.LazyText        as AtomicWrite.LazyText
-import qualified System.FilePath
 import qualified System.Console.ANSI
+import qualified System.FilePath
 import qualified System.IO
 
 -- | Arguments to the `format` subcommand
@@ -77,11 +76,11 @@ format (Format { input = input0, ..}) = go input0
         headerAndExpr@(_, parsedExpression) <- Dhall.Util.getExpressionAndHeaderFromStdinText censor originalText
 
         case transitivity of
-            Transitive -> do
+            Transitive ->
                 for_ parsedExpression $ \import_ -> do
                     maybeFilepath <- Dhall.Import.dependencyToFile status import_
 
-                    for_ maybeFilepath $ \filepath -> do
+                    for_ maybeFilepath $ \filepath ->
                         go (PossiblyTransitiveInputFile filepath Transitive)
 
             NonTransitive ->
@@ -92,9 +91,9 @@ format (Format { input = input0, ..}) = go input0
         let formattedText = Pretty.Text.renderStrict docStream
 
         case outputMode of
-            Write -> do
+            Write ->
                 case input of
-                    PossiblyTransitiveInputFile file _ -> do
+                    PossiblyTransitiveInputFile file _ ->
                         if originalText == formattedText
                             then return ()
                             else AtomicWrite.LazyText.atomicWriteFile
@@ -110,7 +109,7 @@ format (Format { input = input0, ..}) = go input0
                                 then (fmap annToAnsiStyle docStream)
                                 else (Pretty.unAnnotateS docStream))
 
-            Check -> do
+            Check ->
                 if originalText == formattedText
                     then return ()
                     else do

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -17,20 +17,25 @@ module Dhall.Freeze
     , Intent(..)
     ) where
 
-import Data.Foldable (for_)
-import Data.Monoid ((<>))
-import Dhall.Pretty (CharacterSet)
-import System.Console.ANSI (hSupportsANSI)
-
-import Dhall.Syntax (Expr(..) , Import(..) , ImportHashed(..) , ImportType(..))
+import Data.Foldable       (for_)
+import Data.Monoid         ((<>))
+import Dhall.Pretty        (CharacterSet)
+import Dhall.Syntax
+    ( Expr (..)
+    , Import (..)
+    , ImportHashed (..)
+    , ImportType (..)
+    )
 import Dhall.Util
     ( Censor
-    , CheckFailed(..)
-    , Header(..)
-    , OutputMode(..)
-    , PossiblyTransitiveInput(..)
-    , Transitivity(..)
+    , CheckFailed (..)
+    , Header (..)
+    , OutputMode (..)
+    , PossiblyTransitiveInput (..)
+    , Transitivity (..)
     )
+import System.Console.ANSI (hSupportsANSI)
+
 import qualified Control.Exception                         as Exception
 import qualified Control.Monad.Trans.State.Strict          as State
 import qualified Data.Text.IO                              as Text.IO
@@ -89,7 +94,7 @@ freezeRemoteImport
     -- ^ Current working directory
     -> Import
     -> IO Import
-freezeRemoteImport directory import_ = do
+freezeRemoteImport directory import_ =
     case importType (importHashed import_) of
         Remote {} -> freezeImport directory import_
         _         -> return import_
@@ -146,11 +151,11 @@ freeze outputMode input0 scope intent characterSet censor = go input0
         (Header header, parsedExpression) <- Util.getExpressionAndHeaderFromStdinText censor originalText
 
         case transitivity of
-            Transitive -> do
+            Transitive ->
                 for_ parsedExpression $ \import_ -> do
                     maybeFilepath <- Dhall.Import.dependencyToFile status import_
 
-                    for_ maybeFilepath $ \filepath -> do
+                    for_ maybeFilepath $ \filepath ->
                         go (PossiblyTransitiveInputFile filepath Transitive)
 
             NonTransitive ->
@@ -187,7 +192,7 @@ freeze outputMode input0 scope intent characterSet censor = go input0
                            else
                              Pretty.renderIO System.IO.stdout unAnnotated
 
-            Check -> do
+            Check ->
                 if originalText == modifiedText
                     then return ()
                     else do
@@ -249,7 +254,7 @@ freezeExpression directory scope intent expression = do
                         Import{ importHashed = ImportHashed{ hash = Nothing } }
                     )
                 )
-            ) = do
+            ) =
                 {- Here we could actually compare the `_expectedHash` and
                    `_actualHash` to see if they differ, but we choose not to do
                    so and instead automatically accept the `_actualHash`.  This
@@ -284,7 +289,7 @@ freezeExpression directory scope intent expression = do
                         }
 
                 return (ImportAlt (Embed frozenImport) (Embed thawedImport))
-        cache expression_ = do
+        cache expression_ =
             return expression_
 
     case intent of

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -178,6 +178,7 @@ import Dhall.Syntax
     )
 
 import System.FilePath ((</>))
+
 #ifdef WITH_HTTP
 import Dhall.Import.HTTP
 #endif
@@ -519,7 +520,7 @@ loadImportWithSemanticCache
     loadImportWithSemisemanticCache import_
 
 loadImportWithSemanticCache
-  import_@(Chained (Import _ Location)) = do
+  import_@(Chained (Import _ Location)) =
     loadImportWithSemisemanticCache import_
 
 loadImportWithSemanticCache
@@ -618,7 +619,7 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
             return r
 
     parsedImport <- case Text.Megaparsec.parse parser path text of
-        Left  errInfo -> do
+        Left  errInfo ->
             throwMissingImport (Imported _stack (ParseError errInfo text))
         Right expr    -> return expr
 
@@ -648,7 +649,7 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
                 -- If this import trivially wraps another import, we can skip
                 -- the type-checking and normalization step as the transitive
                 -- import was already type-checked and normalized
-                Embed _ -> do
+                Embed _ ->
                     return (Core.denote substitutedExpr)
 
                 _ -> do
@@ -740,9 +741,9 @@ fetchFresh (Env env) = do
     Status { _stack } <- State.get
     x <- liftIO $ System.Environment.lookupEnv (Text.unpack env)
     case x of
-        Just string -> do
+        Just string ->
             return (Text.pack string)
-        Nothing -> do
+        Nothing ->
                 throwMissingImport (Imported _stack (MissingEnvironmentVariable env))
 
 fetchFresh Missing = throwM (MissingImports [])
@@ -786,7 +787,7 @@ toHeader (RecordLit m) = do
       where
         lookupHeader = liftA2 (,) (Dhall.Map.lookup "header" m) (Dhall.Map.lookup "value" m)
         lookupMapKey = liftA2 (,) (Dhall.Map.lookup "mapKey" m) (Dhall.Map.lookup "mapValue" m)
-toHeader _ = do
+toHeader _ =
     empty
 
 getCacheFile
@@ -875,7 +876,7 @@ getOrCreateCacheDirectory showWarning cacheName = do
             existsDir <- existsDirectory dir
 
             if existsDir
-                then do
+                then
                     assertPermissions dir
 
                 else do
@@ -921,7 +922,7 @@ getCacheBaseDirectory :: (Alternative m, MonadIO m) => Bool -> m FilePath
 getCacheBaseDirectory showWarning = alternative₀ <|> alternative₁ <|> alternative₂
   where
     alternative₀ = do
-        maybeXDGCacheHome <- do
+        maybeXDGCacheHome <-
           liftIO (System.Environment.lookupEnv "XDG_CACHE_HOME")
 
         case maybeXDGCacheHome of

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -6,38 +6,39 @@
 
 module Dhall.Import.Types where
 
-import Control.Exception (Exception)
+import Control.Exception                (Exception)
 import Control.Monad.Trans.State.Strict (StateT)
 import Data.Dynamic
-import Data.List.NonEmpty (NonEmpty)
-import Dhall.Map (Map)
-import Data.Semigroup ((<>))
-import Data.Text.Prettyprint.Doc (Pretty(..))
-import Data.Void (Void)
-import Dhall.Context (Context)
+import Data.List.NonEmpty               (NonEmpty)
+import Data.Semigroup                   ((<>))
+import Data.Text.Prettyprint.Doc        (Pretty (..))
+import Data.Void                        (Void)
+import Dhall.Context                    (Context)
 import Dhall.Core
-  ( Directory (..)
-  , Expr
-  , File (..)
-  , FilePrefix (..)
-  , Import (..)
-  , ImportHashed (..)
-  , ImportMode (..)
-  , ImportType (..)
-  , ReifiedNormalizer(..)
-  , URL
-  )
+    ( Directory (..)
+    , Expr
+    , File (..)
+    , FilePrefix (..)
+    , Import (..)
+    , ImportHashed (..)
+    , ImportMode (..)
+    , ImportType (..)
+    , ReifiedNormalizer (..)
+    , URL
+    )
+import Dhall.Map                        (Map)
+import Dhall.Parser                     (Src)
+import Lens.Family                      (LensLike')
+import System.FilePath                  (isRelative, splitDirectories)
+
 #ifdef WITH_HTTP
 import Dhall.Import.Manager (Manager)
 #endif
-import Dhall.Parser (Src)
-import Lens.Family (LensLike')
-import System.FilePath (isRelative, splitDirectories)
 
-import qualified Dhall.Context
-import qualified Dhall.Map     as Map
-import qualified Dhall.Substitution
 import qualified Data.Text
+import qualified Dhall.Context
+import qualified Dhall.Map          as Map
+import qualified Dhall.Substitution
 
 -- | A fully 'chained' import, i.e. if it contains a relative path that path is
 --   relative to the current directory. If it is a remote import with headers

--- a/dhall/src/Dhall/Lint.hs
+++ b/dhall/src/Dhall/Lint.hs
@@ -20,16 +20,16 @@ module Dhall.Lint
 import Control.Applicative ((<|>))
 
 import Dhall.Syntax
-    ( Binding(..)
-    , Chunks(..)
-    , Directory(..)
-    , Expr(..)
-    , File(..)
-    , FilePrefix(..)
-    , Import(..)
-    , ImportHashed(..)
-    , ImportType(..)
-    , Var(..)
+    ( Binding (..)
+    , Chunks (..)
+    , Directory (..)
+    , Expr (..)
+    , File (..)
+    , FilePrefix (..)
+    , Import (..)
+    , ImportHashed (..)
+    , ImportType (..)
+    , Var (..)
     , subExpressions
     )
 

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -3,7 +3,6 @@
 -}
 
 {-# LANGUAGE ApplicativeDo     #-}
-{-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -39,7 +38,7 @@ import Dhall.Import
     )
 import Dhall.Parser              (Src)
 import Dhall.Pretty              (Ann, CharacterSet (..), annToAnsiStyle)
-import Dhall.Schemas             (Schemas(..))
+import Dhall.Schemas             (Schemas (..))
 import Dhall.TypeCheck
     ( Censored (..)
     , DetailedTypeError (..)
@@ -64,10 +63,10 @@ import Dhall.Util
     , CheckFailed (..)
     , Header (..)
     , Input (..)
-    , PossiblyTransitiveInput (..)
     , Output (..)
     , OutputMode (..)
-    , Transitivity(..)
+    , PossiblyTransitiveInput (..)
+    , Transitivity (..)
     )
 
 import qualified Codec.CBOR.JSON
@@ -586,7 +585,7 @@ command (Options {..}) = do
                         Data.Text.IO.hPutStrLn System.IO.stderr "\ESC[2mUse \"dhall --explain\" for detailed errors\ESC[0m"
                         Control.Exception.throwIO (Imported ps e)
 
-            handleExitCode e = do
+            handleExitCode e =
                 Control.Exception.throwIO (e :: ExitCode)
 
     let renderDoc :: Handle -> Doc Ann -> IO ()
@@ -617,7 +616,7 @@ command (Options {..}) = do
     when (not $ ignoreSemanticCache mode) Dhall.Import.warnAboutMissingCaches
 
     handle $ case mode of
-        Version -> do
+        Version ->
             putStrLn dhallVersionString
 
         Default {..} -> do
@@ -741,7 +740,7 @@ command (Options {..}) = do
                 then return ()
                 else render System.IO.stdout inferredType
 
-        Repl -> do
+        Repl ->
             Dhall.Repl.repl characterSet explain
 
         Diff {..} -> do
@@ -757,7 +756,7 @@ command (Options {..}) = do
                 then return ()
                 else Exit.exitFailure
 
-        Format {..} -> do
+        Format {..} ->
             Dhall.Format.format
                 Dhall.Format.Format{ input = possiblyTransitiveInput, ..}
 
@@ -800,15 +799,15 @@ command (Options {..}) = do
 
                         return (text, NonTransitive)
 
-                (Header header, parsedExpression) <- do
+                (Header header, parsedExpression) <-
                     Dhall.Util.getExpressionAndHeaderFromStdinText censor originalText
 
                 case transitivity of
-                    Transitive -> do
+                    Transitive ->
                         for_ parsedExpression $ \import_ -> do
                             maybeFilepath <- Dhall.Import.dependencyToFile status import_
 
-                            for_ maybeFilepath $ \filepath -> do
+                            for_ maybeFilepath $ \filepath ->
                                 go (PossiblyTransitiveInputFile filepath Transitive)
 
                     NonTransitive ->
@@ -824,7 +823,7 @@ command (Options {..}) = do
                 let modifiedText = Pretty.Text.renderStrict stream <> "\n"
 
                 case outputMode of
-                    Write -> do
+                    Write ->
                         case input of
                             PossiblyTransitiveInputFile file _ ->
                                 if originalText == modifiedText
@@ -834,7 +833,7 @@ command (Options {..}) = do
                             NonTransitiveStandardInput ->
                                 renderDoc System.IO.stdout doc
 
-                    Check -> do
+                    Check ->
                         if originalText == modifiedText
                             then return ()
                             else do
@@ -857,16 +856,16 @@ command (Options {..}) = do
 
                     Data.ByteString.Lazy.Char8.putStrLn jsonBytes
 
-                else do
+                else
                     Data.ByteString.Lazy.putStr bytes
 
         Decode {..} -> do
-            bytes <- do
+            bytes <-
                 case file of
                     InputFile f   -> Data.ByteString.Lazy.readFile f
                     StandardInput -> Data.ByteString.Lazy.getContents
 
-            expression <- do
+            expression <-
                 if json
                     then do
                         value <- case Data.Aeson.eitherDecode' bytes of
@@ -878,7 +877,7 @@ command (Options {..}) = do
                         let cborgBytes = Codec.CBOR.Write.toLazyByteString encoding
 
                         Dhall.Core.throws (Dhall.Binary.decodeExpression cborgBytes)
-                    else do
+                    else
                         Dhall.Core.throws (Dhall.Binary.decodeExpression bytes)
 
 
@@ -903,7 +902,7 @@ command (Options {..}) = do
             let normalizedExpression = Dhall.Core.normalize resolvedExpression
 
             case normalizedExpression of
-                Dhall.Core.TextLit (Dhall.Core.Chunks [] text) -> do
+                Dhall.Core.TextLit (Dhall.Core.Chunks [] text) ->
                     Data.Text.IO.putStr text
                 _ -> do
                     let invalidDecoderExpected :: Expr Void Void
@@ -935,7 +934,7 @@ command (Options {..}) = do
 
             DirectoryTree.toDirectoryTree path normalizedExpression
 
-        Dhall.Main.Schemas{..} -> do
+        Dhall.Main.Schemas{..} ->
             Dhall.Schemas.schemasCommand Dhall.Schemas.Schemas{ input = file, ..}
 
         SyntaxTree {..} -> do

--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DeriveLift         #-}
-{-# LANGUAGE DeriveTraversable  #-}
-{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE ExplicitForAll     #-}
 {-# LANGUAGE TypeFamilies       #-}
 
 -- | `Map` type used to represent records and unions
@@ -69,14 +68,14 @@ module Dhall.Map
     , elems
     ) where
 
-import Control.Applicative ((<|>))
-import Control.DeepSeq (NFData)
-import Data.Data (Data)
+import Control.Applicative        ((<|>))
+import Control.DeepSeq            (NFData)
+import Data.Data                  (Data)
 import Data.Semigroup
-import GHC.Generics (Generic)
-import Instances.TH.Lift ()
+import GHC.Generics               (Generic)
+import Instances.TH.Lift          ()
 import Language.Haskell.TH.Syntax (Lift)
-import Prelude hiding (filter, lookup)
+import Prelude                    hiding (filter, lookup)
 
 import qualified Data.List
 import qualified Data.Map

--- a/dhall/src/Dhall/Normalize.hs
+++ b/dhall/src/Dhall/Normalize.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE BangPatterns       #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RankNTypes         #-}
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
 
 module Dhall.Normalize (
       alphaNormalize
@@ -18,23 +18,23 @@ module Dhall.Normalize (
     , freeIn
     ) where
 
-import Control.Applicative (empty)
+import Control.Applicative   (empty)
 import Data.Foldable
-import Data.Functor.Identity (Identity(..))
-import Data.Semigroup (Semigroup(..))
-import Data.Sequence (ViewL(..), ViewR(..))
+import Data.Functor.Identity (Identity (..))
+import Data.Semigroup        (Semigroup (..))
+import Data.Sequence         (ViewL (..), ViewR (..))
 import Data.Traversable
-import Instances.TH.Lift ()
-import Prelude hiding (succ)
+import Instances.TH.Lift     ()
+import Prelude               hiding (succ)
 
 import Dhall.Syntax
-    ( Expr(..)
-    , Var(..)
-    , Binding(Binding)
-    , Chunks(..)
-    , DhallDouble(..)
-    , PreferAnnotation(..)
-    , RecordField(..)
+    ( Binding (Binding)
+    , Chunks (..)
+    , DhallDouble (..)
+    , Expr (..)
+    , PreferAnnotation (..)
+    , RecordField (..)
+    , Var (..)
     )
 
 import qualified Data.Sequence
@@ -280,7 +280,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
                     let b₂ = shift (-1) (V x 0) b₁
 
                     loop b₂
-                _ -> do
+                _ ->
                   case App f' a' of
                     App (App (App (App NaturalFold (NaturalLit n0)) t) succ') zero -> do
                       t' <- loop t
@@ -293,10 +293,10 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
                         strict =       strictLoop (fromIntegral n0 :: Integer)
                         lazy   = loop (  lazyLoop (fromIntegral n0 :: Integer))
 
-                        strictLoop !0 = loop zero
+                        strictLoop 0 = loop zero
                         strictLoop !n = App succ' <$> strictLoop (n - 1) >>= loop
 
-                        lazyLoop !0 = zero
+                        lazyLoop 0 = zero
                         lazyLoop !n = App succ' (lazyLoop (n - 1))
                     App NaturalBuild g -> loop (App (App (App g Natural) succ) zero)
                       where
@@ -359,7 +359,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
                         strictNil = loop nil
                         lazyNil   =      nil
 
-                        strictCons y ys = do
+                        strictCons y ys =
                           App (App cons y) <$> ys >>= loop
                         lazyCons   y ys =       App (App cons y) ys
                     App (App ListLength _) (ListLit _ ys) ->
@@ -576,7 +576,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
             l
         decide l r =
             Prefer PreferFromSource l r
-    RecordCompletion x y -> do
+    RecordCompletion x y ->
         loop (Annot (Prefer PreferFromCompletion (Field x "default") y) (Field x "Type"))
     Merge x y t      -> do
         x' <- loop x
@@ -634,7 +634,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
                             Nothing
 
                 return (ListLit listType keyValues)
-            _ -> do
+            _ ->
                 return (ToMap x' t')
     Field r x        -> do
         let singletonRecordLit v = RecordLit (Dhall.Map.singleton x v)
@@ -678,7 +678,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
         e2 <- loop e1
 
         case e2 of
-            Record kts -> do
+            Record kts ->
                 loop (Project r (Left (Dhall.Set.fromSet (Dhall.Map.keysSet kts))))
             _ -> do
                 r' <- loop r
@@ -692,7 +692,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
         r' <- loop r
 
         pure (Equivalent l' r')
-    With e' k v -> do
+    With e' k v ->
         loop (Syntax.desugarWith (With e' k v))
     Note _ e' -> loop e'
     ImportAlt l _r -> loop l

--- a/dhall/src/Dhall/Optics.hs
+++ b/dhall/src/Dhall/Optics.hs
@@ -12,9 +12,9 @@ module Dhall.Optics
     , mapMOf
     ) where
 
-import Control.Applicative (WrappedMonad(..))
-import Data.Profunctor.Unsafe ((#.))
-import Lens.Family (ASetter, LensLike, over)
+import Control.Applicative    (WrappedMonad (..))
+import Data.Profunctor.Unsafe (( #. ))
+import Lens.Family            (ASetter, LensLike, over)
 
 -- | Identical to @"Control.Lens".`Control.Lens.rewriteOf`@
 rewriteOf :: ASetter a b a b -> (b -> Maybe a) -> a -> b

--- a/dhall/src/Dhall/Parser.hs
+++ b/dhall/src/Dhall/Parser.hs
@@ -21,13 +21,12 @@ module Dhall.Parser (
     ) where
 
 import Control.Exception (Exception)
-import Data.Semigroup (Semigroup(..))
-import Data.Text (Text)
-import Data.Void (Void)
+import Data.Semigroup    (Semigroup (..))
+import Data.Text         (Text)
+import Data.Void         (Void)
+import Dhall.Src         (Src (..))
 import Dhall.Syntax
-import Dhall.Src (Src(..))
-import Prelude hiding (const, pi)
-import Text.Megaparsec (ParseErrorBundle(..), PosState(..))
+import Text.Megaparsec   (ParseErrorBundle (..), PosState (..))
 
 import qualified Data.Char
 import qualified Data.Text
@@ -35,8 +34,8 @@ import qualified Dhall.Core      as Core
 import qualified Text.Megaparsec
 
 import Dhall.Parser.Combinators
-import Dhall.Parser.Token hiding (text)
 import Dhall.Parser.Expression
+import Dhall.Parser.Token       hiding (text)
 
 -- | Parser for a top-level Dhall expression
 expr :: Parser (Expr Src Import)

--- a/dhall/src/Dhall/Parser/Combinators.hs
+++ b/dhall/src/Dhall/Parser/Combinators.hs
@@ -1,24 +1,22 @@
 {-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 module Dhall.Parser.Combinators where
 
 
-import           Control.Applicative        (Alternative (..), liftA2)
-import           Control.Exception          (Exception)
-import           Control.Monad              (MonadPlus (..))
-import           Data.Semigroup             (Semigroup (..))
-import           Data.String                (IsString (..))
-import           Data.Text                  (Text)
-import           Data.Text.Prettyprint.Doc  (Pretty (..))
-import           Data.Void                  (Void)
-import           Dhall.Map                  (Map)
-import           Dhall.Set                  (Set)
-import           Dhall.Src                  (Src(..))
-import           Prelude                    hiding (const, pi)
-import           Text.Parser.Combinators    (try, (<?>))
-import           Text.Parser.Token          (TokenParsing (..))
+import Control.Applicative       (Alternative (..), liftA2)
+import Control.Exception         (Exception)
+import Control.Monad             (MonadPlus (..))
+import Data.Semigroup            (Semigroup (..))
+import Data.String               (IsString (..))
+import Data.Text                 (Text)
+import Data.Text.Prettyprint.Doc (Pretty (..))
+import Data.Void                 (Void)
+import Dhall.Map                 (Map)
+import Dhall.Set                 (Set)
+import Dhall.Src                 (Src (..))
+import Text.Parser.Combinators   (try, (<?>))
+import Text.Parser.Token         (TokenParsing (..))
 
 import qualified Control.Monad.Fail
 import qualified Data.Char

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE OverloadedLists     #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Parsing Dhall expressions.
@@ -16,7 +16,6 @@ import Data.Semigroup          (Semigroup (..))
 import Data.Text               (Text)
 import Dhall.Src               (Src (..))
 import Dhall.Syntax
-import Prelude                 hiding (const, pi)
 import Text.Parser.Combinators (choice, try, (<?>))
 
 import qualified Control.Monad
@@ -365,7 +364,7 @@ parsers embedded = Parsers {..}
 
                     return (\a -> ToMap a Nothing, Just "argument to ❰toMap❱")
 
-            let alternative2 = do
+            let alternative2 =
                     return (id, Nothing)
 
             (f, maybeMessage) <- alternative0 <|> alternative1 <|> alternative2

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 -- | Parse Dhall tokens. Even though we don't have a tokenizer per-se this
 ---  module is useful for keeping some small parsing utilities.
@@ -116,7 +116,6 @@ import Data.Semigroup          (Semigroup (..))
 import Data.Text               (Text)
 import Dhall.Set               (Set)
 import Dhall.Syntax
-import Prelude                 hiding (const, pi)
 import Text.Parser.Combinators (choice, try, (<?>))
 
 import qualified Control.Monad
@@ -135,7 +134,6 @@ import qualified Text.Parser.Combinators
 import qualified Text.Parser.Token
 
 import Numeric.Natural (Natural)
-import Prelude         hiding (const, pi)
 
 -- | Returns `True` if the given `Int` is a valid Unicode codepoint
 validCodepoint :: Int -> Bool
@@ -559,9 +557,9 @@ pathComponent componentType = do
 
     let pathData =
             case componentType of
-                FileComponent -> do
+                FileComponent ->
                     Text.Megaparsec.takeWhile1P Nothing Dhall.Syntax.pathCharacter
-                URLComponent -> do
+                URLComponent ->
                     star pchar
 
     let quotedPathData = do

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -73,7 +73,6 @@ import Dhall.Set                 (Set)
 import Dhall.Src                 (Src (..))
 import Dhall.Syntax
 import Numeric.Natural           (Natural)
-import Prelude                   hiding (succ)
 
 import qualified Data.Char
 import qualified Data.HashSet
@@ -166,9 +165,9 @@ renderSrc strip (Just (Src {..}))
     strippedText = strip srcText
 
     suffix =
-        if Text.null strippedText
+        if Text.null strippedText || Text.last strippedText == '\n'
         then mempty
-        else if Text.last strippedText == '\n' then mempty else " "
+        else " "
 
     oldLines = Text.splitOn "\n" strippedText
 
@@ -290,7 +289,7 @@ hangingBraces n docs =
             (  lbrace
             <> Pretty.hardline
             <> Pretty.indent n
-               ( mconcat (zipWith combineLong (repeat separator) docsLong)
+               ( mconcat (map (combineLong separator) docsLong)
                <> rbrace
                )
             )
@@ -372,7 +371,6 @@ enclose
     -> Doc ann
 enclose beginShort _         _        _       endShort _       []   =
     beginShort <> endShort
-  where
 enclose beginShort beginLong sepShort sepLong endShort endLong docs =
     Pretty.group
         (Pretty.flatAlt
@@ -623,7 +621,7 @@ prettyCharacterSet characterSet expression =
                 [ prettyExpression c ]
     prettyExpression (Let a0 b0) =
         enclose' "" "" space Pretty.hardline
-            (fmap duplicate (fmap docA (toList as)) ++ [ docB ])
+            (fmap (duplicate . docA) (toList as) ++ [ docB ])
       where
         MultiLet as b = multiLet a0 b0
 

--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -1,67 +1,80 @@
 -- | This module contains the implementation of the @dhall repl@ subcommand
 
-{-# language CPP               #-}
-{-# language FlexibleContexts  #-}
-{-# language LambdaCase        #-}
-{-# language NamedFieldPuns    #-}
-{-# language OverloadedStrings #-}
-{-# language RecordWildCards   #-}
-{-# language ViewPatterns      #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Dhall.Repl
     ( -- * Repl
       repl
     ) where
 
-import Control.Exception ( SomeException(SomeException), displayException, throwIO )
-import Control.Monad ( forM_ )
-import Control.Monad.Fail ( MonadFail )
-import Control.Monad.IO.Class ( MonadIO, liftIO )
-import Control.Monad.State.Class ( MonadState, get, modify )
-import Control.Monad.State.Strict ( evalStateT )
+import Control.Exception
+    ( SomeException (SomeException)
+    , displayException
+    , throwIO
+    )
+import Control.Monad              (forM_)
+import Control.Monad.Fail         (MonadFail)
+import Control.Monad.IO.Class     (MonadIO, liftIO)
+import Control.Monad.State.Class  (MonadState, get, modify)
+import Control.Monad.State.Strict (evalStateT)
 -- For the MonadFail instance for StateT.
-import Control.Monad.Trans.Instances ()
-import Data.Char ( isSpace )
-import Data.List ( dropWhileEnd, groupBy, isPrefixOf, nub )
-import Data.Maybe ( mapMaybe )
-import Data.Semigroup ((<>))
-import Data.Text ( Text )
-import Data.Void (Void)
-import Dhall.Context (Context)
-import Dhall.Import (hashExpressionToCode)
-import Dhall.Parser (Parser(..))
-import Dhall.Src (Src)
-import Dhall.Pretty (CharacterSet(..))
-import System.Console.Haskeline (Interrupt(..))
-import System.Console.Haskeline.Completion ( Completion, simpleCompletion )
-import System.Directory ( getDirectoryContents )
-import System.Environment ( getEnvironment )
+import Control.Monad.Trans.Instances       ()
+import Data.Char                           (isSpace)
+import Data.List
+    ( dropWhileEnd
+    , groupBy
+    , isPrefixOf
+    , nub
+    )
+import Data.Maybe                          (mapMaybe)
+import Data.Semigroup                      ((<>))
+import Data.Text                           (Text)
+import Data.Void                           (Void)
+import Dhall.Context                       (Context)
+import Dhall.Import                        (hashExpressionToCode)
+import Dhall.Parser                        (Parser (..))
+import Dhall.Pretty                        (CharacterSet (..))
+import Dhall.Src                           (Src)
+import System.Console.Haskeline            (Interrupt (..))
+import System.Console.Haskeline.Completion (Completion, simpleCompletion)
+import System.Directory                    (getDirectoryContents)
+import System.Environment                  (getEnvironment)
 
-import qualified Control.Monad.Fail as Fail
-import qualified Control.Monad.Trans.State.Strict as State
+import qualified Control.Monad.Fail                        as Fail
+import qualified Control.Monad.Trans.State.Strict          as State
 import qualified Data.HashSet
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text.IO
-import qualified Data.Text.Prettyprint.Doc as Pretty
-import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty ( renderIO )
+import qualified Data.Text                                 as Text
+import qualified Data.Text.IO                              as Text.IO
+import qualified Data.Text.Prettyprint.Doc                 as Pretty
+import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty (renderIO)
 import qualified Dhall
 import qualified Dhall.Context
 import qualified Dhall.Core
-import qualified Dhall.Core as Dhall ( Var(V), Expr, normalize )
-import qualified Dhall.Parser.Token                      as Parser.Token
+import qualified Dhall.Core                                as Dhall
+    ( Expr
+    , Var (V)
+    , normalize
+    )
+import qualified Dhall.Core                                as Expr (Expr (..))
+import qualified Dhall.Import                              as Dhall
+import qualified Dhall.Map                                 as Map
+import qualified Dhall.Parser                              as Dhall
+import qualified Dhall.Parser.Token                        as Parser.Token
 import qualified Dhall.Pretty
 import qualified Dhall.Pretty.Internal
-import qualified Dhall.Core as Expr ( Expr(..) )
-import qualified Dhall.Import                            as Dhall
-import qualified Dhall.Map                               as Map
-import qualified Dhall.Parser                            as Dhall
-import qualified Dhall.TypeCheck                         as Dhall
-import qualified Dhall.Version                           as Meta
+import qualified Dhall.TypeCheck                           as Dhall
+import qualified Dhall.Version                             as Meta
 import qualified System.Console.ANSI
-import qualified System.Console.Haskeline.Completion     as Haskeline
-import qualified System.Console.Repline                  as Repline
+import qualified System.Console.Haskeline.Completion       as Haskeline
+import qualified System.Console.Repline                    as Repline
 import qualified System.IO
-import qualified Text.Megaparsec                         as Megaparsec
+import qualified Text.Megaparsec                           as Megaparsec
 
 #if MIN_VERSION_haskeline(0,8,0)
 import qualified Control.Monad.Catch
@@ -392,15 +405,15 @@ saveBinding (Right (file, src)) = do
   writeOutputHandle $ "Expression saved to `" <> Text.pack file <> "`\n"
 
 setOption :: ( MonadIO m, MonadState Env m ) => String -> m ()
-setOption "--explain" = do
+setOption "--explain" =
   modify (\e -> e { explain = True })
-setOption _ = do
+setOption _ =
   writeOutputHandle ":set should be of the form `:set <command line option>`"
 
 unsetOption :: ( MonadIO m, MonadState Env m ) => String -> m ()
-unsetOption "--explain" = do
+unsetOption "--explain" =
   modify (\e -> e { explain = False })
-unsetOption _ = do
+unsetOption _ =
   writeOutputHandle ":unset should be of the form `:unset <command line option>`"
 
 quitMessage :: String

--- a/dhall/src/Dhall/Schemas.hs
+++ b/dhall/src/Dhall/Schemas.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE OverloadedLists   #-}
-{-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 {-| This module contains the implementation of the @dhall rewrite-with-schemas@
     subcommand
@@ -16,25 +16,30 @@ module Dhall.Schemas
     ) where
 
 import Control.Applicative (empty)
-import Control.Exception (Exception)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Data.Void (Void)
-import Dhall.Crypto (SHA256Digest)
-import Dhall.Map (Map)
-import Dhall.Src (Src)
-import Dhall.Syntax (Expr(..), Import, Var(..))
-import Dhall.Pretty (CharacterSet(..))
+import Control.Exception   (Exception)
+import Data.Monoid         ((<>))
+import Data.Text           (Text)
+import Data.Void           (Void)
+import Dhall.Crypto        (SHA256Digest)
+import Dhall.Map           (Map)
+import Dhall.Pretty        (CharacterSet (..))
+import Dhall.Src           (Src)
+import Dhall.Syntax        (Expr (..), Import, Var (..))
 import Dhall.Util
-    (Censor(..), CheckFailed(..), Header(..), Input(..), OutputMode(..))
+    ( Censor (..)
+    , CheckFailed (..)
+    , Header (..)
+    , Input (..)
+    , OutputMode (..)
+    )
 
 import qualified Control.Exception                         as Exception
-import qualified Data.Maybe                                as Maybe
 import qualified Data.Map
+import qualified Data.Maybe                                as Maybe
 import qualified Data.Text.IO                              as Text.IO
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
-import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty.Text
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Pretty.Terminal
+import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty.Text
 import qualified Data.Void                                 as Void
 import qualified Dhall.Core                                as Core
 import qualified Dhall.Import                              as Import
@@ -83,9 +88,9 @@ schemasCommand Schemas{..} = do
     let schemasText = Pretty.Text.renderStrict docStream
 
     case outputMode of
-        Write -> do
+        Write ->
             case input of
-                InputFile file -> do
+                InputFile file ->
                     if originalText == schemasText
                         then return ()
                         else AtomicWrite.atomicWriteFile
@@ -100,7 +105,7 @@ schemasCommand Schemas{..} = do
                             then fmap Dhall.Pretty.annToAnsiStyle docStream
                             else Pretty.unAnnotateS docStream)
 
-        Check -> do
+        Check ->
             if originalText == schemasText
                 then return ()
                 else do
@@ -130,7 +135,7 @@ decodeSchemas (RecordLit keyValues) = do
             return (Import.hashExpression (Syntax.denote _Type), (name, _default))
 
     return typeMetadata
-decodeSchemas  _ = do
+decodeSchemas  _ =
     empty
 
 -- | Simplify a Dhall expression using a record of schemas

--- a/dhall/src/Dhall/Set.hs
+++ b/dhall/src/Dhall/Set.hs
@@ -1,7 +1,7 @@
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveLift         #-}
 
 -- | This module only exports ways of constructing a Set,
 -- retrieving List, Set, and Seq representations of the same data,
@@ -25,18 +25,18 @@ module Dhall.Set (
     , size
     ) where
 
-import Prelude hiding (null)
-import Control.DeepSeq (NFData)
-import Data.List (foldl')
-import Data.Sequence (Seq, (|>))
-import Data.Data (Data)
-import GHC.Generics (Generic)
-import Instances.TH.Lift ()
+import Control.DeepSeq            (NFData)
+import Data.Data                  (Data)
+import Data.List                  (foldl')
+import Data.Sequence              (Seq, (|>))
+import GHC.Generics               (Generic)
+import Instances.TH.Lift          ()
 import Language.Haskell.TH.Syntax (Lift)
+import Prelude                    hiding (null)
 
-import qualified Data.Set
-import qualified Data.Sequence
 import qualified Data.Foldable
+import qualified Data.Sequence
+import qualified Data.Set
 
 {-| This is a variation on @"Data.Set".`Data.Set.Set`@ that remembers the
     original order of elements.  This ensures that ordering is not lost when

--- a/dhall/src/Dhall/Src.hs
+++ b/dhall/src/Dhall/Src.hs
@@ -12,15 +12,15 @@ module Dhall.Src
       Src(..)
     ) where
 
-import Control.DeepSeq (NFData)
-import Data.Data (Data)
-import Data.Monoid ((<>))
-import Data.Text (Text)
+import Control.DeepSeq            (NFData)
+import Data.Data                  (Data)
+import Data.Monoid                ((<>))
+import Data.Text                  (Text)
 import Data.Text.Prettyprint.Doc  (Pretty (..))
-import GHC.Generics (Generic)
-import Instances.TH.Lift ()
-import Language.Haskell.TH.Syntax (Lift(..))
-import Text.Megaparsec (SourcePos (SourcePos), mkPos, unPos)
+import GHC.Generics               (Generic)
+import Instances.TH.Lift          ()
+import Language.Haskell.TH.Syntax (Lift (..))
+import Text.Megaparsec            (SourcePos (SourcePos), mkPos, unPos)
 
 import {-# SOURCE #-} qualified Dhall.Util
 

--- a/dhall/src/Dhall/Substitution.hs
+++ b/dhall/src/Dhall/Substitution.hs
@@ -4,9 +4,9 @@
 
 module Dhall.Substitution where
 
-import Data.Text (Text)
+import Data.Text       (Text)
 import Dhall.Normalize (subst)
-import Dhall.Syntax (Expr, Var(..))
+import Dhall.Syntax    (Expr, Var (..))
 
 import qualified Dhall.Map
 

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
@@ -90,7 +89,7 @@ import Data.Sequence              (Seq)
 import Data.String                (IsString (..))
 import Data.Text                  (Text)
 import Data.Text.Prettyprint.Doc  (Doc, Pretty)
-import Data.Traversable
+import Data.Traversable           ()
 import Data.Void                  (Void)
 import Dhall.Map                  (Map)
 import {-# SOURCE #-} Dhall.Pretty.Internal
@@ -100,7 +99,6 @@ import GHC.Generics               (Generic)
 import Instances.TH.Lift          ()
 import Language.Haskell.TH.Syntax (Lift)
 import Numeric.Natural            (Natural)
-import Prelude                    hiding (succ)
 import Unsafe.Coerce              (unsafeCoerce)
 
 import qualified Control.Monad

--- a/dhall/src/Dhall/Tags.hs
+++ b/dhall/src/Dhall/Tags.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- | This module contains the implementation of the @dhall tags@ command
 
@@ -7,27 +7,27 @@ module Dhall.Tags
     ( generate
     ) where
 
-import Control.Exception (handle, SomeException(..))
-import Data.List (isSuffixOf, foldl')
-import Data.Maybe (fromMaybe)
-import Data.Semigroup (Semigroup(..))
-import Dhall.Map (foldMapWithKey)
-import Data.Text (Text)
+import Control.Exception  (SomeException (..), handle)
+import Data.List          (foldl', isSuffixOf)
+import Data.Maybe         (fromMaybe)
+import Data.Semigroup     (Semigroup (..))
+import Data.Text          (Text)
 import Data.Text.Encoding (encodeUtf8)
-import Dhall.Util (Input(..))
-import Dhall.Syntax (Expr(..), Binding(..), RecordField (..))
-import Dhall.Src (Src(srcStart))
-import Dhall.Parser (exprFromText)
-import System.FilePath ((</>), takeFileName)
-import Text.Megaparsec (sourceLine, sourceColumn, unPos)
+import Dhall.Map          (foldMapWithKey)
+import Dhall.Parser       (exprFromText)
+import Dhall.Src          (Src (srcStart))
+import Dhall.Syntax       (Binding (..), Expr (..), RecordField (..))
+import Dhall.Util         (Input (..))
+import System.FilePath    (takeFileName, (</>))
+import Text.Megaparsec    (sourceColumn, sourceLine, unPos)
 
-import qualified Data.ByteString as BS (length)
-import qualified Data.Map      as M
-import qualified Data.Text     as T
-import qualified Data.Text.IO  as TIO
+import qualified Data.ByteString  as BS (length)
+import qualified Data.Map         as M
+import qualified Data.Text        as T
+import qualified Data.Text.IO     as TIO
 import qualified System.Directory as SD
 
-{- 
+{-
     Documentation for the etags format is not very informative and not very correct.
     You can find some documentation here:
     https://en.wikipedia.org/wiki/Ctags#Etags_2
@@ -35,14 +35,14 @@ import qualified System.Directory as SD
     http://cvs.savannah.gnu.org/viewvc/vtags/vtags/vtags.el?view=markup
 -}
 
-data LineColumn = LC 
+data LineColumn = LC
     { _lcLine :: Int
       -- ^ line number, starting from 1, where to find the tag
     , _lcColumn :: Int
       -- ^ column of line where tag is
     } deriving (Eq, Ord, Show)
 
-data LineOffset = LO 
+data LineOffset = LO
     { loLine :: Int
       -- ^ line number, starting from 1, where to find the tag
     , loOffset :: Int
@@ -138,7 +138,7 @@ fixPosAndDefinition t = foldMap (\(LC ln c, term) ->
              let (ln', offset, tPattern) = fromMaybe (fallbackInfoForText ln c)
                                                      (infoForText term ln)
              in [(LO ln' offset, Tag tPattern term)])
-    where mls :: M.Map Int (Text, Int) 
+    where mls :: M.Map Int (Text, Int)
           -- ^ mls is map that for each line has length of file before this map and line content.
           --   In example above, first line is 15 bytes long and '\n', mls contain:
           --   (1, (16, "let foo = "bar"")
@@ -166,7 +166,7 @@ fixPosAndDefinition t = foldMap (\(LC ln c, term) ->
               In most cases, `LineColumn` after `getTagsFromExpr` points to byte before term.
               It's better to have term in term pattern, so this function finds and updates
               line number and byte offset and generate pattern.
-          -} 
+          -}
           infoForText
               :: Text
               -- ^ term to find

--- a/dhall/src/Dhall/Tutorial.hs
+++ b/dhall/src/Dhall/Tutorial.hs
@@ -102,37 +102,37 @@ import Dhall
 -- The simplest way to use Dhall is to ignore the programming language features
 -- and use it as a strongly typed configuration format.  For example, suppose
 -- that you create the following configuration file:
--- 
+--
 -- > -- ./config.dhall
 -- > { foo = 1
 -- > , bar = [3.0, 4.0, 5.0]
 -- > }
--- 
+--
 -- You can read the above configuration file into Haskell using the following
 -- code:
--- 
+--
 -- > -- example.hs
--- > 
+-- >
 -- > {-# LANGUAGE DeriveGeneric     #-}
 -- > {-# LANGUAGE OverloadedStrings #-}
--- > 
+-- >
 -- > import Dhall
--- > 
+-- >
 -- > data Example = Example { foo :: Natural, bar :: Vector Double }
 -- >     deriving (Generic, Show)
--- > 
+-- >
 -- > instance FromDhall Example
--- > 
+-- >
 -- > main :: IO ()
 -- > main = do
 -- >     x <- input auto "./config.dhall"
 -- >     print (x :: Example)
--- 
+--
 -- __WARNING__: You must not instantiate FromDhall with a recursive type. See [Limitations](#limitations).
 --
 -- If you compile and run the above example, the program prints the corresponding
 -- Haskell record:
--- 
+--
 -- > $ ./example
 -- > Example {foo = 1, bar = [3.0,4.0,5.0]}
 --
@@ -155,7 +155,7 @@ import Dhall
 -- ... and we can either specify an explicit type like `bool`:
 --
 -- > bool :: Type Bool
--- > 
+-- >
 -- > input bool :: Text -> IO Bool
 -- >
 -- > input bool "True" :: IO Bool
@@ -206,12 +206,12 @@ import Dhall
 -- > {-# LANGUAGE DeriveAnyClass    #-}
 -- > {-# LANGUAGE DeriveGeneric     #-}
 -- > {-# LANGUAGE OverloadedStrings #-}
--- > 
+-- >
 -- > import Dhall
--- > 
+-- >
 -- > data Person = Person { age :: Natural, name :: Text }
 -- >     deriving (Generic, FromDhall, Show)
--- > 
+-- >
 -- > main :: IO ()
 -- > main = do
 -- >     x <- input auto "./config.dhall"
@@ -221,12 +221,12 @@ import Dhall
 -- decode:
 --
 -- > {-# LANGUAGE OverloadedStrings #-}
--- > 
+-- >
 -- > import Data.Functor.Identity
 -- > import Dhall
--- > 
+-- >
 -- > instance FromDhall a => FromDhall (Identity a)
--- > 
+-- >
 -- > main :: IO ()
 -- > main = do
 -- >     x <- input auto "./config.dhall"
@@ -312,13 +312,13 @@ import Dhall
 -- expressions by their file path.
 --
 -- To illustrate this, let's create three files:
--- 
+--
 -- > $ echo "True"  > bool1
 -- > $ echo "False" > bool2
 -- > $ echo "./bool1 && ./bool2" > both
 --
 -- ... and read in all three files in a single expression:
--- 
+--
 -- >>> input auto "[ ./bool1 , ./bool2 , ./both ]" :: IO (Vector Bool)
 -- [True,False,False]
 --
@@ -354,7 +354,7 @@ import Dhall
 -- ... then the interpreter will reject the import:
 --
 -- >>> input auto "./file1" :: IO Natural
--- *** Exception: 
+-- *** Exception:
 -- ↳ ./file1
 --   ↳ ./file2
 -- ...
@@ -373,7 +373,7 @@ import Dhall
 --
 -- >>> input auto "https://raw.githubusercontent.com/dhall-lang/dhall-haskell/18e4e9a18dc53271146df3ccf5b4177c3552236b/examples/True" :: IO Bool
 -- True
--- 
+--
 -- ... or inside of a larger expression:
 --
 -- >>> input auto "False == https://raw.githubusercontent.com/dhall-lang/dhall-haskell/18e4e9a18dc53271146df3ccf5b4177c3552236b/examples/True" :: IO Bool
@@ -409,8 +409,8 @@ import Dhall
 --
 -- >>> writeFile "baz" "2.0"
 -- >>> input auto "./baz: Double" :: IO Double
--- *** Exception: 
--- ↳ ./baz: 
+-- *** Exception:
+-- ↳ ./baz:
 -- ...
 -- ...Error...: Missing file ...baz:
 -- ...
@@ -650,14 +650,14 @@ import Dhall
 -- > {-# LANGUAGE DeriveAnyClass    #-}
 -- > {-# LANGUAGE DeriveGeneric     #-}
 -- > {-# LANGUAGE OverloadedStrings #-}
--- > 
+-- >
 -- > module Main where
--- > 
+-- >
 -- > import Dhall
--- > 
+-- >
 -- > data Example0 = Example0 { foo :: Bool, bar :: Bool }
 -- >     deriving (Generic, ToDhall)
--- > 
+-- >
 -- > main = do
 -- >     f <- input auto "λ(r : { foo : Bool, bar : Bool }) → r.foo && r.bar"
 -- >     print (f (Example0 { foo = True, bar = False }) :: Bool)
@@ -687,14 +687,14 @@ import Dhall
 -- keyword:
 --
 -- > ∀(x : a) → b        -- This type ...
--- > 
+-- >
 -- > forall (x : a) → b  -- ... is the same as this type
 --
 -- ... and Dhall's @forall@ keyword behaves the same way as Haskell's @forall@
 -- keyword for input values that are @Type@s:
 --
 -- > forall (x : Type) → b  -- This Dhall type ...
--- 
+--
 -- > forall x . b           -- ... is the same as this Haskell type
 --
 -- The part where Dhall differs from Haskell is that you can also use
@@ -726,7 +726,7 @@ import Dhall
 --
 -- Remember that file paths are synonymous with their contents, so the above
 -- code is exactly equivalent to:
--- 
+--
 -- > $ dhall <<< '(λ(n : Bool) → [n && True, n && False, n || True, n || False]) True'
 -- > [True, False, True, True]
 --
@@ -784,7 +784,7 @@ import Dhall
 -- > $ dhall
 -- > ''
 -- >     #!/bin/bash
--- >     
+-- >
 -- >     echo "Hi!"
 -- > ''
 -- > <Ctrl-D>
@@ -874,11 +874,11 @@ import Dhall
 -- > { foo = 1, bar = "ABC" } ∧ { foo = True }
 -- > <Ctrl-D>
 -- > Use "dhall --explain" for detailed errors
--- > 
+-- >
 -- > Error: Field collision
--- > 
+-- >
 -- > { foo = 1, bar = "ABC" } ∧ { foo = True }
--- > 
+-- >
 -- > (input):1:1
 --
 -- __Exercise__: Combine any record with the empty record.  What do you expect
@@ -945,7 +945,7 @@ import Dhall
 -- > let twice (x : Text) = x ++ x in twice "ha"
 -- > <Ctrl-D>
 -- > Error: Invalid input
--- > 
+-- >
 -- > (input):1:11:
 -- >   |
 -- > 1 | let twice (x : Text) = x ++ x in twice "ha"
@@ -969,7 +969,7 @@ import Dhall
 --
 -- > $ dhall <<< 'let Name : Type = Text in [ "John", "Mary" ] : List Name'
 -- > List Text
--- > 
+-- >
 -- > [ "John", "Mary" ]
 --
 -- __Exercise:__ What do you think the following code will normalize to?
@@ -999,12 +999,12 @@ import Dhall
 -- > let greet =
 -- >           \(args : { greeting : Text, name : Text })
 -- >       ->  "${args.greeting}, ${args.name}!"
--- > 
+-- >
 -- > let Greeting =
 -- >       { Type = { greeting : Text, name : Text }
 -- >       , default = { greeting = "Hello", name = "John" }
 -- >       }
--- > 
+-- >
 -- > in  ''
 -- >     ${greet Greeting::{=}}
 -- >     ${greet Greeting::{ greeting = "Hola" }}
@@ -1055,7 +1055,7 @@ import Dhall
 -- You can specify the value of a union constructor like this:
 --
 -- > let Union = < Left : Natural | Right : Bool>
--- > 
+-- >
 -- > in  [ Union.Left 0, Union.Right True ]
 --
 -- In other words, you can access a union constructor as a field of a union
@@ -1105,7 +1105,7 @@ import Dhall
 --
 -- > merge handlers union [ : type ]
 --
--- ... where: 
+-- ... where:
 --
 -- * @union@ is the union you want to consume
 -- * @handlers@ is a record with one function per alternative of the union
@@ -1149,7 +1149,7 @@ import Dhall
 -- Empty alternatives like @Empty@ require no argument:
 --
 -- > let Example = < Empty | Person : { name : Text, age : Natural } >
--- > 
+-- >
 -- > in  [ Example.Empty  -- Note the absence of any argument to `Empty`
 -- >     , Example.Person { name = "John", age = 23 }
 -- >     , Example.Person { name = "Amy" , age = 25 }
@@ -1207,7 +1207,7 @@ import Dhall
 --
 -- Let's ask the interpreter for the type of this function:
 -- the first line:
--- 
+--
 -- > $ dhall type <<< './id'
 -- > ∀(a : Type) → ∀(x : a) → a
 --
@@ -1343,11 +1343,11 @@ import Dhall
 -- > let not
 -- >     : Bool → Bool
 -- >     = λ(b : Bool) → b == False
--- > 
+-- >
 -- > let example0 = assert : not False === True
--- > 
+-- >
 -- > let example1 = assert : not True === False
--- > 
+-- >
 -- > in  not
 --
 -- The expression @assert : not False == True@ is a type-checking assertion
@@ -1370,22 +1370,22 @@ import Dhall
 --
 -- The type-checker then rejects the assertion with the following error message:
 --
--- > $ dhall <<< './test.dhall' 
--- > 
+-- > $ dhall <<< './test.dhall'
+-- >
 -- > ↳ ./test.dhall
--- > 
+-- >
 -- > Error: Assertion failed
--- > 
+-- >
 -- > - False
 -- > + True
--- > 
+-- >
 -- > 7│                assert : not True === True -- Oops!
--- > 8│ 
--- > 
+-- > 8│
+-- >
 -- > ./test.dhall:7:16
--- > 
+-- >
 -- > 1│ ./test.dhall
--- > 
+-- >
 -- > (input):1:1
 --
 -- You can compare expressions that contain variables, too, which is equivalent
@@ -1403,18 +1403,18 @@ import Dhall
 -- if they don't share the same normal form, such as these:
 --
 -- > $ dhall <<< '\(n : Natural) -> assert : Natural/even (n + n) === True'
--- > 
+-- >
 -- > Use "dhall --explain" for detailed errors
--- > 
+-- >
 -- > n : Natural
--- > 
+-- >
 -- > Error: Assertion failed
--- > 
+-- >
 -- > - … …
 -- > + True
--- > 
+-- >
 -- > 1│                   assert : Natural/even (n + n) === True
--- > 
+-- >
 -- > (input):1:19
 --
 -- Here the interpreter is not smart enough to simplify @Natural/even (n + n)@
@@ -1461,9 +1461,9 @@ import Dhall
 -- Dhall will forward imports if you import an expression from a URL that
 -- contains a relative import.  For example, if you import an expression like
 -- this:
--- 
+--
 -- > http://example.com/example.dhall using ./headers
--- 
+--
 -- ... and @http:\/\/example.com/example.dhall@ contains a relative import of @./foo@
 -- then Dhall will import @http:\/\/example.com/foo@ using the same @./headers@ file.
 
@@ -1497,7 +1497,7 @@ import Dhall
 --
 -- > $ dhall <<< './foo'
 -- > Natural
--- > 
+-- >
 -- > 1
 --
 -- Any import protected by a semantic integrity check is automatically cached
@@ -1526,7 +1526,7 @@ import Dhall
 --
 -- > $ XDG_CACHE_HOME=/var/empty dhall <<< './foo'
 -- > Natural
--- > 
+-- >
 -- > 1
 --
 -- We'll use this trick to test changes to the protected import in the following
@@ -1544,10 +1544,10 @@ import Dhall
 --
 -- > $ XDG_CACHE_HOME=/var/empty dhall <<< './foo'  # This still succeeds
 -- > Natural
--- > 
+-- >
 -- > 1
 --
--- You can compute the Hash for any import by using the hash subcommand 
+-- You can compute the Hash for any import by using the hash subcommand
 -- of this package.  For example:
 --
 -- > $ dhall hash <<< './bar'
@@ -1562,15 +1562,15 @@ import Dhall
 -- text of the @./bar@ file technically never changed:
 --
 -- > XDG_CACHE_HOME=/var/empty dhall <<< './foo'
--- > 
+-- >
 -- > Error: Import integrity check failed
--- > 
+-- >
 -- > Expected hash:
--- > 
+-- >
 -- > ↳ d60d8415e36e86dae7f42933d3b0c4fe3ca238f057fba206c7e9fbf5d784fe15
--- > 
+-- >
 -- > Actual hash:
--- > 
+-- >
 -- > ↳ 4caf97e8c445d4d4b5c5b992973e098ed4ae88a355915f5a59db640a589bc9cb
 --
 -- This is because the @./bar@ file now represents a new value (@2@ instead of
@@ -1607,7 +1607,7 @@ import Dhall
 -- > $ cat ./foo.dhall
 -- > let replicate =
 -- >       https://prelude.dhall-lang.org/List/replicate sha256:d4250b45278f2d692302489ac3e78280acb238d27541c837ce46911ff3baa347
--- > 
+-- >
 -- > in  replicate 5
 
 -- $rawText
@@ -1628,7 +1628,7 @@ import Dhall
 -- > ''
 -- > Copyright (c) 2017 Gabriel Gonzalez
 -- > All rights reserved.
--- > 
+-- >
 -- > ...
 -- > (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 -- > SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -1650,28 +1650,28 @@ import Dhall
 -- > $ cat LICENSE
 -- > Copyright (c) 2017 Gabriel Gonzalez
 -- > All rights reserved.
--- > 
+-- >
 -- > ...
 -- > (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 -- > SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -- $format
 --
--- A format subcommand is also available that you can use to 
+-- A format subcommand is also available that you can use to
 -- automatically format Dhall expressions.  For example, we can take the
 -- following unformatted Dhall expression:
 --
 -- > $ cat ./unformatted
--- > λ(a : Type) → λ(kvss : List (List { index : Natural, value : a })) → 
--- > List/build { index : Natural, value : a } (λ(list : Type) → λ(cons : { 
--- > index : Natural, value : a } → list → list) → λ(nil : list) → 
--- > (List/fold (List { index : Natural, value : a }) kvss { count : Natural, diff : 
--- > Natural → list } (λ(kvs : List { index : Natural, value : a }) → λ(y : { 
--- > count : Natural, diff : Natural → list }) → { count = y.count + List/length 
--- > { index : Natural, value : a } kvs, diff = λ(n : Natural) → List/fold { 
--- > index : Natural, value : a } kvs list (λ(kvOld : { index : Natural, value : a 
--- > }) → λ(z : list) → cons { index = kvOld.index + n, value = kvOld.value } 
--- > z) (y.diff (n + List/length { index : Natural, value : a } kvs)) }) { count = 
+-- > λ(a : Type) → λ(kvss : List (List { index : Natural, value : a })) →
+-- > List/build { index : Natural, value : a } (λ(list : Type) → λ(cons : {
+-- > index : Natural, value : a } → list → list) → λ(nil : list) →
+-- > (List/fold (List { index : Natural, value : a }) kvss { count : Natural, diff :
+-- > Natural → list } (λ(kvs : List { index : Natural, value : a }) → λ(y : {
+-- > count : Natural, diff : Natural → list }) → { count = y.count + List/length
+-- > { index : Natural, value : a } kvs, diff = λ(n : Natural) → List/fold {
+-- > index : Natural, value : a } kvs list (λ(kvOld : { index : Natural, value : a
+-- > }) → λ(z : list) → cons { index = kvOld.index + n, value = kvOld.value }
+-- > z) (y.diff (n + List/length { index : Natural, value : a } kvs)) }) { count =
 -- > 0, diff = λ(_ : Natural) → nil }).diff 0)
 --
 -- ... and run the expression through the formatter:
@@ -1718,11 +1718,11 @@ import Dhall
 -- normalizing them:
 --
 -- > $ dhall format
--- > let replicate = https://prelude.dhall-lang.org/List/replicate 
+-- > let replicate = https://prelude.dhall-lang.org/List/replicate
 -- > in replicate 5 (List (List Natural)) (replicate 5 (List Natural) (replicate 5 Natural 1))
 -- > <Ctrl-D>
 -- > let replicate = https://prelude.dhall-lang.org/List/replicate
--- > 
+-- >
 -- > in  replicate
 -- >       5
 -- >       (List (List Natural))
@@ -1757,7 +1757,7 @@ import Dhall
 -- >     x {- This comment will also be preserved-} =
 -- >     {- ... and this one will be preserved, too -}
 -- >       1
--- > 
+-- >
 -- > in  x
 --
 -- Note that you do not need to format the output of the
@@ -1765,7 +1765,7 @@ import Dhall
 -- multi-line expressions, too:
 --
 -- > $ dhall
--- > let replicate = https://prelude.dhall-lang.org/List/replicate 
+-- > let replicate = https://prelude.dhall-lang.org/List/replicate
 -- > in replicate 5 (List (List Natural)) (replicate 5 (List Natural) (replicate 5 Natural 1))
 -- > <Ctrl-D>
 -- > [ [ [ 1, 1, 1, 1, 1 ]
@@ -1849,11 +1849,11 @@ import Dhall
 -- > +2 + +2
 -- > <Ctrl-D>
 -- > Use "dhall --explain" for detailed errors
--- > 
+-- >
 -- > Error: ❰+❱ only works on ❰Natural❱s
--- > 
+-- >
 -- > +2 + +2
--- > 
+-- >
 -- > (input):1:1
 --
 -- In fact, there are no built-in functions for @Integer@s (or @Double@s) other
@@ -1876,49 +1876,49 @@ import Dhall
 -- > Natural/equal : Natural → Natural → Bool
 --
 -- To do so, we:
--- 
+--
 -- * extend the type-checking context to include the type of @Natural/equal@
 -- * extend the normalizer to evaluate all occurrences of @Natural/equal@
 --
 -- ... like this:
 --
 -- > -- example.hs
--- > 
+-- >
 -- > {-# LANGUAGE OverloadedStrings #-}
--- > 
+-- >
 -- > module Main where
--- > 
+-- >
 -- > import Dhall.Core (Expr(..), ReifiedNormalizer(..))
--- > 
+-- >
 -- > import qualified Data.Text.IO
 -- > import qualified Dhall
 -- > import qualified Dhall.Context
 -- > import qualified Lens.Family   as Lens
--- > 
+-- >
 -- > main :: IO ()
 -- > main = do
 -- >     text <- Data.Text.IO.getContents
--- > 
+-- >
 -- >     let startingContext = transform Dhall.Context.empty
 -- >           where
 -- >             transform = Dhall.Context.insert "Natural/equal" naturalEqualType
--- > 
+-- >
 -- >             naturalEqualType =
 -- >                 Pi "_" Natural (Pi "_" Natural Bool)
--- > 
+-- >
 -- >     let normalizer (App (App (Var "Natural/equal") (NaturalLit x)) (NaturalLit y)) =
 -- >             Just (BoolLit (x == y))
 -- >         normalizer _ =
 -- >             Nothing
--- > 
+-- >
 -- >     let inputSettings = transform Dhall.defaultInputSettings
 -- >           where
 -- >             transform =
 -- >                   Lens.set Dhall.normalizer      (Just (ReifiedNormalizer (pure . normalizer)))
 -- >                 . Lens.set Dhall.startingContext startingContext
--- > 
+-- >
 -- >     x <- Dhall.inputWithSettings inputSettings Dhall.auto text
--- > 
+-- >
 -- >     Data.Text.IO.putStrLn x
 --
 -- Here is an example use of the above program:
@@ -1930,22 +1930,22 @@ import Dhall
 -- expressions containing unexpected free variable such as @Natural/equal@:
 --
 -- > $ dhall <<< 'Natural/equal 2 (1 + 1)'
--- > 
+-- >
 -- > Use "dhall --explain" for detailed errors
--- > 
+-- >
 -- > Error: Unbound variable
--- > 
--- > Natural/equal 
--- > 
+-- >
+-- > Natural/equal
+-- >
 -- > (input):1:1
 --
 -- You will need to either:
--- 
+--
 -- * create your own parallel versions of these tools, or:
 -- * < https://github.com/dhall-lang/dhall-lang/blob/master/.github/CONTRIBUTING.md#how-do-i-change-the-language try to upstream your built-ins into the language>
--- 
+--
 -- The general guidelines for adding new built-ins to the language are:
--- 
+--
 -- * Keep built-ins easy to implement across language bindings
 -- * Prefer general purpose built-ins or built-ins appropriate for the task of program configuration
 -- * Design built-ins to catch errors as early as possible (i.e. when type-checking the configuration)
@@ -2029,11 +2029,11 @@ import Dhall
 -- > Flip the value of a `Bool`
 -- > -}
 -- > let not : Bool → Bool = λ(b : Bool) → b == False
--- > 
+-- >
 -- > let example0 = assert : not True ≡ False
--- > 
+-- >
 -- > let example1 = assert : not False ≡ True
--- > 
+-- >
 -- > in  not
 -- > ''
 --
@@ -2078,11 +2078,11 @@ import Dhall
 -- > Returns `True` if a number if even and returns `False` otherwise
 -- > -}
 -- > let even : Natural → Bool = Natural/even
--- > 
+-- >
 -- > let example0 = assert : even 3 ≡ False
--- > 
+-- >
 -- > let example1 = assert : even 0 ≡ True
--- > 
+-- >
 -- > in  even
 -- > ''
 --
@@ -2253,7 +2253,7 @@ import Dhall
 -- `FromDhall` has a limitiation: It won't work for recursive types.
 -- If you instantiate these using their Generic instance you end up with one of
 -- the following two cases:
--- 
+--
 -- If the type appears in it's own definition like
 --
 -- > data Foo = Foo Foo

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -28,32 +28,37 @@ module Dhall.TypeCheck (
     , ErrorMessages(..)
     ) where
 
-import Control.Exception (Exception)
-import Control.Monad.Trans.Class (lift)
+import Control.Exception                 (Exception)
+import Control.Monad.Trans.Class         (lift)
 import Control.Monad.Trans.Writer.Strict (execWriterT, tell)
-import Data.Monoid (Endo(..))
-import Data.List.NonEmpty (NonEmpty(..))
-import Data.Semigroup (Max(..), Semigroup(..))
-import Data.Sequence (Seq, ViewL(..))
-import Data.Set (Set)
-import Data.Text (Text)
-import Data.Text.Prettyprint.Doc (Doc, Pretty(..))
-import Data.Typeable (Typeable)
-import Data.Void (Void, absurd)
-import Dhall.Context (Context)
-import Dhall.Eval (Environment(..), Names(..), Val(..), (~>))
-import Dhall.Pretty (Ann)
-import Dhall.Src (Src)
-import Lens.Family (over)
+import Data.List.NonEmpty                (NonEmpty (..))
+import Data.Monoid                       (Endo (..))
+import Data.Semigroup                    (Max (..), Semigroup (..))
+import Data.Sequence                     (Seq, ViewL (..))
+import Data.Set                          (Set)
+import Data.Text                         (Text)
+import Data.Text.Prettyprint.Doc         (Doc, Pretty (..))
+import Data.Typeable                     (Typeable)
+import Data.Void                         (Void, absurd)
+import Dhall.Context                     (Context)
+import Dhall.Eval
+    ( Environment (..)
+    , Names (..)
+    , Val (..)
+    , (~>)
+    )
+import Dhall.Pretty                      (Ann)
+import Dhall.Src                         (Src)
+import Lens.Family                       (over)
 
 import Dhall.Syntax
-    ( Binding(..)
-    , Const(..)
-    , Chunks(..)
-    , Expr(..)
-    , PreferAnnotation(..)
+    ( Binding (..)
+    , Chunks (..)
+    , Const (..)
+    , Expr (..)
+    , PreferAnnotation (..)
     , RecordField (..)
-    , Var(..)
+    , Var (..)
     )
 
 import qualified Data.Foldable                           as Foldable
@@ -210,7 +215,7 @@ infer typer = loop
     -}
     loop :: Ctx a -> Expr s a -> Either (TypeError s a) (Val a)
     loop ctx@Ctx{..} expression = case expression of
-        Const c -> do
+        Const c ->
             fmap VConst (axiom c)
 
         Var (V x0 n0) -> do
@@ -281,7 +286,7 @@ infer typer = loop
                             let _A₀'' = quote names _A₀'
                             let _A₁'' = quote names _A₁'
                             die (TypeMismatch f _A₀'' a _A₁'')
-                Nothing -> do
+                Nothing ->
                     die (NotAFunction f (quote names tf'))
 
         Let (Binding { value = a₀, variable = x, ..}) body -> do
@@ -300,7 +305,7 @@ infer typer = loop
                     _A₁' <- loop ctx a₀
 
                     if Eval.conv values _A₀' _A₁'
-                        then do
+                        then
                             return ()
 
                         else do
@@ -325,7 +330,7 @@ infer typer = loop
             _T₁' <- loop ctx t
 
             if Eval.conv values _T₀' _T₁'
-                then do
+                then
                     return _T₁'
 
                 else do
@@ -333,10 +338,10 @@ infer typer = loop
                     let _T₁'' = quote names _T₁'
                     die (AnnotMismatch t _T₀'' _T₁'')
 
-        Bool -> do
+        Bool ->
             return (VConst Type)
 
-        BoolLit _ -> do
+        BoolLit _ ->
             return VBool
 
         BoolAnd l r -> do
@@ -415,7 +420,7 @@ infer typer = loop
             let _L'' = quote names _L'
 
             case tL' of
-                VConst Type -> do
+                VConst Type ->
                     return ()
                 _  -> do
                     let tL'' = quote names tL'
@@ -426,7 +431,7 @@ infer typer = loop
             let _R'' = quote names _R'
 
             case tR' of
-                VConst Type -> do
+                VConst Type ->
                     return ()
                 _ -> do
                     let tR'' = quote names tR'
@@ -438,13 +443,13 @@ infer typer = loop
 
             return _L'
 
-        Natural -> do
+        Natural ->
             return (VConst Type)
 
-        NaturalLit _ -> do
+        NaturalLit _ ->
             return VNatural
 
-        NaturalFold -> do
+        NaturalFold ->
             return
                 (   VNatural
                 ~>  VHPi "natural" (VConst Type) (\natural ->
@@ -456,7 +461,7 @@ infer typer = loop
                     )
                 )
 
-        NaturalBuild -> do
+        NaturalBuild ->
             return
                 (   VHPi "natural" (VConst Type) (\natural ->
                         VHPi "succ" (natural ~> natural) (\_succ ->
@@ -468,22 +473,22 @@ infer typer = loop
                 ~>  VNatural
                 )
 
-        NaturalIsZero -> do
+        NaturalIsZero ->
             return (VNatural ~> VBool)
 
-        NaturalEven -> do
+        NaturalEven ->
             return (VNatural ~> VBool)
 
-        NaturalOdd -> do
+        NaturalOdd ->
             return (VNatural ~> VBool)
 
-        NaturalToInteger -> do
+        NaturalToInteger ->
             return (VNatural ~> VInteger)
 
-        NaturalShow -> do
+        NaturalShow ->
             return (VNatural ~> VText)
 
-        NaturalSubtract -> do
+        NaturalSubtract ->
             return (VNatural ~> VNatural ~> VNatural)
 
         NaturalPlus l r -> do
@@ -516,34 +521,34 @@ infer typer = loop
 
             return VNatural
 
-        Integer -> do
+        Integer ->
             return (VConst Type)
 
-        IntegerLit _ -> do
+        IntegerLit _ ->
             return VInteger
 
-        IntegerClamp -> do
+        IntegerClamp ->
             return (VInteger ~> VNatural)
 
-        IntegerNegate -> do
+        IntegerNegate ->
             return (VInteger ~> VInteger)
 
-        IntegerShow -> do
+        IntegerShow ->
             return (VInteger ~> VText)
 
-        IntegerToDouble -> do
+        IntegerToDouble ->
             return (VInteger ~> VDouble)
 
-        Double -> do
+        Double ->
             return (VConst Type)
 
-        DoubleLit _ -> do
+        DoubleLit _ ->
             return VDouble
 
-        DoubleShow -> do
+        DoubleShow ->
             return (VDouble ~> VText)
 
-        Text -> do
+        Text ->
             return (VConst Type)
 
         TextLit (Chunks xys _) -> do
@@ -573,13 +578,13 @@ infer typer = loop
 
             return VText
 
-        TextShow -> do
+        TextShow ->
             return (VText ~> VText)
 
-        List -> do
+        List ->
             return (VConst Type ~> VConst Type)
 
-        ListLit Nothing ts₀ -> do
+        ListLit Nothing ts₀ ->
             case Data.Sequence.viewl ts₀ of
                 t₀ :< ts₁ -> do
                     _T₀' <- loop ctx t₀
@@ -596,7 +601,7 @@ infer typer = loop
                             _T₁' <- loop ctx t₁
 
                             if Eval.conv values _T₀' _T₁'
-                                then do
+                                then
                                     return ()
 
                                 else do
@@ -614,10 +619,10 @@ infer typer = loop
 
                     return (VList _T₀')
 
-                _ -> do
+                _ ->
                     die MissingListType
 
-        ListLit (Just _T₀) ts -> do
+        ListLit (Just _T₀) ts ->
             if Data.Sequence.null ts
                 then do
                     _ <- loop ctx _T₀
@@ -655,7 +660,7 @@ infer typer = loop
 
             return (VList _A₀')
 
-        ListBuild -> do
+        ListBuild ->
             return
                 (   VHPi "a" (VConst Type) (\a ->
                             VHPi "list" (VConst Type) (\list ->
@@ -667,7 +672,7 @@ infer typer = loop
                     )
                 )
 
-        ListFold -> do
+        ListFold ->
             return
                 (   VHPi "a" (VConst Type) (\a ->
                             VList a
@@ -679,16 +684,16 @@ infer typer = loop
                     )
                 )
 
-        ListLength -> do
+        ListLength ->
             return (VHPi "a" (VConst Type) (\a -> VList a ~> VNatural))
 
-        ListHead -> do
+        ListHead ->
             return (VHPi "a" (VConst Type) (\a -> VList a ~> VOptional a))
 
-        ListLast -> do
+        ListLast ->
             return (VHPi "a" (VConst Type) (\a -> VList a ~> VOptional a))
 
-        ListIndexed -> do
+        ListIndexed ->
             return
                 (   VHPi "a" (VConst Type) (\a ->
                             VList a
@@ -702,13 +707,13 @@ infer typer = loop
                                 )
                     )
                 )
-        ListReverse -> do
+        ListReverse ->
             return (VHPi "a" (VConst Type) (\a -> VList a ~> VList a))
 
-        Optional -> do
+        Optional ->
             return (VConst Type ~> VConst Type)
 
-        None -> do
+        None ->
             return (VHPi "A" (VConst Type) (\_A -> VOptional _A))
 
         Some a -> do
@@ -753,7 +758,7 @@ infer typer = loop
             return (VRecord xTs)
 
         Union xTs -> do
-            let process _ Nothing = do
+            let process _ Nothing =
                     return mempty
 
                 process x₁ (Just _T₁) = do
@@ -775,7 +780,7 @@ infer typer = loop
             let r'' = quote names (eval values l)
 
             xLs' <- case _L' of
-                VRecord xLs' -> do
+                VRecord xLs' ->
                     return xLs'
 
                 _ -> do
@@ -786,7 +791,7 @@ infer typer = loop
                         Just t  -> die (InvalidDuplicateField t l _L'')
 
             xRs' <- case _R' of
-                VRecord xRs' -> do
+                VRecord xRs' ->
                     return xRs'
 
                 _ -> do
@@ -800,7 +805,7 @@ infer typer = loop
                     let combine x (VRecord xLs₁') (VRecord xRs₁') =
                             combineTypes (x : xs) xLs₁' xRs₁'
 
-                        combine x _ _ = do
+                        combine x _ _ =
                             case mk of
                                 Nothing -> die (FieldCollision (NonEmpty.reverse (x :| xs)))
                                 Just t  -> die (DuplicateFieldCannotBeMerged (t :| reverse (x : xs)))
@@ -909,7 +914,7 @@ infer typer = loop
             _T' <- loop ctx t
 
             yTs' <- case _T' of
-                VRecord yTs' -> do
+                VRecord yTs' ->
                     return yTs'
 
                 _ -> do
@@ -920,7 +925,7 @@ infer typer = loop
             _U' <- loop ctx u
 
             yUs' <- case _U' of
-                VUnion yUs' -> do
+                VUnion yUs' ->
                     return yUs'
 
                 VOptional _O' ->
@@ -953,7 +958,7 @@ infer typer = loop
 
                 match y handler' (Just _A₁') =
                     case Eval.toVHPi handler' of
-                        Just (x, _A₀', _T₀') -> do
+                        Just (x, _A₀', _T₀') ->
                             if Eval.conv values _A₀' _A₁'
                                 then do
                                     let _T₁' = _T₀' (fresh ctx x)
@@ -1030,7 +1035,7 @@ infer typer = loop
                     return _T₁'
                 (Just _T₀', Nothing) ->
                     return _T₀'
-                (Just _T₀', Just _T₁') -> do
+                (Just _T₀', Just _T₁') ->
                     if Eval.conv values _T₀' _T₁'
                         then return _T₀'
 
@@ -1085,22 +1090,22 @@ infer typer = loop
                         )
 
             case (r, mT₁') of
-                (Nothing, Nothing) -> do
+                (Nothing, Nothing) ->
                     die MissingToMapType
-                (Just err@(Left _), _) -> do
+                (Just err@(Left _), _) ->
                     err
-                (Just (Right _T'), Nothing) -> do
+                (Just (Right _T'), Nothing) ->
                     pure (mapType _T')
                 (Nothing, Just _T₁'@(VList (VRecord itemTypes)))
                    | Just _T' <- Dhall.Map.lookup "mapValue" itemTypes
-                   , Eval.conv values (mapType _T') _T₁' -> do
+                   , Eval.conv values (mapType _T') _T₁' ->
                        pure _T₁'
                 (Nothing, Just _T₁') -> do
                     let _T₁'' = quote names _T₁'
 
                     die (InvalidToMapType _T₁'')
                 (Just (Right _T'), Just _T₁')
-                   | Eval.conv values (mapType _T') _T₁' -> do
+                   | Eval.conv values (mapType _T') _T₁' ->
                        pure (mapType _T')
                    | otherwise -> do
                        let _T₁'' = quote names _T₁'
@@ -1113,7 +1118,7 @@ infer typer = loop
             let _E'' = quote names _E'
 
             case _E' of
-                VRecord xTs' -> do
+                VRecord xTs' ->
                     case Dhall.Map.lookup x xTs' of
                         Just _T' -> return _T'
                         Nothing  -> die (MissingField x _E'')
@@ -1123,7 +1128,7 @@ infer typer = loop
                     let e'' = quote names e'
 
                     case e' of
-                        VUnion xTs' -> do
+                        VUnion xTs' ->
                             case Dhall.Map.lookup x xTs' of
                                 Just (Just _T') -> return (VHPi x _T' (\_ -> e'))
                                 Just  Nothing   -> return e'
@@ -1177,10 +1182,10 @@ infer typer = loop
                                     let _S'' = quote names _S'
 
                                     case Dhall.Map.lookup x xEs' of
-                                        Nothing -> do
+                                        Nothing ->
                                             die (MissingField x _E'')
 
-                                        Just _E' -> do
+                                        Just _E' ->
                                             if Eval.conv values _E' _S'
                                                 then return ()
                                                 else die (ProjectionTypeMismatch x _E'' _S'' expectedSubset actualSubset)
@@ -1189,7 +1194,7 @@ infer typer = loop
 
                             return s'
 
-                        _ -> do
+                        _ ->
                             die (CantProjectByExpression s)
 
                 _ -> do
@@ -1211,7 +1216,7 @@ infer typer = loop
                         then return _T'
                         else die (AssertionFailed x'' y'')
 
-                _ -> do
+                _ ->
                     die (NotAnEquivalence _T)
 
         Equivalent x y -> do
@@ -1241,7 +1246,7 @@ infer typer = loop
 
             return (VConst Type)
 
-        e@With{} -> do
+        e@With{} ->
             loop ctx (Syntax.desugarWith e)
 
         Note s e ->
@@ -1253,10 +1258,10 @@ infer typer = loop
                 Right r ->
                     Right r
 
-        ImportAlt l _r -> do
+        ImportAlt l _r ->
             loop ctx l
 
-        Embed p -> do
+        Embed p ->
             return (eval values (typer p))
       where
         die err = Left (TypeError context expression err)
@@ -2348,7 +2353,7 @@ prettyTypeMessage (InvalidListType expr0) = ErrorMessages {..}
       where
         txt0 = insert expr0
 
-prettyTypeMessage MissingListType = do
+prettyTypeMessage MissingListType =
     ErrorMessages {..}
   where
     short = "An empty list requires a type annotation"
@@ -4708,7 +4713,7 @@ prettyDetailedTypeError (DetailedTypeError (TypeError ctx expr msg)) =
 checkContext :: Context (Expr s X) -> Either (TypeError s X) ()
 checkContext context =
     case Dhall.Context.match context of
-        Nothing -> do
+        Nothing ->
             return ()
         Just (x, v, context') -> do
             let shiftedV       =       Dhall.Core.shift (-1) (V x 0)  v

--- a/dhall/src/Dhall/URL.hs
+++ b/dhall/src/Dhall/URL.hs
@@ -4,14 +4,9 @@
 module Dhall.URL where
 
 import Data.Monoid ((<>))
-import Data.Text (Text)
+import Data.Text   (Text)
 
-import Dhall.Syntax
-    ( Scheme(..)
-    , URL(..)
-    , File(..)
-    , Directory(..)
-    )
+import Dhall.Syntax (Directory (..), File (..), Scheme (..), URL (..))
 
 import qualified Network.URI.Encode as URI.Encode
 

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -21,17 +21,17 @@ module Dhall.Util
     , CheckFailed(..)
     ) where
 
-import Control.Exception (Exception(..))
-import Control.Monad.IO.Class (MonadIO(..))
-import Data.Bifunctor (first)
-import Data.Monoid ((<>))
-import Data.String (IsString)
-import Data.Text (Text)
+import Control.Exception         (Exception (..))
+import Control.Monad.IO.Class    (MonadIO (..))
+import Data.Bifunctor            (first)
+import Data.Monoid               ((<>))
+import Data.String               (IsString)
+import Data.Text                 (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty)
-import Dhall.Parser (ParseError, Header(..))
-import Dhall.Pretty (Ann)
-import Dhall.Syntax (Expr, Import)
-import Dhall.Src (Src)
+import Dhall.Parser              (Header (..), ParseError)
+import Dhall.Pretty              (Ann)
+import Dhall.Src                 (Src)
+import Dhall.Syntax              (Expr, Import)
 
 import qualified Control.Exception
 import qualified Data.Text
@@ -109,7 +109,7 @@ get
     -> InputOrTextFromStdin
     -> IO a
 get parser censor input = do
-    inText <- do
+    inText <-
         case input of
             Input_ (InputFile file) -> Data.Text.IO.readFile file
             Input_ StandardInput    -> Data.Text.IO.getContents

--- a/dhall/tests/Dhall/Test/Dhall.hs
+++ b/dhall/tests/Dhall/Test/Dhall.hs
@@ -1,36 +1,32 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveFoldable      #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE DeriveTraversable   #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE OverloadedLists     #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Dhall.Test.Dhall where
 
-import Control.Exception (SomeException, try)
-import Data.Fix (Fix(..))
-import Data.Maybe (isJust)
+import Control.Exception  (SomeException, try)
+import Data.Fix           (Fix (..))
 import Data.List.NonEmpty (NonEmpty (..))
-import Data.Sequence (Seq)
-import Data.Scientific (Scientific)
-import Data.Text (Text)
-import Data.Vector (Vector)
-import Data.Void (Void)
-import Dhall (ToDhall, FromDhall)
-import Dhall.Core (Expr(..))
-import GHC.Generics (Generic, Rep)
-import Numeric.Natural (Natural)
-import System.Timeout (timeout)
+import Data.Maybe         (isJust)
+import Data.Scientific    (Scientific)
+import Data.Sequence      (Seq)
+import Data.Text          (Text)
+import Data.Vector        (Vector)
+import Data.Void          (Void)
+import Dhall              (FromDhall, ToDhall)
+import Dhall.Core         (Expr (..))
+import GHC.Generics       (Generic, Rep)
+import Numeric.Natural    (Natural)
+import System.Timeout     (timeout)
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/dhall/tests/Dhall/Test/Diff.hs
+++ b/dhall/tests/Dhall/Test/Diff.hs
@@ -3,10 +3,10 @@
 module Dhall.Test.Diff where
 
 import Data.Monoid ((<>))
-import Data.Text (Text)
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath)
+import Data.Text   (Text)
+import Prelude     hiding (FilePath)
+import Test.Tasty  (TestTree)
+import Turtle      (FilePath)
 
 import qualified Data.Text                             as Text
 import qualified Data.Text.IO                          as Text.IO

--- a/dhall/tests/Dhall/Test/Format.hs
+++ b/dhall/tests/Dhall/Test/Format.hs
@@ -2,11 +2,11 @@
 
 module Dhall.Test.Format where
 
-import Data.Monoid (mempty, (<>))
-import Data.Text (Text)
-import Dhall.Parser (Header(..))
-import Dhall.Pretty (CharacterSet(..))
-import Test.Tasty (TestTree)
+import Data.Monoid  (mempty, (<>))
+import Data.Text    (Text)
+import Dhall.Parser (Header (..))
+import Dhall.Pretty (CharacterSet (..))
+import Test.Tasty   (TestTree)
 
 import qualified Control.Monad                         as Monad
 import qualified Data.Text                             as Text

--- a/dhall/tests/Dhall/Test/Freeze.hs
+++ b/dhall/tests/Dhall/Test/Freeze.hs
@@ -2,11 +2,11 @@
 
 module Dhall.Test.Freeze where
 
-import Data.Text (Text)
-import Dhall.Freeze (Intent(..), Scope(..))
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath)
+import Data.Text    (Text)
+import Dhall.Freeze (Intent (..), Scope (..))
+import Prelude      hiding (FilePath)
+import Test.Tasty   (TestTree)
+import Turtle       (FilePath)
 
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO
@@ -30,7 +30,7 @@ getTests = do
     return testTree
 
 freezeTest :: Text -> TestTree
-freezeTest prefix = do
+freezeTest prefix =
     Tasty.HUnit.testCase (Text.unpack prefix) $ do
         let inputFile  = Text.unpack (prefix <> "A.dhall")
         let outputFile = Text.unpack (prefix <> "B.dhall")

--- a/dhall/tests/Dhall/Test/Lint.hs
+++ b/dhall/tests/Dhall/Test/Lint.hs
@@ -2,24 +2,24 @@
 
 module Dhall.Test.Lint where
 
-import Data.Monoid (mempty, (<>))
-import Data.Text (Text)
-import Dhall.Parser (Header(..))
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath)
+import Data.Monoid  (mempty, (<>))
+import Data.Text    (Text)
+import Dhall.Parser (Header (..))
+import Prelude      hiding (FilePath)
+import Test.Tasty   (TestTree)
+import Turtle       (FilePath)
 
-import qualified Data.Text        as Text
-import qualified Data.Text.IO     as Text.IO
-import qualified Data.Text.Prettyprint.Doc as Doc
+import qualified Data.Text                             as Text
+import qualified Data.Text.IO                          as Text.IO
+import qualified Data.Text.Prettyprint.Doc             as Doc
 import qualified Data.Text.Prettyprint.Doc.Render.Text as Doc.Render.Text
-import qualified Dhall.Core       as Core
-import qualified Dhall.Lint       as Lint
-import qualified Dhall.Parser     as Parser
-import qualified Dhall.Pretty     as Pretty
-import qualified Dhall.Test.Util  as Test.Util
-import qualified Test.Tasty       as Tasty
-import qualified Test.Tasty.HUnit as Tasty.HUnit
+import qualified Dhall.Core                            as Core
+import qualified Dhall.Lint                            as Lint
+import qualified Dhall.Parser                          as Parser
+import qualified Dhall.Pretty                          as Pretty
+import qualified Dhall.Test.Util                       as Test.Util
+import qualified Test.Tasty                            as Tasty
+import qualified Test.Tasty.HUnit                      as Tasty.HUnit
 import qualified Turtle
 
 lintDirectory :: FilePath

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -5,10 +5,8 @@ import Test.Tasty      (TestTree)
 
 import qualified Dhall.Test.Dhall
 import qualified Dhall.Test.Diff
-import qualified Dhall.Test.Tags
 import qualified Dhall.Test.Format
 import qualified Dhall.Test.Freeze
-import qualified Dhall.Test.SemanticHash
 import qualified Dhall.Test.Import
 import qualified Dhall.Test.Lint
 import qualified Dhall.Test.Normalization
@@ -16,6 +14,8 @@ import qualified Dhall.Test.Parser
 import qualified Dhall.Test.QuickCheck
 import qualified Dhall.Test.Regression
 import qualified Dhall.Test.Schemas
+import qualified Dhall.Test.SemanticHash
+import qualified Dhall.Test.Tags
 import qualified Dhall.Test.TH
 import qualified Dhall.Test.Tutorial
 import qualified Dhall.Test.TypeInference

--- a/dhall/tests/Dhall/Test/Normalization.hs
+++ b/dhall/tests/Dhall/Test/Normalization.hs
@@ -3,12 +3,12 @@
 module Dhall.Test.Normalization where
 
 import Data.Monoid ((<>))
-import Data.Text (Text)
-import Data.Void (Void)
-import Dhall.Core (Expr(..), Var(..), throws)
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath, (</>))
+import Data.Text   (Text)
+import Data.Void   (Void)
+import Dhall.Core  (Expr (..), Var (..), throws)
+import Prelude     hiding (FilePath)
+import Test.Tasty  (TestTree)
+import Turtle      (FilePath, (</>))
 
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO

--- a/dhall/tests/Dhall/Test/Parser.hs
+++ b/dhall/tests/Dhall/Test/Parser.hs
@@ -3,20 +3,20 @@
 module Dhall.Test.Parser where
 
 import Data.Monoid ((<>))
-import Data.Text (Text)
-import Data.Void (Void)
-import Dhall.Core (Binding(..), Expr(..), Import, Var(..))
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath, (</>))
+import Data.Text   (Text)
+import Data.Void   (Void)
+import Dhall.Core  (Binding (..), Expr (..), Import, Var (..))
+import Prelude     hiding (FilePath)
+import Test.Tasty  (TestTree)
+import Turtle      (FilePath, (</>))
 
 import qualified Control.Monad        as Monad
 import qualified Data.Bifunctor       as Bifunctor
 import qualified Data.ByteString      as ByteString
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import qualified Data.Text            as Text
-import qualified Data.Text.IO         as Text.IO
 import qualified Data.Text.Encoding   as Text.Encoding
+import qualified Data.Text.IO         as Text.IO
 import qualified Dhall.Binary         as Binary
 import qualified Dhall.Core           as Core
 import qualified Dhall.Parser         as Parser
@@ -36,23 +36,23 @@ getTests :: IO TestTree
 getTests = do
     let successFiles = Turtle.lstree (parseDirectory </> "success")
 
-    successTests <- do
+    successTests <-
         Test.Util.discover (Turtle.chars <* "A.dhall") shouldParse successFiles
 
     let failureFiles = Turtle.lstree (parseDirectory </> "failure")
 
-    failureTests <- do
+    failureTests <-
         Test.Util.discover (Turtle.chars <> ".dhall") shouldNotParse failureFiles
 
     let binaryDecodeSuccessFiles =
             Turtle.lstree (binaryDecodeDirectory </> "success")
 
-    binaryDecodeSuccessTests <- do
+    binaryDecodeSuccessTests <-
         Test.Util.discover (Turtle.chars <* "A.dhallb") shouldDecode binaryDecodeSuccessFiles
 
     let binaryDecodeFailureFiles = Turtle.lstree (binaryDecodeDirectory </> "failure")
 
-    binaryDecodeFailureTests <- do
+    binaryDecodeFailureTests <-
         Test.Util.discover (Turtle.chars <* ".dhallb") shouldNotDecode binaryDecodeFailureFiles
 
     let testTree =
@@ -72,7 +72,7 @@ internalTests =
         [ notesInLetInLet ]
 
 notesInLetInLet :: TestTree
-notesInLetInLet = do
+notesInLetInLet =
     Tasty.HUnit.testCase "Notes in let-in-let" $ do
         let code = "let x = 0 let y = 1 in let z = 2 in x"
 
@@ -177,7 +177,7 @@ shouldNotParse path = do
 
         case Text.Encoding.decodeUtf8' bytes of
             Left _ -> return ()
-            Right text -> do
+            Right text ->
                 case Parser.exprFromText mempty text of
                     Left  _ -> return ()
                     Right _ -> Tasty.HUnit.assertFailure "Unexpected successful parse" )

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE ViewPatterns        #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -13,71 +13,87 @@
 
 module Dhall.Test.QuickCheck where
 
-import Data.Either (isRight)
-import Data.Either.Validation (Validation(..))
-import Data.Monoid ((<>))
-import Data.Void (Void)
-import Dhall (ToDhall(..), FromDhall(..), auto, extract, inject, embed, Vector)
-import Dhall.Map (Map)
-import Dhall.Core
-    ( Binding(..)
-    , Chunks(..)
-    , Const(..)
-    , Directory(..)
-    , DhallDouble(..)
-    , Expr(..)
-    , File(..)
-    , FilePrefix(..)
-    , Import(..)
-    , ImportHashed(..)
-    , ImportMode(..)
-    , ImportType(..)
-    , PreferAnnotation(..)
-    , RecordField (..)
-    , Scheme(..)
-    , URL(..)
-    , Var(..)
+import Data.Either            (isRight)
+import Data.Either.Validation (Validation (..))
+import Data.Monoid            ((<>))
+import Data.Void              (Void)
+import Dhall
+    ( FromDhall (..)
+    , ToDhall (..)
+    , Vector
+    , auto
+    , embed
+    , extract
+    , inject
     )
+import Dhall.Core
+    ( Binding (..)
+    , Chunks (..)
+    , Const (..)
+    , DhallDouble (..)
+    , Directory (..)
+    , Expr (..)
+    , File (..)
+    , FilePrefix (..)
+    , Import (..)
+    , ImportHashed (..)
+    , ImportMode (..)
+    , ImportType (..)
+    , PreferAnnotation (..)
+    , RecordField (..)
+    , Scheme (..)
+    , URL (..)
+    , Var (..)
+    )
+import Dhall.Map              (Map)
 
-import Data.Functor.Identity (Identity(..))
-import Data.Typeable (Typeable, typeRep)
-import Data.Proxy (Proxy(..))
-import Dhall.Set (Set)
-import Dhall.Parser (Header(..), createHeader)
-import Dhall.Pretty (CharacterSet(..))
-import Dhall.Src (Src(..))
-import Dhall.Test.Format (format)
-import Dhall.TypeCheck (Typer, TypeError)
-import Generic.Random (Weights, W, (%), (:+)(..))
+import Data.Functor.Identity     (Identity (..))
+import Data.Proxy                (Proxy (..))
+import Data.Typeable             (Typeable, typeRep)
+import Dhall.Parser              (Header (..), createHeader)
+import Dhall.Pretty              (CharacterSet (..))
+import Dhall.Set                 (Set)
+import Dhall.Src                 (Src (..))
+import Dhall.Test.Format         (format)
+import Dhall.TypeCheck           (TypeError, Typer)
+import Generic.Random            ((:+) (..), W, Weights, (%))
 import Test.QuickCheck
-    ( Arbitrary(..), Gen, Positive(..), Property, NonNegative(..)
-    , genericShrink, suchThat, (===), (==>))
+    ( Arbitrary (..)
+    , Gen
+    , NonNegative (..)
+    , Positive (..)
+    , Property
+    , genericShrink
+    , suchThat
+    , (===)
+    , (==>)
+    )
 import Test.QuickCheck.Instances ()
-import Test.Tasty (TestTree)
-import Test.Tasty.QuickCheck (QuickCheckTests(..))
-import Text.Megaparsec (SourcePos(..), Pos)
+import Test.Tasty                (TestTree)
+import Test.Tasty.QuickCheck     (QuickCheckTests (..))
+import Text.Megaparsec           (Pos, SourcePos (..))
 
 import qualified Control.Spoon
-import qualified Data.Foldable as Foldable
-import qualified Data.List
-import qualified Data.Sequence
-import qualified Data.SpecialValues
+import qualified Data.Foldable         as Foldable
+import qualified Data.HashMap.Strict   as HashMap
 import qualified Data.HashSet
-import qualified Data.Set
-import qualified Data.Text as Text
+import qualified Data.List
 import qualified Data.Map
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Sequence
+import qualified Data.Set
+import qualified Data.SpecialValues
+import qualified Data.Text             as Text
 import qualified Dhall.Binary
 import qualified Dhall.Context
 import qualified Dhall.Core
 import qualified Dhall.Diff
 import qualified Dhall.Map
-import qualified Dhall.Parser as Parser
+import qualified Dhall.Parser          as Parser
 import qualified Dhall.Set
 import qualified Dhall.TypeCheck
 import qualified Generic.Random
-import qualified Lens.Family as Lens
-import qualified Numeric.Natural as Nat
+import qualified Lens.Family           as Lens
+import qualified Numeric.Natural       as Nat
 import qualified Test.QuickCheck
 import qualified Test.Tasty
 import qualified Test.Tasty.QuickCheck
@@ -453,7 +469,7 @@ isNormalizedIsConsistentWithNormalize :: Expr () Import -> Property
 isNormalizedIsConsistentWithNormalize expression =
     case maybeProp of
         Nothing -> Test.QuickCheck.discard
-        Just prop -> prop
+        Just v -> v
   where
       maybeProp = do
           nf <- Control.Spoon.spoon (Dhall.Core.normalize expression)

--- a/dhall/tests/Dhall/Test/Regression.hs
+++ b/dhall/tests/Dhall/Test/Regression.hs
@@ -5,6 +5,14 @@
 
 module Dhall.Test.Regression where
 
+import Data.Either.Validation (Validation (..))
+import Data.Void              (Void)
+import Dhall.Import           (Imported, MissingImports (..))
+import Dhall.Parser           (SourcedException (..), Src)
+import Dhall.TypeCheck        (TypeError)
+import Test.Tasty             (TestTree)
+import Test.Tasty.HUnit       ((@?=))
+
 import qualified Control.Exception
 import qualified Data.Text.IO
 import qualified Data.Text.Lazy.IO
@@ -16,19 +24,11 @@ import qualified Dhall.Core
 import qualified Dhall.Map
 import qualified Dhall.Parser
 import qualified Dhall.Pretty
-import qualified Dhall.Test.Util as Util
+import qualified Dhall.Test.Util                       as Util
 import qualified Dhall.TypeCheck
 import qualified System.Timeout
 import qualified Test.Tasty
 import qualified Test.Tasty.HUnit
-
-import Data.Either.Validation (Validation(..))
-import Data.Void (Void)
-import Dhall.Import (Imported, MissingImports(..))
-import Dhall.Parser (Src, SourcedException(..))
-import Dhall.TypeCheck (TypeError)
-import Test.Tasty (TestTree)
-import Test.Tasty.HUnit ((@?=))
 
 tests :: TestTree
 tests =
@@ -114,7 +114,7 @@ issue151 = Test.Tasty.HUnit.testCase "Issue #151" (do
                     case Control.Exception.fromException e :: Maybe (Imported (TypeError Src Void)) of
                         Just _ -> return True
                         Nothing -> return False
-                handler _ = do
+                handler _ =
                     return True
 
             let typeCheck = do
@@ -223,7 +223,7 @@ issue1884 = Test.Tasty.HUnit.testCase "Issue #1884" (do
     return () )
 
 parsing0 :: TestTree
-parsing0 = Test.Tasty.HUnit.testCase "Parsing regression #0" (do
+parsing0 = Test.Tasty.HUnit.testCase "Parsing regression #0" (
     -- Verify that parsing should not fail
     --
     -- In 267093f8cddf1c2f909f2d997c31fd0a7cb2440a I broke the parser when left

--- a/dhall/tests/Dhall/Test/Schemas.hs
+++ b/dhall/tests/Dhall/Test/Schemas.hs
@@ -2,24 +2,24 @@
 
 module Dhall.Test.Schemas where
 
-import Data.Monoid (mempty, (<>))
-import Data.Text (Text)
-import Dhall.Parser (Header(..))
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath)
+import Data.Monoid  (mempty, (<>))
+import Data.Text    (Text)
+import Dhall.Parser (Header (..))
+import Prelude      hiding (FilePath)
+import Test.Tasty   (TestTree)
+import Turtle       (FilePath)
 
-import qualified Data.Text        as Text
-import qualified Data.Text.IO     as Text.IO
-import qualified Data.Text.Prettyprint.Doc as Doc
+import qualified Data.Text                             as Text
+import qualified Data.Text.IO                          as Text.IO
+import qualified Data.Text.Prettyprint.Doc             as Doc
 import qualified Data.Text.Prettyprint.Doc.Render.Text as Doc.Render.Text
-import qualified Dhall.Core       as Core
-import qualified Dhall.Parser     as Parser
-import qualified Dhall.Pretty     as Pretty
-import qualified Dhall.Schemas    as Schemas
-import qualified Dhall.Test.Util  as Test.Util
-import qualified Test.Tasty       as Tasty
-import qualified Test.Tasty.HUnit as Tasty.HUnit
+import qualified Dhall.Core                            as Core
+import qualified Dhall.Parser                          as Parser
+import qualified Dhall.Pretty                          as Pretty
+import qualified Dhall.Schemas                         as Schemas
+import qualified Dhall.Test.Util                       as Test.Util
+import qualified Test.Tasty                            as Tasty
+import qualified Test.Tasty.HUnit                      as Tasty.HUnit
 import qualified Turtle
 
 schemasDirectory :: FilePath

--- a/dhall/tests/Dhall/Test/SemanticHash.hs
+++ b/dhall/tests/Dhall/Test/SemanticHash.hs
@@ -2,20 +2,20 @@
 
 module Dhall.Test.SemanticHash where
 
-import Data.Monoid((<>))
-import Data.Text (Text)
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath)
+import Data.Monoid ((<>))
+import Data.Text   (Text)
+import Prelude     hiding (FilePath)
+import Test.Tasty  (TestTree)
+import Turtle      (FilePath)
 
-import qualified Data.Text                             as Text
-import qualified Data.Text.IO                          as Text.IO
-import qualified Dhall.Core                            as Core
-import qualified Dhall.Import                          as Import
-import qualified Dhall.Parser                          as Parser
-import qualified Dhall.Test.Util                       as Test.Util
-import qualified Test.Tasty                            as Tasty
-import qualified Test.Tasty.HUnit                      as Tasty.HUnit
+import qualified Data.Text        as Text
+import qualified Data.Text.IO     as Text.IO
+import qualified Dhall.Core       as Core
+import qualified Dhall.Import     as Import
+import qualified Dhall.Parser     as Parser
+import qualified Dhall.Test.Util  as Test.Util
+import qualified Test.Tasty       as Tasty
+import qualified Test.Tasty.HUnit as Tasty.HUnit
 import qualified Turtle
 
 hashDirectory :: FilePath

--- a/dhall/tests/Dhall/Test/Substitution.hs
+++ b/dhall/tests/Dhall/Test/Substitution.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Dhall.Test.Substitution where
 
 import Control.Exception (throwIO)
-import Data.Void (Void)
-import Dhall.Core (Expr(BoolLit, Var))
-import Dhall.Src (Src)
+import Data.Void         (Void)
+import Dhall.Core        (Expr (BoolLit, Var))
+import Dhall.Src         (Src)
 
 import qualified Data.Either.Validation
 import qualified Dhall
 import qualified Dhall.Map
-import qualified Lens.Family   as Lens
+import qualified Lens.Family            as Lens
 
 data Result = Failure Integer | Success String
     deriving (Eq, Dhall.Generic, Show)

--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -11,7 +11,7 @@
 
 module Dhall.Test.TH where
 
-import Dhall.TH (HaskellType(..))
+import Dhall.TH   (HaskellType (..))
 import Test.Tasty (TestTree)
 
 import qualified Dhall

--- a/dhall/tests/Dhall/Test/Tags.hs
+++ b/dhall/tests/Dhall/Test/Tags.hs
@@ -3,11 +3,11 @@
 module Dhall.Test.Tags where
 
 import Data.Monoid ((<>))
-import Data.Text (Text)
-import Dhall.Util (Input(..))
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath)
+import Data.Text   (Text)
+import Dhall.Util  (Input (..))
+import Prelude     hiding (FilePath)
+import Test.Tasty  (TestTree)
+import Turtle      (FilePath)
 
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO

--- a/dhall/tests/Dhall/Test/Tutorial.hs
+++ b/dhall/tests/Dhall/Test/Tutorial.hs
@@ -11,12 +11,12 @@ import qualified Dhall.Test.Util         as Util
 import qualified Test.Tasty
 import qualified Test.Tasty.HUnit
 
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import Dhall (ToDhall)
-import GHC.Generics (Generic)
-import Numeric.Natural (Natural)
-import Test.Tasty (TestTree)
+import Data.Monoid      ((<>))
+import Data.Text        (Text)
+import Dhall            (ToDhall)
+import GHC.Generics     (Generic)
+import Numeric.Natural  (Natural)
+import Test.Tasty       (TestTree)
 import Test.Tasty.HUnit ((@?=))
 
 tests :: TestTree

--- a/dhall/tests/Dhall/Test/TypeInference.hs
+++ b/dhall/tests/Dhall/Test/TypeInference.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Dhall.Test.TypeInference where
 
-import Control.Exception (SomeException(..))
-import Data.Monoid (mempty, (<>))
-import Data.Text (Text)
-import Prelude hiding (FilePath)
-import Test.Tasty (TestTree)
-import Turtle (FilePath, (</>))
+import Control.Exception (SomeException (..))
+import Data.Monoid       (mempty, (<>))
+import Data.Text         (Text)
+import Prelude           hiding (FilePath)
+import Test.Tasty        (TestTree)
+import Turtle            (FilePath, (</>))
 
 import qualified Control.Exception as Exception
 import qualified Control.Monad     as Monad

--- a/dhall/tests/Dhall/Test/Util.hs
+++ b/dhall/tests/Dhall/Test/Util.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes        #-}
 
 module Dhall.Test.Util
     ( code
@@ -22,21 +22,27 @@ module Dhall.Test.Util
     ) where
 
 import Control.Monad.Trans.State.Strict (StateT)
-import Data.Bifunctor (first)
-import Data.Text (Text)
-import Data.Void (Void)
-import Dhall.Context (Context)
-import Dhall.Core (Expr, Normalizer, ReifiedNormalizer(..), Import)
-import Dhall.Import (Status(..), SemanticCacheMode(..))
-import Data.Monoid((<>))
-import Dhall.Parser (Src)
-import Prelude hiding (FilePath)
+import Data.Bifunctor                   (first)
+import Data.Monoid                      ((<>))
+import Data.Text                        (Text)
+import Data.Void                        (Void)
+import Dhall.Context                    (Context)
+import Dhall.Core
+    ( Expr
+    , Import
+    , Normalizer
+    , ReifiedNormalizer (..)
+    )
+import Dhall.Import                     (SemanticCacheMode (..), Status (..))
+import Dhall.Parser                     (Src)
+import Prelude                          hiding (FilePath)
+import Test.Tasty                       (TestTree)
 import Test.Tasty.HUnit
-import Test.Tasty (TestTree)
-import Turtle (FilePath, Pattern, Shell, fp)
+import Turtle                           (FilePath, Pattern, Shell, fp)
 
 import qualified Control.Exception
 import qualified Control.Foldl                    as Foldl
+import qualified Control.Monad.Trans.State.Strict as State
 import qualified Data.Functor
 import qualified Data.Text                        as Text
 import qualified Dhall.Context
@@ -44,15 +50,14 @@ import qualified Dhall.Core
 import qualified Dhall.Import
 import qualified Dhall.Parser
 import qualified Dhall.TypeCheck
-import qualified Control.Monad.Trans.State.Strict as State
 import qualified System.FilePath                  as FilePath
 import qualified Test.Tasty                       as Tasty
 import qualified Test.Tasty.ExpectedFailure       as Tasty.ExpectedFailure
 import qualified Turtle
 
 #ifndef WITH_HTTP
-import Control.Monad.IO.Class (MonadIO(..))
-import Dhall.Core (URL(..))
+import Control.Monad.IO.Class   (MonadIO (..))
+import Dhall.Core               (URL (..))
 import Lens.Family.State.Strict (zoom)
 
 import qualified Data.Foldable


### PR DESCRIPTION
This PR came from @sjakobi suggestion of splitting formatting changes from #1908 

There are two commits:
* `50d09330` does stylish-haskell related formatting
* `9703e06b` adds `.hlint.yaml` with curated settings for hlint and applies the suggested changes from `hlint`.

If you don't like the changes on `9703e06b`, let me know so I revert the commit so we only keep `stylish-haskell`