### PR TITLE
dhall-openapi: make `metadata` optional for "inner" k8s types

### DIFF
--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -65,6 +65,15 @@ requiredFields maybeName required
       , ( ModelName "io.k8s.api.core.v1.PersistentVolumeClaim"
         , Set.fromList [ FieldName "apiVersion", FieldName "kind" ]
         )
+      , ( ModelName "io.k8s.api.batch.v1beta1.JobTemplateSpec"
+        , Set.fromList [ FieldName "metadata" ]
+        )
+      , ( ModelName "io.k8s.api.batch.v2alpha1.JobTemplateSpec"
+        , Set.fromList [ FieldName "metadata" ]
+        )
+      , ( ModelName "io.k8s.api.core.v1.PodTemplateSpec"
+        , Set.fromList [ FieldName "metadata" ]
+        )
       ]
 
 


### PR DESCRIPTION
The `metadata` field is required for all top level resources
according to
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata.

However for "inner" types this is not the case. For example
`io.k8s.api.batch.v1beta1.JobTemplateSpec` has a `metadata` field,
but it is not required. The example in the official k8s docs does
not include this field:
https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#example.

I searched the kubernetes 1.17 OpenAPI spec for "inner" types
that include a `metadata` field with:

```
curl -s https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.17/api/openapi-spec/swagger.json | jq '.definitions | with_entries(select(.value.properties.apiVersion == null and .value.properties.metadata != null))'
```

It came up with:

* io.k8s.api.batch.v1beta1.JobTemplateSpec
* io.k8s.api.batch.v2alpha1.JobTemplateSpec
* io.k8s.api.core.v1.PodTemplateSpec

The pod spec template example in
https://kubernetes.io/docs/concepts/workloads/pods/
also does not include a `metadata` field.

This PR adds special cases to these types to make these fields
optional.

In general I think a nicer solution would be
https://github.com/dhall-lang/dhall-kubernetes/issues/8#issuecomment-755213541.