### PR TITLE
dhall-nixpkgs: Allow aeson 1.5

### DIFF
--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -17,7 +17,7 @@ Build-Type:          Simple
 Executable dhall-to-nixpkgs
   Main-Is:             Main.hs
   Build-Depends:       base                 >= 4.11     && < 5
-                     , aeson                >= 1.0.0.0  && < 1.5
+                     , aeson                >= 1.0.0.0  && < 1.6
                      , data-fix
                      , dhall                >= 1.32.0   && < 1.38
                      , foldl                               < 1.5


### PR DESCRIPTION
Tested locally with `cabal build dhall-nixpkgs/ --constraint 'aeson>=1.5'`.