### PR TITLE
Improve cache warning messages

### DIFF
--- a/dhall/doctest/Main.hs
+++ b/dhall/doctest/Main.hs
@@ -6,6 +6,7 @@ import System.FilePath ((</>))
 
 import qualified GHC.IO.Encoding
 import qualified System.Directory
+import qualified System.Environment
 import qualified System.IO
 import qualified Test.DocTest
 import qualified Test.Mockery.Directory
@@ -16,6 +17,8 @@ main = do
     GHC.IO.Encoding.setLocaleEncoding System.IO.utf8
     pwd    <- System.Directory.getCurrentDirectory
     prefix <- System.Directory.makeAbsolute pwd
+
+    System.Environment.setEnv "XDG_CACHE_HOME" (pwd </> ".cache")
 
     Test.Mockery.Directory.inTempDirectory $ do
         writeFile "makeBools.dhall" "λ(n : Bool) → [ n && True, n && False, n || True, n || False ]"

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -84,6 +84,10 @@ defaultNewManager =
   pure ()
 #endif
 
+{-| Used internally to track whether or not we've already warned the user about
+    caching issues
+-}
+data CacheWarning = CacheNotWarned | CacheWarned
 
 -- | State threaded throughout the import process
 data Status = Status
@@ -115,7 +119,7 @@ data Status = Status
 
     , _semanticCacheMode :: SemanticCacheMode
 
-    , _cacheWarning :: Bool
+    , _cacheWarning :: CacheWarning
     -- ^ Records whether or not we already warned the user about issues with
     --   cache directory
     }
@@ -141,7 +145,7 @@ emptyStatusWith _newManager _remote rootDirectory = Status {..}
 
     _semanticCacheMode = UseSemanticCache
 
-    _cacheWarning = False
+    _cacheWarning = CacheNotWarned
 
     prefix = if isRelative rootDirectory
       then Here
@@ -191,7 +195,7 @@ startingContext k s =
     fmap (\x -> s { _startingContext = x }) (k (_startingContext s))
 
 -- | Lens from a `Status` to its `_cacheWarning` field
-cacheWarning :: Functor f => LensLike' f Status Bool
+cacheWarning :: Functor f => LensLike' f Status CacheWarning
 cacheWarning k s = fmap (\x -> s { _cacheWarning = x }) (k (_cacheWarning s))
 
 {-| This exception indicates that there was an internal error in Dhall's

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -114,6 +114,10 @@ data Status = Status
     , _startingContext :: Context (Expr Src Void)
 
     , _semanticCacheMode :: SemanticCacheMode
+
+    , _cacheWarning :: Bool
+    -- ^ Records whether or not we already warned the user about issues with
+    --   cache directory
     }
 
 -- | Initial `Status`, parameterised over the HTTP 'Manager' and the remote resolver,
@@ -136,6 +140,8 @@ emptyStatusWith _newManager _remote rootDirectory = Status {..}
     _startingContext = Dhall.Context.empty
 
     _semanticCacheMode = UseSemanticCache
+
+    _cacheWarning = False
 
     prefix = if isRelative rootDirectory
       then Here
@@ -173,8 +179,7 @@ remote k s = fmap (\x -> s { _remote = x }) (k (_remote s))
 
 -- | Lens from a `Status` to its `_substitutions` field
 substitutions :: Functor f => LensLike' f Status (Dhall.Substitution.Substitutions Src Void)
-substitutions k s =
-    fmap (\x -> s { _substitutions = x }) (k (_substitutions s))
+substitutions k s = fmap (\x -> s { _substitutions = x }) (k (_substitutions s))
 
 -- | Lens from a `Status` to its `_normalizer` field
 normalizer :: Functor f => LensLike' f Status (Maybe (ReifiedNormalizer Void))
@@ -184,6 +189,10 @@ normalizer k s = fmap (\x -> s {_normalizer = x}) (k (_normalizer s))
 startingContext :: Functor f => LensLike' f Status (Context (Expr Src Void))
 startingContext k s =
     fmap (\x -> s { _startingContext = x }) (k (_startingContext s))
+
+-- | Lens from a `Status` to its `_cacheWarning` field
+cacheWarning :: Functor f => LensLike' f Status Bool
+cacheWarning k s = fmap (\x -> s { _cacheWarning = x }) (k (_cacheWarning s))
 
 {-| This exception indicates that there was an internal error in Dhall's
     import-related logic

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -23,7 +23,6 @@ module Dhall.Main
 
 import Control.Applicative       (optional, (<|>))
 import Control.Exception         (Handler (..), SomeException)
-import Control.Monad             (when)
 import Data.Foldable             (for_)
 import Data.List.NonEmpty        (NonEmpty (..))
 import Data.Text                 (Text)
@@ -119,12 +118,6 @@ data Options = Options
     , ascii   :: Bool
     , censor  :: Censor
     }
-
-ignoreSemanticCache :: Mode -> Bool
-ignoreSemanticCache Default {..} = semanticCacheMode == IgnoreSemanticCache
-ignoreSemanticCache Resolve {..} = semanticCacheMode == IgnoreSemanticCache
-ignoreSemanticCache Type {..}    = semanticCacheMode == IgnoreSemanticCache
-ignoreSemanticCache _            = False
 
 -- | The subcommands for the @dhall@ executable
 data Mode
@@ -630,8 +623,6 @@ command (Options {..}) = do
             let stream = Dhall.Pretty.layout (doc <> "\n")
 
             AtomicWrite.LazyText.atomicWriteFile file (Pretty.Text.renderLazy stream)
-
-    when (not $ ignoreSemanticCache mode) Dhall.Import.warnAboutMissingCaches
 
     handle $ case mode of
         Version ->


### PR DESCRIPTION
The immediate motivation for this fix is to ensure that
command-line utilities other than `dhall` correctly warn about
issues with cache directories, as reported in:

https://github.com/dhall-lang/dhall-haskell/issues/2091#issuecomment-726081917

The main change along those lines is to move the cache check from
the `Dhall.Main` module to checking on the fly as cache files are
read/written.  However, in order to avoid going back to too many
cache warnings this also includes logic to avoid warning more than
once by tracking a `cacheWarning` state `Bool`.

This also includes a small improvement to the permissions error
message to better render the directory permissions.