### PR TITLE
Allow cryptonite 0.28

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -63,7 +63,7 @@ Library
         base                 >= 4.11.0.0  && < 5   ,
         bytestring                           < 0.11,
         containers                                 ,
-        cryptonite                           < 0.28,
+        cryptonite                           < 0.29,
         directory            >= 1.3.0.0   && < 1.4 ,
         dhall                >= 1.35.0    && < 1.38,
         file-embed           >= 0.0.10.0           ,


### PR DESCRIPTION
https://hackage.haskell.org/package/cryptonite-0.28/changelog

Tested locally by adding `cryptonite-0.28` to the `extra-deps`
in the `stack.yaml`.