### PR TITLE
Shrink `Header`s to the empty string

### DIFF
--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -202,7 +202,8 @@ instance Arbitrary Header where
 
       pure . createHeader $ Text.unlines comments
 
-    shrink _ = []
+    shrink (Header "") = []
+    shrink _           = [Header ""]
 
 instance (Ord k, Arbitrary k, Arbitrary v) => Arbitrary (Map k v) where
     arbitrary = do


### PR DESCRIPTION
This simplifies some test failures.