### PR TITLE
Require dhall >= 1.35.0 for dhall-bash 1.0.33

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -31,7 +31,7 @@ Library
         base                      >= 4.11.0.0 && < 5   ,
         bytestring                               < 0.11,
         containers                               < 0.7 ,
-        dhall                     >= 1.34.0   && < 1.36,
+        dhall                     >= 1.35.0   && < 1.36,
         neat-interpolation                       < 0.6 ,
         shell-escape                             < 0.3 ,
         text                      >= 0.2      && < 1.3


### PR DESCRIPTION
It doesn't build with dhall 1.34.0:

```
[1 of 1] Compiling Dhall.Bash       ( src/Dhall/Bash.hs, dist/build/Dhall/Bash.dyn_o )

src/Dhall/Bash.hs:364:28: error:
    Not in scope: ‘Dhall.Core.fieldSelectionLabel’
    Module ‘Dhall.Core’ does not export ‘fieldSelectionLabel’.
    |
364 |     go e@(Field (Union m) (Dhall.Core.fieldSelectionLabel -> k)) =
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```