### PR TITLE
Remove unneeded semigroups dependency

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -660,7 +660,6 @@ Test-Suite tasty
         QuickCheck                >= 2.10     && < 2.15,
         quickcheck-instances      >= 0.3.12   && < 0.4 ,
         scientific                                     ,
-        semigroups                                     ,
         serialise                                      ,
         special-values                           < 0.2 ,
         spoon                                    < 0.4 ,


### PR DESCRIPTION
It's not needed for GHC 8+ and we only support those.