### PR TITLE
feat(type-on-hover): Add type-on-hover on boolean and natural literals

### DIFF
--- a/dhall-docs/src/Dhall/Docs/CodeRenderer.hs
+++ b/dhall-docs/src/Dhall/Docs/CodeRenderer.hs
@@ -255,6 +255,11 @@ fragments = Data.List.sortBy sorter . removeUnusedDecls . Writer.execWriter . in
                 Left _ -> fileAnIssue "typeOfStatic"
                 Right e -> e
 
+        Note src (NaturalLit n) -> Writer.tell [SourceCodeFragment src $ StaticExpression _type] >> return NoInfo
+          where
+            _type = TypeFromSource $ case TypeCheck.typeOf (NaturalLit n) of
+                Left _ -> fileAnIssue "typeOfStatic"
+                Right e -> e
 
         Note _ e -> infer context e
         e -> do

--- a/dhall-docs/src/Dhall/Docs/Core.hs
+++ b/dhall-docs/src/Dhall/Docs/Core.hs
@@ -44,6 +44,7 @@ import Dhall.Docs.Embedded
 import Dhall.Docs.Html
 import Dhall.Docs.Markdown
 import Dhall.Docs.Store
+import Dhall.Docs.Util
 import Dhall.Parser
     ( Header (..)
     , ParseError (..)
@@ -396,26 +397,6 @@ createIndexes packageName characterSet files = map toIndex dirToDirsAndFilesMapA
 addHtmlExt :: Path Rel File -> Path Rel File
 addHtmlExt relFile =
     Data.Maybe.fromMaybe (fileAnIssue "addHtmlExt") $ Path.addExtension ".html" relFile
-
--- | If you're wondering the GitHub query params for issue creation:
--- https://docs.github.com/en/github/managing-your-work-on-github/about-automation-for-issues-and-pull-requests-with-query-parameters
-fileAnIssue :: Text -> a
-fileAnIssue titleName =
-    error $ "\ESC[1;31mError\ESC[0m Documentation generator bug\n\n" <>
-
-            "Explanation: This error message means that there is a bug in the " <>
-            "Dhall Documentation generator. You didn't did anything wrong, but " <>
-            "if you would like to see this problem fixed then you should report " <>
-            "the bug at:\n\n" <>
-
-            "https://github.com/dhall-lang/dhall-haskell/issues/new?labels=dhall-docs,bug\n\n" <>
-
-            "explaining your issue and add \"" <> Data.Text.unpack titleName <> "\" as error code " <>
-            "so we can find the proper location in the source code where the error happened\n\n" <>
-
-            "Please, also include your package in the issue. It can be in:\n\n" <>
-            "* A compressed archive (zip, tar, etc)\n" <>
-            "* A git repository, preferably with a commit reference"
 
 {-| Generate all of the docs for a package. This function does all the `IO ()`
     related tasks to call `generateDocsPure`

--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -68,7 +68,7 @@ dhallFileToHtml filePath contents expr examples header params@DocParams{..} =
                     div_ [class_ "source-code code-examples"] $
                         mapM_ (renderCodeSnippet characterSet AssertionExample) examples
                 h3_ "Source"
-                div_ [class_ "source-code"] $ renderCodeWithHyperLinks contents expr
+                div_ [class_ "source-code"] $ renderCodeWithHyperLinks characterSet contents expr
   where
     breadcrumb = relPathToBreadcrumb filePath
     htmlTitle = breadCrumbsToText breadcrumb
@@ -224,7 +224,9 @@ headContents title DocParams{..} =
         title_ $ toHtml title
         stylesheet $ relativeResourcesPath <> "index.css"
         stylesheet "https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Lato:ital,wght@0,400;0,700;1,400&display=swap"
-        script relativeResourcesPath
+        script $ "https://unpkg.com/@popperjs/core@2"
+        script $ "https://unpkg.com/tippy.js@6"
+        script $ relativeResourcesPath <> "index.js"
         meta_ [charset_ "UTF-8"]
 
 -- | main-container component builder of the HTML documentation
@@ -239,8 +241,8 @@ stylesheet path =
         , href_ $ Data.Text.pack path]
 
 script :: FilePath -> Html ()
-script relativeResourcesPath =
+script path =
     script_
         [ type_ "text/javascript"
-        , src_ $ Data.Text.pack $ relativeResourcesPath <> "index.js"]
+        , src_ $ Data.Text.pack path]
         ("" :: Text)

