### PR TITLE
Use a longer HTTP response timeout in the import tests

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -665,6 +665,8 @@ Test-Suite tasty
         filepath                                       ,
         foldl                                    < 1.5 ,
         generic-random            >= 1.3.0.0  && < 1.4 ,
+        http-client                                    ,
+        http-client-tls                                ,
         lens-family-core                               ,
         megaparsec                                     ,
         prettyprinter                                  ,


### PR DESCRIPTION
…in order to reduce flakiness, as suggested by @Gabriel439 in https://github.com/dhall-lang/dhall-haskell/pull/2041#issuecomment-692863870.