### PR TITLE
Give priority to native k8s over crds

### DIFF
--- a/dhall-openapi/openapi-to-dhall/Main.hs
+++ b/dhall-openapi/openapi-to-dhall/Main.hs
@@ -150,11 +150,15 @@ getAutoscaling ModelName{..}
     | otherwise =
         Nothing
 
+isK8sNative :: ModelName -> Bool
+isK8sNative ModelName{..} = Text.isPrefixOf "io.k8s." unModelName
+
 preferStableResource :: DuplicateHandler
 preferStableResource (_, names) = do
     let issue112 = Ord.comparing getAutoscaling
+    let k8sOverCrd = Ord.comparing isK8sNative
     let defaultComparison = Ord.comparing getVersion
-    let comparison = issue112 <> defaultComparison
+    let comparison = issue112 <> k8sOverCrd <> defaultComparison
     return (List.maximumBy comparison names)
 
 skipDuplicatesHandler :: DuplicateHandler

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -261,7 +261,7 @@ getImportsMap prefixMap duplicateNameHandler objectNames folder toInclude
     namespacedToSimple
       = Data.Map.fromList $ mapMaybe selectObject $ Data.Map.toList $ groupByObjectName objectNames
 
-    -- | Given a list of fully namespaced bjects, it will group them by the
+    -- | Given a list of fully namespaced objects, it will group them by the
     --   object name
     groupByObjectName :: [ModelName] -> Data.Map.Map Text [ModelName]
     groupByObjectName modelNames = Data.Map.unionsWith (<>)


### PR DESCRIPTION
Context is given an openapi.json with both k8s resources and CRDs, some
CRDs will have model names matching the native k8s resources (i.e.
calico NetworkPolicy). Longer term it would be desirable to not have to
"choose" between these types but in the short term we should at least
ensure the k8s native resources don't get clobbered.