### PR TITLE
dhall-lsp-server: Remove dependency on lens-family-core

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -57,7 +57,6 @@ library
     , rope-utf16-splay     >= 0.3.1.0  && < 0.4
     , hslogger             >= 1.2.10   && < 1.4
     , lens                 >= 4.16.1   && < 5.1
-    , lens-family-core     >= 1.2.2    && < 2.2
     , megaparsec           >= 7.0.2    && < 9.1
     , mtl                  >= 2.2.2    && < 2.3
     , network-uri          >= 2.6.1.0  && < 2.7

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
@@ -22,12 +22,12 @@ import Dhall.Core   (Expr)
 import Dhall.Parser (Src)
 
 import Control.Exception                (SomeException, catch)
+import Control.Lens                     (set, view)
 import Control.Monad.Trans.State.Strict (runStateT)
 import Data.Bifunctor                   (first)
 import Data.List.NonEmpty               (NonEmpty ((:|)))
 import Data.Text                        (Text)
 import Data.Void                        (Void)
-import Lens.Family                      (set, view)
 import Network.URI                      (URI)
 import System.FilePath
     ( splitDirectories

--- a/dhall-lsp-server/src/Dhall/LSP/State.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/State.hs
@@ -4,6 +4,7 @@
 module Dhall.LSP.State where
 
 import Control.Lens.TH                  (makeLenses)
+import Control.Lens.Type                (LensLike')
 import Control.Monad.Trans.Except       (ExceptT)
 import Control.Monad.Trans.State.Strict (StateT)
 import Data.Aeson
@@ -19,7 +20,6 @@ import Data.Map.Strict                  (Map, empty)
 import Data.Text                        (Text)
 import Dhall.LSP.Backend.Dhall          (Cache, DhallError, emptyCache)
 import Dhall.Pretty                     (CharacterSet)
-import Lens.Family                      (LensLike')
 
 import qualified Language.Haskell.LSP.Core     as LSP
 import qualified Language.Haskell.LSP.Messages as LSP


### PR DESCRIPTION
lens-family-core is still a transitive dependency because we use it in the core dhall library.