### PR TITLE
feat(parsing): centralize comments parsing extraction on Dhall.Parser.Token

### DIFF
--- a/dhall-docs/src/Dhall/Docs/Comment.hs
+++ b/dhall-docs/src/Dhall/Docs/Comment.hs
@@ -24,14 +24,13 @@ import Text.Megaparsec     (SourcePos, (<?>))
 
 import qualified Data.Either
 import qualified Data.Foldable
-import qualified Data.List.NonEmpty       as NonEmpty
-import qualified Data.Maybe               as Maybe
+import qualified Data.List.NonEmpty      as NonEmpty
+import qualified Data.Maybe              as Maybe
 import qualified Data.Text
-import qualified Dhall.Parser.Combinators as Combinators
-import qualified Dhall.Parser.Expression  as Expression
-import qualified Dhall.Parser.Token       as Token
+import qualified Dhall.Parser.Expression as Expression
+import qualified Dhall.Parser.Token      as Token
 import qualified Text.Megaparsec
-import qualified Text.Megaparsec.Pos      as Megaparsec.Pos
+import qualified Text.Megaparsec.Pos     as Megaparsec.Pos
 
 -- | For explanation of this data-type see 'DhallComment'
 data CommentType = DhallDocsComment | MarkedComment | RawComment
@@ -102,7 +101,7 @@ lineCommentParser = do
 -- | Consume whitespace lines or lines that only have whitespaces *before* a comment
 whitespace :: Parser ()
 whitespace = Text.Megaparsec.skipMany (Text.Megaparsec.choice
-    [ void (Combinators.takeWhile1 predicate)
+    [ void (Text.Megaparsec.takeWhile1P Nothing predicate)
     , void (Token.text "\r\n")
     ] <?> "whitespace")
   where

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -564,7 +564,6 @@ Library
         Dhall.Optics
         Dhall.Parser
         Dhall.Parser.Expression
-        Dhall.Parser.Combinators
         Dhall.Parser.Token
         Dhall.Pretty
         Dhall.Repl
@@ -587,6 +586,7 @@ Library
         Dhall.Eval
         Dhall.Import.Types
         Dhall.Normalize
+        Dhall.Parser.Combinators
         Dhall.Pretty.Internal
         Dhall.Syntax
         Dhall.URL

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -34,12 +34,6 @@ import qualified Text.Megaparsec
 import Dhall.Parser.Combinators
 import Dhall.Parser.Token
 
--- | Get the current source position
-getSourcePos :: Text.Megaparsec.MonadParsec e s m =>
-                m Text.Megaparsec.SourcePos
-getSourcePos =
-    Text.Megaparsec.getSourcePos
-{-# INLINE getSourcePos #-}
 
 -- | Get the current source offset (in tokens)
 getOffset :: Text.Megaparsec.MonadParsec e s m => m Int

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -34,6 +34,12 @@ import qualified Text.Megaparsec
 import Dhall.Parser.Combinators
 import Dhall.Parser.Token
 
+-- | Get the current source position
+getSourcePos :: Text.Megaparsec.MonadParsec e s m =>
+                m Text.Megaparsec.SourcePos
+getSourcePos =
+    Text.Megaparsec.getSourcePos
+{-# INLINE getSourcePos #-}
 
 -- | Get the current source offset (in tokens)
 getOffset :: Text.Megaparsec.MonadParsec e s m => m Int

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -352,6 +352,8 @@ hexNumber = choice [ hexDigit, hexUpper, hexLower ]
       where
         predicate c = 'a' <= c && c <= 'f'
 
+-- | Parse a Dhall's single-line comment, starting from `--` and until the
+--   last character of the line /before/ the end-of-line character
 lineComment :: Parser Text
 lineComment = do
     _ <- text "--"

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -6,6 +6,8 @@
 module Dhall.Parser.Token (
     validCodepoint,
     whitespace,
+    lineComment,
+    blockComment,
     nonemptyWhitespace,
     bashEnvironmentVariable,
     posixEnvironmentVariable,
@@ -360,11 +362,12 @@ lineComment = do
 
     endOfLine
 
-    return commentText
+    return ("--" <> commentText)
   where
     endOfLine =
         (   void (Text.Parser.Char.char '\n'  )
         <|> void (Text.Parser.Char.text "\r\n")
+        <|> Text.Megaparsec.eof
         ) <?> "newline"
 
 -- | Parsed text doesn't include opening braces

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -369,7 +369,6 @@ lineComment = do
     endOfLine =
         (   void (Text.Parser.Char.char '\n'  )
         <|> void (Text.Parser.Char.text "\r\n")
-        <|> Text.Megaparsec.eof
         ) <?> "newline"
 
 -- | Parsed text doesn't include opening braces

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -4,7 +4,6 @@
 -- | Parse Dhall tokens. Even though we don't have a tokenizer per-se this
 ---  module is useful for keeping some small parsing utilities.
 module Dhall.Parser.Token (
-    getSourcePos,
     validCodepoint,
     whitespace,
     nonemptyWhitespace,
@@ -136,12 +135,6 @@ import qualified Text.Parser.Token
 
 import Numeric.Natural (Natural)
 
--- | Get the current source position
-getSourcePos :: Text.Megaparsec.MonadParsec e s m =>
-                m Text.Megaparsec.SourcePos
-getSourcePos =
-    Text.Megaparsec.getSourcePos
-{-# INLINE getSourcePos #-}
 
 -- | Returns `True` if the given `Int` is a valid Unicode codepoint
 validCodepoint :: Int -> Bool
@@ -357,9 +350,8 @@ hexNumber = choice [ hexDigit, hexUpper, hexLower ]
       where
         predicate c = 'a' <= c && c <= 'f'
 
-lineComment :: Parser (Text.Megaparsec.SourcePos, Text)
+lineComment :: Parser Text
 lineComment = do
-    sourcePos <- getSourcePos
     _ <- text "--"
 
     let predicate c = ('\x20' <= c && c <= '\x10FFFF') || c == '\t'
@@ -368,7 +360,7 @@ lineComment = do
 
     endOfLine
 
-    return (sourcePos, commentText)
+    return commentText
   where
     endOfLine =
         (   void (Text.Parser.Char.char '\n'  )


### PR DESCRIPTION
...as @Gabriel439 suggested [(comment)](https://github.com/dhall-lang/dhall-haskell/pull/1929#discussion_r459529799)

I didn't create any `newtype` over Comment's `Text` because I don't feel it's really necessary. If you believe it could be better by doing so let me know in your review :+1: 