--- a/dhall-docs/src/Dhall/data/index.css
+++ b/dhall-docs/src/Dhall/data/index.css
@@ -181,6 +181,33 @@ span.of-type-token {
     margin-right: 0.5rem;
 }
 
+.tippy-box[data-theme~='source-code'] {
+    background-color: #EBEBEB;
+    border: 2px solid #484848;
+}
+
+.tippy-box[data-theme~='source-code'] pre {
+    font-size: 16px;
+    font-family: 'Fira Code', monospace !important;
+    color: #333333;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+/* .tippy-box[data-theme~='source-code'][data-placement^='top'] > .tippy-arrow::before {
+    border-top-color: #333333;
+  }
+  .tippy-box[data-theme~='source-code'][data-placement^='bottom'] > .tippy-arrow::before {
+    border-bottom-color: #333333;
+  }
+  .tippy-box[data-theme~='source-code'][data-placement^='left'] > .tippy-arrow::before {
+    border-left-color: #333333;
+  }
+  .tippy-box[data-theme~='source-code'][data-placement^='right'] > .tippy-arrow::before {
+    border-right-color: #333333;
+  }
+   */
+
 /******** Dark mode styling ********/
 
 .dark-mode .main-container {

--- a/dhall-docs/src/Dhall/data/index.js
+++ b/dhall-docs/src/Dhall/data/index.js
@@ -33,6 +33,15 @@ function onReady() {
       node.addEventListener('mouseover', () => highlightNames(node.dataset.name, true))
       node.addEventListener('mouseout', () => highlightNames(node.dataset.name, false))
     })
+
+  tippy('.type-tooltip', {
+    allowHTML: true,
+    theme: 'source-code',
+    arrow: false,
+    // uncomment to debug the tooltip
+    hideOnClick: false,
+    trigger: 'click'
+  })
 }
 
 function highlightNames(varId, highlight) {

--- a/dhall-docs/src/Dhall/data/index.js
+++ b/dhall-docs/src/Dhall/data/index.js
@@ -39,8 +39,8 @@ function onReady() {
     theme: 'source-code',
     arrow: false,
     // uncomment to debug the tooltip
-    hideOnClick: false,
-    trigger: 'click'
+    // hideOnClick: false,
+    // trigger: 'click'
   })
 }
 

--- a/dhall-docs/tasty/data/golden/ImportAsType.dhall.html
+++ b/dhall-docs/tasty/data/golden/ImportAsType.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/InvalidBlockComment.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidBlockComment.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/InvalidConsecutiveComments.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidConsecutiveComments.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToDefOnUnused.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToDefOnUnused.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -46,17 +49,29 @@ are unused and therefore won&#39;t be highlighted</p>
           />are unused and therefore won&#39;t be highlighted<br
           />-}<br
           /><br
-          />let unused = 1<br
+          />let unused = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                               class="type-tooltip"
+          >1</span
+          ><br
           />let <span data-name="var7-5" id="var7-5" class="name-decl"
           >used</span
-          > = 3<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >3</span
+          ><br
           /><br
-          />let unusedRecord = { foo = 1 }<br
+          />let unusedRecord = { foo = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                                             class="type-tooltip"
+          >1</span
+          > }<br
           />let <span data-name="var10-5" id="var10-5" class="name-decl"
           >usedRecord</span
           > = { <span data-name="var10-20" id="var10-20" class="name-decl"
           >foo</span
-          > = 1 }<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          > }<br
           /><br
           />let <span data-name="var12-5" id="var12-5" class="name-decl"
           >f</span
@@ -89,4 +104,13 @@ are unused and therefore won&#39;t be highlighted</p>
           >foo</a
           > + <a href="#var12-5" data-name="var12-5" class="name-use"
           >f</a
