### PR TITLE
Fix parsing of annotated `toMap` and `merge` expressions 

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -356,19 +356,17 @@ parsers embedded = Parsers {..}
             let alternative0 = do
                     try (_merge *> nonemptyWhitespace)
 
-                    a <- importExpression_
-
-                    nonemptyWhitespace
+                    a <- importExpression_ <* nonemptyWhitespace
 
                     return (\b -> Merge a b Nothing, Just "second argument to ❰merge❱")
 
             let alternative1 = do
-                    _ <- try (_Some <* nonemptyWhitespace)
+                    try (_Some *> nonemptyWhitespace)
 
                     return (Some, Just "argument to ❰Some❱")
 
             let alternative2 = do
-                    _ <- try (_toMap *> nonemptyWhitespace)
+                    try (_toMap *> nonemptyWhitespace)
 
                     return (\a -> ToMap a Nothing, Just "argument to ❰toMap❱")
 

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -354,19 +354,28 @@ parsers embedded = Parsers {..}
     applicationExpressionWithInfo :: Parser (ApplicationExprInfo, Expr Src a)
     applicationExpressionWithInfo = do
             let alternative0 = do
+                    try (_merge *> nonemptyWhitespace)
+
+                    a <- importExpression_
+
+                    nonemptyWhitespace
+
+                    return (\b -> Merge a b Nothing, Just "second argument to ❰merge❱")
+
+            let alternative1 = do
                     _ <- try (_Some <* nonemptyWhitespace)
 
                     return (Some, Just "argument to ❰Some❱")
 
-            let alternative1 = do
+            let alternative2 = do
                     _ <- try (_toMap *> nonemptyWhitespace)
 
                     return (\a -> ToMap a Nothing, Just "argument to ❰toMap❱")
 
-            let alternative2 =
+            let alternative3 =
                     return (id, Nothing)
 
-            (f, maybeMessage) <- alternative0 <|> alternative1 <|> alternative2
+            (f, maybeMessage) <- alternative0 <|> alternative1 <|> alternative2 <|> alternative3
 
             let adapt parser =
                     case maybeMessage of
@@ -445,7 +454,6 @@ parsers embedded = Parsers {..}
                     , alternative04
                     , unionType
                     , listLiteral
-                    , alternative07
                     , alternative37
                     , alternative09
                     , builtin
@@ -487,13 +495,6 @@ parsers embedded = Parsers {..}
                 _closeBrace
 
                 return a ) <?> "literal"
-
-            alternative07 = do
-                try (_merge *> nonemptyWhitespace)
-                a <- importExpression_
-                nonemptyWhitespace
-                b <- importExpression_ <?> "second argument to ❰merge❱"
-                return (Merge a b Nothing)
 
             alternative09 = do
                 a <- try doubleInfinity

--- a/dhall/tests/Dhall/Test/Parser.hs
+++ b/dhall/tests/Dhall/Test/Parser.hs
@@ -123,11 +123,7 @@ notesInLetInLet =
 
 shouldParse :: Text -> TestTree
 shouldParse path = do
-    let expectedFailures =
-            -- This is a bug created by a parsing performance
-            -- improvement
-            [ parseDirectory </> "success/unit/MergeParenAnnotation"
-            ]
+    let expectedFailures = []
 
     let pathString = Text.unpack path
 

--- a/dhall/tests/Dhall/Test/TypeInference.hs
+++ b/dhall/tests/Dhall/Test/TypeInference.hs
@@ -100,11 +100,10 @@ successTest prefix = do
 failureTest :: Text -> TestTree
 failureTest prefix = do
     let expectedFailures =
-               [ typeInferenceDirectory </> "failure/unit/MergeEmptyNeedsDirectAnnotation1"
-
+               [
                -- Duplicate fields are incorrectly caught during parsing:
                -- https://github.com/dhall-lang/dhall-haskell/issues/772
-               , typeInferenceDirectory </> "failure/unit/RecordProjectionDuplicateFields"
+                 typeInferenceDirectory </> "failure/unit/RecordProjectionDuplicateFields"
                , typeInferenceDirectory </> "failure/unit/RecordTypeDuplicateFields"
                , typeInferenceDirectory </> "failure/unit/UnionTypeDuplicateVariants1"
                , typeInferenceDirectory </> "failure/unit/UnionTypeDuplicateVariants2"


### PR DESCRIPTION
This addresses the issue that had recently come up in https://github.com/dhall-lang/dhall-haskell/issues/1924#issuecomment-660678952. `(merge a b) : c` and `(toMap a) : b` are now correctly parsed as `Annot`s.