### PR TITLE
Pack up manpages alongside binaries (for linux + mac)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,17 @@ script:
   - export PATH="${PATH}:$(pwd)/bin"
   - stack build --copy-bins --local-bin-path ./bin
   - source .travis-functions.sh
-  - tar -jcvf $(mk_release_name dhall) bin/dhall
+  - mkdir -p share/man/man1
+  - cp dhall/man/dhall.1 share/man/man1/
+  - cp dhall-docs/src/Dhall/data/man/dhall-docs.1 share/man/man1/
+  - tar -jcvf $(mk_release_name dhall) bin/dhall share/man/man1/dhall.1
   - tar -jcvf $(mk_release_name dhall-json) bin/dhall-to-json bin/dhall-to-yaml bin/json-to-dhall
   - tar -jcvf $(mk_release_name dhall-bash) bin/dhall-to-bash
   - tar -jcvf $(mk_release_name dhall-lsp-server) bin/dhall-lsp-server
   - tar -jcvf $(mk_release_name dhall-nix) bin/dhall-to-nix
   - tar -jcvf $(mk_release_name dhall-openapi) bin/openapi-to-dhall
   - tar -jcvf $(mk_release_name dhall-yaml) bin/dhall-to-yaml-ng bin/yaml-to-dhall
-  - tar -jcvf $(mk_release_name dhall-docs) bin/dhall-docs bin/dhall-docs
+  - tar -jcvf $(mk_release_name dhall-docs) bin/dhall-docs bin/dhall-docs share/man/man1/dhall-docs.1
   - mkdir -p uploads
   - mv *.tar.bz2 uploads/
 


### PR DESCRIPTION
`dhall-docs` and `dhall` themselves have manpages, so these could be packed up in the binary distributions. This adds some travis machinery to do so. 