-          > True 1 { unused = &quot;foo&quot;, used = 3 }<br/></pre></div></div></body></html>
+          > <span data-tippy-content="&lt;pre&gt;Bool&lt;br&gt;&lt;/pre&gt;"
+                  class="type-tooltip"
+          >True</span
+          > <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                  class="type-tooltip"
+          >1</span
+          > { unused = &quot;foo&quot;, used = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                                                     class="type-tooltip"
+          >3</span
+          > }<br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/JumpToHereImports.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToHereImports.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingSimple.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingSimple.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -57,7 +60,10 @@ to the declaration of a</p>
           />-}<br
           />let <span data-name="var9-5" id="var9-5" class="name-decl"
           >a</span
-          > = 1<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          ><br
           /><br
           /><br
           /><br

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithIndex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithIndex.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -48,9 +51,15 @@ this example showcases the jump-to-definition feature when indexes are used.</p>
           />-}<br
           />let <span data-name="var5-5" id="var5-5" class="name-decl"
           >a</span
-          > = 1<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          ><br
           /><br
-          />let a = 2<br
+          />let a = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                          class="type-tooltip"
+          >2</span
+          ><br
           /><br
           />in <a href="#var5-5" data-name="var5-5" class="name-use"
           >a@1</a

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithQuotes.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithQuotes.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -45,11 +48,17 @@
           />-}<br
           />let <span data-name="var4-5" id="var4-5" class="name-decl"
           >`quoted variable`</span
-          > = 1<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          ><br
           /><br
           />let <span data-name="var6-5" id="var6-5" class="name-decl"
           >nonQuoted</span
-          > = 2<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >2</span
+          ><br
           /><br
           />in <a href="#var4-5" data-name="var4-5" class="name-use"
           >`quoted variable`</a

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithShadowing.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithShadowing.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -52,11 +55,17 @@ declaration should not change the others</p>
           />should not highlight the first declaration, and interacting with the first<br
           />declaration should not change the others<br
           />-}<br
-          />let a = 1<br
+          />let a = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                          class="type-tooltip"
+          >1</span
+          ><br
           /><br
           />let <span data-name="var9-5" id="var9-5" class="name-decl"
           >a</span
-          > = 2<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >2</span
+          ><br
           /><br
           />in <a href="#var9-5" data-name="var9-5" class="name-use"
           >a</a

--- a/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -50,7 +53,10 @@
           > : Natural) -&gt;<br
           />    let <span data-name="var5-9" id="var5-9" class="name-decl"
           >a</span
-          > = 1 in <a href="#var4-11" data-name="var4-11" class="name-use"
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          > in <a href="#var4-11" data-name="var4-11" class="name-use"
           >f</a
           > + <a href="#var5-9" data-name="var5-9" class="name-use"
           >a</a
@@ -60,7 +66,10 @@
           >a</span
           > = <a href="#var4-5" data-name="var4-5" class="name-use"
           >f</a
-          > 1<br
+          > <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                  class="type-tooltip"
+          >1</span
+          ><br
           /><br
           />let <span data-name="var9-5" id="var9-5" class="name-decl"
           >b</span
@@ -68,7 +77,10 @@
           >a</a
           > + <a href="#var4-5" data-name="var4-5" class="name-use"
           >f</a
-          > 3<br
+          > <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                  class="type-tooltip"
+          >3</span
+          ><br
           /><br
           />in <a href="#var9-5" data-name="var9-5" class="name-use"
           >b</a

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenFieldDoesNotExist.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenFieldDoesNotExist.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -58,7 +61,10 @@ no-link will be created</p>
           > = { x = &quot;foo&quot; }<br
           />let <span data-name="var8-5" id="var8-5" class="name-decl"
           >b</span
-          > = False<br
+          > = <span data-tippy-content="&lt;pre&gt;Bool&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >False</span
+          ><br
           /><br
           />in <a href="#var7-5" data-name="var7-5" class="name-use"
           >a</a

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordType.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordType.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -58,7 +61,10 @@ the user clicks the <code
           />to a record literal. It will also be aware that that the attribute `x`. When<br
           />the user clicks the `x` from `a.x`, it will jump to the `x` punned-entry<br
           />-}<br
