### PR TITLE
feat(dhall-text): add output file command line argument

### DIFF
--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -161,7 +161,7 @@ data Mode
           }
     | Encode { file :: Input, json :: Bool }
     | Decode { file :: Input, json :: Bool, quiet :: Bool }
-    | Text { file :: Input, outputFile :: Output }
+    | Text { file :: Input, output :: Output }
     | DirectoryTree { file :: Input, path :: FilePath }
     | Schemas { file :: Input, outputMode :: OutputMode, schemas :: Text }
     | SyntaxTree { file :: Input, noted :: Bool }
@@ -902,7 +902,7 @@ command (Options {..}) = do
 
             case normalizedExpression of
                 Dhall.Core.TextLit (Dhall.Core.Chunks [] text) ->
-                    let write = case outputFile of
+                    let write = case output of
                           StandardOutput -> Data.Text.IO.putStr
                           OutputFile file_ -> Data.Text.IO.writeFile file_
                     in write text

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -161,7 +161,7 @@ data Mode
           }
     | Encode { file :: Input, json :: Bool }
     | Decode { file :: Input, json :: Bool, quiet :: Bool }
-    | Text { file :: Input, outputFile :: Maybe FilePath }
+    | Text { file :: Input, outputFile :: Output }
     | DirectoryTree { file :: Input, path :: FilePath }
     | Schemas { file :: Input, outputMode :: OutputMode, schemas :: Text }
     | SyntaxTree { file :: Input, noted :: Bool }
@@ -250,7 +250,7 @@ parseMode =
             Generate
             "text"
             "Render a Dhall expression that evaluates to a Text literal"
-            (Text <$> parseFile <*> optional parseTextOutput)
+            (Text <$> parseFile <*> parseOutput)
     <|> subcommand
             Generate
             "to-directory-tree"
@@ -503,13 +503,6 @@ parseMode =
             (   Options.Applicative.long "output"
             <>  Options.Applicative.help "The destination path to create"
             <>  Options.Applicative.metavar "PATH"
-            )
-
-    parseTextOutput =
-        Options.Applicative.strOption
-            (   Options.Applicative.long "output"
-            <>  Options.Applicative.help "Write text to a file instead of standard output"
-            <>  Options.Applicative.metavar "FILE"
             )
 
     parseNoted =
@@ -910,8 +903,8 @@ command (Options {..}) = do
             case normalizedExpression of
                 Dhall.Core.TextLit (Dhall.Core.Chunks [] text) ->
                     let write = case outputFile of
-                          Nothing -> Data.Text.IO.putStr
-                          Just file_ -> Data.Text.IO.writeFile file_
+                          StandardOutput -> Data.Text.IO.putStr
+                          OutputFile file_ -> Data.Text.IO.writeFile file_
                     in write text
                 _ -> do
                     let invalidDecoderExpected :: Expr Void Void

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -161,7 +161,7 @@ data Mode
           }
     | Encode { file :: Input, json :: Bool }
     | Decode { file :: Input, json :: Bool, quiet :: Bool }
-    | Text { file :: Input }
+    | Text { file :: Input, outputFile :: Maybe FilePath }
     | DirectoryTree { file :: Input, path :: FilePath }
     | Schemas { file :: Input, outputMode :: OutputMode, schemas :: Text }
     | SyntaxTree { file :: Input, noted :: Bool }
@@ -250,7 +250,7 @@ parseMode =
             Generate
             "text"
             "Render a Dhall expression that evaluates to a Text literal"
-            (Text <$> parseFile)
+            (Text <$> parseFile <*> optional parseTextOutput)
     <|> subcommand
             Generate
             "to-directory-tree"
@@ -503,6 +503,13 @@ parseMode =
             (   Options.Applicative.long "output"
             <>  Options.Applicative.help "The destination path to create"
             <>  Options.Applicative.metavar "PATH"
+            )
+
+    parseTextOutput =
+        Options.Applicative.strOption
+            (   Options.Applicative.long "output"
+            <>  Options.Applicative.help "Write text to a file instead of standard output"
+            <>  Options.Applicative.metavar "FILE"
             )
 
     parseNoted =
@@ -902,7 +909,10 @@ command (Options {..}) = do
 
             case normalizedExpression of
                 Dhall.Core.TextLit (Dhall.Core.Chunks [] text) ->
-                    Data.Text.IO.putStr text
+                    let write = case outputFile of
+                          Nothing -> Data.Text.IO.putStr
+                          Just file_ -> Data.Text.IO.writeFile file_
+                    in write text
                 _ -> do
                     let invalidDecoderExpected :: Expr Void Void
                         invalidDecoderExpected = Dhall.Core.Text


### PR DESCRIPTION
This change enables setting a file output for the dhall text command
so that it is consistent with the other command that generate an
output.