### PR TITLE
Allow lsp-test 0.12

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -106,7 +106,7 @@ Test-Suite tests
     Build-Depends:
         base                                   ,
         haskell-lsp-types >= 0.19.0  && < 0.25 ,
-        lsp-test          >= 0.9     && < 0.12 ,
+        lsp-test          >= 0.9     && < 0.13 ,
         tasty             >= 0.11.2  && < 1.5  ,
         tasty-hspec       >= 1.1     && < 1.2  ,
         text              >= 0.11    && < 1.3


### PR DESCRIPTION
http://hackage.haskell.org/package/lsp-test-0.12.0.0/changelog

Tested locally with:

    cabal test dhall-lsp-server:test:tests --constraint 'lsp-test==0.12.0.0' --enable-tests -O0