### PR TITLE
WIP: implement toJSON keyword

### DIFF
--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -711,6 +711,7 @@ eval !env t0 =
                     in  VListLit Nothing s
                 (x', ma') ->
                     VToMap x' ma'
+        ToJSON _x _ma -> error "ToJSON not implemented"
         Field t (Syntax.fieldSelectionLabel -> k) ->
             vField (eval env t) k
         Project t (Left ks) ->
@@ -1292,6 +1293,8 @@ alphaNormalize = goEnv EmptyNames
                 Merge (go x) (go y) (fmap go ma)
             ToMap x ma ->
                 ToMap (go x) (fmap go ma)
+            ToJSON x ma ->
+                ToJSON (go x) (fmap go ma)
             Field t k ->
                 Field (go t) k
             Project t ks ->

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -47,6 +47,7 @@ module Dhall.Eval (
   , Environment(..)
   , Val(..)
   , (~>)
+  , vJSON
   , textShow
   ) where
 
@@ -76,6 +77,7 @@ import qualified Data.Sequence as Sequence
 import qualified Data.Set
 import qualified Data.Text     as Text
 import qualified Dhall.Map     as Map
+import qualified Dhall.Map
 import qualified Dhall.Set
 import qualified Dhall.Syntax  as Syntax
 import qualified Text.Printf
