### PR TITLE
Allow hnix-0.12

### DIFF
--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -31,7 +31,7 @@ Library
         containers                               < 0.7 ,
         data-fix                                 < 0.4 ,
         dhall                     >= 1.36     && < 1.38,
-        hnix                      >= 0.7      && < 0.12,
+        hnix                      >= 0.7      && < 0.13,
         lens-family-core          >= 1.0.0    && < 2.2 ,
         neat-interpolation                       < 0.6 ,
         text                      >= 0.8.0.0  && < 1.3

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -21,7 +21,7 @@ Executable dhall-to-nixpkgs
                      , data-fix
                      , dhall                >= 1.32.0   && < 1.38
                      , foldl                               < 1.5
-                     , hnix                 >= 0.10.1   && < 0.12
+                     , hnix                 >= 0.10.1   && < 0.13
                      , lens-family-core     >= 1.0.0    && < 2.2
                      , megaparsec           >= 7.0.0    && < 9.1
                      , mmorph                              < 1.2


### PR DESCRIPTION
Changelog: http://hackage.haskell.org/package/hnix-0.12.0.1/changelog

Tested with

    cabal build -O0 dhall-nix dhall-nixpkgs --constraint='hnix>=0.12' --allow-newer='cryptohash-sha512:base'