### PR TITLE
Allow doctest-0.18

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -120,7 +120,7 @@ Test-Suite doctest
         base                           ,
         directory,
         filepath                 < 1.5 ,
-        doctest    >= 0.7.0   && < 0.18
+        doctest    >= 0.7.0   && < 0.19
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010
 

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -93,7 +93,7 @@ Test-Suite doctest
         base                           ,
         directory  >= 1.3.1.5 && < 1.4 ,
         filepath                 < 1.5 ,
-        doctest    >= 0.7.0   && < 0.18,
+        doctest    >= 0.7.0   && < 0.19,
         QuickCheck
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -705,7 +705,7 @@ Test-Suite doctest
         directory                     ,
         filepath                < 1.5 ,
         mockery                 < 0.4 ,
-        doctest   >= 0.7.0   && < 0.18
+        doctest   >= 0.7.0   && < 0.19
     Default-Language: Haskell2010
 
 Benchmark dhall-parser


### PR DESCRIPTION
Tested locally with

```patch
--- a/stack.yaml
+++ b/stack.yaml
@@ -33,6 +33,7 @@ extra-deps:
   - semialign-indexed-1.1@sha256:bc375898351fea11ab3f4279844fcfc00aa42c90182eedfc28c4754098da3e0e,2026
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - tasty-silver-3.1.15@sha256:f40b3f59dfabe14f185b5d27fdb8aa8b7c75458aa7999f8aa244b9dcbaf8dc31,2328
+  - doctest-0.18
 nix:
   packages:
     - ncurses
```