### PR TITLE
Support GHC 9.0.1 (at least in some packages)

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -137,6 +137,12 @@ Test-Suite tasty
         dhall                             ,
         dhall-docs                        ,
         foldl        < 1.5                ,
+
+        -- hashable isn't used directly, but lucid's rendering output depends
+        -- on the Hashable Text instance defined in hashable.
+        -- See https://github.com/chrisdone/lucid/issues/107.
+        hashable     < 1.3.1              ,
+
         path                              ,
         path-io                           ,
         pretty       >= 1.1.1.1           ,

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -65,7 +65,7 @@ Library
         base                 >= 4.11.0.0  && < 5   ,
         bytestring                           < 0.12,
         containers                                 ,
-        cryptonite                           < 0.29,
+        cryptonite                           < 0.30,
         directory            >= 1.3.0.0   && < 1.4 ,
         dhall                >= 1.38.0    && < 1.39,
         file-embed           >= 0.0.10.0           ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -533,7 +533,7 @@ Library
     else
       Hs-Source-Dirs: ghc-src
       Build-Depends:
-        cryptonite                  >= 0.23     && < 1.0
+        cryptonite                  >= 0.23     && < 0.30
       if flag(with-http)
         Build-Depends:
           http-types                  >= 0.7.0    && < 0.13,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -510,7 +510,7 @@ Library
         repline                     >= 0.4.0.0  && < 0.5 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
-        template-haskell            >= 2.13.0.0 && < 2.17,
+        template-haskell            >= 2.13.0.0 && < 2.18,
         text                        >= 0.11.1.0 && < 1.3 ,
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
         th-lift-instances           >= 0.1.13   && < 0.2 ,


### PR DESCRIPTION
Blocked on:
* Build failures:
  * [x] https://github.com/haskell-foundation/foundation/issues/548 (`basement` <--- {`cryptonite`,`http-client-tls`,`memory`} <- `dhall`)
  * [x] https://github.com/DanBurton/lens-family-th/issues/18 (`lens-family-th` <- `hnix` <- `dhall-nix`)
  * [x] `lens-family` <- `hnix` <- `dhall-nix` (Contacted via email)
  * [x] https://github.com/mrkkrp/modern-uri/issues/34 (`modern-uri` <- `mmark` <- `dhall-docs`)
  * [x] https://github.com/commercialhaskell/path/issues/174 (`path` <- `dhall-docs`)
  * [ ] https://github.com/haskell-nix/hnix/issues/858 (`hnix` <- `dhall-nix`)
  * [x] https://github.com/sol/doctest/issues/275
  * [ ] https://github.com/haskell-nix/hnix-store/issues/142 (`hnix-store-core` <- `hnix`  <- `dhall-nix`)
  * [x] https://github.com/vincenthz/hs-memory/issues/84 (`memory` <- {`cryptonite`,`dhall`,`http-client-tls`})
* Bounds:
  * [x] https://github.com/well-typed/cborg/issues/260
  * [x] https://github.com/chrisdone/lucid/pull/104
  * [ ] https://github.com/haskell-hvr/cryptohash-sha512/issues/7 (via `hnix-store-core`)
  * [ ] https://github.com/haskell-hvr/cryptohash-sha256/issues/12 (via `hnix-store-core`)
  * [ ] https://github.com/haskell-hvr/cryptohash-sha1/issues/10 (via `hnix-store-core`)
  * [ ] https://github.com/haskell-hvr/cryptohash-md5/issues/5 (via `hnix-store-core`)
  * [x] https://github.com/haskell-hvr/HsYAML-aeson/issues/9
  * [x] https://github.com/haskell-hvr/HsYAML/issues/54
  * [ ] https://github.com/haskell-hvr/hslogger/issues/61 (via `haskell-lsp`)
  * [x] https://github.com/mitchellwrosen/tasty-hspec/issues/23

The incantation for circumventing the bounds issues is:

```
cabal build -O0 all --enable-tests --enable-benchmarks --allow-newer=haskell-lsp:base,haskell-lsp-types:base,hnix:hashable,hnix:template-haskell,hnix:semialign-indexed,hnix:semialign,cryptohash-sha512:base,cryptohash-sha256:base,cryptohash-sha1:base,cryptohash-md5:base,hslogger:base
```