### PR TITLE
Add `dhall lint` support for Prelude extensions

### DIFF
--- a/dhall/src/Dhall/Lint.hs
+++ b/dhall/src/Dhall/Lint.hs
@@ -108,6 +108,9 @@ fixParentPath (Embed oldImport) = do
             Nothing
 fixParentPath _  = Nothing
 
+{-| This transforms @https://prelude.dhall-lang.org/…/foo@ to
+    @https://prelude.dhall-lang.org/…/foo.dhall@
+-}
 addPreludeExtensions :: Expr s Import -> Maybe (Expr s Import)
 addPreludeExtensions (Embed oldImport) = do
     let Import{ importHashed = oldImportHashed, .. } = oldImport

--- a/dhall/tests/lint/success/PreludeExtensionA.dhall
+++ b/dhall/tests/lint/success/PreludeExtensionA.dhall
@@ -1,0 +1,1 @@
+https://prelude.dhall-lang.org/List/map

--- a/dhall/tests/lint/success/PreludeExtensionB.dhall
+++ b/dhall/tests/lint/success/PreludeExtensionB.dhall
@@ -1,0 +1,1 @@
+https://prelude.dhall-lang.org/List/map.dhall

--- a/dhall/tests/lint/success/multiletA.dhall
+++ b/dhall/tests/lint/success/multiletA.dhall
@@ -21,7 +21,7 @@ let example
 
 let everybody
     : Person → List Text
-    = let concat = http://prelude.dhall-lang.org/List/concat
+    = let concat = http://prelude.dhall-lang.org/List/concat.dhall
       
       in    λ(x : Person)
           → x

--- a/dhall/tests/lint/success/multiletB.dhall
+++ b/dhall/tests/lint/success/multiletB.dhall
@@ -20,7 +20,7 @@ let example
 
 let everybody
     : Person → List Text
-    = let concat = http://prelude.dhall-lang.org/List/concat
+    = let concat = http://prelude.dhall-lang.org/List/concat.dhall
 
       in  λ(x : Person) →
             x

--- a/dhall/tests/lint/success/regression0A.dhall
+++ b/dhall/tests/lint/success/regression0A.dhall
@@ -1,4 +1,4 @@
-    let replicate = https://prelude.dhall-lang.org/List/replicate
+    let replicate = https://prelude.dhall-lang.org/List/replicate.dhall
 
 in  let Config = { name : Text, age : Natural }
 

--- a/dhall/tests/lint/success/regression0B.dhall
+++ b/dhall/tests/lint/success/regression0B.dhall
@@ -1,3 +1,3 @@
-let replicate = https://prelude.dhall-lang.org/List/replicate
+let replicate = https://prelude.dhall-lang.org/List/replicate.dhall
 
 in  replicate 10 Text "!"


### PR DESCRIPTION
`dhall lint` will now add a `.dhall` extension to any
Prelude import missing the extension.