### PR TITLE
dhall-openapi: support signed openapi integers

### DIFF
--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -51,6 +51,7 @@ library
     containers              >= 0.5.8.0   && < 0.7  ,
     dhall                   >= 1.35.0    && < 1.38 ,
     prettyprinter           >= 1.7.0     && < 1.8  ,
+    scientific              >= 0.3.0.0   && < 0.4  ,
     sort                    >= 1.0       && < 1.1  ,
     text                    >= 0.11.1.0  && < 1.3  ,
     vector                  >= 0.11.0.0  && < 0.13

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -15,6 +15,7 @@ import Data.Aeson
 import Data.Aeson.Types (Parser, parseMaybe)
 import Data.Bifunctor (first, second)
 import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Scientific (Scientific)
 import Data.Set (Set)
 import Data.Text (Text)
 import Dhall.Kubernetes.Types
@@ -153,8 +154,11 @@ toTypes prefixMap definitions = memo
         "string"  | format == Just "int-or-string" -> intOrStringType
         "string"  -> Dhall.Text
         "boolean" -> Dhall.Bool
-        "integer" -> Dhall.Integer
-        "number"  -> Dhall.Double
+        "integer" -> case (minimum_, exclusiveMinimum) of
+          (Just min_, Just True) | min_ >= -1 -> Dhall.Natural
+          (Just min_, _)         | min_ >= 0 -> Dhall.Natural
+          _                      -> Dhall.Integer
+        "number"  -> Dhall.Double 
         other     -> error $ "Found missing Swagger type: " <> Text.unpack other
       -- There are empty schemas that only have a description, so we return empty record
       _ -> Dhall.Record mempty
