### PR TITLE
Increase lower bound on `aeson`

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -39,7 +39,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                      >= 4.11.0.0  && < 5   ,
-        aeson                     >= 1.0.0.0   && < 1.6 ,
+        aeson                     >= 1.4.6.0   && < 1.6 ,
         aeson-pretty                              < 0.9 ,
         aeson-yaml                >= 1.1.0     && < 1.2 ,
         bytestring                                < 0.11,


### PR DESCRIPTION
`dhall-json` depends on `Data.Aeson.Types.formatPath`, which is only available
in `aeson-1.4.6.0` or later