### PR TITLE
Handle empty lists without annotations as parse errors

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -291,7 +291,13 @@ parsers embedded = Parsers {..}
                                     return (ToMap c (Just b))
                                 _ -> return (Annot a b)
 
-                    alternative5B0 <|> alternative5B1 <|> pure a
+                    let alternative5B2 =
+                            case shallowDenote a of
+                                ListLit Nothing [] ->
+                                    fail "Empty list literal without annotation"
+                                _ -> pure a
+
+                    alternative5B0 <|> alternative5B1 <|> alternative5B2
 
             alternative5A <|> alternative5B
 

--- a/dhall/src/Dhall/Tutorial.hs
+++ b/dhall/src/Dhall/Tutorial.hs
@@ -447,15 +447,18 @@ import Dhall
 --
 -- Every list can be followed by the type of the list.  The type annotation is
 -- required for empty lists but optional for non-empty lists.  You will get a
--- type error if you provide an empty list without a type annotation:
+-- parse error if you provide an empty list without a type annotation:
 --
 -- >>> input auto "[]" :: IO (Vector Natural)
 -- *** Exception:
--- ...Error...: An empty list requires a type annotation
+-- ...Error...: Invalid input
 -- ...
--- 1│ []
+-- (input):1:3:
+--   |
+-- 1 | []
+--   |   ^
+-- Empty list literal without annotation
 -- ...
--- (input):1:1
 --
 -- Also, list elements must all have the same type.  You will get an error if
 -- you try to store elements of different types in a list:

--- a/dhall/tests/Dhall/Test/Parser.hs
+++ b/dhall/tests/Dhall/Test/Parser.hs
@@ -152,14 +152,7 @@ shouldParse path = do
 
 shouldNotParse :: Text -> TestTree
 shouldNotParse path = do
-    let expectedFailures =
-            [ -- For parsing performance reasons the implementation
-              -- treats a missing type annotation on an empty list as
-              -- as a type-checking failure instead of a parse failure,
-              -- but this might be fixable.
-              parseDirectory </> "failure/unit/ListLitEmptyMissingAnnotation.dhall"
-            , parseDirectory </> "failure/unit/ListLitEmptyAnnotation.dhall"
-            ]
+    let expectedFailures = []
 
     let pathString = Text.unpack path
 

--- a/dhall/tests/format/issue1400-1A.dhall
+++ b/dhall/tests/format/issue1400-1A.dhall
@@ -1,6 +1,6 @@
 { conversation =
-    [ { author = "robert", content = [] }
-    , { author = "robert", content = [] }
+    [ { author = "robert", content = xs }
+    , { author = "robert", content = xs }
     , { author =
           "bob"
       , content =

--- a/dhall/tests/format/issue1400-1B.dhall
+++ b/dhall/tests/format/issue1400-1B.dhall
@@ -1,6 +1,6 @@
 { conversation =
-  [ { author = "robert", content = [] }
-  , { author = "robert", content = [] }
+  [ { author = "robert", content = xs }
+  , { author = "robert", content = xs }
   , { author = "bob"
     , content =
       [ text


### PR DESCRIPTION
Here are a few samples of the parse errors:

```
⊢ []

Error: Invalid input

(input):2:1:
  |
2 | <empty line>
  | ^
Empty list literal without annotation

⊢ ([]) : T

Error: Invalid input

(input):1:4:
  |
1 | ([]) : T
  |    ^
Empty list literal without annotation

⊢ { c = [] }

Error: Invalid input

(input):1:10:
  |
1 | { c = [] }
  |          ^
Empty list literal without annotation

```