### PR TITLE
feat(parsing): preserve whitespaces on Lam

### DIFF
--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -500,8 +500,8 @@ dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
                     return (Aeson.toJSON (Dhall.Map.toMap a'))
         Core.App (Core.Field (Core.Union _) _) b -> loop b
         Core.Field (Core.Union _) k -> return (Aeson.toJSON k)
-        Core.Lam _ (Core.Const Core.Type)
-            (Core.Lam _
+        Core.Lam (Core.fbAnnotation -> Core.Const Core.Type)
+            (Core.Lam (Core.fbAnnotation ->
                 (Core.Record
                     [ ("array" , Core.recordFieldValue -> Core.Pi _ (Core.App Core.List (V 0)) (V 1))
                     , ("bool"  , Core.recordFieldValue -> Core.Pi _ Core.Bool (V 1))
@@ -513,7 +513,7 @@ dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
                         , ("mapValue", Core.recordFieldValue -> V 0)])) (V 1))
                     , ("string", Core.recordFieldValue -> Core.Pi _ Core.Text (V 1))
                     ]
-                )
+                ))
                 value
             ) -> do
                 let outer (Core.Field (V 0) "null") = return Aeson.Null
@@ -542,8 +542,8 @@ dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
                     outer _ = Left (Unsupported e)
 
                 outer value
-        Core.Lam _ (Core.Const Core.Type)
-            (Core.Lam _
+        Core.Lam (Core.fbAnnotation -> Core.Const Core.Type)
+            (Core.Lam (Core.fbAnnotation ->
                 (Core.Record
                     [ ("array" , Core.recordFieldValue -> Core.Pi _ (Core.App Core.List (V 0)) (V 1))
                     , ("bool"  , Core.recordFieldValue -> Core.Pi _ Core.Bool (V 1))
@@ -557,7 +557,7 @@ dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
                         ])) (V 1))
                     , ("string", Core.recordFieldValue -> Core.Pi _ Core.Text (V 1))
                     ]
-                )
+                ))
                 value
             ) -> do
                 let outer (Core.Field (V 0) "null") =
@@ -728,8 +728,8 @@ convertToHomogeneousMaps (Conversion {..}) e0 = loop (Core.normalize e0)
            case we do *not* want to perform this rewrite since it will
            interfere with decoding the value.
         -}
