### PR TITLE
Fix `Arbitrary` instance for `URL`

### DIFF
--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -401,7 +401,7 @@ instance Arbitrary ImportType where
     arbitrary =
         Test.QuickCheck.oneof
             [ lift2 Local
-            , lift5 (\a b c d e -> Remote (URL a b c d e))
+            , lift1 Remote
             , lift1 Env
             , lift0 Missing
             ]
@@ -435,7 +435,27 @@ instance Arbitrary Scheme where
     shrink = genericShrink
 
 instance Arbitrary URL where
-    arbitrary = lift5 URL
+    arbitrary = do
+        scheme <- arbitrary
+
+        authority <- arbitrary
+
+        path <- arbitrary
+
+        let validQueryCharacter c =
+                   ('\x41' <= c && c <= '\x5A')
+                || ('\x61' <= c && c <= '\x7A')
+                || ('\x30' <= c && c <= '\x39')
+                || c `elem` ("-._~!$&'()*+,;=:@/?" :: String)
+
+        let validQuery  Nothing  = True
+            validQuery (Just q ) = Text.all validQueryCharacter q
+
+        query <- suchThat arbitrary validQuery
+
+        headers <- arbitrary
+
+        return URL{..}
 
     shrink = genericShrink
 


### PR DESCRIPTION
... to only generate valid query strings

Fixes https://github.com/dhall-lang/dhall-haskell/issues/1923