### PR TITLE
Add support for explicit splitting of definitions

### DIFF
--- a/dhall-openapi/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Types.hs
@@ -22,6 +22,8 @@ type DuplicateHandler = (Text, [ModelName]) -> Maybe ModelName
 
 type Prefix = Text
 
+type ModelHierarchy = [ModelName]
+
 {-| Type for the Swagger specification.
 
 There is such a type defined in the `swagger2` package, but Kubernetes' OpenAPI
@@ -48,7 +50,7 @@ data Definition = Definition
   , required         :: Maybe (Set FieldName)
   , baseData         :: Maybe BaseData
   , intOrString      :: Maybe Bool
-  } deriving (Generic, Show)
+  } deriving (Generic, Show, Eq)
 
 instance FromJSON Definition where
   parseJSON = withObject "definition" $ \o -> do
@@ -67,12 +69,11 @@ instance FromJSON Definition where
 
 
 newtype Ref = Ref { unRef :: Text }
-  deriving (Generic, Show, FromJSON)
+  deriving (Generic, Show, FromJSON, Eq)
 
 
 newtype ModelName = ModelName { unModelName :: Text }
   deriving (Generic, Show, Ord, FromJSONKey, Eq, Pretty)
-
 
 newtype FieldName = FieldName { unFieldName :: Text }
   deriving (Generic, Show, FromJSON, FromJSONKey, Ord, Eq, Pretty)
@@ -95,7 +96,7 @@ For example for a v1 Deployment we have
 data BaseData = BaseData
   { kind       :: Text
   , apiVersion :: Text
-  } deriving (Generic, Show)
+  } deriving (Generic, Show, Eq)
 
 instance FromJSON BaseData where
   parseJSON = withArray "array of values" $ \arr -> withObject "baseData" (\o -> do


### PR DESCRIPTION
The motivation behind this is better user experience when dealing
with Kubernetes CRDs. CRDs in an openapi definition are expressed
as one massive definition rather than the Kubernetes builtin types
which rarely nest and instead make use of references within openapi.
These references are desirable as it makes it more manageable to
sparsely define resources utilizing the nested defaults as you go down
the structure.

Unfortunately it looks like support for references wrt CRDs is unlikely
to be supported in the near future:

https://github.com/kubernetes/kubernetes/issues/62872

As a workaround, this adds a new option `--splitPaths` that takes a path
and an optional new model name. The path roughly emulates the idea
behind `kubectl explain` but I ended up using the `~` character instead
of `.` such that the full parent model name could still be used without
ambiguities. During type conversion any matches of path will cause a
Dhall reference to be injected with the nested definition being pushed
back on the stack of definitions to convert. The top level model name
can either be specified on the command line via `=com.some.ModelName` or
be guessed in the case the CRD author follows the best practice of using
the field name as the first word in the description.

Some future work that might need exploring related to this are:
1. Allow specifying `splitPaths` from a file
2. Clean up which types get accumulated into the `typesUnion`. I noticed
   while doing this that all? top level definitions are being dumped
   into this union where really it should only be top level definitions
   that have an `apiVersion` and `kind`
3. See if the `mergeNoConflicts` function needs to be improved such that
   it takes semantic equality (traversing imports) into account.