### PR TITLE
Fix `subDelims` predicate for URL parsing

### DIFF
--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -742,7 +742,7 @@ pctEncoded :: Parser Text
 pctEncoded = "%" <> count 2 (satisfy hexdig)
 
 subDelims :: Char -> Bool
-subDelims c = c `elem` ("!$&'()*+,;=" :: String)
+subDelims c = c `elem` ("!$&'*+;=" :: String)
 
 unreserved :: Char -> Bool
 unreserved c =


### PR DESCRIPTION
Fixes #1952.