### PR TITLE
Only put models with GVK in types union (with some refactoring)

### DIFF
--- a/dhall-openapi/openapi-to-dhall/Main.hs
+++ b/dhall-openapi/openapi-to-dhall/Main.hs
@@ -44,7 +44,6 @@ import qualified Dhall.Core                            as Dhall
 import qualified Dhall.Format
 import qualified Dhall.Kubernetes.Convert              as Convert
 import qualified Dhall.Kubernetes.Types                as Types
-import qualified Dhall.Map
 import qualified Dhall.Parser
 import qualified Dhall.Util
 import qualified GHC.IO.Encoding
@@ -331,7 +330,7 @@ main = do
 
   -- Output the types record, the defaults record, and the giant union type
   let getImportsMap = Convert.getImportsMap prefixMap duplicateHandler objectNames
-      makeRecordMap = Dhall.Map.mapMaybe (Just . Dhall.makeRecordField)
+      makeRecord = Dhall.RecordLit . fmap Dhall.makeRecordField
       objectNames = Data.Map.keys types
       typesMap = getImportsMap "types" $ Data.Map.keys types
       defaultsMap = getImportsMap "defaults" $ Data.Map.keys defaults
@@ -344,7 +343,7 @@ main = do
       packageRecordPath = "./package.dhall"
 
   writeDhall typesUnionPath (Dhall.Union $ fmap Just typesMap)
-  writeDhall typesRecordPath (Dhall.RecordLit $ makeRecordMap typesMap)
-  writeDhall defaultsRecordPath (Dhall.RecordLit $ makeRecordMap defaultsMap)
-  writeDhall schemasRecordPath (Dhall.RecordLit $ makeRecordMap schemasMap)
+  writeDhall typesRecordPath $ makeRecord typesMap
+  writeDhall defaultsRecordPath $ makeRecord defaultsMap
+  writeDhall schemasRecordPath $ makeRecord schemasMap
   writeDhall packageRecordPath package

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -5,17 +5,17 @@
 module Dhall.Kubernetes.Convert
   ( toTypes
   , toDefault
-  , getImportsMap
   , mkImport
   , toDefinition
   , pathSplitter
+  , groupBySimpleModelName
   ) where
 
 import Control.Applicative (empty)
 import Data.Aeson
 import Data.Aeson.Types (Parser, parseMaybe)
 import Data.Bifunctor (first, second)
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Scientific (Scientific)
 import Data.Set (Set)
 import Data.Text (Text)
@@ -315,46 +315,27 @@ toDefault prefixMap definitions modelName = go
       = Dhall.Embed $ mkImport prefixMap ["types", ".."] (file <> ".dhall")
     adjustImport other = other
 
-
--- | Get a Dhall.Map filled with imports, for creating giant Records or Unions of types or defaults
-getImportsMap
-  :: Data.Map.Map Prefix Dhall.Import -- ^ Mapping of prefixes to import roots
-  -> DuplicateHandler                 -- ^ Duplicate name handler
-  -> [ModelName]                      -- ^ A list of all the object names
-  -> Text                             -- ^ The folder we should get imports from
-  -> [ModelName]                      -- ^ List of the object names we want to include in the Map
-  -> Dhall.Map.Map SimpleModelName Expr
-getImportsMap prefixMap duplicateNameHandler objectNames folder toInclude
-  = Dhall.Map.fromList
-  $ Data.Map.elems
-  -- This intersection is here to "pick" common elements between "all the objects"
-  -- and "objects we want to include", already associating keys to their import
-  $ Data.Map.intersectionWithKey
-      (\(ModelName name) simple _ -> (simple, Dhall.Embed $ mkImport prefixMap [folder] (name <> ".dhall")))
-      namespacedToSimple
-      (Data.Map.fromList $ fmap (,()) toInclude)
+-- | Given a list of fully namespaced models, it will group them by the
+--   object name resolving duplicates with the given function
+groupBySimpleModelName :: DuplicateHandler -> [ModelName] -> Data.Map.Map SimpleModelName ModelName
+groupBySimpleModelName duplicateNameHandler models = Data.Map.mapMaybe selectObject $ groupBySimpleName models
   where
-    -- | A map from namespaced names to simple ones (i.e. without the namespace)
-    namespacedToSimple
-      = Data.Map.fromList $ mapMaybe selectObject $ Data.Map.toList $ groupBySimpleName objectNames
-
-    -- | Given a list of fully namespaced objects, it will group them by the
-    --   object name
     groupBySimpleName :: [ModelName] -> Data.Map.Map SimpleModelName [ModelName]
     groupBySimpleName modelNames = Data.Map.unionsWith (<>)
-      $ (\name -> Data.Map.singleton (getKind name) [name])
+      $ (\name -> Data.Map.singleton (toSimpleModelName name) [name])
       <$> modelNames
-      where
-        getKind (ModelName name) =
-          let elems = Text.split (== '.') name
-          in elems List.!! (length elems - 1)
 
-    -- | There will be more than one namespaced object for a simple model name
+    toSimpleModelName :: ModelName -> SimpleModelName
+    toSimpleModelName (ModelName name) =
+      let elems = Text.split (== '.') name
+      in elems List.!! (length elems - 1)
+
+    -- | There will be more than one namespaced object for a single object name
     --   (because different API versions, and objects move around packages but k8s
     --   cannot break compatibility so we have all of them), so we have to select one
     --   (and we error out if it's not so after the filtering)
-    selectObject :: (SimpleModelName, [ModelName]) -> Maybe (ModelName, SimpleModelName)
-    selectObject (kind, namespacedNames) = fmap (,kind) namespaced
+    selectObject :: ([ModelName]) -> Maybe ModelName
+    selectObject (namespacedNames) = namespaced
       where
         filterFn (ModelName name) = not $ or
           -- The reason why we filter these two prefixes is that they are "internal"
@@ -368,7 +349,7 @@ getImportsMap prefixMap duplicateNameHandler objectNames folder toInclude
         namespaced = case filter filterFn namespacedNames of
           [name] -> Just name
           []     -> Nothing
-          names  -> duplicateNameHandler (kind, names)
+          names  -> duplicateNameHandler (names)
 
 stripPrefix :: (Generic a, GFromJSON Zero (Rep a)) => Int -> Value -> Parser a
 stripPrefix n = genericParseJSON options

--- a/dhall-openapi/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Types.hs
@@ -18,11 +18,13 @@ import           GHC.Generics              (Generic)
 
 type Expr = Dhall.Expr Dhall.Src Dhall.Import
 
-type DuplicateHandler = (Text, [ModelName]) -> Maybe ModelName
+type DuplicateHandler = (SimpleModelName, [ModelName]) -> Maybe ModelName
 
 type Prefix = Text
 
 type ModelHierarchy = [ModelName]
+
+type SimpleModelName = Text
 
 {-| Type for the Swagger specification.
 

--- a/dhall-openapi/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Types.hs
@@ -18,7 +18,7 @@ import           GHC.Generics              (Generic)
 
 type Expr = Dhall.Expr Dhall.Src Dhall.Import
 
-type DuplicateHandler = (SimpleModelName, [ModelName]) -> Maybe ModelName
+type DuplicateHandler = [ModelName] -> Maybe ModelName
 
 type Prefix = Text
 


### PR DESCRIPTION
The types unions main/only purpose was to allow creating lists of objects to
output to a single yaml document for sending to kubernetes. These
objects must have a group/version and kind. Therefore any objects
without would not be used in this manner and should be removed from the
typesUnion.

Let me know if you'd like these commits/prs split/merged differently