### PR TITLE
Add trailing character to Text bullet point

### DIFF
--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -27,7 +27,7 @@
     * @Natural@s
     * @Integer@s
     * @Double@s
-    * @Text@&#x2800;
+    * @Text@ values
     * @List@s
     * @Optional@ values
     * unions
@@ -1178,4 +1178,3 @@ codeToValue conversion specialDoubleMode mFilePath code = do
     case dhallToJSON specialDoubleExpression of
       Left  err  -> Control.Exception.throwIO err
       Right json -> return json
-

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -27,7 +27,7 @@
     * @Natural@s
     * @Integer@s
     * @Double@s
-    * @Text@
+    * @Text@&#x2800;
     * @List@s
     * @Optional@ values
     * unions


### PR DESCRIPTION
The bullet point for `Text` at the top of the Dhall.JSON module
documentation was rendered as a code block because there were no
characters following the inline literal.

Added a trailing character so the literal is properly interpreted as
inline rather than block. Selected the Braille Pattern Blank U+2800
because it's a blank character that is not recognized as whitespace.
Alternatives include appending an s, `@Text@s`, or adding a neutral word
as in `@Text@ values`.