### PR TITLE
Disable coverage-checking for shell

### DIFF
--- a/dhall-docs/shell.nix
+++ b/dhall-docs/shell.nix
@@ -1,1 +1,1 @@
-(import ../nix/shared.nix { coverage = true; }).shell-dhall-docs
+(import ../nix/shared.nix { coverage = false; }).shell-dhall-docs


### PR DESCRIPTION
... for consistency with other shells

Otherwise, the test executables create `*.tix` files which might
surprise people doing development on the project.  The coverage
checking can still be locally enabled by setting `coverage = true`
in the `shell.nix` file.