-        Core.Lam a b c ->
-            Core.Lam a b c
+        Core.Lam a b ->
+            Core.Lam a b
 
         Core.Pi a b c ->
             Core.Pi a b' c'

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -500,8 +500,8 @@ dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
                     return (Aeson.toJSON (Dhall.Map.toMap a'))
         Core.App (Core.Field (Core.Union _) _) b -> loop b
         Core.Field (Core.Union _) k -> return (Aeson.toJSON k)
-        Core.Lam (Core.fbAnnotation -> Core.Const Core.Type)
-            (Core.Lam (Core.fbAnnotation ->
+        Core.Lam (Core.functionBindingAnnotation -> Core.Const Core.Type)
+            (Core.Lam (Core.functionBindingAnnotation ->
                 (Core.Record
                     [ ("array" , Core.recordFieldValue -> Core.Pi _ (Core.App Core.List (V 0)) (V 1))
                     , ("bool"  , Core.recordFieldValue -> Core.Pi _ Core.Bool (V 1))
@@ -542,8 +542,8 @@ dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
                     outer _ = Left (Unsupported e)
 
                 outer value
-        Core.Lam (Core.fbAnnotation -> Core.Const Core.Type)
-            (Core.Lam (Core.fbAnnotation ->
+        Core.Lam (Core.functionBindingAnnotation -> Core.Const Core.Type)
+            (Core.Lam (Core.functionBindingAnnotation ->
                 (Core.Record
                     [ ("array" , Core.recordFieldValue -> Core.Pi _ (Core.App Core.List (V 0)) (V 1))
                     , ("bool"  , Core.recordFieldValue -> Core.Pi _ Core.Bool (V 1))

--- a/dhall-json/src/Dhall/JSONToDhall.hs
+++ b/dhall-json/src/Dhall/JSONToDhall.hs
@@ -1007,8 +1007,8 @@ dhallFromJSON (Conversion {..}) expressionType =
                   D.Field "json" "null"
 
           let result =
-                D.Lam "JSON" (D.Const D.Type)
-                    (D.Lam "json"
+                D.Lam (D.makeFunctionBinding "JSON" (D.Const D.Type))
+                    (D.Lam (D.makeFunctionBinding "json"
                         (D.Record
                             [ ("array" , D.makeRecordField $ D.Pi "_" (D.App D.List "JSON") "JSON")
                             , ("bool"  , D.makeRecordField $ D.Pi "_" D.Bool "JSON")
@@ -1021,7 +1021,7 @@ dhallFromJSON (Conversion {..}) expressionType =
                                     ])) "JSON")
                             , ("string", D.makeRecordField $ D.Pi "_" D.Text "JSON")
                             ]
-                        )
+                        ))
                         (outer value)
                     )
 
@@ -1097,8 +1097,8 @@ dhallFromJSON (Conversion {..}) expressionType =
                   D.Field "json" "null"
 
           let result =
-                D.Lam "JSON" (D.Const D.Type)
-                    (D.Lam "json"
+                D.Lam (D.makeFunctionBinding "JSON" (D.Const D.Type))
+                    (D.Lam (D.makeFunctionBinding "json"
                         (D.Record
                             [ ("array" , D.makeRecordField $ D.Pi "_" (D.App D.List "JSON") "JSON")
                             , ("bool"  , D.makeRecordField $ D.Pi "_" D.Bool "JSON")
@@ -1111,7 +1111,7 @@ dhallFromJSON (Conversion {..}) expressionType =
                                     , ("mapValue", D.makeRecordField "JSON")])) "JSON")
                             , ("string", D.makeRecordField $ D.Pi "_" D.Text "JSON")
                             ]
-                        )
+                        ))
                         (outer value)
                     )
 

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
@@ -124,7 +124,7 @@ buildCompletionContext' context values (Let (Binding { variable = x, annotation 
 
     in buildCompletionContext' context' values' e
 
-buildCompletionContext' context values (Lam (FunctionBinding { fbVariable = x, fbAnnotation = _A}) b) =
+buildCompletionContext' context values (Lam (FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = _A}) b) =
   let _A' | Right _ <- typeWithA absurd context _A = normalize _A
           | otherwise = holeExpr
 

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
@@ -16,6 +16,7 @@ import System.Timeout                (timeout)
 import Dhall.Core
     ( Binding (..)
     , Expr (..)
+    , FunctionBinding (..)
     , RecordField (..)
     , Var (..)
     , normalize
@@ -123,7 +124,7 @@ buildCompletionContext' context values (Let (Binding { variable = x, annotation 
 
     in buildCompletionContext' context' values' e
 
-buildCompletionContext' context values (Lam x _A b) =
+buildCompletionContext' context values (Lam (FunctionBinding { fbVariable = x, fbAnnotation = _A}) b) =
   let _A' | Right _ <- typeWithA absurd context _A = normalize _A
           | otherwise = holeExpr
 

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Parsing.hs
@@ -13,7 +13,13 @@ where
 
 import Control.Applicative     (optional, (<|>))
 import Data.Text               (Text)
-import Dhall.Core              (Binding (..), Expr (..), Import, Var (..))
+import Dhall.Core
+    ( Binding (..)
+    , Expr (..)
+    , Import
+    , Var (..)
+    , makeFunctionBinding
+    )
 import Dhall.Parser
 import Dhall.Parser.Expression
     ( getSourcePos
@@ -308,4 +314,4 @@ binderExprFromText txt =
           <|> (do skipManyTill anySingle _arrow; return holeExpr)
       whitespace
       inner <- parseBinderExpr
-      return (Lam name typ inner)
+      return (Lam (makeFunctionBinding name typ) inner)

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
@@ -4,6 +4,7 @@ import Dhall.Context   (Context, empty, insert)
 import Dhall.Core
     ( Binding (..)
     , Expr (..)
+    , FunctionBinding (..)
     , Var (..)
     , normalize
     , shift
@@ -49,7 +50,7 @@ typeAt' pos ctx (Note src (Let (Binding { value = a }) _)) | pos `inside` getLet
   return (Just $ getLetIdentifier src, typ)
 
 -- "..." in a lambda expression
-typeAt' pos _ctx (Note src (Lam _ _A _)) | Just src' <- getLamIdentifier src
+typeAt' pos _ctx (Note src (Lam FunctionBinding { fbAnnotation = _A} _)) | Just src' <- getLamIdentifier src
                                          , pos `inside` src' =
   return (Just src', _A)
 
@@ -63,7 +64,7 @@ typeAt' pos ctx (Let (Binding { variable = x, value = a }) e@(Note src _)) | pos
   let a' = shift 1 (V x 0) (normalize a)
   typeAt' pos ctx (shift (-1) (V x 0) (subst (V x 0) a' e))
 
-typeAt' pos ctx (Lam x _A b@(Note src _)) | pos `inside` src = do
+typeAt' pos ctx (Lam FunctionBinding { fbVariable = x, fbAnnotation = _A} b@(Note src _)) | pos `inside` src = do
   let _A' = Dhall.Core.normalize _A
       ctx' = fmap (shift 1 (V x 0)) (insert x _A' ctx)
   typeAt' pos ctx' b
@@ -136,7 +137,7 @@ annotateLet' pos ctx (Let (Binding { variable = x, value = a }) e@(Note src _)) 
   let a' = shift 1 (V x 0) (normalize a)
   annotateLet' pos ctx (shift (-1) (V x 0) (subst (V x 0) a' e))
 
-annotateLet' pos ctx (Lam x _A b@(Note src _)) | pos `inside` src = do
+annotateLet' pos ctx (Lam FunctionBinding{ fbVariable = x, fbAnnotation = _A } b@(Note src _)) | pos `inside` src = do
   let _A' = Dhall.Core.normalize _A
       ctx' = fmap (shift 1 (V x 0)) (insert x _A' ctx)
   annotateLet' pos ctx' b

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Typing.hs
@@ -50,8 +50,9 @@ typeAt' pos ctx (Note src (Let (Binding { value = a }) _)) | pos `inside` getLet
   return (Just $ getLetIdentifier src, typ)
 
 -- "..." in a lambda expression
-typeAt' pos _ctx (Note src (Lam FunctionBinding { fbAnnotation = _A} _)) | Just src' <- getLamIdentifier src
-                                         , pos `inside` src' =
+typeAt' pos _ctx (Note src (Lam FunctionBinding { functionBindingAnnotation = _A} _))
+  | Just src' <- getLamIdentifier src
+  , pos `inside` src' =
   return (Just src', _A)
 
 -- "..." in a forall expression
@@ -64,10 +65,11 @@ typeAt' pos ctx (Let (Binding { variable = x, value = a }) e@(Note src _)) | pos
   let a' = shift 1 (V x 0) (normalize a)
   typeAt' pos ctx (shift (-1) (V x 0) (subst (V x 0) a' e))
 
-typeAt' pos ctx (Lam FunctionBinding { fbVariable = x, fbAnnotation = _A} b@(Note src _)) | pos `inside` src = do
-  let _A' = Dhall.Core.normalize _A
-      ctx' = fmap (shift 1 (V x 0)) (insert x _A' ctx)
-  typeAt' pos ctx' b
+typeAt' pos ctx (Lam FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = _A} b@(Note src _))
+  | pos `inside` src = do
+      let _A' = Dhall.Core.normalize _A
+          ctx' = fmap (shift 1 (V x 0)) (insert x _A' ctx)
+      typeAt' pos ctx' b
 
 typeAt' pos ctx (Pi x _A  _B@(Note src _)) | pos `inside` src = do
   let _A' = Dhall.Core.normalize _A
@@ -137,7 +139,7 @@ annotateLet' pos ctx (Let (Binding { variable = x, value = a }) e@(Note src _)) 
   let a' = shift 1 (V x 0) (normalize a)
   annotateLet' pos ctx (shift (-1) (V x 0) (subst (V x 0) a' e))
 
