### PR TITLE
Improve error message for duplicate projection label

### DIFF
--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -73,7 +73,6 @@ import qualified Data.List.NonEmpty    as NonEmpty
 import qualified Data.Sequence
 import qualified Dhall.Crypto
 import qualified Dhall.Map
-import qualified Dhall.Set
 import qualified Dhall.Syntax          as Syntax
 import qualified Text.Printf           as Printf
 
@@ -415,7 +414,7 @@ decodeExpressionInternal decodeEmbed = go
 
                                             TypeString -> do
                                                 x <- Decoding.decodeString
-                                                return (Left (Dhall.Set.fromList [x]))
+                                                return (Left [x])
 
                                             _ ->
                                                 die ("Unexpected token type for projection: " <> show tokenType₂)
@@ -423,7 +422,7 @@ decodeExpressionInternal decodeEmbed = go
                                     _ -> do
                                         xs <- replicateDecoder (len - 2) Decoding.decodeString
 
-                                        return (Left (Dhall.Set.fromList xs))
+                                        return (Left xs)
 
                                 return (Project t xs)
 
@@ -852,10 +851,10 @@ encodeExpressionInternal encodeEmbed = go
 
         Project t (Left xs) ->
             encodeListN
-                (2 + Dhall.Set.size xs)
+                (2 + length xs)
                 ( Encoding.encodeInt 10
                 : go t
-                : map Encoding.encodeString (Dhall.Set.toList xs)
+                : map Encoding.encodeString xs
                 )
 
         Project t (Right _T) ->

--- a/dhall/src/Dhall/Parser/Combinators.hs
+++ b/dhall/src/Dhall/Parser/Combinators.hs
@@ -17,7 +17,6 @@ module Dhall.Parser.Combinators
     , satisfy
     , Dhall.Parser.Combinators.takeWhile
     , takeWhile1
-    , noDuplicates
     , toMap
     , toMapWith
     ) where
@@ -31,19 +30,16 @@ import Data.Text                 (Text)
 import Data.Text.Prettyprint.Doc (Pretty (..))
 import Data.Void                 (Void)
 import Dhall.Map                 (Map)
-import Dhall.Set                 (Set)
 import Dhall.Src                 (Src (..))
 import Text.Parser.Combinators   (try, (<?>))
 import Text.Parser.Token         (TokenParsing (..))
 
 import qualified Control.Monad.Fail
 import qualified Data.Char
-import qualified Data.Set
 import qualified Data.Text
 import qualified Data.Text.Prettyprint.Doc.Render.String as Pretty
 import qualified Dhall.Map
 import qualified Dhall.Pretty
-import qualified Dhall.Set
 import qualified Text.Megaparsec
 import qualified Text.Megaparsec.Char
 import qualified Text.Parser.Char
@@ -263,16 +259,6 @@ takeWhile predicate = Parser (Text.Megaparsec.takeWhileP Nothing predicate)
 --   that match the given predicate. It fails when no character was consumed
 takeWhile1 :: (Char -> Bool) -> Parser Text
 takeWhile1 predicate = Parser (Text.Megaparsec.takeWhile1P Nothing predicate)
-
--- | Construct a 'Set a' from a '[a]', failing if there was a duplicate element
-noDuplicates :: Ord a => [a] -> Parser (Set a)
-noDuplicates = go Dhall.Set.empty
-  where
-    go found    []  = return found
-    go found (x:xs) =
-        if Data.Set.member x (Dhall.Set.toSet found)
-        then fail "Duplicate key"
-        else go (Dhall.Set.append x found) xs
 
 -- | Creates a map with the given key-value pairs, failing if there was a
 --   duplicate key.

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -116,7 +116,6 @@ import Control.Applicative     (Alternative (..), optional)
 import Data.Bits               ((.&.))
 import Data.Functor            (void, ($>))
 import Data.Text               (Text)
-import Dhall.Set               (Set)
 import Dhall.Syntax
 import Text.Parser.Combinators (choice, try, (<?>))
 
@@ -128,7 +127,6 @@ import qualified Data.List                  as List
 import qualified Data.List.NonEmpty
 import qualified Data.Scientific            as Scientific
 import qualified Data.Text
-import qualified Dhall.Set
 import qualified Text.Megaparsec
 import qualified Text.Megaparsec.Char.Lexer
 import qualified Text.Parser.Char
@@ -443,7 +441,7 @@ backtickLabel = do
 
     This corresponds to the @labels@ rule in the official grammar
 -}
-labels :: Parser (Set Text)
+labels :: Parser [Text]
 labels = do
     _openBrace
 
@@ -454,7 +452,7 @@ labels = do
     emptyLabels = do
         try (optional (_comma *> whitespace) *> _closeBrace)
 
-        pure Dhall.Set.empty
+        pure []
 
     nonEmptyLabels = do
         x  <- try (optional (_comma *> whitespace) *> anyLabelOrSome)
@@ -467,7 +465,7 @@ labels = do
 
         _closeBrace
 
