### PR TITLE
Allow optparse-applicative 0.16

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -76,7 +76,7 @@ Library
         tar                  >= 0.5.1.0   && < 0.6 ,
         text                 >= 0.11.1.0  && < 1.3 ,
         mtl                  >= 2.2.1     && < 2.3 ,
-        optparse-applicative >= 0.14.0.0  && < 0.16
+        optparse-applicative >= 0.14.0.0  && < 0.17
     Exposed-Modules:
         Dhall.Docs
         Dhall.Docs.Core

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -48,7 +48,7 @@ Library
         exceptions                >= 0.8.3     && < 0.11,
         filepath                                  < 1.5 ,
         lens-family-core          >= 1.0.0     && < 2.2 ,
-        optparse-applicative      >= 0.14.0.0  && < 0.16,
+        optparse-applicative      >= 0.14.0.0  && < 0.17,
         prettyprinter             >= 1.5.1     && < 1.8 ,
         scientific                >= 0.3.0.0   && < 0.4 ,
         text                      >= 0.11.1.0  && < 1.3 ,

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -26,7 +26,7 @@ Executable dhall-to-nixpkgs
                      , megaparsec           >= 7.0.0    && < 8.1
                      , mmorph                              < 1.2
                      , neat-interpolation                  < 0.6
-                     , optparse-applicative >= 0.14.0.0 && < 0.16
+                     , optparse-applicative >= 0.14.0.0 && < 0.17
                      , prettyprinter        >= 1.5.1    && < 1.8
                      , text                 >= 0.11.1.0 && < 1.3
                      , transformers         >= 0.2.0.0  && < 0.6

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -25,7 +25,7 @@ executable openapi-to-dhall
     containers              >= 0.5.0.0   && < 0.7  ,
     dhall                   >= 1.34.0    && < 1.35 ,
     megaparsec              >= 7.0       && < 8.1  ,
-    optparse-applicative    >= 0.14.3.0  && < 0.16 ,
+    optparse-applicative    >= 0.14.3.0  && < 0.17 ,
     parser-combinators      >= 1.0.3     && < 1.3  ,
     prettyprinter           >= 1.2.0.1   && < 1.8  ,
     sort                    >= 1.0       && < 1.1  ,

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -39,7 +39,7 @@ Library
         bytestring                                < 0.11,
         dhall                     >= 1.31.0    && < 1.35,
         dhall-json                >= 1.6.0     && < 1.8 ,
-        optparse-applicative      >= 0.14.0.0  && < 0.16,
+        optparse-applicative      >= 0.14.0.0  && < 0.17,
         text                      >= 0.11.1.0  && < 1.3 ,
         vector
     Exposed-Modules:

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -491,7 +491,7 @@ Library
         mmorph                                     < 1.2 ,
         mtl                         >= 2.2.1    && < 2.3 ,
         network-uri                 >= 2.6      && < 2.7 ,
-        optparse-applicative        >= 0.14.0.0 && < 0.16,
+        optparse-applicative        >= 0.14.0.0 && < 0.17,
         parsers                     >= 0.12.4   && < 0.13,
         parser-combinators                               ,
         prettyprinter               >= 1.5.1    && < 1.8 ,


### PR DESCRIPTION
Changelog:
http://hackage.haskell.org/package/optparse-applicative-0.16.0.0/changelog

Stackage: https://github.com/commercialhaskell/stackage/issues/5597