-annotateLet' pos ctx (Lam FunctionBinding{ fbVariable = x, fbAnnotation = _A } b@(Note src _)) | pos `inside` src = do
+annotateLet' pos ctx (Lam FunctionBinding{ functionBindingVariable = x, functionBindingAnnotation = _A } b@(Note src _)) | pos `inside` src = do
   let _A' = Dhall.Core.normalize _A
       ctx' = fmap (shift 1 (V x 0)) (insert x _A' ctx)
   annotateLet' pos ctx' b

--- a/dhall-nix/src/Dhall/Nix.hs
+++ b/dhall-nix/src/Dhall/Nix.hs
@@ -237,7 +237,7 @@ dhallToNix e =
     -- If any other number, then rename the variable to include the maximum
     -- depth.
     maximumDepth :: Var -> Expr s Void -> Maybe Int
-    maximumDepth v@(V x n) (Lam FunctionBinding {fbVariable = x', fbAnnotation = a} b)
+    maximumDepth v@(V x n) (Lam FunctionBinding {functionBindingVariable = x', functionBindingAnnotation = a} b)
         | x == x' =
             max (maximumDepth v a) (fmap (+ 1) (maximumDepth (V x (n + 1)) b))
     maximumDepth v@(V x n) (Pi x' a b)
@@ -272,7 +272,7 @@ dhallToNix e =
                 x' = x <> Data.Text.pack (show n)
 
     renameShadowed :: Expr s Void -> Maybe (Expr s Void)
-    renameShadowed (Lam FunctionBinding { fbVariable = x, fbAnnotation = a} b) = do
+    renameShadowed (Lam FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = a} b) = do
         (x', b') <- rename (x, b)
 
         return (Lam (Dhall.Core.makeFunctionBinding x' a) b')
@@ -294,7 +294,7 @@ dhallToNix e =
     loop (Const _) = return untranslatable
     loop (Var (V a 0)) = return (Fix (NSym a))
     loop (Var  a     ) = Left (CannotReferenceShadowedVariable a)
-    loop (Lam FunctionBinding { fbVariable = a } c) = do
+    loop (Lam FunctionBinding { functionBindingVariable = a } c) = do
         c' <- loop c
         return (Fix (NAbs (Param a) c'))
     loop (Pi _ _ _) = return untranslatable

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -161,6 +161,7 @@ import Dhall.Syntax
     ( Chunks (..)
     , DhallDouble (..)
     , Expr (..)
+    , FunctionBinding (..)
     , RecordField (..)
     , Var (..)
     )
@@ -1361,10 +1362,10 @@ instance (Functor f, FromDhall (f (Result f))) => FromDhall (Fix f) where
           where
             die = typeError expected expr0
 
-            extract0 (Lam x _ expr) = extract1 (rename x "result" expr)
+            extract0 (Lam (FunctionBinding { fbVariable = x }) expr) = extract1 (rename x "result" expr)
             extract0  _             = die
 
-            extract1 (Lam y _ expr) = extract2 (rename y "Make" expr)
+            extract1 (Lam (FunctionBinding { fbVariable = y }) expr) = extract2 (rename y "Make" expr)
             extract1  _             = die
 
             extract2 expr = fmap resultToFix (Dhall.extract (autoWith inputNormalizer) expr)

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -1362,10 +1362,12 @@ instance (Functor f, FromDhall (f (Result f))) => FromDhall (Fix f) where
           where
             die = typeError expected expr0
 
-            extract0 (Lam (FunctionBinding { fbVariable = x }) expr) = extract1 (rename x "result" expr)
+            extract0 (Lam (FunctionBinding { functionBindingVariable = x }) expr) =
+                extract1 (rename x "result" expr)
             extract0  _             = die
 
-            extract1 (Lam (FunctionBinding { fbVariable = y }) expr) = extract2 (rename y "Make" expr)
+            extract1 (Lam (FunctionBinding { functionBindingVariable = y }) expr) =
+                extract2 (rename y "Make" expr)
             extract1  _             = die
 
             extract2 expr = fmap resultToFix (Dhall.extract (autoWith inputNormalizer) expr)

--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -39,6 +39,7 @@ import Dhall.Syntax
     , Expr (..)
     , File (..)
     , FilePrefix (..)
+    , FunctionBinding (..)
     , Import (..)
     , ImportHashed (..)
     , ImportMode (..)
@@ -256,7 +257,7 @@ decodeExpressionInternal decodeEmbed = go
 
                                         b <- go
 
-                                        return (Lam "_" _A b)
+                                        return (Lam (Syntax.makeFunctionBinding "_" _A) b)
 
                                     4 -> do
                                         x <- Decoding.decodeString
@@ -269,7 +270,7 @@ decodeExpressionInternal decodeEmbed = go
 
                                         b <- go
 
-                                        return (Lam x _A b)
+                                        return (Lam (Syntax.makeFunctionBinding x _A) b)
 
                                     _ ->
                                         die ("Incorrect number of tokens used to encode a λ expression: " <> show len)
@@ -706,13 +707,13 @@ encodeExpressionInternal encodeEmbed = go
           where
             (function, arguments) = unApply a
 
-        Lam "_" _A b ->
+        Lam (FunctionBinding { fbVariable = "_", fbAnnotation = _A }) b ->
             encodeList3
                 (Encoding.encodeInt 1)
                 (go _A)
                 (go b)
 
-        Lam x _A b ->
+        Lam (FunctionBinding { fbVariable = x, fbAnnotation = _A }) b ->
             encodeList4
                 (Encoding.encodeInt 1)
                 (Encoding.encodeString x)

--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -707,13 +707,13 @@ encodeExpressionInternal encodeEmbed = go
           where
             (function, arguments) = unApply a
 
-        Lam (FunctionBinding { fbVariable = "_", fbAnnotation = _A }) b ->
+        Lam (FunctionBinding { functionBindingVariable = "_", functionBindingAnnotation = _A }) b ->
             encodeList3
                 (Encoding.encodeInt 1)
                 (go _A)
                 (go b)
 
-        Lam (FunctionBinding { fbVariable = x, fbAnnotation = _A }) b ->
+        Lam (FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = _A }) b ->
             encodeList4
                 (Encoding.encodeInt 1)
                 (Encoding.encodeString x)

--- a/dhall/src/Dhall/Core.hs
+++ b/dhall/src/Dhall/Core.hs
@@ -27,6 +27,8 @@ module Dhall.Core (
     , PreferAnnotation(..)
     , RecordField(..)
     , makeRecordField
+    , FunctionBinding(..)
+    , makeFunctionBinding
     , Expr(..)
 
     -- * Normalization
@@ -55,6 +57,7 @@ module Dhall.Core (
     , chunkExprs
     , bindingExprs
     , recordFieldExprs
+    , functionBindingExprs
 
     -- * Let-blocks
     , multiLet

--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -647,8 +647,8 @@ diff l@(Lam {}) r@(Lam {}) =
     enclosed' "  " (rarrow <> " ") (docs l r)
   where
     docs
-        (Lam (FunctionBinding { fbVariable = aL, fbAnnotation = bL }) cL)
-        (Lam (FunctionBinding { fbVariable = aR, fbAnnotation = bR }) cR) =
+        (Lam (FunctionBinding { functionBindingVariable = aL, functionBindingAnnotation = bL }) cL)
+        (Lam (FunctionBinding { functionBindingVariable = aR, functionBindingAnnotation = bR }) cR) =
         Data.List.NonEmpty.cons (align doc) (docs cL cR)
       where
         doc =   lambda

--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -32,6 +32,7 @@ import Dhall.Syntax
     , Const (..)
     , DhallDouble (..)
     , Expr (..)
+    , FunctionBinding (..)
     , RecordField (..)
     , Var (..)
     )
@@ -645,7 +646,9 @@ diff :: (Eq a, Pretty a) => Expr Void a -> Expr Void a -> Diff
 diff l@(Lam {}) r@(Lam {}) =
     enclosed' "  " (rarrow <> " ") (docs l r)
   where
-    docs (Lam aL bL cL) (Lam aR bR cR) =
+    docs
+        (Lam (FunctionBinding { fbVariable = aL, fbAnnotation = bL }) cL)
+        (Lam (FunctionBinding { fbVariable = aR, fbAnnotation = bR }) cR) =
         Data.List.NonEmpty.cons (align doc) (docs cL cR)
       where
         doc =   lambda

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -390,7 +390,7 @@ eval !env t0 =
             VConst k
         Var v ->
             vVar env v
-        Lam (FunctionBinding { fbVariable = x, fbAnnotation = a }) t ->
+        Lam (FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = a }) t ->
             VLam (eval env a) (Closure x env t)
         Pi x a b ->
             VPi (eval env a) (Closure x env b)

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -173,6 +173,7 @@ import Dhall.Syntax
     , RecordField (..)
     , URL (..)
     , bindingExprs
+    , functionBindingExprs
     , recordFieldExprs
     )
 
@@ -1074,6 +1075,7 @@ loadWith expr₀ = case expr₀ of
   Let a b              -> Let <$> bindingExprs loadWith a <*> loadWith b
   Record m             -> Record <$> traverse (recordFieldExprs loadWith) m
   RecordLit m          -> RecordLit <$> traverse (recordFieldExprs loadWith) m
+  Lam a b              -> Lam <$> functionBindingExprs loadWith a <*> loadWith b
   expression           -> Syntax.unsafeSubExpressions loadWith expression
 
 -- | Resolve all imports within an expression

--- a/dhall/src/Dhall/Normalize.hs
+++ b/dhall/src/Dhall/Normalize.hs
@@ -202,7 +202,7 @@ boundedType _                = False
 
 >>> mfb = Syntax.makeFunctionBinding
 >>> alphaNormalize (Lam (mfb "a" (Const Type)) (Lam (mfb "b" (Const Type)) (Lam (mfb "x" "a") (Lam (mfb "y" "b") "x"))))
-Lam (FunctionBinding {fbSrc0 = Nothing, fbVariable = "_", fbSrc1 = Nothing, fbSrc2 = Nothing, fbAnnotation = Const Type}) (Lam (FunctionBinding {fbSrc0 = Nothing, fbVariable = "_", fbSrc1 = Nothing, fbSrc2 = Nothing, fbAnnotation = Const Type}) (Lam (FunctionBinding {fbSrc0 = Nothing, fbVariable = "_", fbSrc1 = Nothing, fbSrc2 = Nothing, fbAnnotation = Var (V "_" 1)}) (Lam (FunctionBinding {fbSrc0 = Nothing, fbVariable = "_", fbSrc1 = Nothing, fbSrc2 = Nothing, fbAnnotation = Var (V "_" 1)}) (Var (V "_" 1)))))
+Lam (FunctionBinding {functionBindingSrc0 = Nothing, functionBindingVariable = "_", functionBindingSrc1 = Nothing, functionBindingSrc2 = Nothing, functionBindingAnnotation = Const Type}) (Lam (FunctionBinding {functionBindingSrc0 = Nothing, functionBindingVariable = "_", functionBindingSrc1 = Nothing, functionBindingSrc2 = Nothing, functionBindingAnnotation = Const Type}) (Lam (FunctionBinding {functionBindingSrc0 = Nothing, functionBindingVariable = "_", functionBindingSrc1 = Nothing, functionBindingSrc2 = Nothing, functionBindingAnnotation = Var (V "_" 1)}) (Lam (FunctionBinding {functionBindingSrc0 = Nothing, functionBindingVariable = "_", functionBindingSrc1 = Nothing, functionBindingSrc2 = Nothing, functionBindingAnnotation = Var (V "_" 1)}) (Var (V "_" 1)))))
 
     α-normalization does not affect free variables:
 
@@ -261,7 +261,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
  loop e =  case e of
     Const k -> pure (Const k)
     Var v -> pure (Var v)
-    Lam (FunctionBinding { fbVariable = x, fbAnnotation = _A }) b ->
+    Lam (FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = _A }) b ->
         Lam <$> (Syntax.makeFunctionBinding x <$> _A') <*> b'
       where
         _A' = loop _A
@@ -738,7 +738,7 @@ isNormalized e0 = loop (Syntax.denote e0)
     loop e = case e of
       Const _ -> True
       Var _ -> True
-      Lam (Syntax.fbAnnotation -> a) b -> loop a && loop b
+      Lam (Syntax.functionBindingAnnotation -> a) b -> loop a && loop b
       Pi _ a b -> loop a && loop b
       App f a -> loop f && loop a && case App f a of
           App (Lam _ _) _ -> False

--- a/dhall/src/Dhall/Normalize.hs
+++ b/dhall/src/Dhall/Normalize.hs
@@ -922,7 +922,7 @@ isNormalized e0 = loop (Syntax.denote e0)
 True
 >>> "x" `freeIn` "y"
 False
->>> "x" `freeIn` Lam (mfb "x" (Const Type)) "x"
+>>> "x" `freeIn` Lam (Syntax.makeFunctionBinding "x" (Const Type)) "x"
 False
 -}
 freeIn :: Eq a => Var -> Expr s a -> Bool

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -137,11 +137,11 @@ parsers embedded = Parsers {..}
             _lambda
             whitespace
             _openParens
-            whitespace
+            src0 <- src whitespace
             a <- label
-            whitespace
+            src1 <- src whitespace
             _colon
-            nonemptyWhitespace
+            src2 <- src nonemptyWhitespace
             b <- expression
             whitespace
             _closeParens
@@ -149,7 +149,7 @@ parsers embedded = Parsers {..}
             _arrow
             whitespace
             c <- expression
-            return (Lam a b c)
+            return (Lam (FunctionBinding (Just src0) a (Just src1) (Just src2) b) c)
 
         alternative1 = do
             try (_if *> nonemptyWhitespace)

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -536,7 +536,7 @@ prettyCharacterSet characterSet expression =
     prettyExpression a0@(Lam _ _) =
         arrows characterSet (docs a0)
       where
-        docs (Lam (FunctionBinding { fbVariable = a, fbAnnotation = b }) c) =
+        docs (Lam (FunctionBinding { functionBindingVariable = a, functionBindingAnnotation = b }) c) =
             Pretty.group (Pretty.flatAlt long short) : docs c
           where
             long =  (lambda characterSet <> space)

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -533,10 +533,11 @@ prettyCharacterSet :: Pretty a => CharacterSet -> Expr Src a -> Doc Ann
 prettyCharacterSet characterSet expression =
     Pretty.group (prettyExpression expression)
   where
-    prettyExpression a0@(Lam _ _ _) =
+    prettyExpression a0@(Lam _ _) =
         arrows characterSet (docs a0)
       where
-        docs (Lam a b c) = Pretty.group (Pretty.flatAlt long short) : docs c
+        docs (Lam (FunctionBinding { fbVariable = a, fbAnnotation = b }) c) =
+            Pretty.group (Pretty.flatAlt long short) : docs c
           where
             long =  (lambda characterSet <> space)
                 <>  Pretty.align

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -339,15 +339,9 @@ data FunctionBinding s a = FunctionBinding
     , fbAnnotation :: Expr s a
     } deriving (Data, Eq, Foldable, Functor, Generic, Lift, NFData, Ord, Show, Traversable)
 
+-- | Smart constructor for 'FunctionBinding' with no src information
 makeFunctionBinding :: Text -> Expr s a -> FunctionBinding s a
 makeFunctionBinding l t = FunctionBinding Nothing l Nothing Nothing t
-
--- pattern Lam :: Text -> Expr s a -> Expr s a -> Expr s a
--- pattern Lam l t e <- Lam (FunctionBinding _ l _ _ t) e
---   where
---     Lam l t e = Lam (FunctionBinding Nothing l Nothing Nothing t) e
-
--- {-# COMPLETE Lam #-}
 
 instance Bifunctor FunctionBinding where
     first k (FunctionBinding src0 label src1 src2 type_) =

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -561,19 +561,6 @@ data Expr s a
 -- NB: If you add a constructor to Expr, please also update the Arbitrary
 -- instance in Dhall.Test.QuickCheck.
 
--- {-# COMPLETE Lam, Var, Pi, App, Let, Annot, Bool, BoolLit, BoolAnd,
---              BoolOr, BoolEQ, BoolNE, BoolIf, Natural, NaturalLit, NaturalFold,
---              NaturalBuild, NaturalIsZero, NaturalEven, NaturalOdd,
---              NaturalToInteger, NaturalShow, NaturalSubtract, NaturalPlus,
---              NaturalTimes, Integer, IntegerLit, IntegerClamp, IntegerNegate,
---              IntegerShow, IntegerToDouble, Double, DoubleLit, DoubleShow, Text,
---              TextLit, TextAppend, TextShow, List, ListLit, ListAppend,
---              ListBuild, ListFold, ListLength, ListHead, ListLast, ListIndexed,
---              ListReverse, Optional, Some, None, Record, RecordLit, Union,
---              Combine, CombineTypes, Prefer, RecordCompletion, Merge, ToMap,
---              Field, Project, Assert, Equivalent, With, Note, ImportAlt, Embed
---              #-}
-
 -- | This instance encodes what the Dhall standard calls an \"exact match\"
 -- between two expressions.
 --

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -325,18 +325,18 @@ For example,
 > λ({- A -} a {- B -} : {- C -} T) -> e
 
 will be instantiated as follows:
-* @fbSrc0@ corresponds to the @A@ comment
-* @fbVariable@ is @a@
-* @fbSrc1@ corresponds to the @B@ comment
-* @fbSrc2@ corresponds to the @C@ comment
-* @fbAnnotation@ is @T@
+* @functionBindingSrc0@ corresponds to the @A@ comment
+* @functionBindingVariable@ is @a@
+* @functionBindingSrc1@ corresponds to the @B@ comment
+* @functionBindingSrc2@ corresponds to the @C@ comment
+* @functionBindingAnnotation@ is @T@
 -}
 data FunctionBinding s a = FunctionBinding
-    { fbSrc0 :: Maybe s
-    , fbVariable :: Text
-    , fbSrc1 :: Maybe s
-    , fbSrc2 :: Maybe s
-    , fbAnnotation :: Expr s a
+    { functionBindingSrc0 :: Maybe s
+    , functionBindingVariable :: Text
+    , functionBindingSrc1 :: Maybe s
+    , functionBindingSrc2 :: Maybe s
+    , functionBindingAnnotation :: Expr s a
     } deriving (Data, Eq, Foldable, Functor, Generic, Lift, NFData, Ord, Show, Traversable)
 
 -- | Smart constructor for 'FunctionBinding' with no src information

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -56,6 +56,7 @@ import Dhall.Syntax
     , Chunks (..)
     , Const (..)
     , Expr (..)
+    , FunctionBinding (..)
     , PreferAnnotation (..)
     , RecordField (..)
     , Var (..)
@@ -227,7 +228,7 @@ infer typer = loop
 
             go types n0
 
-        Lam x _A b -> do
+        Lam (FunctionBinding { fbVariable = x, fbAnnotation = _A}) b -> do
             tA' <- loop ctx _A
 
             case tA' of

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -228,7 +228,7 @@ infer typer = loop
 
             go types n0
 
-        Lam (FunctionBinding { fbVariable = x, fbAnnotation = _A}) b -> do
+        Lam (FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = _A}) b -> do
             tA' <- loop ctx _A
 
             case tA' of


### PR DESCRIPTION
This partially solves #1978 

---

`Lam` is ready. I caught the whitespace that I thought would make more sense to write comments. Check the haddocks for more information. I did not catch the whitespace between a `_lambda` and an open parenthesis because I don't see why would somebody write comments there, but if you want me to handle the whitespace there as well please let me know.

An example of running this would be to:

```
$ dhall haskell-syntax-tree --noted <<< '\( {- A -} x {- B -} : {- C -} A) -> B'
...
    ( Lam 
        ( FunctionBinding 
            { fbSrc0 = Just 
                ( Src 
                    { srcStart = SourcePos 
                        { sourceName = "(input)" 
                        , sourceLine = Pos 1
                        , sourceColumn = Pos 3
                        } 
                    , srcEnd = SourcePos 
                        { sourceName = "(input)" 
                        , sourceLine = Pos 1
                        , sourceColumn = Pos 12
                        } 
                    , srcText = " {- A -} " 
                    } 
                )
            , fbVariable = "x" 
            , fbSrc1 = Just 
                ( Src 
                    { srcStart = SourcePos 
                        { sourceName = "(input)" 
                        , sourceLine = Pos 1
                        , sourceColumn = Pos 13
                        } 
                    , srcEnd = SourcePos 
                        { sourceName = "(input)" 
                        , sourceLine = Pos 1
                        , sourceColumn = Pos 22
                        } 
                    , srcText = " {- B -} " 
                    } 
                )
            , fbSrc2 = Just 
                ( Src 
                    { srcStart = SourcePos 
                        { sourceName = "(input)" 
                        , sourceLine = Pos 1
                        , sourceColumn = Pos 23
                        } 
                    , srcEnd = SourcePos 
                        { sourceName = "(input)" 
                        , sourceLine = Pos 1
                        , sourceColumn = Pos 32
                        } 
                    , srcText = " {- C -} " 
                    } 
                )
            , fbAnnotation = Note 
                ( Src 
                    { srcStart = SourcePos 
                        { sourceName = "(input)" 
                        , sourceLine = Pos 1
                        , sourceColumn = Pos 32
                        } 
                    , srcEnd = SourcePos 
                        { sourceName = "(input)" 
                        , sourceLine = Pos 1
                        , sourceColumn = Pos 33
                        } 
                    , srcText = "A" 
                    } 
                ) 
                ( Var ( V "A" 0 ) )
            } 
        ) 
...
```

Regarding `Pi`, I noticed that there are two possible ways of creating it:

```
    -- | > Pi (FunctionBinding _ "_" _ _ A) B       ~        A  -> B
    --   > Pi (FunctionBinding _ x _ _ A) B         ~  ∀(x : A) -> B
```

but I feel that using `FunctionBinding` on the `A -> B` case isn't right because `FunctionBinding` should be used for the later case

I see we can do the following to tackle this:

* A more strongly-typed solution is to add another constructor, say `PiFree`, that corresponds to `A -> B`. The counterpart of this approach is that we need to handle carefully other usages, although it's not so complicated
* A weakly-typed solution is to use `Either (NoBinding s a) (FunctionBinding s a)` on the second parameter of the `Pi` constructor and use the `Left` constructor for the `A -> B`. `NoBinding` would include the prefix whitespace and `A`, although I don't need to handle that case on the jump-to-definition context.
* Enforce `Nothing` on the `FunctionBinding`'s `Maybe Src`s on the `A -> B`.

Since it looks like preserving whitespace for `Pi` seems like more work than what I thought, I can add it in another PR to keep this one small