### PR TITLE
Test formatting idempotence with comments in let-bindings

### DIFF
--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -519,9 +519,9 @@ instance Arbitrary URL where
 
         let validPChar =
                 Test.QuickCheck.frequency
-                    [ (26, chooseCharacter ('\x41', '\x5A'))
-                    , (26, chooseCharacter ('\x61', '\x7A'))
-                    , (10, chooseCharacter ('\x30', '\x39'))
+                    [ (26, chooseCharacter ('A', 'Z'))
+                    , (26, chooseCharacter ('a', 'z'))
+                    , (10, chooseCharacter ('0', '9'))
                     , (17, Test.QuickCheck.elements "-._~!$&'*+;=:@")
                     ]
 


### PR DESCRIPTION
…and configure the formatting idempotence test so it is run by default.

Since generated HTTP headers can now also `Src`s in let-`Binding`s, the
`binaryRoundtrip` test required an extension to its preparatory `denote`
step – `denote` doesn't affect the HTTP headers directly.

This also includes some tweaks for the URL generator which previously
produced some invalid URLs.

Closes #1465.