### PR TITLE
Remove expected failure for ListLitEmptyPrecedence test

### DIFF
--- a/dhall/tests/Dhall/Test/Parser.hs
+++ b/dhall/tests/Dhall/Test/Parser.hs
@@ -163,10 +163,6 @@ shouldNotParse path = do
               -- but this might be fixable.
               parseDirectory </> "failure/unit/ListLitEmptyMissingAnnotation.dhall"
             , parseDirectory </> "failure/unit/ListLitEmptyAnnotation.dhall"
-
-              -- The same performance improvements also broke the
-              -- precedence of parsing empty list literals
-            , parseDirectory </> "failure/unit/ListLitEmptyPrecedence.dhall"
             ]
 
     let pathString = Text.unpack path


### PR DESCRIPTION
The test file hasn't existed since https://github.com/dhall-lang/dhall-lang/pull/654.