### PR TITLE
feat(dhall-docs): add jump to definition on lam parameters

### DIFF
--- a/dhall-docs/src/Dhall/data/index.css
+++ b/dhall-docs/src/Dhall/data/index.css
@@ -1,11 +1,3 @@
-/*
-    primary-color: #C4C4C4
-    secondary-color: #EBEBEB
-    accent-color1: #FFA632
-    accent-color2: #008489
-    accent-color3: #914669
-*/
-
 /******** Common rules ********/
 
 body {
@@ -156,6 +148,10 @@ h2.doc-title {
     color: #333333;
 }
 
+.source-code span.variable-decl {
+    border-bottom: 1px solid #bdbdbd;
+}
+
 .source-code a {
     transition: 0s;
     font-family: 'Fira Code', monospace;
@@ -164,6 +160,7 @@ h2.doc-title {
 .source-code a.variable-use {
     text-decoration: none;
     color: inherit;
+    border-bottom: 1px solid #bdbdbd;
 }
 
 .source-code .highlighted {
@@ -218,21 +215,6 @@ body.dark-mode {
     color: #D4D4D4;
 }
 
-.dark-mode .source-code span.dhall-keyword {
-    color: #569CD6;
-}
-
-.dark-mode .source-code span.dhall-syntax {
-    color: #C586C0;
-}
-
-.dark-mode .source-code span.dhall-literal {
-    color: #B5CEA8;
-}
-
-.dark-mode .source-code span.dhall-builtin {
-    color: #4EC9B0;
-}
 
 .dark-mode a.copy-to-clipboard {
     color: #bdbdbd !important;

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
@@ -1,0 +1,87 @@
+<!DOCTYPE HTML>
+<html
+  ><head
+    ><title
+    >/JumpToLamBindingComplex.dhall</title
+    ><link href="index.css" type="text/css" rel="stylesheet"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
+            type="text/css" rel="stylesheet"
+    /><script src="index.js" type="text/javascript"
+    /><meta charset="UTF-8"/></head
+  ><body
+    ><div class="nav-bar"
+      ><img src="dhall-icon.svg" class="dhall-icon"
+      /><p class="package-title"
+      >test-package</p
+      ><div class="nav-bar-content-divider"
+      /><a id="switch-light-dark-mode" class="nav-option"
+      >Switch Light/Dark Mode</a></div
+    ><div class="main-container"
+      ><h2 class="doc-title"
+        ><span class="crumb-divider"
+        >/</span
+        ><a href="index.html"
+        >test-package</a
+        ><span class="crumb-divider"
+        >/</span
+        ><span href="index.html" class="title-crumb"
+        >JumpToLamBindingComplex.dhall</span></h2
+      ><a data-path="/JumpToLamBindingComplex.dhall"
+          class="copy-to-clipboard"
+        ><i
+          ><small
+          >Copy path to clipboard</small></i></a
+      ><br
+      /><div class="doc-contents"
+        ><p
+        >A complex example of jump-to-definition on let-bindings</p>
+</div
+      ><h3
+      >Source</h3
+      ><div class="source-code"
+        ><pre
+          >{-|<br
+          />A complex example of jump-to-definition on let-bindings<br
+          />-}<br
+          />let <span id="var4-5" data-variable="var4-5"
+                      class="variable-decl"
+          >fun</span
+          > =<br
+          />    λ(<span id="var5-7" data-variable="var5-7"
+                        class="variable-decl"
+          >a</span
+          > : Text) -&gt;<br
+          />    λ(<span id="var6-7" data-variable="var6-7"
+                        class="variable-decl"
+          >b</span
+          > : Text) -&gt;<br
+          />    λ(<span id="var7-7" data-variable="var7-7"
+                        class="variable-decl"
+          >c</span
+          > : Text) -&gt;<br
+          />    λ(<span id="var8-7" data-variable="var8-7"
+                        class="variable-decl"
+          >d</span
+          > : Text) -&gt;<br
+          />    [ <a href="#var5-7" data-variable="var5-7"
+                     class="variable-use"
+          >a</a
+          > ++ <a href="#var6-7" data-variable="var6-7" class="variable-use"
+          >b</a
+          >, <a href="#var6-7" data-variable="var6-7" class="variable-use"
+          >b</a
+          > ++ <a href="#var7-7" data-variable="var7-7" class="variable-use"
+          >c</a
+          >, <a href="#var7-7" data-variable="var7-7" class="variable-use"
+          >c</a
+          > ++ <a href="#var8-7" data-variable="var8-7" class="variable-use"
+          >d</a
+          >, <a href="#var8-7" data-variable="var8-7" class="variable-use"
+          >d</a
+          > ++ <a href="#var5-7" data-variable="var5-7" class="variable-use"
+          >a</a
+          > ]<br
+          /><br
+          />in <a href="#var4-5" data-variable="var4-5" class="variable-use"
+          >fun</a
+          ><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
@@ -1,0 +1,127 @@
+<!DOCTYPE HTML>
+<html
+  ><head
+    ><title
+    >/JumpToLamBindingSimple.dhall</title
+    ><link href="index.css" type="text/css" rel="stylesheet"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
+            type="text/css" rel="stylesheet"
+    /><script src="index.js" type="text/javascript"
+    /><meta charset="UTF-8"/></head
+  ><body
+    ><div class="nav-bar"
+      ><img src="dhall-icon.svg" class="dhall-icon"
+      /><p class="package-title"
+      >test-package</p
+      ><div class="nav-bar-content-divider"
+      /><a id="switch-light-dark-mode" class="nav-option"
+      >Switch Light/Dark Mode</a></div
+    ><div class="main-container"
+      ><h2 class="doc-title"
+        ><span class="crumb-divider"
+        >/</span
+        ><a href="index.html"
+        >test-package</a
+        ><span class="crumb-divider"
+        >/</span
+        ><span href="index.html" class="title-crumb"
+        >JumpToLamBindingSimple.dhall</span></h2
+      ><a data-path="/JumpToLamBindingSimple.dhall"
+          class="copy-to-clipboard"
+        ><i
+          ><small
+          >Copy path to clipboard</small></i></a
+      ><br
+      /><div class="doc-contents"
+        ><p
+          >This examples shows a demo of jumping to a let-binding definition. If you hover
+the <code
+          >a</code> paramter, the front-end will highlight all of its usages and if you
+click it you will navigate to its definition.</p
+        >
+<p
+        >The amount of empty lines left are intentional to show you how the browser jumps
+to the declaration of a</p>
+</div
+      ><h3
+      >Source</h3
+      ><div class="source-code"
+        ><pre
+          >{-|<br
+          />This examples shows a demo of jumping to a let-binding definition. If you hover<br
+          />the `a` paramter, the front-end will highlight all of its usages and if you<br
+          />click it you will navigate to its definition.<br
+          /><br
+          />The amount of empty lines left are intentional to show you how the browser jumps<br
+          />to the declaration of a<br
+          />-}<br
+          />let <span id="var9-5" data-variable="var9-5"
+                      class="variable-decl"
+          >fun</span
+          > = \(<span id="var9-13" data-variable="var9-13"
+                      class="variable-decl"
+          >v</span
+          > : Text) -&gt;<br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          /><br
+          />    <a href="#var9-13" data-variable="var9-13"
+                   class="variable-use"
+          >v</a
+          ><br
+          /><br
+          /><br
+          /><br
+          />in <a href="#var9-5" data-variable="var9-5" class="variable-use"
+          >fun</a
+          ><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
@@ -1,0 +1,88 @@
+<!DOCTYPE HTML>
+<html
+  ><head
+    ><title
+    >/JumpToLamBindingWithIndex.dhall</title
+    ><link href="index.css" type="text/css" rel="stylesheet"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
+            type="text/css" rel="stylesheet"
+    /><script src="index.js" type="text/javascript"
+    /><meta charset="UTF-8"/></head
+  ><body
+    ><div class="nav-bar"
+      ><img src="dhall-icon.svg" class="dhall-icon"
+      /><p class="package-title"
+      >test-package</p
+      ><div class="nav-bar-content-divider"
+      /><a id="switch-light-dark-mode" class="nav-option"
+      >Switch Light/Dark Mode</a></div
+    ><div class="main-container"
+      ><h2 class="doc-title"
+        ><span class="crumb-divider"
+        >/</span
+        ><a href="index.html"
+        >test-package</a
+        ><span class="crumb-divider"
+        >/</span
+        ><span href="index.html" class="title-crumb"
+        >JumpToLamBindingWithIndex.dhall</span></h2
+      ><a data-path="/JumpToLamBindingWithIndex.dhall"
+          class="copy-to-clipboard"
+        ><i
+          ><small
+          >Copy path to clipboard</small></i></a
+      ><br
+      /><div class="doc-contents"
+        ><p
+          >On this example, we introduce the <code
+          >a</code
+          > variable in the two parameters of the
+<code
+          >fun</code> function and the jump-to-definition engine correctly highlights the usage
+when indexes are used</p>
+</div
+      ><h3
+      >Examples</h3
+      ><div class="source-code code-examples"
+        ><pre
+          >fun &quot;a&quot; &quot;b&quot; ≡ [ &quot;ab&quot; ]<br/></pre></div
+      ><h3
+      >Source</h3
+      ><div class="source-code"
+        ><pre
+          >{-|<br
+          />On this example, we introduce the `a` variable in the two parameters of the<br
+          />`fun` function and the jump-to-definition engine correctly highlights the usage<br
+          />when indexes are used<br
+          />-}<br
+          />let <span id="var6-5" data-variable="var6-5"
+                      class="variable-decl"
+          >fun</span
+          > =<br
+          />    λ(<span id="var7-7" data-variable="var7-7"
+                        class="variable-decl"
+          >a</span
+          > : Text) -&gt;<br
+          />    λ(<span id="var8-7" data-variable="var8-7"
+                        class="variable-decl"
+          >a</span
+          > : Text) -&gt;<br
+          />    [ <a href="#var7-7" data-variable="var7-7"
+                     class="variable-use"
+          >a@1</a
+          > ++ <a href="#var8-7" data-variable="var8-7" class="variable-use"
+          >a@0</a
+          > ]<br
+          /><br
+          />let <span id="var11-5" data-variable="var11-5"
+                      class="variable-decl"
+          >example0</span
+          > = assert : <a href="#var6-5" data-variable="var6-5"
+                          class="variable-use"
+          >fun</a
+          > &quot;a&quot; &quot;b&quot; === [&quot;ab&quot;]<br
+          /><br
+          />in <a href="#var6-5" data-variable="var6-5" class="variable-use"
+          >fun</a
+          ><br
+          /><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
@@ -1,0 +1,83 @@
+<!DOCTYPE HTML>
+<html
+  ><head
+    ><title
+    >/JumpToLamBindingWithQuotes.dhall</title
+    ><link href="index.css" type="text/css" rel="stylesheet"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
+            type="text/css" rel="stylesheet"
+    /><script src="index.js" type="text/javascript"
+    /><meta charset="UTF-8"/></head
+  ><body
+    ><div class="nav-bar"
+      ><img src="dhall-icon.svg" class="dhall-icon"
+      /><p class="package-title"
+      >test-package</p
+      ><div class="nav-bar-content-divider"
+      /><a id="switch-light-dark-mode" class="nav-option"
+      >Switch Light/Dark Mode</a></div
+    ><div class="main-container"
+      ><h2 class="doc-title"
+        ><span class="crumb-divider"
+        >/</span
+        ><a href="index.html"
+        >test-package</a
+        ><span class="crumb-divider"
+        >/</span
+        ><span href="index.html" class="title-crumb"
+        >JumpToLamBindingWithQuotes.dhall</span></h2
+      ><a data-path="/JumpToLamBindingWithQuotes.dhall"
+          class="copy-to-clipboard"
+        ><i
+          ><small
+          >Copy path to clipboard</small></i></a
+      ><br
+      /><div class="doc-contents"
+        ><p
+        >This tests shows that the feature works for quoted vars on function parameters
+as well</p>
+</div
+      ><h3
+      >Examples</h3
+      ><div class="source-code code-examples"
+        ><pre
+          >fun &quot;a&quot; &quot;b&quot; ≡ [ &quot;ab&quot; ]<br/></pre></div
+      ><h3
+      >Source</h3
+      ><div class="source-code"
+        ><pre
+          >{-|<br
+          />This tests shows that the feature works for quoted vars on function parameters<br
+          />as well<br
+          />-}<br
+          />let <span id="var5-5" data-variable="var5-5"
+                      class="variable-decl"
+          >fun</span
+          > =<br
+          />    λ(<span id="var6-7" data-variable="var6-7"
+                        class="variable-decl"
+          >`param 1`</span
+          > : Text) -&gt;<br
+          />    λ(<span id="var7-7" data-variable="var7-7"
+                        class="variable-decl"
+          >`param 2`</span
+          > : Text) -&gt;<br
+          />    [ <a href="#var6-7" data-variable="var6-7"
+                     class="variable-use"
+          >`param 1`</a
+          > ++ <a href="#var7-7" data-variable="var7-7" class="variable-use"
+          >`param 2`</a
+          > ]<br
+          /><br
+          />let <span id="var10-5" data-variable="var10-5"
+                      class="variable-decl"
+          >example0</span
+          > = assert : <a href="#var5-5" data-variable="var5-5"
+                          class="variable-use"
+          >fun</a
+          > &quot;a&quot; &quot;b&quot; === [&quot;ab&quot;]<br
+          /><br
+          />in <a href="#var5-5" data-variable="var5-5" class="variable-use"
+          >fun</a
+          ><br
+          /><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
@@ -1,0 +1,88 @@
+<!DOCTYPE HTML>
+<html
+  ><head
+    ><title
+    >/JumpToLamBindingWithShadowing.dhall</title
+    ><link href="index.css" type="text/css" rel="stylesheet"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
+            type="text/css" rel="stylesheet"
+    /><script src="index.js" type="text/javascript"
+    /><meta charset="UTF-8"/></head
+  ><body
+    ><div class="nav-bar"
+      ><img src="dhall-icon.svg" class="dhall-icon"
+      /><p class="package-title"
+      >test-package</p
+      ><div class="nav-bar-content-divider"
+      /><a id="switch-light-dark-mode" class="nav-option"
+      >Switch Light/Dark Mode</a></div
+    ><div class="main-container"
+      ><h2 class="doc-title"
+        ><span class="crumb-divider"
+        >/</span
+        ><a href="index.html"
+        >test-package</a
+        ><span class="crumb-divider"
+        >/</span
+        ><span href="index.html" class="title-crumb"
+        >JumpToLamBindingWithShadowing.dhall</span></h2
+      ><a data-path="/JumpToLamBindingWithShadowing.dhall"
+          class="copy-to-clipboard"
+        ><i
+          ><small
+          >Copy path to clipboard</small></i></a
+      ><br
+      /><div class="doc-contents"
+        ><p
+          >On this example, the first parameter <code
+          >a</code
+          > is shadowed with the second declaration.
+The jump-to-definintion on the usage of <code
+          >a</code> should not highlight the first declaration,
+and interacting with the first declaration should not change the others</p>
+</div
+      ><h3
+      >Examples</h3
+      ><div class="source-code code-examples"
+        ><pre
+          >fun &quot;a&quot; &quot;b&quot; ≡ [ &quot;bb&quot; ]<br/></pre></div
+      ><h3
+      >Source</h3
+      ><div class="source-code"
+        ><pre
+          >{-|<br
+          />On this example, the first parameter `a` is shadowed with the second declaration.<br
+          />The jump-to-definintion on the usage of `a` should not highlight the first declaration,<br
+          />and interacting with the first declaration should not change the others<br
+          />-}<br
+          />let <span id="var6-5" data-variable="var6-5"
+                      class="variable-decl"
+          >fun</span
+          > =<br
+          />    λ(<span id="var7-7" data-variable="var7-7"
+                        class="variable-decl"
+          >a</span
+          > : Text) -&gt;<br
+          />    λ(<span id="var8-7" data-variable="var8-7"
+                        class="variable-decl"
+          >a</span
+          > : Text) -&gt;<br
+          />    [ <a href="#var8-7" data-variable="var8-7"
+                     class="variable-use"
+          >a</a
+          > ++ <a href="#var8-7" data-variable="var8-7" class="variable-use"
+          >a</a
+          > ]<br
+          /><br
+          />let <span id="var11-5" data-variable="var11-5"
+                      class="variable-decl"
+          >example0</span
+          > = assert : <a href="#var6-5" data-variable="var6-5"
+                          class="variable-use"
+          >fun</a
+          > &quot;a&quot; &quot;b&quot; === [&quot;bb&quot;]<br
+          /><br
+          />in <a href="#var6-5" data-variable="var6-5" class="variable-use"
+          >fun</a
+          ><br
+          /><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
@@ -46,12 +46,17 @@
           />let <span id="var4-5" data-variable="var4-5"
                       class="variable-decl"
           >f</span
-          > = \(f : Natural) -&gt;<br
+          > = \(<span id="var4-11" data-variable="var4-11"
+                      class="variable-decl"
+          >f</span
+          > : Natural) -&gt;<br
           />    let <span id="var5-9" data-variable="var5-9"
                           class="variable-decl"
           >a</span
-          > = 1 in f + <a href="#var5-9" data-variable="var5-9"
-                          class="variable-use"
+          > = 1 in <a href="#var4-11" data-variable="var4-11"
+                      class="variable-use"
+          >f</a
+          > + <a href="#var5-9" data-variable="var5-9" class="variable-use"
           >a</a
           ><br
           /><br

--- a/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
@@ -55,5 +55,12 @@
           /><br
           />in <a href="#var6-5" data-variable="var6-5" class="variable-use"
           >List/generate</a
-          > 10 Text (\(n : Natural) -&gt; &quot;Result #${Natural/show n}&quot;)<br
+          > 10 Text (\(<span id="var8-29" data-variable="var8-29"
+                             class="variable-decl"
+          >n</span
+          > : Natural) -&gt; &quot;Result #${Natural/show <a href="#var8-29"
+                                                             data-variable="var8-29"
+                                                             class="variable-use"
+          >n</a
+          >}&quot;)<br
           /><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/Pair.dhall.html
+++ b/dhall-docs/tasty/data/golden/Pair.dhall.html
@@ -52,7 +52,19 @@
           />  : forall(A: Type) -- | Type of first position<br
           />  -&gt; forall(B: Type) -- | Type of second position<br
           />  -&gt; Type<br
-          />  = λ(A: Type) -&gt; λ(B: Type) -&gt; {first: A, second: B}<br
+          />  = λ(<span id="var10-7" data-variable="var10-7"
+                        class="variable-decl"
+          >A</span
+          >: Type) -&gt; λ(<span id="var10-21" data-variable="var10-21"
+                                 class="variable-decl"
+          >B</span
+          >: Type) -&gt; {first: <a href="#var10-7" data-variable="var10-7"
+                                    class="variable-use"
+          >A</a
+          >, second: <a href="#var10-21" data-variable="var10-21"
+                        class="variable-use"
+          >B</a
+          >}<br
           /><br
           />in <a href="#var6-5" data-variable="var6-5" class="variable-use"
           >Pair</a

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
@@ -64,8 +64,14 @@
           >my-even</span
           ><br
           />    : Natural → &lt; even | odd &gt;<br
-          />    = λ(n : Natural) →<br
-          />        if Natural/even n then &lt; even | odd&gt;.even else &lt; even | odd &gt;.odd<br
+          />    = λ(<span id="var6-9" data-variable="var6-9"
+                          class="variable-decl"
+          >n</span
+          > : Natural) →<br
+          />        if Natural/even <a href="#var6-9" data-variable="var6-9"
+                                       class="variable-use"
+          >n</a
+          > then &lt; even | odd&gt;.even else &lt; even | odd &gt;.odd<br
           /><br
           />let <span id="var9-5" data-variable="var9-5"
                       class="variable-decl"

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -56,6 +56,21 @@
           ><a href="JumpToHereImports.dhall.html"
           >JumpToHereImports.dhall</a></li
         ><li
+          ><a href="JumpToLamBindingComplex.dhall.html"
+          >JumpToLamBindingComplex.dhall</a></li
+        ><li
+          ><a href="JumpToLamBindingSimple.dhall.html"
+          >JumpToLamBindingSimple.dhall</a></li
+        ><li
+          ><a href="JumpToLamBindingWithIndex.dhall.html"
+          >JumpToLamBindingWithIndex.dhall</a></li
+        ><li
+          ><a href="JumpToLamBindingWithQuotes.dhall.html"
+          >JumpToLamBindingWithQuotes.dhall</a></li
+        ><li
+          ><a href="JumpToLamBindingWithShadowing.dhall.html"
+          >JumpToLamBindingWithShadowing.dhall</a></li
+        ><li
           ><a href="JumpToLetBindingSimple.dhall.html"
           >JumpToLetBindingSimple.dhall</a></li
         ><li

--- a/dhall-docs/tasty/data/package/JumpToLamBindingComplex.dhall
+++ b/dhall-docs/tasty/data/package/JumpToLamBindingComplex.dhall
@@ -1,0 +1,11 @@
+{-|
+A complex example of jump-to-definition on let-bindings
+-}
+let fun =
+    λ(a : Text) ->
+    λ(b : Text) ->
+    λ(c : Text) ->
+    λ(d : Text) ->
+    [ a ++ b, b ++ c, c ++ d, d ++ a ]
+
+in fun

--- a/dhall-docs/tasty/data/package/JumpToLamBindingSimple.dhall
+++ b/dhall-docs/tasty/data/package/JumpToLamBindingSimple.dhall
@@ -1,0 +1,67 @@
+{-|
+This examples shows a demo of jumping to a let-binding definition. If you hover
+the `a` paramter, the front-end will highlight all of its usages and if you
+click it you will navigate to its definition.
+
+The amount of empty lines left are intentional to show you how the browser jumps
+to the declaration of a
+-}
+let fun = \(v : Text) ->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    v
+
+
+
+in fun

--- a/dhall-docs/tasty/data/package/JumpToLamBindingWithIndex.dhall
+++ b/dhall-docs/tasty/data/package/JumpToLamBindingWithIndex.dhall
@@ -1,0 +1,14 @@
+{-|
+On this example, we introduce the `a` variable in the two parameters of the
+`fun` function and the jump-to-definition engine correctly highlights the usage
+when indexes are used
+-}
+let fun =
+    λ(a : Text) ->
+    λ(a : Text) ->
+    [ a@1 ++ a@0 ]
+
+let example0 = assert : fun "a" "b" === ["ab"]
+
+in fun
+

--- a/dhall-docs/tasty/data/package/JumpToLamBindingWithQuotes.dhall
+++ b/dhall-docs/tasty/data/package/JumpToLamBindingWithQuotes.dhall
@@ -1,0 +1,13 @@
+{-|
+This tests shows that the feature works for quoted vars on function parameters
+as well
+-}
+let fun =
+    λ(`param 1` : Text) ->
+    λ(`param 2` : Text) ->
+    [ `param 1` ++ `param 2` ]
+
+let example0 = assert : fun "a" "b" === ["ab"]
+
+in fun
+

--- a/dhall-docs/tasty/data/package/JumpToLamBindingWithShadowing.dhall
+++ b/dhall-docs/tasty/data/package/JumpToLamBindingWithShadowing.dhall
@@ -1,0 +1,14 @@
+{-|
+On this example, the first parameter `a` is shadowed with the second declaration.
+The jump-to-definintion on the usage of `a` should not highlight the first declaration,
+and interacting with the first declaration should not change the others
+-}
+let fun =
+    λ(a : Text) ->
+    λ(a : Text) ->
+    [ a ++ a ]
+
+let example0 = assert : fun "a" "b" === ["bb"]
+
+in fun
+


### PR DESCRIPTION
`Pi`-introduced variables are missing, but I'll introduce them at another time.

I also added a _small_ underline on variables to make this feature easier to discover.