### PR TITLE
Allow haskell-lsp 0.24

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -53,7 +53,7 @@ library
     , dhall                >= 1.35.0   && < 1.38
     , dhall-json           >= 1.4      && < 1.8
     , filepath             >= 1.4.2    && < 1.5
-    , haskell-lsp          >= 0.19.0.0 && < 0.24
+    , haskell-lsp          >= 0.19.0.0 && < 0.25
     , rope-utf16-splay     >= 0.3.1.0  && < 0.4
     , hslogger             >= 1.2.10   && < 1.4
     , lens                 >= 4.16.1   && < 4.20
@@ -105,8 +105,8 @@ Test-Suite tests
     GHC-Options: -Wall
     Build-Depends:
         base                                   ,
-        haskell-lsp-types >= 0.19.0  && < 0.24 ,
-        lsp-test          >= 0.9     && < 0.12  ,
+        haskell-lsp-types >= 0.19.0  && < 0.25 ,
+        lsp-test          >= 0.9     && < 0.12 ,
         tasty             >= 0.11.2  && < 1.5  ,
         tasty-hspec       >= 1.1     && < 1.2  ,
         text              >= 0.11    && < 1.3


### PR DESCRIPTION
http://hackage.haskell.org/package/haskell-lsp-0.24.0.0/changelog

Tested locally with

```
$ cabal test -O0 dhall-lsp-server:test:tests --constraint 'haskell-lsp >= 0.24' --enable-tests --allow-newer='lsp-test:haskell-lsp'
```