@@ -357,6 +361,8 @@ data V1JSONSchemaProps =
         { v1JSONSchemaPropsRef :: Maybe Text
         , v1JSONSchemaPropsDescription :: Maybe Text
         , v1JSONSchemaPropsFormat :: Maybe Text
+        , v1JSONSchemaPropsMinimum :: Maybe Scientific
+        , v1JSONSchemaPropsExclusiveMinimum :: Maybe Bool
         , v1JSONSchemaPropsItems :: Maybe Value
         , v1JSONSchemaPropsProperties :: Maybe (Data.Map.Map String V1JSONSchemaProps)
         , v1JSONSchemaPropsRequired :: Maybe [Text]
@@ -373,6 +379,8 @@ mkV1JSONSchemaProps =
         { v1JSONSchemaPropsRef = Nothing
         , v1JSONSchemaPropsDescription = Nothing
         , v1JSONSchemaPropsFormat = Nothing
+        , v1JSONSchemaPropsMinimum = Nothing
+        , v1JSONSchemaPropsExclusiveMinimum = Nothing
         , v1JSONSchemaPropsItems = Nothing
         , v1JSONSchemaPropsProperties = Nothing
         , v1JSONSchemaPropsRequired = Nothing
@@ -438,15 +446,17 @@ toDefinition crd = fmap (\d -> (modelName, d)) definition
     propsToDefinition :: V1JSONSchemaProps -> Maybe BaseData -> Definition
     propsToDefinition V1JSONSchemaProps{..} basedata =
       Definition
-        { typ         = v1JSONSchemaPropsType
-        , ref         = Ref <$> v1JSONSchemaPropsRef
-        , format      = v1JSONSchemaPropsFormat
-        , description = v1JSONSchemaPropsDescription
-        , items       = v1JSONSchemaPropsItems >>= parseMaybe parseJSON
-        , properties  = fmap toProperties v1JSONSchemaPropsProperties
-        , required    = fmap (Set.fromList . fmap FieldName) v1JSONSchemaPropsRequired
-        , baseData    = basedata
-        , intOrString = v1JSONSchemaPropsIntOrString
+        { typ              = v1JSONSchemaPropsType
+        , ref              = Ref <$> v1JSONSchemaPropsRef
+        , format           = v1JSONSchemaPropsFormat
+        , minimum_         = v1JSONSchemaPropsMinimum
+        , exclusiveMinimum = v1JSONSchemaPropsExclusiveMinimum
+        , description      = v1JSONSchemaPropsDescription
+        , items            = v1JSONSchemaPropsItems >>= parseMaybe parseJSON
+        , properties       = fmap toProperties v1JSONSchemaPropsProperties
+        , required         = fmap (Set.fromList . fmap FieldName) v1JSONSchemaPropsRequired
+        , baseData         = basedata
+        , intOrString      = v1JSONSchemaPropsIntOrString
         }
 
     toProperties :: Data.Map.Map String V1JSONSchemaProps -> Data.Map.Map ModelName Definition

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -153,7 +153,7 @@ toTypes prefixMap definitions = memo
         "string"  | format == Just "int-or-string" -> intOrStringType
         "string"  -> Dhall.Text
         "boolean" -> Dhall.Bool
-        "integer" -> Dhall.Natural
+        "integer" -> Dhall.Integer
         "number"  -> Dhall.Double
         other     -> error $ "Found missing Swagger type: " <> Text.unpack other
       -- There are empty schemas that only have a description, so we return empty record

--- a/dhall-openapi/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Types.hs
@@ -9,6 +9,7 @@ import           Control.Applicative       (optional)
 import           Control.Monad             (join)
 import           Data.Aeson
 import           Data.Map                  (Map)
+import           Data.Scientific           (Scientific)
 import           Data.Set                  (Set)
 import           Data.Text                 (Text)
 import           Data.Text.Prettyprint.Doc (Pretty)
@@ -36,28 +37,32 @@ instance FromJSON Swagger
 
 
 data Definition = Definition
-  { typ         :: Maybe Text
-  , ref         :: Maybe Ref
-  , format      :: Maybe Text
-  , description :: Maybe Text
-  , items       :: Maybe Definition
-  , properties  :: Maybe (Map ModelName Definition)
-  , required    :: Maybe (Set FieldName)
-  , baseData    :: Maybe BaseData
-  , intOrString :: Maybe Bool
+  { typ              :: Maybe Text
+  , ref              :: Maybe Ref
+  , format           :: Maybe Text
+  , minimum_         :: Maybe Scientific -- Avoid shadowing with Prelude.minimum
+  , exclusiveMinimum :: Maybe Bool
+  , description      :: Maybe Text
+  , items            :: Maybe Definition
+  , properties       :: Maybe (Map ModelName Definition)
+  , required         :: Maybe (Set FieldName)
+  , baseData         :: Maybe BaseData
+  , intOrString      :: Maybe Bool
   } deriving (Generic, Show)
 
 instance FromJSON Definition where
   parseJSON = withObject "definition" $ \o -> do
-    typ         <- o .:? "type"
-    ref         <- o .:? "$ref"
-    format      <- o .:? "format"
-    properties  <- o .:? "properties"
-    required    <- o .:? "required"
-    items       <- o .:? "items"
-    description <- o .:? "description"
-    baseData    <- fmap join $ optional (o .:? "x-kubernetes-group-version-kind")
-    intOrString <- o .:? "x-kubernetes-int-or-string"
+    typ              <- o .:? "type"
+    ref              <- o .:? "$ref"
+    format           <- o .:? "format"
+    minimum_         <- o .:? "minimum"
+    exclusiveMinimum <- o .:? "exclusiveMinimum"
+    properties       <- o .:? "properties"
+    required         <- o .:? "required"
+    items            <- o .:? "items"
+    description      <- o .:? "description"
+    baseData         <- fmap join $ optional (o .:? "x-kubernetes-group-version-kind")
+    intOrString      <- o .:? "x-kubernetes-int-or-string"
     pure Definition{..}
 
 


### PR DESCRIPTION
OpenAPI integer types are signed ([see `integer`](http://spec.openapis.org/oas/v3.0.3#data-types)), but they are currently decoded into the Dhall Natural type, which is unsigned. This PR updates the behaviour to decode into Dhall Integers.