### PR TITLE
Add support for octal literals

### DIFF
--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -273,7 +273,8 @@ integerLiteral = (do
 -}
 naturalLiteral :: Parser Natural
 naturalLiteral = (do
-    a <-    try (char '0' >> char 'x' >> Text.Megaparsec.Char.Lexer.hexadecimal)
+    a <-    (try (char '0' >> char 'x') >> Text.Megaparsec.Char.Lexer.hexadecimal)
+        <|> (try (char '0' >> char 'o') >> Text.Megaparsec.Char.Lexer.octal)
         <|> decimal
         <|> (char '0' $> 0)
     return a ) <?> "literal"


### PR DESCRIPTION
… as standardized in https://github.com/dhall-lang/dhall-lang/pull/1062

This also slightly improves the parsing performance of hex literals