@@ -227,6 +229,22 @@ deriving instance (Show a, Show (Val a -> Val a)) => Show (Val a)
 (~>) :: Val a -> Val a -> Val a
 (~>) a b = VHPi "_" a (\_ -> b)
 {-# INLINE (~>) #-}
+
+vJSON :: Val a
+vJSON = VHPi "t" (VConst Type) (\t ->
+              (VRecord (Dhall.Map.fromList [
+              ("array", (VList t) ~> t),
+              ("bool", VBool ~> t),
+              ("double", VDouble ~> t),
+              ("integer", VInteger ~> t),
+              ("null", t),
+              ("object", VList (VRecord (Dhall.Map.fromList [
+                ("mapKey", VText),
+                ("mapValue", t)
+              ]))),
+              ("string", VText ~> t)
+            ])) ~> t)
+
 
 infixr 5 ~>
 

--- a/dhall/src/Dhall/Normalize.hs
+++ b/dhall/src/Dhall/Normalize.hs
@@ -557,6 +557,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
                 return (ListLit listType keyValues)
             _ ->
                 return (ToMap x' t')
+    ToJSON _x _t -> error "ToJSON not implemented"
     Field r k@FieldSelection{fieldSelectionLabel = x}        -> do
         let singletonRecordLit v = RecordLit (Dhall.Map.singleton x v)
 
@@ -814,6 +815,7 @@ isNormalized e0 = loop (Syntax.denote e0)
       ToMap x t -> case x of
           RecordLit _ -> False
           _ -> loop x && all loop t
+      ToJSON _x _t -> error "ToJSON is not implemented"
       Field r (FieldSelection Nothing k Nothing) -> case r of
           RecordLit _ -> False
           Project _ _ -> False

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -295,6 +295,12 @@ parsers embedded = Parsers {..}
                                     b <- applicationExpression
 
                                     return (ToMap c (Just b))
+
+                                (ToJSON c Nothing, NakedMergeOrSomeOrToMap) -> do
+                                    b <- applicationExpression
+
+                                    return (ToJSON c (Just b))
+
                                 _ -> do
                                     b <- expression
 
@@ -385,10 +391,18 @@ parsers embedded = Parsers {..}
 
                     return (\a -> ToMap a Nothing, Just "argument to ❰toMap❱")
 
-            let alternative3 =
+            let alternative3 = do
+                    try (_toJSON *> nonemptyWhitespace)
+
+                    return (\a -> ToJSON a Nothing, Just "argument to ❰toJSON❱")
+
+            let alternative4 =
                     return (id, Nothing)
 
-            (f, maybeMessage) <- alternative0 <|> alternative1 <|> alternative2 <|> alternative3
+            (f, maybeMessage) <- alternative0 <|> alternative1
+                                              <|> alternative2
+                                              <|> alternative3
+                                              <|> alternative4
 
             let adapt parser =
                     case maybeMessage of

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -37,6 +37,7 @@ module Dhall.Parser.Token (
     _using,
     _merge,
     _toMap,
+    _toJSON,
     _assert,
     _Some,
     _None,
@@ -845,6 +846,14 @@ _merge = keyword "merge"
 -}
 _toMap :: Parser ()
 _toMap = keyword "toMap"
+
+{-| Parse @toJSON@ keyword
+
+    This DO NOT correspont to the official grammar because it is quick
+    and dirty hack.
+-}
+_toJSON :: Parser ()
+_toJSON = keyword "toJSON"
 
 {-| Parse the @assert@ keyword
 

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -603,6 +603,9 @@ data Expr s a
     -- | > ToMap x (Just t)                         ~  toMap x : t
     --   > ToMap x  Nothing                         ~  toMap x
     | ToMap (Expr s a) (Maybe (Expr s a))
+    -- | > ToJSON x (Just t)                        ~  toJSON x : t
+    --   > ToJSON x  Nothing                        ~  toJSON x
+    | ToJSON (Expr s a) (Maybe (Expr s a))
     -- | > Field e (FieldSelection _ x _)              ~  e.x
     | Field (Expr s a) (FieldSelection s)
     -- | > Project e (Left xs)                      ~  e.{ xs }
@@ -835,6 +838,7 @@ unsafeSubExpressions f (Prefer a b c) = Prefer <$> a' <*> f b <*> f c
 unsafeSubExpressions f (RecordCompletion a b) = RecordCompletion <$> f a <*> f b
 unsafeSubExpressions f (Merge a b t) = Merge <$> f a <*> f b <*> traverse f t
 unsafeSubExpressions f (ToMap a t) = ToMap <$> f a <*> traverse f t
+unsafeSubExpressions f (ToJSON a t) = ToJSON <$> f a <*> traverse f t
 unsafeSubExpressions f (Project a b) = Project <$> f a <*> traverse f b
 unsafeSubExpressions f (Assert a) = Assert <$> f a
 unsafeSubExpressions f (Equivalent a b) = Equivalent <$> f a <*> f b

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -1116,6 +1116,7 @@ infer typer = loop
                        let _T₁'' = quote names _T₁'
 
                        die (MapTypeMismatch (quote names (mapType _T')) _T₁'')
+        ToJSON _e _mt -> error "ToJSON not implemented"
 
         Field e (Syntax.fieldSelectionLabel -> x) -> do
             _E' <- loop ctx e

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -47,6 +47,7 @@ import Dhall.Eval
     , Names (..)
     , Val (..)
     , (~>)
+    , vJSON
     )
 import Dhall.Pretty                      (Ann)
 import Dhall.Src                         (Src)
@@ -1116,7 +1117,8 @@ infer typer = loop
                        let _T₁'' = quote names _T₁'
 
                        die (MapTypeMismatch (quote names (mapType _T')) _T₁'')
-        ToJSON _e _mt -> error "ToJSON not implemented"
+
+        ToJSON _e _mt -> return vJSON
 
         Field e (Syntax.fieldSelectionLabel -> x) -> do
             _E' <- loop ctx e

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -398,6 +398,7 @@ instance (Arbitrary s, Arbitrary a) => Arbitrary (Expr s a) where
             % (7 :: W "RecordCompletion")
             % (1 :: W "Merge")
             % (1 :: W "ToMap")
+            % (1 :: W "ToJSON")
             % (7 :: W "Field")
             % (7 :: W "Project")
             % (1 :: W "Assert")


### PR DESCRIPTION
Hello. I am trying to implement toJSON (#336) keyword. I managed to
add keyword to parser (that was easy), added constructor ToJSON into
Expr, created Expr corresponding to Prelude.JSON.Type and returned it
unconditionally in TypeCheck.hs. Yes, I know that I have to check that
it actually possible to convert argument to JSON, but it is WIP.

Next step is handle ToJSON constructor in Eval.hs. I started with very
trivial case when argument for toJSON keyword is integer (currently
"eval" is partial and can crash). Here is example input I tested on:


````
(toJSON +42) Natural
{
  array = \(x: List Natural) -> 1,
  bool = \(x: Bool) -> 2,
  integer = \(x: Integer) -> 3,
  null = 4,
  object = \(x: List { mapKey : Text, mapValue : Natural }) -> 5,
  double = \(x: Double) -> 6,
  string = \(x: Text) -> 7
}
````

It evaluates to following expression:

````
  ( forall (t : Type) ->
    forall  ( json
            : { array : List t -> t
              , bool : Bool -> t
              , double : Double -> t
              , integer : Integer -> t
              , null : t
              , string : Text -> t
              , object : List { mapKey : Text, mapValue : t } -> t
              }
            ) ->
      json.integer +42
  )
    Natural
    { array = \(x : List Natural) -> 1
    , bool = \(x : Bool) -> 2
    , double = \(x : Double) -> 6
    , integer = \(x : Integer) -> 3
    , null = 4
    , object = \(x : List { mapKey : Text, mapValue : Natural }) -> 5
    , string = \(x : Text) -> 7
    }
: Natural
````

which is correct, but should be simplified further. And here I am stuck,
I can't understand how to simplify all this to `3 : Natural`.

May I ask for some advice and guidance?