### PR TITLE
dhall-openapi: use Integer in IntOrString instead of Natural

### DIFF
--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -186,7 +186,7 @@ toTypes' prefixMap typeSplitter definitions toMerge
         kvList = Dhall.App Dhall.List $ Dhall.Record $ Dhall.Map.fromList
           [ ("mapKey", Dhall.makeRecordField Dhall.Text), ("mapValue", Dhall.makeRecordField Dhall.Text) ]
         intOrStringType = Dhall.Union $ Dhall.Map.fromList $ fmap (second Just)
-          [ ("Int", Dhall.Natural), ("String", Dhall.Text) ]
+          [ ("Int", Dhall.Integer), ("String", Dhall.Text) ]
 
         -- | Convert a single Definition to a Dhall Type, yielding any definitions to be split
         --   Note: model hierarchy contains the modelName of of the current definition as the last entry


### PR DESCRIPTION
The Kubernetes OpenAPI definition describes this type as:

> IntOrString is a type that can hold an int32 or a string.
> When used in JSON or YAML marshalling and unmarshalling, it
> produces or consumes the inner type.  This allows you to have,
> for example, a JSON field that can accept a name or number.

Which implies it should be an Integer rather than a Natural.

This should have been done as part of
bb3c4c964ef25421c1423a8cb4c361c4845c9098, but I missed this case.