### PR TITLE
Allow prettyprinter-1.7

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -71,7 +71,7 @@ Library
         megaparsec           >= 7         && < 8.1 ,
         path                 >= 0.7.0     && < 0.8 ,
         path-io              >= 1.6.0     && < 1.7 ,
-        prettyprinter        >= 1.5.1     && < 1.7 ,
+        prettyprinter        >= 1.5.1     && < 1.8 ,
         tar                  >= 0.5.1.0   && < 0.6 ,
         text                 >= 0.11.1.0  && < 1.3 ,
         mtl                  >= 2.2.1     && < 2.3 ,

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -49,7 +49,7 @@ Library
         filepath                                  < 1.5 ,
         lens-family-core          >= 1.0.0     && < 2.2 ,
         optparse-applicative      >= 0.14.0.0  && < 0.16,
-        prettyprinter             >= 1.5.1     && < 1.7 ,
+        prettyprinter             >= 1.5.1     && < 1.8 ,
         scientific                >= 0.3.0.0   && < 0.4 ,
         text                      >= 0.11.1.0  && < 1.3 ,
         unordered-containers                      < 0.3 ,

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -61,7 +61,7 @@ library
     , megaparsec           >= 7.0.2    && < 8.1
     , mtl                  >= 2.2.2    && < 2.3
     , network-uri          >= 2.6.1.0  && < 2.7
-    , prettyprinter        >= 1.5.1    && < 1.7
+    , prettyprinter        >= 1.5.1    && < 1.8
     , text                 >= 1.2.3.0  && < 1.3
     , transformers         >= 0.5.5.0  && < 0.6
     , unordered-containers >= 0.2.9.0  && < 0.3

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -27,7 +27,7 @@ Executable dhall-to-nixpkgs
                      , mmorph                              < 1.2
                      , neat-interpolation                  < 0.6
                      , optparse-applicative >= 0.14.0.0 && < 0.16
-                     , prettyprinter        >= 1.5.1    && < 1.7
+                     , prettyprinter        >= 1.5.1    && < 1.8
                      , text                 >= 0.11.1.0 && < 1.3
                      , transformers         >= 0.2.0.0  && < 0.6
                      , turtle                              < 1.6

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -27,7 +27,7 @@ executable openapi-to-dhall
     megaparsec              >= 7.0       && < 8.1  ,
     optparse-applicative    >= 0.14.3.0  && < 0.16 ,
     parser-combinators      >= 1.0.3     && < 1.3  ,
-    prettyprinter           >= 1.2.0.1   && < 1.7  ,
+    prettyprinter           >= 1.2.0.1   && < 1.8  ,
     sort                    >= 1.0       && < 1.1  ,
     text                    >= 0.11.1.0  && < 1.3  ,
     turtle                  >= 1.5.0     && < 1.6  ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -481,7 +481,7 @@ Library
         optparse-applicative        >= 0.14.0.0 && < 0.16,
         parsers                     >= 0.12.4   && < 0.13,
         parser-combinators                               ,
-        prettyprinter               >= 1.5.1    && < 1.7 ,
+        prettyprinter               >= 1.5.1    && < 1.8 ,
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
         pretty-simple                              < 4   ,
         profunctors                 >= 3.1.2    && < 5.6 ,


### PR DESCRIPTION
Context: https://github.com/commercialhaskell/stackage/issues/5558

I have run the tests locally using the new version.

There are a few goodies in the [`prettyprinter`](http://hackage.haskell.org/package/prettyprinter-1.7.0/changelog) and [`prettyprinter-ansi-terminal`](http://hackage.haskell.org/package/prettyprinter-ansi-terminal-1.1.2/changelog) changes that I want to take advantage of, but this will be easier once the rest of the ecosystem has caught up, especially `hnix`.