### PR TITLE
Fix lower bound on `dhall`

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -44,7 +44,7 @@ Library
         aeson-yaml                >= 1.1.0     && < 1.2 ,
         bytestring                                < 0.11,
         containers                >= 0.5.9     && < 0.7 ,
-        dhall                     >= 1.33.0    && < 1.35,
+        dhall                     >= 1.34.0    && < 1.35,
         exceptions                >= 0.8.3     && < 0.11,
         filepath                                  < 1.5 ,
         lens-family-core          >= 1.0.0     && < 2.2 ,

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -50,7 +50,7 @@ library
     , containers           >= 0.5.11.0 && < 0.7
     , data-default         >= 0.7.1.1  && < 0.8
     , directory            >= 1.2.2.0  && < 1.4
-    , dhall                >= 1.29.0   && < 1.35
+    , dhall                >= 1.34.0   && < 1.35
     , dhall-json           >= 1.4      && < 1.8
     , filepath             >= 1.4.2    && < 1.5
     , haskell-lsp          >= 0.19.0.0 && < 0.23


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1983

The `dhall-json` and `dhall-lsp-server` packages need a lower bound
of `dhall-1.34.0` because they use `Dhall.Core.recordFieldValue`