### PR TITLE
Allow profunctors 5.6

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -503,7 +503,7 @@ Library
         prettyprinter               >= 1.5.1    && < 1.8 ,
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
         pretty-simple                              < 4.1 ,
-        profunctors                 >= 3.1.2    && < 5.6 ,
+        profunctors                 >= 3.1.2    && < 5.7 ,
         repline                     >= 0.4.0.0  && < 0.5 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,


### PR DESCRIPTION
http://hackage.haskell.org/package/profunctors-5.6/changelog

Tested locally with `--allow-newer`.