-          />let x = 1<br
+          />let x = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                          class="type-tooltip"
+          >1</span
+          ><br
           />let <span data-name="var7-5" id="var7-5" class="name-decl"
           >a</span
           > = { <span data-name="var7-11" id="var7-11" class="name-decl"

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -62,7 +65,10 @@ that is the actual definition of the fields.</p>
           >a</span
           > = { <span data-name="var7-11" id="var7-11" class="name-decl"
           >x</span
-          > = 1 }<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          > }<br
           />let <span data-name="var8-5" id="var8-5" class="name-decl"
           >b</span
           > = <a href="#var7-5" data-name="var7-5" class="name-use"

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -68,7 +71,10 @@ The same applies for each other field.</p>
           >y</span
           >.<span data-name="var8-15" id="var8-15" class="name-decl"
           >z</span
-          > = 1 }<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          > }<br
           /><br
           />let <span data-name="var10-5" id="var10-5" class="name-decl"
           >ax</span

--- a/dhall-docs/tasty/data/golden/JumpToSelf.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToSelf.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -54,8 +57,10 @@
           /><br
           />in <a href="#var6-5" data-name="var6-5" class="name-use"
           >List/generate</a
-          > 10 Text (\(<span data-name="var8-29" id="var8-29"
-                             class="name-decl"
+          > <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                  class="type-tooltip"
+          >10</span
+          > Text (\(<span data-name="var8-29" id="var8-29" class="name-decl"
           >n</span
           > : Natural) -&gt; &quot;Result #${Natural/show <a href="#var8-29"
                                                              data-name="var8-29" class="name-use"

--- a/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/MultilineIndentationExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/MultilineIndentationExample.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/NoDoc.dhall.html
+++ b/dhall-docs/tasty/data/golden/NoDoc.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/NonDhallDocsCommentAfterValid.dhall.html
+++ b/dhall-docs/tasty/data/golden/NonDhallDocsCommentAfterValid.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/OrdinaryAnnotation.dhall.html
+++ b/dhall-docs/tasty/data/golden/OrdinaryAnnotation.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -44,4 +47,7 @@ should be selected as the expression&#39;s type</p>
           />This file contains a Dhall expression with just a type annotation, which<br
           />should be selected as the expression&#39;s type<br
           />-}<br
-          />1 : Natural<br/></pre></div></div></body></html>
+          /><span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                  class="type-tooltip"
+          >1</span
+          > : Natural<br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/Pair.dhall.html
+++ b/dhall-docs/tasty/data/golden/Pair.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/RenderTypeIndexesExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/RenderTypeIndexesExample.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -49,8 +52,14 @@ index respecting variable indices</p>
           /><br
           />let <span data-name="var6-5" id="var6-5" class="name-decl"
           >x</span
-          > : Bool = True<br
-          />let x : Natural = 1<br
+          > : Bool = <span data-tippy-content="&lt;pre&gt;Bool&lt;br&gt;&lt;/pre&gt;"
+                           class="type-tooltip"
+          >True</span
+          ><br
+          />let x : Natural = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                                    class="type-tooltip"
+          >1</span
+          ><br
           /><br
           />in <a href="#var6-5" data-name="var6-5" class="name-use"
           >x@1</a

--- a/dhall-docs/tasty/data/golden/TwoAnnotations.dhall.html
+++ b/dhall-docs/tasty/data/golden/TwoAnnotations.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -51,7 +54,10 @@ latter annotation.</p>
           />-}<br
           />let <span data-name="var6-5" id="var6-5" class="name-decl"
           >x</span
-          > = 1<br
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          ><br
           /><br
           />let <span data-name="var8-5" id="var8-5" class="name-decl"
           >y</span

--- a/dhall-docs/tasty/data/golden/TypeOnHover.dhall.html
+++ b/dhall-docs/tasty/data/golden/TypeOnHover.dhall.html
@@ -2,18 +2,18 @@
 <html
   ><head
     ><title
-    >/a/b/JumpToGrandfather.dhall</title
-    ><link href="../../index.css" type="text/css" rel="stylesheet"
+    >/TypeOnHover.dhall</title
+    ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
     /><script src="https://unpkg.com/@popperjs/core@2"
               type="text/javascript"
     /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
-    /><script src="../../index.js" type="text/javascript"
+    /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
     ><div class="nav-bar"
-      ><img src="../../dhall-icon.svg" class="dhall-icon"
+      ><img src="dhall-icon.svg" class="dhall-icon"
       /><p class="package-title"
       >test-package</p
       ><div class="nav-bar-content-divider"
@@ -23,39 +23,41 @@
       ><h2 class="doc-title"
         ><span class="crumb-divider"
         >/</span
-        ><a href="../../index.html"
+        ><a href="index.html"
         >test-package</a
         ><span class="crumb-divider"
         >/</span
-        ><a href="../index.html" class="title-crumb"
-        >a</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html" class="title-crumb"
-        >b</a
-        ><span class="crumb-divider"
-        >/</span
         ><span href="index.html" class="title-crumb"
-        >JumpToGrandfather.dhall</span></h2
-      ><a data-path="/a/b/JumpToGrandfather.dhall"
-          class="copy-to-clipboard"
+        >TypeOnHover.dhall</span></h2
+      ><a data-path="/TypeOnHover.dhall" class="copy-to-clipboard"
         ><i
           ><small
           >Copy path to clipboard</small></i></a
       ><br
       /><div class="doc-contents"
-      /><h3
+        ><p
+        >This example shows the type-on-hover feature over builtins</p>
+</div
+      ><h3
       >Source</h3
       ><div class="source-code"
         ><pre
-          >let <span data-name="var1-5" id="var1-5" class="name-decl"
-          >parents</span
-          > =<br
-          />    [ <a href="../../IndexesExample.dhall.html"
-          >../../IndexesExample.dhall</a
+          >{-|<br
+          />This example shows the type-on-hover feature over builtins<br
+          />-}<br
+          />let true = <span data-tippy-content="&lt;pre&gt;Bool&lt;br&gt;&lt;/pre&gt;"
+                             class="type-tooltip"
+          >True</span
           ><br
-          />    ]<br
+          />let false = <span data-tippy-content="&lt;pre&gt;Bool&lt;br&gt;&lt;/pre&gt;"
+                              class="type-tooltip"
+          >False</span
+          ><br
           /><br
-          />in <a href="#var1-5" data-name="var1-5" class="name-use"
-          >parents</a
+          />in <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                     class="type-tooltip"
+          >1</span
+          > + <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >3</span
           ><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/a/JumpToParent.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/JumpToParent.dhall.html
@@ -6,6 +6,9 @@
     ><link href="../index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/a/b.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b.dhall.html
@@ -6,6 +6,9 @@
     ><link href="../index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -46,6 +49,9 @@
           /><br
           />let <span data-name="var5-5" id="var5-5" class="name-decl"
           >b</span
-          > = 1 in <a href="#var5-5" data-name="var5-5" class="name-use"
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          > in <a href="#var5-5" data-name="var5-5" class="name-use"
           >b</a
           ><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/a/b/c.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c.dhall.html
@@ -6,6 +6,9 @@
     ><link href="../../index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -50,6 +53,9 @@
           /><br
           />let <span data-name="var5-5" id="var5-5" class="name-decl"
           >c</span
-          > = 1 in <a href="#var5-5" data-name="var5-5" class="name-use"
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          > in <a href="#var5-5" data-name="var5-5" class="name-use"
           >c</a
           ><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
@@ -6,6 +6,9 @@
     ><link href="../../../index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="../../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -54,6 +57,9 @@
           /><br
           />let <span data-name="var5-5" id="var5-5" class="name-decl"
           >a</span
-          > = 1 in <a href="#var5-5" data-name="var5-5" class="name-use"
+          > = <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                    class="type-tooltip"
+          >1</span
+          > in <a href="#var5-5" data-name="var5-5" class="name-use"
           >a</a
           ><br/></pre></div></div></body></html>

--- a/dhall-docs/tasty/data/golden/a/b/c/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/index.html
@@ -6,6 +6,9 @@
     ><link href="../../../index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="../../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/a/b/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/index.html
@@ -6,6 +6,9 @@
     ><link href="../../index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/a/index.html
+++ b/dhall-docs/tasty/data/golden/a/index.html
@@ -6,6 +6,9 @@
     ><link href="../index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
@@ -6,6 +6,9 @@
     ><link href="../../../index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="../../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
@@ -6,6 +6,9 @@
     ><link href="../../../index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="../../../index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -49,9 +52,15 @@
       >Examples</h3
       ><div class="source-code code-examples"
         ><pre
-          >my-even 1 ≡ &lt; even | odd &gt;.odd<br/></pre
+          >my-even <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                         class="type-tooltip"
+          >1</span
+          > ≡ &lt; even | odd &gt;.odd<br/></pre
         ><pre
-          >my-even 2 ≡ &lt; even | odd &gt;.even<br/></pre></div
+          >my-even <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                         class="type-tooltip"
+          >2</span
+          > ≡ &lt; even | odd &gt;.even<br/></pre></div
       ><h3
       >Source</h3
       ><div class="source-code"
@@ -74,11 +83,17 @@
           />let example0 = assert : <a href="#var4-5" data-name="var4-5"
                                        class="name-use"
           >my-even</a
-          > 1 === &lt;even | odd&gt;.odd<br
+          > <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                  class="type-tooltip"
+          >1</span
+          > === &lt;even | odd&gt;.odd<br
           />let example0 = assert : <a href="#var4-5" data-name="var4-5"
                                        class="name-use"
           >my-even</a
-          > 2 === &lt;even | odd&gt;.even<br
+          > <span data-tippy-content="&lt;pre&gt;Natural&lt;br&gt;&lt;/pre&gt;"
+                  class="type-tooltip"
+          >2</span
+          > === &lt;even | odd&gt;.even<br
           /><br
           />in <a href="#var4-5" data-name="var4-5" class="name-use"
           >my-even</a

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body
@@ -173,6 +176,9 @@
           ><span class="dhall-type source-code"
             ><pre
               >y<br/></pre></span></li
+        ><li
+          ><a href="TypeOnHover.dhall.html"
+          >TypeOnHover.dhall</a></li
         ><li
           ><a href="package.dhall.html"
           >package.dhall</a></li></ul

--- a/dhall-docs/tasty/data/golden/package.dhall.html
+++ b/dhall-docs/tasty/data/golden/package.dhall.html
@@ -6,6 +6,9 @@
     ><link href="index.css" type="text/css" rel="stylesheet"
     /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
             type="text/css" rel="stylesheet"
+    /><script src="https://unpkg.com/@popperjs/core@2"
+              type="text/javascript"
+    /><script src="https://unpkg.com/tippy.js@6" type="text/javascript"
     /><script src="index.js" type="text/javascript"
     /><meta charset="UTF-8"/></head
   ><body

--- a/dhall-docs/tasty/data/package/TypeOnHover.dhall
+++ b/dhall-docs/tasty/data/package/TypeOnHover.dhall
@@ -4,4 +4,4 @@ This example shows the type-on-hover feature over builtins
 let true = True
 let false = False
 
-in 1
+in 1 + 3

--- a/dhall-docs/tasty/data/package/TypeOnHover.dhall
+++ b/dhall-docs/tasty/data/package/TypeOnHover.dhall
@@ -1,0 +1,7 @@
+{-|
+This example shows the type-on-hover feature over builtins
+-}
+let true = True
+let false = False
+
+in 1


### PR DESCRIPTION
This is the first implementation of the type-on-hover feature. It is currently a draft and it is intended to be really small (excluding the golden file updates).

The reason for this PR to be that small is because this idea will be expanded on further PRs related to type-on-hover. So please let me know what you think and what can be improved before working on the next elements that will have this feature.

The tooltip library that I'm using is https://atomiks.github.io/tippyjs/, which is really lightweight.

I wanted to add jump-to-definition on imports before this, but I got blocked on that... didn't found the best way to do it. My problem is with implementation, I got an idea which I described [here (comment)](https://github.com/dhall-lang/dhall-haskell/issues/1994#issuecomment-675622903). Path manipulation was really messy and I felt that working on this feature first might be better because I already had a clearer idea about how to do this and I prefer to deliver as much work before ending the program as I can.

To end, I feel that the `dhall-docs` package structure is not the best... do you have any advice about organizing Haskell packages? I feel that the entire tool can fit roughly in a single file :laughing: 