### PR TITLE
dhall-nixpkgs: Use hnix-0.10.1

### DIFF
--- a/dhall-nixpkgs/Main.hs
+++ b/dhall-nixpkgs/Main.hs
@@ -75,7 +75,6 @@ import Control.Monad.Morph              (hoist)
 import Control.Monad.Trans.Class        (lift)
 import Control.Monad.Trans.State.Strict (StateT)
 import Data.Aeson                       (FromJSON)
-import Data.Fix                         (Fix)
 import Data.List.NonEmpty               (NonEmpty (..))
 import Data.Text                        (Text)
 import Data.Void                        (Void)
@@ -286,13 +285,6 @@ toListWith _  Nothing  = [ ]
 
 nub :: Ord a => [a] -> [a]
 nub = Foldl.fold Foldl.nub
-
-{-| This specialization of `nub` is necessary to work around a type-checking
-    loop with GHC 8.4
--}
-nub'
-    :: Ord (f (Fix f)) => [ (Text, Maybe (Fix f)) ] -> [ (Text, Maybe (Fix f)) ]
-nub' = nub
 
 {-| The Nixpkgs support for Dhall essentially replaces all remote imports with
     cache hits, but doing so implies that all remote imports must be protected
@@ -601,7 +593,7 @@ githubToNixpkgs GitHub{ name, uri, rev = maybeRev, hash, fetchSubmodules, direct
             Nix.mkFunction
                 (Nix.mkParamset
                     (   [ (buildDhallGitHubPackage, Nothing) ]
-                    <>  nub' (fmap functionParameter nixDependencies)
+                    <>  nub (fmap functionParameter nixDependencies)
                     )
                     False
                 )
@@ -662,7 +654,7 @@ directoryToNixpkgs Directory{ name, directory, file, source } = do
             Nix.mkFunction
                 (Nix.mkParamset
                     (   [ (buildDhallDirectoryPackage, Nothing) ]
-                    <>  nub' (fmap functionParameter nixDependencies)
+                    <>  nub (fmap functionParameter nixDependencies)
                     )
                     False
                 )

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -21,7 +21,7 @@ Executable dhall-to-nixpkgs
                      , data-fix
                      , dhall                >= 1.32.0   && < 1.36
                      , foldl                               < 1.5
-                     , hnix                 >= 0.7      && < 0.10
+                     , hnix                 >= 0.10.1   && < 0.11
                      , lens-family-core     >= 1.0.0    && < 2.2
                      , megaparsec           >= 7.0.0    && < 9.1
                      , mmorph                              < 1.2

--- a/nix/packages/data-fix.nix
+++ b/nix/packages/data-fix.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, deepseq, hashable, stdenv }:
+mkDerivation {
+  pname = "data-fix";
+  version = "0.3.0";
+  sha256 = "9e59b3ed694b5139316093b3767842e60ad4821858459e7cd763e5773dfa99a0";
+  libraryHaskellDepends = [ base deepseq hashable ];
+  homepage = "https://github.com/spell-music/data-fix";
+  description = "Fixpoint data types";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/packages/hnix.nix
+++ b/nix/packages/hnix.nix
@@ -1,49 +1,41 @@
 { mkDerivation, aeson, array, base, base16-bytestring, binary
-, bytestring, comonad, containers, contravariant, criterion
-, data-fix, deepseq, deriving-compat, Diff, directory, exceptions
-, filepath, free, generic-random, Glob, hashable, hashing
-, haskeline, hedgehog, hnix-store-core, http-client
-, http-client-tls, http-types, interpolate, lens-family
+, bytestring, comonad, containers, criterion, data-fix, deepseq
+, deriving-compat, Diff, directory, exceptions, filepath, free
+, gitrev, Glob, hashable, hashing, hedgehog, hnix-store-core
+, http-client, http-client-tls, http-types, lens-family
 , lens-family-core, lens-family-th, logict, megaparsec
-, monad-control, monadlist, mtl, optparse-applicative
-, parser-combinators, pretty-show, prettyprinter, process, ref-tf
-, regex-tdfa, repline, scientific, semialign, semialign-indexed
-, semigroups, serialise, some, split, stdenv, syb, tasty
-, tasty-hedgehog, tasty-hunit, tasty-quickcheck, tasty-th
-, template-haskell, text, these, time, transformers
-, transformers-base, unix, unordered-containers, vector, xml
+, monad-control, monadlist, mtl, neat-interpolation
+, optparse-applicative, parser-combinators, pretty-show
+, prettyprinter, process, ref-tf, regex-tdfa, scientific, semialign
+, semialign-indexed, serialise, some, split, stdenv, syb, tasty
+, tasty-hedgehog, tasty-hunit, tasty-th, template-haskell, text
+, these, time, transformers, transformers-base, unix
+, unordered-containers, vector, xml
 }:
 mkDerivation {
   pname = "hnix";
-  version = "0.9.0";
-  sha256 = "5cecc7cf00e7479914be12b5021f54ff8f6096ea1ccedf20eb79be88d52b929e";
+  version = "0.10.1";
+  sha256 = "9e31ed9f8a051ec3b17049d23f2f93a859ed2dac72ae2df7c812922883ba45a5";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     aeson array base base16-bytestring binary bytestring comonad
-    containers contravariant data-fix deepseq deriving-compat directory
-    exceptions filepath free hashable hashing hnix-store-core
-    http-client http-client-tls http-types interpolate lens-family
-    lens-family-core lens-family-th logict megaparsec monad-control
-    monadlist mtl optparse-applicative parser-combinators pretty-show
-    prettyprinter process ref-tf regex-tdfa scientific semialign
-    semialign-indexed semigroups serialise some split syb
+    containers data-fix deepseq deriving-compat directory exceptions
+    filepath free gitrev hashable hashing hnix-store-core http-client
+    http-client-tls http-types lens-family lens-family-core
+    lens-family-th logict megaparsec monad-control monadlist mtl
+    neat-interpolation optparse-applicative parser-combinators
+    pretty-show prettyprinter process ref-tf regex-tdfa scientific
+    semialign semialign-indexed serialise some split syb
     template-haskell text these time transformers transformers-base
     unix unordered-containers vector xml
   ];
-  executableHaskellDepends = [
-    aeson base base16-bytestring bytestring comonad containers data-fix
-    deepseq exceptions filepath free haskeline mtl optparse-applicative
-    pretty-show prettyprinter ref-tf repline serialise template-haskell
-    text time transformers unordered-containers
-  ];
   testHaskellDepends = [
     base base16-bytestring bytestring containers data-fix deepseq Diff
-    directory exceptions filepath generic-random Glob hedgehog
-    interpolate megaparsec mtl optparse-applicative pretty-show
-    prettyprinter process serialise split tasty tasty-hedgehog
-    tasty-hunit tasty-quickcheck tasty-th template-haskell text time
-    transformers unix unordered-containers
+    directory exceptions filepath Glob hedgehog megaparsec mtl
+    neat-interpolation optparse-applicative pretty-show prettyprinter
+    process serialise split tasty tasty-hedgehog tasty-hunit tasty-th
+    template-haskell text time transformers unix unordered-containers
   ];
   benchmarkHaskellDepends = [
     base base16-bytestring bytestring containers criterion data-fix

--- a/nix/packages/neat-interpolation.nix
+++ b/nix/packages/neat-interpolation.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, megaparsec, QuickCheck, quickcheck-instances
+, rerebase, stdenv, tasty, tasty-hunit, tasty-quickcheck
+, template-haskell, text
+}:
+mkDerivation {
+  pname = "neat-interpolation";
+  version = "0.5.1.2";
+  sha256 = "962a4a92da4911c8e5b784ed43200b764ea8c6b3add032a09c57658e4b4684a1";
+  libraryHaskellDepends = [ base megaparsec template-haskell text ];
+  testHaskellDepends = [
+    QuickCheck quickcheck-instances rerebase tasty tasty-hunit
+    tasty-quickcheck
+  ];
+  homepage = "https://github.com/nikita-volkov/neat-interpolation";
+  description = "A quasiquoter for neat and simple multiline text interpolation";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/packages/prettyprinter.nix
+++ b/nix/packages/prettyprinter.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, ansi-wl-pprint, base, base-compat, bytestring
+, containers, deepseq, doctest, gauge, mtl, pgp-wordlist
+, QuickCheck, quickcheck-instances, random, stdenv, tasty
+, tasty-hunit, tasty-quickcheck, text, transformers
+}:
+mkDerivation {
+  pname = "prettyprinter";
+  version = "1.7.0";
+  sha256 = "591b87ce8a5cff39d66cb1c156c7d27d04de57952f16eb3ce3afe309ac26e0a7";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [ base text ];
+  testHaskellDepends = [
+    base bytestring doctest pgp-wordlist QuickCheck
+    quickcheck-instances tasty tasty-hunit tasty-quickcheck text
+  ];
+  benchmarkHaskellDepends = [
+    ansi-wl-pprint base base-compat containers deepseq gauge mtl
+    QuickCheck random text transformers
+  ];
+  homepage = "http://github.com/quchen/prettyprinter";
+  description = "A modern, easy to use, well-documented, extensible pretty-printer";
+  license = stdenv.lib.licenses.bsd2;
+}

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -274,8 +274,6 @@ let
 
                     path-io = haskellPackagesNew.path-io_1_6_0;
 
-                    prettyprinter = haskellPackagesNew.prettyprinter_1_6_0;
-
                     semialign = haskellPackagesNew.semialign_1_1;
                   };
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,21 +10,23 @@ packages:
   - dhall-openapi
 extra-deps:
   - aeson-yaml-1.1.0.0
+  - data-fix-0.3.0
   - generic-random-1.3.0.0@sha256:e5dc3bc7854cfefddc41b562ae78771aaf2e06ea20d7a5c1ecbdb01ba12dd7b7,1346
   - hashing-0.1.0.1@sha256:98861f16791946cdf28e3c7a6ee9ac8b72d546d6e33c569c7087ef18253294e7,2816
   - haskeline-0.8.0.0@sha256:0630452b759a5b40e0e3e7ca2ef4b0d55d5161d95e8d7b0dd3cf55888971437f,5440
   - haskell-lsp-0.22.0.0
   - haskell-lsp-types-0.22.0.0
-  - hnix-0.9.0
+  - hnix-0.10.1
   - hnix-store-core-0.1.0.0@sha256:719a261870367b3ce2e2e8d11502e7170faa664109a14486b95b555bc3672807,2541
   - HsYAML-0.2.1.0@sha256:e4677daeba57f7a1e9a709a1f3022fe937336c91513e893166bd1f023f530d68,5311
   - HsYAML-aeson-0.2.0.0@sha256:04796abfc01cffded83f37a10e6edba4f0c0a15d45bef44fc5bb4313d9c87757,1791
   - lsp-test-0.10.3.0
   - monadlist-0.0.2@sha256:978305e3f03dd5f65c673b551124dac0c39a247c2c14d84739ca9a3405fbb63a,904
+  - neat-interpolation-0.5.1.2
   - parser-combinators-1.2.1@sha256:16c3490e007ec10b1255a2b36fb483d000156d555269107131241d9e0fa96412,1788
   - path-0.8.0
   - path-io-1.6.0
-  - prettyprinter-1.6.1@sha256:11876ec94a79048e1d2942a99bfaa6f2be5222eafeedac6a9545673a79465009,5459
+  - prettyprinter-1.7.0
   - ref-tf-0.4.0.2@sha256:69de3550250e0cd69f45d080359cb314a9487c915024349c75b78732bbee9332,1134
   - repline-0.4.0.0@sha256:3324479e497d27c40c3d4762bffc52058f9921621d20d2947dcf9a554b94cd0d,2253
   - semialign-1.1@sha256:5ff1788b6bcec97084ca60f736c126334e4ba4a450517e7ca4f69dd1156d38a0,2471


### PR DESCRIPTION
http://hackage.haskell.org/package/hnix-0.10.1/changelog

The `nub'` workaround appears to be redundant now, so I removed it.