### PR TITLE
Fix dhall-docs index generation

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -38,6 +38,7 @@ Extra-Source-Files:
     tasty/data/golden/a/b/*.html
     tasty/data/golden/a/b/c/*.html
     tasty/data/golden/deep/nested/folder/*.html
+    tasty/data/golden/deep/nested/*.html
     tasty/data/comments/empty/*.txt
     tasty/data/comments/invalid/*.txt
     tasty/data/comments/valid/*.txt

--- a/dhall-docs/tasty/data/golden/deep/nested/index.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html
+  ><head
+    ><title
+    >/deep/nested</title
+    ><link href="../../index.css" type="text/css" rel="stylesheet"
+    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
+            type="text/css" rel="stylesheet"
+    /><script src="../../index.js" type="text/javascript"
+    /><meta charset="UTF-8"/></head
+  ><body
+    ><div class="nav-bar"
+      ><img src="../../dhall-icon.svg" class="dhall-icon"
+      /><p class="package-title"
+      >test-package</p
+      ><div class="nav-bar-content-divider"
+      /><a id="switch-light-dark-mode" class="nav-option"
+      >Switch Light/Dark Mode</a></div
+    ><div class="main-container"
+      ><h2 class="doc-title"
+        ><span class="crumb-divider"
+        >/</span
+        ><a href="../../index.html"
+        >test-package</a
+        ><span class="crumb-divider"
+        >/</span
+        ><a href="../index.html" class="title-crumb"
+        >deep</a
+        ><span class="crumb-divider"
+        >/</span
+        ><span href="index.html" class="title-crumb"
+        >nested</span></h2
+      ><a data-path="/deep/nested" class="copy-to-clipboard"
+        ><i
+          ><small
+          >Copy path to clipboard</small></i></a
+      ><br
+      /><h3
+      >Exported packages: </h3
+      ><ul
+        ><li
+          ><a href="folder/index.html"
+          >folder/</a></li></ul></div></body></html>

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -181,7 +181,4 @@
       ><ul
         ><li
           ><a href="a/index.html"
-          >a/</a></li
-        ><li
-          ><a href="deep/nested/folder/index.html"
-          >deep/nested/folder/</a></li></ul></div></body></html>
+          >a/</a></li></ul></div></body></html>


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/1917

This fixes two separate issues raised in #1917:

* Indices not being created for empty directories
* `dhall-docs` hanging when the top-level directory had no index