-        noDuplicates (x : xs)
+        return (x : xs)
 
 {-| Parse a label (e.g. a variable\/field\/alternative name)
 

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -70,7 +70,6 @@ import Data.List.NonEmpty        (NonEmpty (..))
 import Data.Text                 (Text)
 import Data.Text.Prettyprint.Doc (Doc, Pretty, space)
 import Dhall.Map                 (Map)
-import Dhall.Set                 (Set)
 import Dhall.Src                 (Src (..))
 import Dhall.Syntax
 import Numeric.Natural           (Natural)
@@ -80,14 +79,12 @@ import qualified Data.HashSet
 import qualified Data.List
 import qualified Data.List.NonEmpty                        as NonEmpty
 import qualified Data.Maybe
-import qualified Data.Set
 import qualified Data.Text                                 as Text
 import qualified Data.Text.Prettyprint.Doc                 as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.String   as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Terminal
 import qualified Data.Text.Prettyprint.Doc.Render.Text     as Pretty
 import qualified Dhall.Map                                 as Map
-import qualified Dhall.Set
 
 {-| Annotation type used to tag elements in a pretty-printed document for
     syntax highlighting purposes
@@ -509,12 +506,10 @@ prettyAnyLabels keys = Pretty.group (Pretty.flatAlt long short)
           , renderSrcMaybe mSrc1
           ]
 
-prettyLabels :: Set Text -> Doc Ann
+prettyLabels :: [Text] -> Doc Ann
 prettyLabels a
-    | Data.Set.null (Dhall.Set.toSet a) =
-        lbrace <> rbrace
-    | otherwise =
-        braces (map (duplicate . prettyAnyLabel) (Dhall.Set.toList a))
+    | null a    = lbrace <> rbrace
+    | otherwise = braces (map (duplicate . prettyAnyLabel) a)
 
 prettyNumber :: Integer -> Doc Ann
 prettyNumber = literal . Pretty.pretty

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -100,7 +100,6 @@ import Data.Traversable           ()
 import Data.Void                  (Void)
 import Dhall.Map                  (Map)
 import {-# SOURCE #-} Dhall.Pretty.Internal
-import Dhall.Set                  (Set)
 import Dhall.Src                  (Src (..))
 import GHC.Generics               (Generic)
 import Instances.TH.Lift          ()
@@ -609,7 +608,7 @@ data Expr s a
     | Field (Expr s a) (FieldSelection s)
     -- | > Project e (Left xs)                      ~  e.{ xs }
     --   > Project e (Right t)                      ~  e.(t)
-    | Project (Expr s a) (Either (Set Text) (Expr s a))
+    | Project (Expr s a) (Either [Text] (Expr s a))
     -- | > Assert e                                 ~  assert : e
     | Assert (Expr s a)
     -- | > Equivalent x y                           ~  x ≡ y

--- a/dhall/tests/Dhall/Test/QuickCheck.hs
+++ b/dhall/tests/Dhall/Test/QuickCheck.hs
@@ -308,7 +308,7 @@ instance (Arbitrary s, Arbitrary a) => Arbitrary (Expr s a) where
             :: ConstrGen "Lam" 0 (FunctionBinding s a)
             :+ ConstrGen "Pi" 0 Text
             :+ ConstrGen "Field" 1 (FieldSelection s)
-            :+ ConstrGen "Project" 1 (Either (Set Text) (Expr s a))
+            :+ ConstrGen "Project" 1 (Either [Text] (Expr s a))
             :+ Gen Integer  -- Generates all Integer fields in Expr
             :+ Gen Text     -- Generates all Text fields in Expr
             :+ ()
@@ -326,7 +326,7 @@ instance (Arbitrary s, Arbitrary a) => Arbitrary (Expr s a) where
 
         projection =
             Test.QuickCheck.oneof
-                [ fmap (Left . Dhall.Set.fromList) (Test.QuickCheck.listOf label)
+                [ fmap Left (Test.QuickCheck.listOf label)
                 , arbitrary
                 ]
 

--- a/dhall/tests/Dhall/Test/TypeInference.hs
+++ b/dhall/tests/Dhall/Test/TypeInference.hs
@@ -103,8 +103,7 @@ failureTest prefix = do
                [
                -- Duplicate fields are incorrectly caught during parsing:
                -- https://github.com/dhall-lang/dhall-haskell/issues/772
-                 typeInferenceDirectory </> "failure/unit/RecordProjectionDuplicateFields"
-               , typeInferenceDirectory </> "failure/unit/RecordTypeDuplicateFields"
+                 typeInferenceDirectory </> "failure/unit/RecordTypeDuplicateFields"
                , typeInferenceDirectory </> "failure/unit/UnionTypeDuplicateVariants1"
                , typeInferenceDirectory </> "failure/unit/UnionTypeDuplicateVariants2"
                ]


### PR DESCRIPTION
… by correctly adhering to the standard, which treats this as a type
error instead of a parse error.

Fixes https://github.com/dhall-lang/dhall-haskell/issues/2094