### PR TITLE
Fix formatting of record fields with multiple labels

### DIFF
--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -1411,10 +1411,10 @@ prettyPrinters characterSet =
                                     )
           where
             (preSeparator, preComment)
-                | not (any hasComment key) = 
-                    (" ", Pretty.hardline <> "    ")
-                | otherwise =
+                | not (any hasComment (NonEmpty.tail key)) = 
                     (Pretty.hardline, " ")
+                | otherwise =
+                    (" ", Pretty.hardline <> "    ")
               where
                 hasComment (_, _, mSrc2) = containsComment mSrc2
 

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -1410,13 +1410,13 @@ prettyPrinters characterSet =
                                     <>  prettyValue val
                                     )
           where
-            (preSeparator, preComment) =
-                case key of
-                    (_, _, mSrc2) :| [] | not (containsComment mSrc2) ->
-                        (" ", Pretty.hardline <> "    ")
-                    _ ->
-                        (Pretty.hardline, " ")
-
+            (preSeparator, preComment)
+                | not (any hasComment key) = 
+                    (" ", Pretty.hardline <> "    ")
+                | otherwise =
+                    (Pretty.hardline, " ")
+              where
+                hasComment (_, _, mSrc2) = containsComment mSrc2
 
     prettyRecord :: Pretty a => Map Text (RecordField Src a) -> Doc Ann
     prettyRecord =

--- a/dhall/tests/format/duplicatesB.dhall
+++ b/dhall/tests/format/duplicatesB.dhall
@@ -1,6 +1,6 @@
 { foo.bar = 1
-, foo.baz
-  = {- Comments within values are still preserved-}
+, foo.baz =
+    {- Comments within values are still preserved-}
     2
 , foo = qux
 }

--- a/dhall/tests/format/duplicatesB.dhall
+++ b/dhall/tests/format/duplicatesB.dhall
@@ -1,6 +1,6 @@
 { foo.bar = 1
-, foo.baz =
-    {- Comments within values are still preserved-}
+, foo.baz
+  = {- Comments within values are still preserved-}
     2
 , foo = qux
 }


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2051

The old formatter had a special case for handling only one
uncommented label, but multiple labels triggered the spacious
fallback for formatting commented labels.

This change fixes that by handling more than one uncommented
label.