### PR TITLE
Don't require `apiVersion`/`type` for `PersistentVolumeClaim`

### DIFF
--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -57,9 +57,14 @@ requiredFields maybeName required
     --   in the Swagger spec but just in the docs
     notRequiredConstraints = Data.Map.fromList
       [ ( ModelName "io.k8s.api.core.v1.ObjectFieldSelector"
-        , Set.fromList [FieldName "apiVersion"])
+        , Set.fromList [ FieldName "apiVersion" ]
+        )
       , ( ModelName "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
-        , Set.fromList [FieldName "kind"])
+        , Set.fromList [ FieldName "kind" ]
+        )
+      , ( ModelName "io.k8s.api.core.v1.PersistentVolumeClaim"
+        , Set.fromList [ FieldName "apiVersion", FieldName "kind" ]
+        )
       ]
 
 


### PR DESCRIPTION
Related to https://github.com/dhall-lang/dhall-kubernetes/issues/136

In the long-run I plan to fix all of the `dhall-kubernetes` special-case
logic by undoing this logic:

https://github.com/dhall-lang/dhall-haskell/blob/9dca2b8129bfec47afa069d5d1008448dcd2f873/dhall-openapi/src/Dhall/Kubernetes/Convert.hs#L44

… which would make `apiVersion`/`kind` `Optional` across the board.
However, until then, this change makes them selectively `Optional`
only for `PersistentVolumeClaim`.