### PR TITLE
dhall-docs: Remove test dependency on HaXml

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -137,7 +137,6 @@ Test-Suite tasty
         dhall                             ,
         dhall-docs                        ,
         foldl        < 1.5                ,
-        HaXml        >= 1.25.5            ,
         path                              ,
         path-io                           ,
         pretty       >= 1.1.1.1           ,

--- a/dhall-docs/tasty/Main.hs
+++ b/dhall-docs/tasty/Main.hs
@@ -28,8 +28,6 @@ import qualified Test.Tasty.HUnit              as Tasty.HUnit
 import qualified Test.Tasty.Silver             as Silver
 import qualified Test.Tasty.Silver.Interactive as Silver
 import qualified Text.PrettyPrint              as Pretty
-import qualified Text.XML.HaXml.Html.Parse     as HaXml
-import qualified Text.XML.HaXml.Pretty         as HaXml
 import qualified Turtle
 
 main :: IO ()
@@ -70,12 +68,11 @@ docGenerationTests docsMap =
       where
         goldenFilePath = Path.fromRelFile $ goldenDir </> testFile
         testName = Path.fromRelFile testFile
-        action = return prettyHtmlDoc
+        action = (return . Data.Text.unpack . prettyHtml) text
         converter = Data.Text.pack
 
-        prettyHtmlDoc = Pretty.render
-            $ HaXml.document
-            $ HaXml.htmlParse testName (Data.Text.unpack text)
+        -- Simply add some line breaks so the result is easier to read.
+        prettyHtml = Data.Text.replace "><" ">\n<"
 
 getCommentTests :: IO TestTree
 getCommentTests = do

--- a/dhall-docs/tasty/data/golden/ImportAsType.dhall.html
+++ b/dhall-docs/tasty/data/golden/ImportAsType.dhall.html
@@ -1,50 +1,44 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/ImportAsType.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >ImportAsType.dhall</span></h2
-      ><a data-path="/ImportAsType.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >This example will show the link on the rendered source code <em
-          >and</em> on the index
+<html>
+<head>
+<title>/ImportAsType.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">ImportAsType.dhall</span>
+</h2>
+<a data-path="/ImportAsType.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This example will show the link on the rendered source code <em>and</em> on the index
 list</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />This example will show the link on the rendered source code _and_ on the index<br
-          />list<br
-          />-}<br
-          />{=} : <a href="./MarkdownExample.dhall.html"
-          >./MarkdownExample.dhall</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>This example will show the link on the rendered source code _and_ on the index<br>list<br>-}<br>{=} : <a href="./MarkdownExample.dhall.html">./MarkdownExample.dhall</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/InvalidBlockComment.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidBlockComment.dhall.html
@@ -1,44 +1,41 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/InvalidBlockComment.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >InvalidBlockComment.dhall</span></h2
-      ><a data-path="/InvalidBlockComment.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-| This example should throw a warning since after the `|` marker of the opening brace<br
-          />    there *must* be a newline (either \n or \r\n) -}<br
-          />{-|<br
-          />    bar -}<br
-          />{=}<br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/InvalidBlockComment.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">InvalidBlockComment.dhall</span>
+</h2>
+<a data-path="/InvalidBlockComment.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-| This example should throw a warning since after the `|` marker of the opening brace<br>    there *must* be a newline (either \n or \r\n) -}<br>{-|<br>    bar -}<br>{=}<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/InvalidConsecutiveComments.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidConsecutiveComments.dhall.html
@@ -1,45 +1,41 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/InvalidConsecutiveComments.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >InvalidConsecutiveComments.dhall</span></h2
-      ><a data-path="/InvalidConsecutiveComments.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />    This example should fail since two or more valid dhall-docs comment on the<br
-          />    same section -}<br
-          />{-|<br
-          />    bar -}<br
-          />{=}<br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/InvalidConsecutiveComments.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">InvalidConsecutiveComments.dhall</span>
+</h2>
+<a data-path="/InvalidConsecutiveComments.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>    This example should fail since two or more valid dhall-docs comment on the<br>    same section -}<br>{-|<br>    bar -}<br>{=}<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
@@ -1,67 +1,47 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/InvalidMarkdown.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >InvalidMarkdown.dhall</span></h2
-      ><a data-path="/InvalidMarkdown.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      >This file contains a markdown error right here `
+<html>
+<head>
+<title>/InvalidMarkdown.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">InvalidMarkdown.dhall</span>
+</h2>
+<a data-path="/InvalidMarkdown.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">This file contains a markdown error right here `
 did you notice it?
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >--| This file contains a markdown error right here `<br
-          />--  did you notice it?<br
-          /><br
-          />let <span data-name="var4-5" id="var4-5" class="name-decl"
-          >Pair</span
-          > = <a href="./Pair.dhall.html"
-          >./Pair.dhall</a
-          ><br
-          /><br
-          />let <span data-name="var6-5" id="var6-5" class="name-decl"
-          >DeliveryStatus</span
-          > =<br
-          />    &lt; Sent: <a href="#var4-5" data-name="var4-5"
-                              class="name-use"
-          >Pair</a
-          > Natural Text {-| Message has been _sent_. It carries a ./Pair.dhall reference<br
-          />                                    containing on the `first` field number of retries<br
-          />                                    and on the `second` field the delivered text<br
-          />                                -}<br
-          />    | InProgress                -- | Message is on the way!<br
-          />    | InQueue                   -- | Delivery for this message **hasn&#39;t** started<br
-          />    &gt;<br
-          /><br
-          />in <a href="#var6-5" data-name="var6-5" class="name-use"
-          >DeliveryStatus</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>--| This file contains a markdown error right here `<br>--  did you notice it?<br>
+<br>let <span data-name="var4-5" id="var4-5" class="name-decl">Pair</span> = <a href="./Pair.dhall.html">./Pair.dhall</a>
+<br>
+<br>let <span data-name="var6-5" id="var6-5" class="name-decl">DeliveryStatus</span> =<br>    &lt; Sent: <a href="#var4-5" data-name="var4-5" class="name-use">Pair</a> Natural Text {-| Message has been _sent_. It carries a ./Pair.dhall reference<br>                                    containing on the `first` field number of retries<br>                                    and on the `second` field the delivered text<br>                                -}<br>    | InProgress                -- | Message is on the way!<br>    | InQueue                   -- | Delivery for this message **hasn&#39;t** started<br>    &gt;<br>
+<br>in <a href="#var6-5" data-name="var6-5" class="name-use">DeliveryStatus</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToDefOnUnused.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToDefOnUnused.dhall.html
@@ -1,92 +1,49 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToDefOnUnused.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToDefOnUnused.dhall</span></h2
-      ><a data-path="/JumpToDefOnUnused.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          ><code
-          >dhall-docs</code> will detect some names (record fields, let-bindings and lam-bindings)
+<html>
+<head>
+<title>/JumpToDefOnUnused.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToDefOnUnused.dhall</span>
+</h2>
+<a data-path="/JumpToDefOnUnused.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>
+<code>dhall-docs</code> will detect some names (record fields, let-bindings and lam-bindings)
 are unused and therefore won&#39;t be highlighted</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />`dhall-docs` will detect some names (record fields, let-bindings and lam-bindings)<br
-          />are unused and therefore won&#39;t be highlighted<br
-          />-}<br
-          /><br
-          />let unused = 1<br
-          />let <span data-name="var7-5" id="var7-5" class="name-decl"
-          >used</span
-          > = 3<br
-          /><br
-          />let unusedRecord = { foo = 1 }<br
-          />let <span data-name="var10-5" id="var10-5" class="name-decl"
-          >usedRecord</span
-          > = { <span data-name="var10-20" id="var10-20" class="name-decl"
-          >foo</span
-          > = 1 }<br
-          /><br
-          />let <span data-name="var12-5" id="var12-5" class="name-decl"
-          >f</span
-          > =<br
-          />       \(unused : Bool)<br
-          />    -&gt; \(<span data-name="var14-10" id="var14-10"
-                              class="name-decl"
-          >used</span
-          > : Natural)<br
-          />    -&gt; \(<span data-name="var15-10" id="var15-10"
-                              class="name-decl"
-          >r</span
-          > : { unused : Text, <span data-name="var15-31" id="var15-31"
-                                     class="name-decl"
-          >used</span
-          > : Natural}) -&gt; <a href="#var14-10" data-name="var14-10"
-                                 class="name-use"
-          >used</a
-          > + <a href="#var15-10" data-name="var15-10" class="name-use"
-          >r</a
-          >.<a href="#var15-31" data-name="var15-31" class="name-use"
-          >used</a
-          ><br
-          /><br
-          />in <a href="#var7-5" data-name="var7-5" class="name-use"
-          >used</a
-          > + <a href="#var10-5" data-name="var10-5" class="name-use"
-          >usedRecord</a
-          >.<a href="#var10-20" data-name="var10-20" class="name-use"
-          >foo</a
-          > + <a href="#var12-5" data-name="var12-5" class="name-use"
-          >f</a
-          > True 1 { unused = &quot;foo&quot;, used = 3 }<br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>`dhall-docs` will detect some names (record fields, let-bindings and lam-bindings)<br>are unused and therefore won&#39;t be highlighted<br>-}<br>
+<br>let unused = 1<br>let <span data-name="var7-5" id="var7-5" class="name-decl">used</span> = 3<br>
+<br>let unusedRecord = { foo = 1 }<br>let <span data-name="var10-5" id="var10-5" class="name-decl">usedRecord</span> = { <span data-name="var10-20" id="var10-20" class="name-decl">foo</span> = 1 }<br>
+<br>let <span data-name="var12-5" id="var12-5" class="name-decl">f</span> =<br>       \(unused : Bool)<br>    -&gt; \(<span data-name="var14-10" id="var14-10" class="name-decl">used</span> : Natural)<br>    -&gt; \(<span data-name="var15-10" id="var15-10" class="name-decl">r</span> : { unused : Text, <span data-name="var15-31" id="var15-31" class="name-decl">used</span> : Natural}) -&gt; <a href="#var14-10" data-name="var14-10" class="name-use">used</a> + <a href="#var15-10" data-name="var15-10" class="name-use">r</a>.<a href="#var15-31" data-name="var15-31" class="name-use">used</a>
+<br>
+<br>in <a href="#var7-5" data-name="var7-5" class="name-use">used</a> + <a href="#var10-5" data-name="var10-5" class="name-use">usedRecord</a>.<a href="#var10-20" data-name="var10-20" class="name-use">foo</a> + <a href="#var12-5" data-name="var12-5" class="name-use">f</a> True 1 { unused = &quot;foo&quot;, used = 3 }<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToHereImports.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToHereImports.dhall.html
@@ -1,66 +1,47 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToHereImports.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToHereImports.dhall</span></h2
-      ><a data-path="/JumpToHereImports.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >let <span data-name="var1-5" id="var1-5" class="name-decl"
-          >relatives</span
-          > =<br
-          />    [ <a href="./IndexesExample.dhall.html"
-          >./IndexesExample.dhall</a
-          ><br
-          />    , <a href="./MarkdownExample.dhall.html"
-          >./MarkdownExample.dhall</a
-          ><br
-          />    , <a href="./NoDoc.dhall.html"
-          >./NoDoc.dhall</a
-          ><br
-          />    ]<br
-          /><br
-          />let <span data-name="var7-5" id="var7-5" class="name-decl"
-          >moreRelatives</span
-          > =<br
-          />    [ <a href="./OrdinaryAnnotation.dhall.html"
-          >./OrdinaryAnnotation.dhall</a
-          > ,    <a href="./TwoAnnotations.dhall.html"
-          >./TwoAnnotations.dhall</a
-          > ]<br
-          /><br
-          />in <a href="#var1-5" data-name="var1-5" class="name-use"
-          >relatives</a
-          > # <a href="#var7-5" data-name="var7-5" class="name-use"
-          >moreRelatives</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/JumpToHereImports.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToHereImports.dhall</span>
+</h2>
+<a data-path="/JumpToHereImports.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>let <span data-name="var1-5" id="var1-5" class="name-decl">relatives</span> =<br>    [ <a href="./IndexesExample.dhall.html">./IndexesExample.dhall</a>
+<br>    , <a href="./MarkdownExample.dhall.html">./MarkdownExample.dhall</a>
+<br>    , <a href="./NoDoc.dhall.html">./NoDoc.dhall</a>
+<br>    ]<br>
+<br>let <span data-name="var7-5" id="var7-5" class="name-decl">moreRelatives</span> =<br>    [ <a href="./OrdinaryAnnotation.dhall.html">./OrdinaryAnnotation.dhall</a> ,    <a href="./TwoAnnotations.dhall.html">./TwoAnnotations.dhall</a> ]<br>
+<br>in <a href="#var1-5" data-name="var1-5" class="name-use">relatives</a> # <a href="#var7-5" data-name="var7-5" class="name-use">moreRelatives</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
@@ -1,81 +1,44 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLamBindingComplex.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLamBindingComplex.dhall</span></h2
-      ><a data-path="/JumpToLamBindingComplex.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-        >A complex example of jump-to-definition on let-bindings</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />A complex example of jump-to-definition on let-bindings<br
-          />-}<br
-          />let <span data-name="var4-5" id="var4-5" class="name-decl"
-          >fun</span
-          > =<br
-          />    λ(<span data-name="var5-7" id="var5-7" class="name-decl"
-          >a</span
-          > : Text) -&gt;<br
-          />    λ(<span data-name="var6-7" id="var6-7" class="name-decl"
-          >b</span
-          > : Text) -&gt;<br
-          />    λ(<span data-name="var7-7" id="var7-7" class="name-decl"
-          >c</span
-          > : Text) -&gt;<br
-          />    λ(<span data-name="var8-7" id="var8-7" class="name-decl"
-          >d</span
-          > : Text) -&gt;<br
-          />    [ <a href="#var5-7" data-name="var5-7" class="name-use"
-          >a</a
-          > ++ <a href="#var6-7" data-name="var6-7" class="name-use"
-          >b</a
-          >, <a href="#var6-7" data-name="var6-7" class="name-use"
-          >b</a
-          > ++ <a href="#var7-7" data-name="var7-7" class="name-use"
-          >c</a
-          >, <a href="#var7-7" data-name="var7-7" class="name-use"
-          >c</a
-          > ++ <a href="#var8-7" data-name="var8-7" class="name-use"
-          >d</a
-          >, <a href="#var8-7" data-name="var8-7" class="name-use"
-          >d</a
-          > ++ <a href="#var5-7" data-name="var5-7" class="name-use"
-          >a</a
-          > ]<br
-          /><br
-          />in <a href="#var4-5" data-name="var4-5" class="name-use"
-          >fun</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/JumpToLamBindingComplex.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLamBindingComplex.dhall</span>
+</h2>
+<a data-path="/JumpToLamBindingComplex.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>A complex example of jump-to-definition on let-bindings</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>A complex example of jump-to-definition on let-bindings<br>-}<br>let <span data-name="var4-5" id="var4-5" class="name-decl">fun</span> =<br>    λ(<span data-name="var5-7" id="var5-7" class="name-decl">a</span> : Text) -&gt;<br>    λ(<span data-name="var6-7" id="var6-7" class="name-decl">b</span> : Text) -&gt;<br>    λ(<span data-name="var7-7" id="var7-7" class="name-decl">c</span> : Text) -&gt;<br>    λ(<span data-name="var8-7" id="var8-7" class="name-decl">d</span> : Text) -&gt;<br>    [ <a href="#var5-7" data-name="var5-7" class="name-use">a</a> ++ <a href="#var6-7" data-name="var6-7" class="name-use">b</a>, <a href="#var6-7" data-name="var6-7" class="name-use">b</a> ++ <a href="#var7-7" data-name="var7-7" class="name-use">c</a>, <a href="#var7-7" data-name="var7-7" class="name-use">c</a> ++ <a href="#var8-7" data-name="var8-7" class="name-use">d</a>, <a href="#var8-7" data-name="var8-7" class="name-use">d</a> ++ <a href="#var5-7" data-name="var5-7" class="name-use">a</a> ]<br>
+<br>in <a href="#var4-5" data-name="var4-5" class="name-use">fun</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
@@ -1,124 +1,105 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLamBindingSimple.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLamBindingSimple.dhall</span></h2
-      ><a data-path="/JumpToLamBindingSimple.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >This examples shows a demo of jumping to a let-binding definition. If you hover
-the <code
-          >a</code> paramter, the front-end will highlight all of its usages and if you
-click it you will navigate to its definition.</p
-        >
-<p
-        >The amount of empty lines left are intentional to show you how the browser jumps
+<html>
+<head>
+<title>/JumpToLamBindingSimple.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLamBindingSimple.dhall</span>
+</h2>
+<a data-path="/JumpToLamBindingSimple.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This examples shows a demo of jumping to a let-binding definition. If you hover
+the <code>a</code> paramter, the front-end will highlight all of its usages and if you
+click it you will navigate to its definition.</p>
+<p>The amount of empty lines left are intentional to show you how the browser jumps
 to the declaration of a</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />This examples shows a demo of jumping to a let-binding definition. If you hover<br
-          />the `a` paramter, the front-end will highlight all of its usages and if you<br
-          />click it you will navigate to its definition.<br
-          /><br
-          />The amount of empty lines left are intentional to show you how the browser jumps<br
-          />to the declaration of a<br
-          />-}<br
-          />let <span data-name="var9-5" id="var9-5" class="name-decl"
-          >fun</span
-          > = \(<span data-name="var9-13" id="var9-13" class="name-decl"
-          >v</span
-          > : Text) -&gt;<br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          />    <a href="#var9-13" data-name="var9-13" class="name-use"
-          >v</a
-          ><br
-          /><br
-          /><br
-          /><br
-          />in <a href="#var9-5" data-name="var9-5" class="name-use"
-          >fun</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>This examples shows a demo of jumping to a let-binding definition. If you hover<br>the `a` paramter, the front-end will highlight all of its usages and if you<br>click it you will navigate to its definition.<br>
+<br>The amount of empty lines left are intentional to show you how the browser jumps<br>to the declaration of a<br>-}<br>let <span data-name="var9-5" id="var9-5" class="name-decl">fun</span> = \(<span data-name="var9-13" id="var9-13" class="name-decl">v</span> : Text) -&gt;<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>    <a href="#var9-13" data-name="var9-13" class="name-use">v</a>
+<br>
+<br>
+<br>
+<br>in <a href="#var9-5" data-name="var9-5" class="name-use">fun</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
@@ -1,81 +1,53 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLamBindingWithIndex.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLamBindingWithIndex.dhall</span></h2
-      ><a data-path="/JumpToLamBindingWithIndex.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, we introduce the <code
-          >a</code
-          > variable in the two parameters of the
-<code
-          >fun</code> function and the jump-to-definition engine correctly highlights the usage
+<html>
+<head>
+<title>/JumpToLamBindingWithIndex.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLamBindingWithIndex.dhall</span>
+</h2>
+<a data-path="/JumpToLamBindingWithIndex.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, we introduce the <code>a</code> variable in the two parameters of the
+<code>fun</code> function and the jump-to-definition engine correctly highlights the usage
 when indexes are used</p>
-</div
-      ><h3
-      >Examples</h3
-      ><div class="source-code code-examples"
-        ><pre
-          >fun &quot;a&quot; &quot;b&quot; ≡ [ &quot;ab&quot; ]<br/></pre></div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, we introduce the `a` variable in the two parameters of the<br
-          />`fun` function and the jump-to-definition engine correctly highlights the usage<br
-          />when indexes are used<br
-          />-}<br
-          />let <span data-name="var6-5" id="var6-5" class="name-decl"
-          >fun</span
-          > =<br
-          />    λ(<span data-name="var7-7" id="var7-7" class="name-decl"
-          >a</span
-          > : Text) -&gt;<br
-          />    λ(<span data-name="var8-7" id="var8-7" class="name-decl"
-          >a</span
-          > : Text) -&gt;<br
-          />    [ <a href="#var7-7" data-name="var7-7" class="name-use"
-          >a@1</a
-          > ++ <a href="#var8-7" data-name="var8-7" class="name-use"
-          >a@0</a
-          > ]<br
-          /><br
-          />let example0 = assert : <a href="#var6-5" data-name="var6-5"
-                                       class="name-use"
-          >fun</a
-          > &quot;a&quot; &quot;b&quot; === [&quot;ab&quot;]<br
-          /><br
-          />in <a href="#var6-5" data-name="var6-5" class="name-use"
-          >fun</a
-          ><br
-          /><br/></pre></div></div></body></html>
+</div>
+<h3>Examples</h3>
+<div class="source-code code-examples">
+<pre>fun &quot;a&quot; &quot;b&quot; ≡ [ &quot;ab&quot; ]<br>
+</pre>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, we introduce the `a` variable in the two parameters of the<br>`fun` function and the jump-to-definition engine correctly highlights the usage<br>when indexes are used<br>-}<br>let <span data-name="var6-5" id="var6-5" class="name-decl">fun</span> =<br>    λ(<span data-name="var7-7" id="var7-7" class="name-decl">a</span> : Text) -&gt;<br>    λ(<span data-name="var8-7" id="var8-7" class="name-decl">a</span> : Text) -&gt;<br>    [ <a href="#var7-7" data-name="var7-7" class="name-use">a@1</a> ++ <a href="#var8-7" data-name="var8-7" class="name-use">a@0</a> ]<br>
+<br>let example0 = assert : <a href="#var6-5" data-name="var6-5" class="name-use">fun</a> &quot;a&quot; &quot;b&quot; === [&quot;ab&quot;]<br>
+<br>in <a href="#var6-5" data-name="var6-5" class="name-use">fun</a>
+<br>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
@@ -1,76 +1,52 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLamBindingWithQuotes.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLamBindingWithQuotes.dhall</span></h2
-      ><a data-path="/JumpToLamBindingWithQuotes.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-        >This tests shows that the feature works for quoted vars on function parameters
+<html>
+<head>
+<title>/JumpToLamBindingWithQuotes.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLamBindingWithQuotes.dhall</span>
+</h2>
+<a data-path="/JumpToLamBindingWithQuotes.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This tests shows that the feature works for quoted vars on function parameters
 as well</p>
-</div
-      ><h3
-      >Examples</h3
-      ><div class="source-code code-examples"
-        ><pre
-          >fun &quot;a&quot; &quot;b&quot; ≡ [ &quot;ab&quot; ]<br/></pre></div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />This tests shows that the feature works for quoted vars on function parameters<br
-          />as well<br
-          />-}<br
-          />let <span data-name="var5-5" id="var5-5" class="name-decl"
-          >fun</span
-          > =<br
-          />    λ(<span data-name="var6-7" id="var6-7" class="name-decl"
-          >`param 1`</span
-          > : Text) -&gt;<br
-          />    λ(<span data-name="var7-7" id="var7-7" class="name-decl"
-          >`param 2`</span
-          > : Text) -&gt;<br
-          />    [ <a href="#var6-7" data-name="var6-7" class="name-use"
-          >`param 1`</a
-          > ++ <a href="#var7-7" data-name="var7-7" class="name-use"
-          >`param 2`</a
-          > ]<br
-          /><br
-          />let example0 = assert : <a href="#var5-5" data-name="var5-5"
-                                       class="name-use"
-          >fun</a
-          > &quot;a&quot; &quot;b&quot; === [&quot;ab&quot;]<br
-          /><br
-          />in <a href="#var5-5" data-name="var5-5" class="name-use"
-          >fun</a
-          ><br
-          /><br/></pre></div></div></body></html>
+</div>
+<h3>Examples</h3>
+<div class="source-code code-examples">
+<pre>fun &quot;a&quot; &quot;b&quot; ≡ [ &quot;ab&quot; ]<br>
+</pre>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>This tests shows that the feature works for quoted vars on function parameters<br>as well<br>-}<br>let <span data-name="var5-5" id="var5-5" class="name-decl">fun</span> =<br>    λ(<span data-name="var6-7" id="var6-7" class="name-decl">`param 1`</span> : Text) -&gt;<br>    λ(<span data-name="var7-7" id="var7-7" class="name-decl">`param 2`</span> : Text) -&gt;<br>    [ <a href="#var6-7" data-name="var6-7" class="name-use">`param 1`</a> ++ <a href="#var7-7" data-name="var7-7" class="name-use">`param 2`</a> ]<br>
+<br>let example0 = assert : <a href="#var5-5" data-name="var5-5" class="name-use">fun</a> &quot;a&quot; &quot;b&quot; === [&quot;ab&quot;]<br>
+<br>in <a href="#var5-5" data-name="var5-5" class="name-use">fun</a>
+<br>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
@@ -1,79 +1,53 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLamBindingWithShadowing.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLamBindingWithShadowing.dhall</span></h2
-      ><a data-path="/JumpToLamBindingWithShadowing.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, the first parameter <code
-          >a</code
-          > is shadowed with the second declaration.
-The jump-to-definintion on the usage of <code
-          >a</code> should not highlight the first declaration,
+<html>
+<head>
+<title>/JumpToLamBindingWithShadowing.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLamBindingWithShadowing.dhall</span>
+</h2>
+<a data-path="/JumpToLamBindingWithShadowing.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, the first parameter <code>a</code> is shadowed with the second declaration.
+The jump-to-definintion on the usage of <code>a</code> should not highlight the first declaration,
 and interacting with the first declaration should not change the others</p>
-</div
-      ><h3
-      >Examples</h3
-      ><div class="source-code code-examples"
-        ><pre
-          >fun &quot;a&quot; &quot;b&quot; ≡ [ &quot;bb&quot; ]<br/></pre></div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, the first parameter `a` is shadowed with the second declaration.<br
-          />The jump-to-definintion on the usage of `a` should not highlight the first declaration,<br
-          />and interacting with the first declaration should not change the others<br
-          />-}<br
-          />let <span data-name="var6-5" id="var6-5" class="name-decl"
-          >fun</span
-          > =<br
-          />    λ(a : Text) -&gt;<br
-          />    λ(<span data-name="var8-7" id="var8-7" class="name-decl"
-          >a</span
-          > : Text) -&gt;<br
-          />    [ <a href="#var8-7" data-name="var8-7" class="name-use"
-          >a</a
-          > ++ <a href="#var8-7" data-name="var8-7" class="name-use"
-          >a</a
-          > ]<br
-          /><br
-          />let example0 = assert : <a href="#var6-5" data-name="var6-5"
-                                       class="name-use"
-          >fun</a
-          > &quot;a&quot; &quot;b&quot; === [&quot;bb&quot;]<br
-          /><br
-          />in <a href="#var6-5" data-name="var6-5" class="name-use"
-          >fun</a
-          ><br
-          /><br/></pre></div></div></body></html>
+</div>
+<h3>Examples</h3>
+<div class="source-code code-examples">
+<pre>fun &quot;a&quot; &quot;b&quot; ≡ [ &quot;bb&quot; ]<br>
+</pre>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, the first parameter `a` is shadowed with the second declaration.<br>The jump-to-definintion on the usage of `a` should not highlight the first declaration,<br>and interacting with the first declaration should not change the others<br>-}<br>let <span data-name="var6-5" id="var6-5" class="name-decl">fun</span> =<br>    λ(a : Text) -&gt;<br>    λ(<span data-name="var8-7" id="var8-7" class="name-decl">a</span> : Text) -&gt;<br>    [ <a href="#var8-7" data-name="var8-7" class="name-use">a</a> ++ <a href="#var8-7" data-name="var8-7" class="name-use">a</a> ]<br>
+<br>let example0 = assert : <a href="#var6-5" data-name="var6-5" class="name-use">fun</a> &quot;a&quot; &quot;b&quot; === [&quot;bb&quot;]<br>
+<br>in <a href="#var6-5" data-name="var6-5" class="name-use">fun</a>
+<br>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingSimple.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingSimple.dhall.html
@@ -1,105 +1,90 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLetBindingSimple.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLetBindingSimple.dhall</span></h2
-      ><a data-path="/JumpToLetBindingSimple.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >This examples shows a demo of jumping to a let-binding definition. If you hover
-the <code
-          >a</code> variable, the front-end will highlight all of its usages and if you
-click it you will navigate to its definition.</p
-        >
-<p
-        >The amount of empty lines left are intentional to show you how the browser jumps
+<html>
+<head>
+<title>/JumpToLetBindingSimple.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLetBindingSimple.dhall</span>
+</h2>
+<a data-path="/JumpToLetBindingSimple.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This examples shows a demo of jumping to a let-binding definition. If you hover
+the <code>a</code> variable, the front-end will highlight all of its usages and if you
+click it you will navigate to its definition.</p>
+<p>The amount of empty lines left are intentional to show you how the browser jumps
 to the declaration of a</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />This examples shows a demo of jumping to a let-binding definition. If you hover<br
-          />the `a` variable, the front-end will highlight all of its usages and if you<br
-          />click it you will navigate to its definition.<br
-          /><br
-          />The amount of empty lines left are intentional to show you how the browser jumps<br
-          />to the declaration of a<br
-          />-}<br
-          />let <span data-name="var9-5" id="var9-5" class="name-decl"
-          >a</span
-          > = 1<br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          /><br
-          />in<br
-          /><br
-          /><a href="#var9-5" data-name="var9-5" class="name-use"
-          >a</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>This examples shows a demo of jumping to a let-binding definition. If you hover<br>the `a` variable, the front-end will highlight all of its usages and if you<br>click it you will navigate to its definition.<br>
+<br>The amount of empty lines left are intentional to show you how the browser jumps<br>to the declaration of a<br>-}<br>let <span data-name="var9-5" id="var9-5" class="name-decl">a</span> = 1<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>in<br>
+<br>
+<a href="#var9-5" data-name="var9-5" class="name-use">a</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithIndex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithIndex.dhall.html
@@ -1,57 +1,46 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLetBindingWithIndex.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLetBindingWithIndex.dhall</span></h2
-      ><a data-path="/JumpToLetBindingWithIndex.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >Although we have a similar example on this <a href="./RenderTypeIndexesExample.dhall"
-          >file</a>,
+<html>
+<head>
+<title>/JumpToLetBindingWithIndex.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLetBindingWithIndex.dhall</span>
+</h2>
+<a data-path="/JumpToLetBindingWithIndex.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>Although we have a similar example on this <a href="./RenderTypeIndexesExample.dhall">file</a>,
 this example showcases the jump-to-definition feature when indexes are used.</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />Although we have a similar example on this [file](./RenderTypeIndexesExample.dhall),<br
-          />this example showcases the jump-to-definition feature when indexes are used.<br
-          />-}<br
-          />let <span data-name="var5-5" id="var5-5" class="name-decl"
-          >a</span
-          > = 1<br
-          /><br
-          />let a = 2<br
-          /><br
-          />in <a href="#var5-5" data-name="var5-5" class="name-use"
-          >a@1</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>Although we have a similar example on this [file](./RenderTypeIndexesExample.dhall),<br>this example showcases the jump-to-definition feature when indexes are used.<br>-}<br>let <span data-name="var5-5" id="var5-5" class="name-decl">a</span> = 1<br>
+<br>let a = 2<br>
+<br>in <a href="#var5-5" data-name="var5-5" class="name-use">a@1</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithQuotes.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithQuotes.dhall.html
@@ -1,58 +1,45 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLetBindingWithQuotes.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLetBindingWithQuotes.dhall</span></h2
-      ><a data-path="/JumpToLetBindingWithQuotes.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-        >This test cases shows that the feature works with quoted variables</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />This test cases shows that the feature works with quoted variables<br
-          />-}<br
-          />let <span data-name="var4-5" id="var4-5" class="name-decl"
-          >`quoted variable`</span
-          > = 1<br
-          /><br
-          />let <span data-name="var6-5" id="var6-5" class="name-decl"
-          >nonQuoted</span
-          > = 2<br
-          /><br
-          />in <a href="#var4-5" data-name="var4-5" class="name-use"
-          >`quoted variable`</a
-          > + <a href="#var6-5" data-name="var6-5" class="name-use"
-          >`nonQuoted`</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/JumpToLetBindingWithQuotes.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLetBindingWithQuotes.dhall</span>
+</h2>
+<a data-path="/JumpToLetBindingWithQuotes.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This test cases shows that the feature works with quoted variables</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>This test cases shows that the feature works with quoted variables<br>-}<br>let <span data-name="var4-5" id="var4-5" class="name-decl">`quoted variable`</span> = 1<br>
+<br>let <span data-name="var6-5" id="var6-5" class="name-decl">nonQuoted</span> = 2<br>
+<br>in <a href="#var4-5" data-name="var4-5" class="name-use">`quoted variable`</a> + <a href="#var6-5" data-name="var6-5" class="name-use">`nonQuoted`</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithShadowing.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithShadowing.dhall.html
@@ -1,63 +1,48 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLetBindingWithShadowing.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLetBindingWithShadowing.dhall</span></h2
-      ><a data-path="/JumpToLetBindingWithShadowing.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, the first declaration of variable <code
-          >a</code
-          > is shadowed with the
-later declaration. The jump-to-definintion on the usage of <code
-          >a</code>
+<html>
+<head>
+<title>/JumpToLetBindingWithShadowing.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLetBindingWithShadowing.dhall</span>
+</h2>
+<a data-path="/JumpToLetBindingWithShadowing.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, the first declaration of variable <code>a</code> is shadowed with the
+later declaration. The jump-to-definintion on the usage of <code>a</code>
 should not highlight the first declaration, and interacting with the first
 declaration should not change the others</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, the first declaration of variable `a` is shadowed with the<br
-          />later declaration. The jump-to-definintion on the usage of `a`<br
-          />should not highlight the first declaration, and interacting with the first<br
-          />declaration should not change the others<br
-          />-}<br
-          />let a = 1<br
-          /><br
-          />let <span data-name="var9-5" id="var9-5" class="name-decl"
-          >a</span
-          > = 2<br
-          /><br
-          />in <a href="#var9-5" data-name="var9-5" class="name-use"
-          >a</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, the first declaration of variable `a` is shadowed with the<br>later declaration. The jump-to-definintion on the usage of `a`<br>should not highlight the first declaration, and interacting with the first<br>declaration should not change the others<br>-}<br>let a = 1<br>
+<br>let <span data-name="var9-5" id="var9-5" class="name-decl">a</span> = 2<br>
+<br>in <a href="#var9-5" data-name="var9-5" class="name-use">a</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
@@ -1,75 +1,47 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToLetbindingComplex.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToLetbindingComplex.dhall</span></h2
-      ><a data-path="/JumpToLetbindingComplex.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-        >A complex example of jump-to-definition on let-bindings</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />A complex example of jump-to-definition on let-bindings<br
-          />-}<br
-          />let <span data-name="var4-5" id="var4-5" class="name-decl"
-          >f</span
-          > = \(<span data-name="var4-11" id="var4-11" class="name-decl"
-          >f</span
-          > : Natural) -&gt;<br
-          />    let <span data-name="var5-9" id="var5-9" class="name-decl"
-          >a</span
-          > = 1 in <a href="#var4-11" data-name="var4-11" class="name-use"
-          >f</a
-          > + <a href="#var5-9" data-name="var5-9" class="name-use"
-          >a</a
-          ><br
-          /><br
-          />let <span data-name="var7-5" id="var7-5" class="name-decl"
-          >a</span
-          > = <a href="#var4-5" data-name="var4-5" class="name-use"
-          >f</a
-          > 1<br
-          /><br
-          />let <span data-name="var9-5" id="var9-5" class="name-decl"
-          >b</span
-          > = <a href="#var7-5" data-name="var7-5" class="name-use"
-          >a</a
-          > + <a href="#var4-5" data-name="var4-5" class="name-use"
-          >f</a
-          > 3<br
-          /><br
-          />in <a href="#var9-5" data-name="var9-5" class="name-use"
-          >b</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/JumpToLetbindingComplex.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToLetbindingComplex.dhall</span>
+</h2>
+<a data-path="/JumpToLetbindingComplex.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>A complex example of jump-to-definition on let-bindings</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>A complex example of jump-to-definition on let-bindings<br>-}<br>let <span data-name="var4-5" id="var4-5" class="name-decl">f</span> = \(<span data-name="var4-11" id="var4-11" class="name-decl">f</span> : Natural) -&gt;<br>    let <span data-name="var5-9" id="var5-9" class="name-decl">a</span> = 1 in <a href="#var4-11" data-name="var4-11" class="name-use">f</a> + <a href="#var5-9" data-name="var5-9" class="name-use">a</a>
+<br>
+<br>let <span data-name="var7-5" id="var7-5" class="name-decl">a</span> = <a href="#var4-5" data-name="var4-5" class="name-use">f</a> 1<br>
+<br>let <span data-name="var9-5" id="var9-5" class="name-decl">b</span> = <a href="#var7-5" data-name="var7-5" class="name-use">a</a> + <a href="#var4-5" data-name="var4-5" class="name-use">f</a> 3<br>
+<br>in <a href="#var9-5" data-name="var9-5" class="name-use">b</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenFieldDoesNotExist.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenFieldDoesNotExist.dhall.html
@@ -1,67 +1,46 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenFieldDoesNotExist.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenFieldDoesNotExist.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenFieldDoesNotExist.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, <code
-          >dhall-docs</code
-          > will detect that the variable <code
-          >a</code
-          > and <code
-          >b</code> is of
+<html>
+<head>
+<title>/JumpToRecordFieldWhenFieldDoesNotExist.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenFieldDoesNotExist.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenFieldDoesNotExist.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, <code>dhall-docs</code> will detect that the variable <code>a</code> and <code>b</code> is of
 record-type. If on a selector-expression the field is not found on the type,
 no-link will be created</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, `dhall-docs` will detect that the variable `a` and `b` is of<br
-          />record-type. If on a selector-expression the field is not found on the type,<br
-          />no-link will be created<br
-          /><br
-          />-}<br
-          />let <span data-name="var7-5" id="var7-5" class="name-decl"
-          >a</span
-          > = { x = &quot;foo&quot; }<br
-          />let <span data-name="var8-5" id="var8-5" class="name-decl"
-          >b</span
-          > = False<br
-          /><br
-          />in <a href="#var7-5" data-name="var7-5" class="name-use"
-          >a</a
-          >.y + <a href="#var8-5" data-name="var8-5" class="name-use"
-          >b</a
-          >.`does not exist`<br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, `dhall-docs` will detect that the variable `a` and `b` is of<br>record-type. If on a selector-expression the field is not found on the type,<br>no-link will be created<br>
+<br>-}<br>let <span data-name="var7-5" id="var7-5" class="name-decl">a</span> = { x = &quot;foo&quot; }<br>let <span data-name="var8-5" id="var8-5" class="name-decl">b</span> = False<br>
+<br>in <a href="#var7-5" data-name="var7-5" class="name-use">a</a>.y + <a href="#var8-5" data-name="var8-5" class="name-use">b</a>.`does not exist`<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html
@@ -1,74 +1,48 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, <code
-          >dhall-docs</code
-          > will detect that the variable <code
-          >a</code
-          > is annotated
-with a type, but it will ignore it anyways. On let-bindings, <code
-          >dhall-docs</code
-          > infers
+<html>
+<head>
+<title>/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, <code>dhall-docs</code> will detect that the variable <code>a</code> is annotated
+with a type, but it will ignore it anyways. On let-bindings, <code>dhall-docs</code> infers
 the type of the variable from the bounded expression. As a consequence, on
-this example, hovering the <code
-          >x</code
-          > on the selector-expression will highlight the
-<code
-          >x</code> label on the record-literal</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, `dhall-docs` will detect that the variable `a` is annotated<br
-          />with a type, but it will ignore it anyways. On let-bindings, `dhall-docs` infers<br
-          />the type of the variable from the bounded expression. As a consequence, on<br
-          />this example, hovering the `x` on the selector-expression will highlight the<br
-          />`x` label on the record-literal<br
-          />-}<br
-          />let <span data-name="var8-5" id="var8-5" class="name-decl"
-          >a</span
-          > : Bool = { <span data-name="var8-18" id="var8-18"
-                             class="name-decl"
-          >x</span
-          > = &quot;foo&quot; }<br
-          /><br
-          />in <a href="#var8-5" data-name="var8-5" class="name-use"
-          >a</a
-          >.<a href="#var8-18" data-name="var8-18" class="name-use"
-          >x</a
-          ><br/></pre></div></div></body></html>
+this example, hovering the <code>x</code> on the selector-expression will highlight the
+<code>x</code> label on the record-literal</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, `dhall-docs` will detect that the variable `a` is annotated<br>with a type, but it will ignore it anyways. On let-bindings, `dhall-docs` infers<br>the type of the variable from the bounded expression. As a consequence, on<br>this example, hovering the `x` on the selector-expression will highlight the<br>`x` label on the record-literal<br>-}<br>let <span data-name="var8-5" id="var8-5" class="name-decl">a</span> : Bool = { <span data-name="var8-18" id="var8-18" class="name-decl">x</span> = &quot;foo&quot; }<br>
+<br>in <a href="#var8-5" data-name="var8-5" class="name-use">a</a>.<a href="#var8-18" data-name="var8-18" class="name-use">x</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html
@@ -1,79 +1,49 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, even when the variable <code
-          >a</code
-          > is annotated with a record-type,
-<code
-          >dhall-docs</code> will infer the actual type from the bounded value.</p
-        >
-<p
-        >All interactions with fields on selector-expressions won&#39;t affect the rendered-type.</p
-        >
-<p
-        >(The example is intended to not type-check as a Dhall expression)</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, even when the variable `a` is annotated with a record-type,<br
-          />`dhall-docs` will infer the actual type from the bounded value.<br
-          /><br
-          />All interactions with fields on selector-expressions won&#39;t affect the rendered-type.<br
-          /><br
-          />(The example is intended to not type-check as a Dhall expression)<br
-          />-}<br
-          />let <span data-name="var9-5" id="var9-5" class="name-decl"
-          >a</span
-          > : { x : Text } = { <span data-name="var9-26" id="var9-26"
-                                     class="name-decl"
-          >x</span
-          > = &quot;foo&quot;, <span data-name="var9-37" id="var9-37"
-                                     class="name-decl"
-          >y</span
-          > = &quot;bar&quot; }<br
-          /><br
-          />in <a href="#var9-5" data-name="var9-5" class="name-use"
-          >a</a
-          >.<a href="#var9-26" data-name="var9-26" class="name-use"
-          >x</a
-          > ++ <a href="#var9-5" data-name="var9-5" class="name-use"
-          >a</a
-          >.<a href="#var9-37" data-name="var9-37" class="name-use"
-          >y</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, even when the variable <code>a</code> is annotated with a record-type,
+<code>dhall-docs</code> will infer the actual type from the bounded value.</p>
+<p>All interactions with fields on selector-expressions won&#39;t affect the rendered-type.</p>
+<p>(The example is intended to not type-check as a Dhall expression)</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, even when the variable `a` is annotated with a record-type,<br>`dhall-docs` will infer the actual type from the bounded value.<br>
+<br>All interactions with fields on selector-expressions won&#39;t affect the rendered-type.<br>
+<br>(The example is intended to not type-check as a Dhall expression)<br>-}<br>let <span data-name="var9-5" id="var9-5" class="name-decl">a</span> : { x : Text } = { <span data-name="var9-26" id="var9-26" class="name-decl">x</span> = &quot;foo&quot;, <span data-name="var9-37" id="var9-37" class="name-decl">y</span> = &quot;bar&quot; }<br>
+<br>in <a href="#var9-5" data-name="var9-5" class="name-use">a</a>.<a href="#var9-26" data-name="var9-26" class="name-use">x</a> ++ <a href="#var9-5" data-name="var9-5" class="name-use">a</a>.<a href="#var9-37" data-name="var9-37" class="name-use">y</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordType.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordType.dhall.html
@@ -1,72 +1,47 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenVarIsOfRecordType.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenVarIsOfRecordType.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenVarIsOfRecordType.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, <code
-          >dhall-docs</code
-          > will detect that the variable <code
-          >a</code
-          > is bounded
-to a record-literal. When the user clicks on the <code
-          >field</code
-          > in the <code
-          >a.field</code
-          >, it
-will jump to the definition of that field in the source code i.e. to the <code
-          >field</code>
+<html>
+<head>
+<title>/JumpToRecordFieldWhenVarIsOfRecordType.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenVarIsOfRecordType.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenVarIsOfRecordType.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, <code>dhall-docs</code> will detect that the variable <code>a</code> is bounded
+to a record-literal. When the user clicks on the <code>field</code> in the <code>a.field</code>, it
+will jump to the definition of that field in the source code i.e. to the <code>field</code>
 key in the record literal</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, `dhall-docs` will detect that the variable `a` is bounded<br
-          />to a record-literal. When the user clicks on the `field` in the `a.field`, it<br
-          />will jump to the definition of that field in the source code i.e. to the `field`<br
-          />key in the record literal<br
-          />-}<br
-          />let <span data-name="var7-5" id="var7-5" class="name-decl"
-          >a</span
-          > = { <span data-name="var7-11" id="var7-11" class="name-decl"
-          >field</span
-          > = &quot;foo&quot; }<br
-          /><br
-          />in Text/show <a href="#var7-5" data-name="var7-5"
-                            class="name-use"
-          >a</a
-          >.<a href="#var7-11" data-name="var7-11" class="name-use"
-          >field</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, `dhall-docs` will detect that the variable `a` is bounded<br>to a record-literal. When the user clicks on the `field` in the `a.field`, it<br>will jump to the definition of that field in the source code i.e. to the `field`<br>key in the record literal<br>-}<br>let <span data-name="var7-5" id="var7-5" class="name-decl">a</span> = { <span data-name="var7-11" id="var7-11" class="name-decl">field</span> = &quot;foo&quot; }<br>
+<br>in Text/show <a href="#var7-5" data-name="var7-5" class="name-use">a</a>.<a href="#var7-11" data-name="var7-11" class="name-use">field</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html
@@ -1,84 +1,45 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-        >A complex example of the jump-to-definition feature on record literals.</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />A complex example of the jump-to-definition feature on record literals.<br
-          />-}<br
-          />let <span data-name="var4-5" id="var4-5" class="name-decl"
-          >a</span
-          > =<br
-          />    { <span data-name="var5-7" id="var5-7" class="name-decl"
-          >foo</span
-          > = &quot;bar&quot;, <span data-name="var5-20" id="var5-20"
-                                     class="name-decl"
-          >number</span
-          > = +1 }<br
-          /><br
-          />let <span data-name="var7-5" id="var7-5" class="name-decl"
-          >b</span
-          > =<br
-          />    { <span data-name="var8-7" id="var8-7" class="name-decl"
-          >foo</span
-          > = &quot;bar&quot;, <span data-name="var8-20" id="var8-20"
-                                     class="name-decl"
-          >number</span
-          > = +1 }<br
-          /><br
-          />in <a href="#var4-5" data-name="var4-5" class="name-use"
-          >a</a
-          >.<a href="#var5-7" data-name="var5-7" class="name-use"
-          >foo</a
-          > ++ Integer/show <a href="#var4-5" data-name="var4-5"
-                               class="name-use"
-          >a</a
-          >.<a href="#var5-20" data-name="var5-20" class="name-use"
-          >number</a
-          > ++ <a href="#var7-5" data-name="var7-5" class="name-use"
-          >b</a
-          >.<a href="#var8-7" data-name="var8-7" class="name-use"
-          >foo</a
-          > ++ Integer/show <a href="#var7-5" data-name="var7-5"
-                               class="name-use"
-          >b</a
-          >.<a href="#var8-20" data-name="var8-20" class="name-use"
-          >number</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>A complex example of the jump-to-definition feature on record literals.</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>A complex example of the jump-to-definition feature on record literals.<br>-}<br>let <span data-name="var4-5" id="var4-5" class="name-decl">a</span> =<br>    { <span data-name="var5-7" id="var5-7" class="name-decl">foo</span> = &quot;bar&quot;, <span data-name="var5-20" id="var5-20" class="name-decl">number</span> = +1 }<br>
+<br>let <span data-name="var7-5" id="var7-5" class="name-decl">b</span> =<br>    { <span data-name="var8-7" id="var8-7" class="name-decl">foo</span> = &quot;bar&quot;, <span data-name="var8-20" id="var8-20" class="name-decl">number</span> = +1 }<br>
+<br>in <a href="#var4-5" data-name="var4-5" class="name-use">a</a>.<a href="#var5-7" data-name="var5-7" class="name-use">foo</a> ++ Integer/show <a href="#var4-5" data-name="var4-5" class="name-use">a</a>.<a href="#var5-20" data-name="var5-20" class="name-use">number</a> ++ <a href="#var7-5" data-name="var7-5" class="name-use">b</a>.<a href="#var8-7" data-name="var8-7" class="name-use">foo</a> ++ Integer/show <a href="#var7-5" data-name="var7-5" class="name-use">b</a>.<a href="#var8-20" data-name="var8-20" class="name-use">number</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html
@@ -1,78 +1,48 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, <code
-          >dhall-docs</code
-          > will detect that the variable <code
-          >a</code
-          > is bounded
-to a record literal. It will also detect that the <code
-          >field</code
-          > key from the record
-literal is another record literal. When the user clicks <code
-          >deep</code
-          > from the
-<code
-          >a.field.deep</code>, it will jump to the definition of that variable in the source
+<html>
+<head>
+<title>/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, <code>dhall-docs</code> will detect that the variable <code>a</code> is bounded
+to a record literal. It will also detect that the <code>field</code> key from the record
+literal is another record literal. When the user clicks <code>deep</code> from the
+<code>a.field.deep</code>, it will jump to the definition of that variable in the source
 code.</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, `dhall-docs` will detect that the variable `a` is bounded<br
-          />to a record literal. It will also detect that the `field` key from the record<br
-          />literal is another record literal. When the user clicks `deep` from the<br
-          />`a.field.deep`, it will jump to the definition of that variable in the source<br
-          />code.<br
-          />-}<br
-          />let <span data-name="var8-5" id="var8-5" class="name-decl"
-          >a</span
-          > = { <span data-name="var8-11" id="var8-11" class="name-decl"
-          >field</span
-          > = { <span data-name="var8-21" id="var8-21" class="name-decl"
-          >deep</span
-          > = &quot;bar&quot; } }<br
-          /><br
-          />in Text/show <a href="#var8-5" data-name="var8-5"
-                            class="name-use"
-          >a</a
-          >.<a href="#var8-11" data-name="var8-11" class="name-use"
-          >field</a
-          >.<a href="#var8-21" data-name="var8-21" class="name-use"
-          >deep</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, `dhall-docs` will detect that the variable `a` is bounded<br>to a record literal. It will also detect that the `field` key from the record<br>literal is another record literal. When the user clicks `deep` from the<br>`a.field.deep`, it will jump to the definition of that variable in the source<br>code.<br>-}<br>let <span data-name="var8-5" id="var8-5" class="name-decl">a</span> = { <span data-name="var8-11" id="var8-11" class="name-decl">field</span> = { <span data-name="var8-21" id="var8-21" class="name-decl">deep</span> = &quot;bar&quot; } }<br>
+<br>in Text/show <a href="#var8-5" data-name="var8-5" class="name-use">a</a>.<a href="#var8-11" data-name="var8-11" class="name-use">field</a>.<a href="#var8-21" data-name="var8-21" class="name-use">deep</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html
@@ -1,112 +1,51 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, <code
-          >dhall-docs</code
-          > will detect that the argument <code
-          >a</code
-          > of the only
+<html>
+<head>
+<title>/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, <code>dhall-docs</code> will detect that the argument <code>a</code> of the only
 function in this file is of record type. Therefore, any interactions on selector
-expressions over the <code
-          >a</code> variable will interact with the fields on the record-type.</p
-        >
-<p
-          >Note that the treatment for <code
-          >Lam</code
-          > variables is different from <code
-          >Let</code
-          > bindings:
+expressions over the <code>a</code> variable will interact with the fields on the record-type.</p>
+<p>Note that the treatment for <code>Lam</code> variables is different from <code>Let</code> bindings:
 the annotation doesn&#39;t affect on the later case. This can be seen in the
-<a href="./JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall"
-          >test case for let bindings</a></p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, `dhall-docs` will detect that the argument `a` of the only<br
-          />function in this file is of record type. Therefore, any interactions on selector<br
-          />expressions over the `a` variable will interact with the fields on the record-type.<br
-          /><br
-          />Note that the treatment for `Lam` variables is different from `Let` bindings:<br
-          />the annotation doesn&#39;t affect on the later case. This can be seen in the<br
-          />[test case for let bindings](./JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall)<br
-          />-}<br
-          /><br
-          />λ(<span data-name="var11-3" id="var11-3" class="name-decl"
-          >b</span
-          > : Type) →<br
-          />λ(<span data-name="var12-3" id="var12-3" class="name-decl"
-          >c</span
-          > : Type) →<br
-          />λ(<span data-name="var13-3" id="var13-3" class="name-decl"
-          >a</span
-          > : { <span data-name="var13-9" id="var13-9" class="name-decl"
-          >list</span
-          > : List <a href="#var11-3" data-name="var11-3" class="name-use"
-          >b</a
-          >, <span data-name="var13-24" id="var13-24" class="name-decl"
-          >cons</span
-          > : <a href="#var11-3" data-name="var11-3" class="name-use"
-          >b</a
-          > → <a href="#var12-3" data-name="var12-3" class="name-use"
-          >c</a
-          > → <a href="#var12-3" data-name="var12-3" class="name-use"
-          >c</a
-          >, <span data-name="var13-42" id="var13-42" class="name-decl"
-          >nil</span
-          > : <a href="#var12-3" data-name="var12-3" class="name-use"
-          >c</a
-          > }) →<br
-          />  List/fold <a href="#var11-3" data-name="var11-3"
-                           class="name-use"
-          >b</a
-          > <a href="#var13-3" data-name="var13-3" class="name-use"
-          >a</a
-          >.<a href="#var13-9" data-name="var13-9" class="name-use"
-          >list</a
-          > <a href="#var12-3" data-name="var12-3" class="name-use"
-          >c</a
-          > <a href="#var13-3" data-name="var13-3" class="name-use"
-          >a</a
-          >.<a href="#var13-24" data-name="var13-24" class="name-use"
-          >cons</a
-          > <a href="#var13-3" data-name="var13-3" class="name-use"
-          >a</a
-          >.<a href="#var13-42" data-name="var13-42" class="name-use"
-          >nil</a
-          ><br/></pre></div></div></body></html>
+<a href="./JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall">test case for let bindings</a>
+</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, `dhall-docs` will detect that the argument `a` of the only<br>function in this file is of record type. Therefore, any interactions on selector<br>expressions over the `a` variable will interact with the fields on the record-type.<br>
+<br>Note that the treatment for `Lam` variables is different from `Let` bindings:<br>the annotation doesn&#39;t affect on the later case. This can be seen in the<br>[test case for let bindings](./JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall)<br>-}<br>
+<br>λ(<span data-name="var11-3" id="var11-3" class="name-decl">b</span> : Type) →<br>λ(<span data-name="var12-3" id="var12-3" class="name-decl">c</span> : Type) →<br>λ(<span data-name="var13-3" id="var13-3" class="name-decl">a</span> : { <span data-name="var13-9" id="var13-9" class="name-decl">list</span> : List <a href="#var11-3" data-name="var11-3" class="name-use">b</a>, <span data-name="var13-24" id="var13-24" class="name-decl">cons</span> : <a href="#var11-3" data-name="var11-3" class="name-use">b</a> → <a href="#var12-3" data-name="var12-3" class="name-use">c</a> → <a href="#var12-3" data-name="var12-3" class="name-use">c</a>, <span data-name="var13-42" id="var13-42" class="name-decl">nil</span> : <a href="#var12-3" data-name="var12-3" class="name-use">c</a> }) →<br>  List/fold <a href="#var11-3" data-name="var11-3" class="name-use">b</a> <a href="#var13-3" data-name="var13-3" class="name-use">a</a>.<a href="#var13-9" data-name="var13-9" class="name-use">list</a> <a href="#var12-3" data-name="var12-3" class="name-use">c</a> <a href="#var13-3" data-name="var13-3" class="name-use">a</a>.<a href="#var13-24" data-name="var13-24" class="name-use">cons</a> <a href="#var13-3" data-name="var13-3" class="name-use">a</a>.<a href="#var13-42" data-name="var13-42" class="name-use">nil</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html
@@ -1,72 +1,46 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, <code
-          >dhall-docs</code
-          > will detect that the variable <code
-          >a</code
-          > is bounded
-to a record literal. It will also be aware that that the attribute <code
-          >x</code
-          >. When
-the user clicks the <code
-          >x</code
-          > from <code
-          >a.x</code
-          >, it will jump to the <code
-          >x</code> punned-entry</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, `dhall-docs` will detect that the variable `a` is bounded<br
-          />to a record literal. It will also be aware that that the attribute `x`. When<br
-          />the user clicks the `x` from `a.x`, it will jump to the `x` punned-entry<br
-          />-}<br
-          />let x = 1<br
-          />let <span data-name="var7-5" id="var7-5" class="name-decl"
-          >a</span
-          > = { <span data-name="var7-11" id="var7-11" class="name-decl"
-          >x</span
-          > }<br
-          /><br
-          />in <a href="#var7-5" data-name="var7-5" class="name-use"
-          >a</a
-          >.<a href="#var7-11" data-name="var7-11" class="name-use"
-          >x</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, <code>dhall-docs</code> will detect that the variable <code>a</code> is bounded
+to a record literal. It will also be aware that that the attribute <code>x</code>. When
+the user clicks the <code>x</code> from <code>a.x</code>, it will jump to the <code>x</code> punned-entry</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, `dhall-docs` will detect that the variable `a` is bounded<br>to a record literal. It will also be aware that that the attribute `x`. When<br>the user clicks the `x` from `a.x`, it will jump to the `x` punned-entry<br>-}<br>let x = 1<br>let <span data-name="var7-5" id="var7-5" class="name-decl">a</span> = { <span data-name="var7-11" id="var7-11" class="name-decl">x</span> }<br>
+<br>in <a href="#var7-5" data-name="var7-5" class="name-use">a</a>.<a href="#var7-11" data-name="var7-11" class="name-use">x</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html
@@ -1,80 +1,48 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, <code
-          >dhall-docs</code
-          > will detect that the variable <code
-          >b</code
-          > is bounded
-to the value of <code
-          >a</code
-          >, and the later is bounded to a record-literal. All selector
-expressions over <code
-          >b</code
-          > will interact with the record-literal assigned to <code
-          >a</code>, since
+<html>
+<head>
+<title>/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, <code>dhall-docs</code> will detect that the variable <code>b</code> is bounded
+to the value of <code>a</code>, and the later is bounded to a record-literal. All selector
+expressions over <code>b</code> will interact with the record-literal assigned to <code>a</code>, since
 that is the actual definition of the fields.</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, `dhall-docs` will detect that the variable `b` is bounded<br
-          />to the value of `a`, and the later is bounded to a record-literal. All selector<br
-          />expressions over `b` will interact with the record-literal assigned to `a`, since<br
-          />that is the actual definition of the fields.<br
-          />-}<br
-          />let <span data-name="var7-5" id="var7-5" class="name-decl"
-          >a</span
-          > = { <span data-name="var7-11" id="var7-11" class="name-decl"
-          >x</span
-          > = 1 }<br
-          />let <span data-name="var8-5" id="var8-5" class="name-decl"
-          >b</span
-          > = <a href="#var7-5" data-name="var7-5" class="name-use"
-          >a</a
-          ><br
-          /><br
-          />in <a href="#var7-5" data-name="var7-5" class="name-use"
-          >a</a
-          >.<a href="#var7-11" data-name="var7-11" class="name-use"
-          >x</a
-          > + <a href="#var8-5" data-name="var8-5" class="name-use"
-          >b</a
-          >.<a href="#var7-11" data-name="var7-11" class="name-use"
-          >x</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, `dhall-docs` will detect that the variable `b` is bounded<br>to the value of `a`, and the later is bounded to a record-literal. All selector<br>expressions over `b` will interact with the record-literal assigned to `a`, since<br>that is the actual definition of the fields.<br>-}<br>let <span data-name="var7-5" id="var7-5" class="name-decl">a</span> = { <span data-name="var7-11" id="var7-11" class="name-decl">x</span> = 1 }<br>let <span data-name="var8-5" id="var8-5" class="name-decl">b</span> = <a href="#var7-5" data-name="var7-5" class="name-use">a</a>
+<br>
+<br>in <a href="#var7-5" data-name="var7-5" class="name-use">a</a>.<a href="#var7-11" data-name="var7-11" class="name-use">x</a> + <a href="#var8-5" data-name="var8-5" class="name-use">b</a>.<a href="#var7-11" data-name="var7-11" class="name-use">x</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html
@@ -1,113 +1,52 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall</span></h2
-      ><a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >On this example, <code
-          >dhall-docs</code
-          > will detect that the variable <code
-          >a</code> is bounded
-to a record literal and it will be aware that it uses dot-syntax.</p
-        >
-<p
-          >When the user clicks <code
-          >x</code
-          > from <code
-          >a.x</code
-          >, it will jump to the <code
-          >x</code> on the record-literal.
+<html>
+<head>
+<title>/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall</span>
+</h2>
+<a data-path="/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>On this example, <code>dhall-docs</code> will detect that the variable <code>a</code> is bounded
+to a record literal and it will be aware that it uses dot-syntax.</p>
+<p>When the user clicks <code>x</code> from <code>a.x</code>, it will jump to the <code>x</code> on the record-literal.
 The same applies for each other field.</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />On this example, `dhall-docs` will detect that the variable `a` is bounded<br
-          />to a record literal and it will be aware that it uses dot-syntax.<br
-          /><br
-          />When the user clicks `x` from `a.x`, it will jump to the `x` on the record-literal.<br
-          />The same applies for each other field.<br
-          />-}<br
-          />let <span data-name="var8-5" id="var8-5" class="name-decl"
-          >a</span
-          > = { <span data-name="var8-11" id="var8-11" class="name-decl"
-          >x</span
-          >.<span data-name="var8-13" id="var8-13" class="name-decl"
-          >y</span
-          >.<span data-name="var8-15" id="var8-15" class="name-decl"
-          >z</span
-          > = 1 }<br
-          /><br
-          />let <span data-name="var10-5" id="var10-5" class="name-decl"
-          >ax</span
-          > = <a href="#var8-5" data-name="var8-5" class="name-use"
-          >a</a
-          >.<a href="#var8-11" data-name="var8-11" class="name-use"
-          >x</a
-          ><br
-          />let <span data-name="var11-5" id="var11-5" class="name-decl"
-          >axy</span
-          > = <a href="#var8-5" data-name="var8-5" class="name-use"
-          >a</a
-          >.<a href="#var8-11" data-name="var8-11" class="name-use"
-          >x</a
-          >.<a href="#var8-13" data-name="var8-13" class="name-use"
-          >y</a
-          ><br
-          />let <span data-name="var12-5" id="var12-5" class="name-decl"
-          >axyz</span
-          > = <a href="#var8-5" data-name="var8-5" class="name-use"
-          >a</a
-          >.<a href="#var8-11" data-name="var8-11" class="name-use"
-          >x</a
-          >.<a href="#var8-13" data-name="var8-13" class="name-use"
-          >y</a
-          >.<a href="#var8-15" data-name="var8-15" class="name-use"
-          >z</a
-          ><br
-          /><br
-          />in <a href="#var10-5" data-name="var10-5" class="name-use"
-          >ax</a
-          >.<a href="#var8-13" data-name="var8-13" class="name-use"
-          >y</a
-          >.<a href="#var8-15" data-name="var8-15" class="name-use"
-          >z</a
-          > + <a href="#var11-5" data-name="var11-5" class="name-use"
-          >axy</a
-          >.<a href="#var8-15" data-name="var8-15" class="name-use"
-          >z</a
-          > + <a href="#var12-5" data-name="var12-5" class="name-use"
-          >axyz</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>On this example, `dhall-docs` will detect that the variable `a` is bounded<br>to a record literal and it will be aware that it uses dot-syntax.<br>
+<br>When the user clicks `x` from `a.x`, it will jump to the `x` on the record-literal.<br>The same applies for each other field.<br>-}<br>let <span data-name="var8-5" id="var8-5" class="name-decl">a</span> = { <span data-name="var8-11" id="var8-11" class="name-decl">x</span>.<span data-name="var8-13" id="var8-13" class="name-decl">y</span>.<span data-name="var8-15" id="var8-15" class="name-decl">z</span> = 1 }<br>
+<br>let <span data-name="var10-5" id="var10-5" class="name-decl">ax</span> = <a href="#var8-5" data-name="var8-5" class="name-use">a</a>.<a href="#var8-11" data-name="var8-11" class="name-use">x</a>
+<br>let <span data-name="var11-5" id="var11-5" class="name-decl">axy</span> = <a href="#var8-5" data-name="var8-5" class="name-use">a</a>.<a href="#var8-11" data-name="var8-11" class="name-use">x</a>.<a href="#var8-13" data-name="var8-13" class="name-use">y</a>
+<br>let <span data-name="var12-5" id="var12-5" class="name-decl">axyz</span> = <a href="#var8-5" data-name="var8-5" class="name-use">a</a>.<a href="#var8-11" data-name="var8-11" class="name-use">x</a>.<a href="#var8-13" data-name="var8-13" class="name-use">y</a>.<a href="#var8-15" data-name="var8-15" class="name-use">z</a>
+<br>
+<br>in <a href="#var10-5" data-name="var10-5" class="name-use">ax</a>.<a href="#var8-13" data-name="var8-13" class="name-use">y</a>.<a href="#var8-15" data-name="var8-15" class="name-use">z</a> + <a href="#var11-5" data-name="var11-5" class="name-use">axy</a>.<a href="#var8-15" data-name="var8-15" class="name-use">z</a> + <a href="#var12-5" data-name="var12-5" class="name-use">axyz</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToSelf.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToSelf.dhall.html
@@ -1,57 +1,44 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToSelf.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToSelf.dhall</span></h2
-      ><a data-path="/JumpToSelf.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >Althtough Dhall forbids cyclic imports, <code
-          >dhall-docs</code> can handle them properly</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />Althtough Dhall forbids cyclic imports, `dhall-docs` can handle them properly<br
-          />-}<br
-          />let <span data-name="var4-5" id="var4-5" class="name-decl"
-          >selfs</span
-          > =<br
-          />    [ <a href="./JumpToSelf.dhall.html"
-          >./JumpToSelf.dhall</a
-          ><br
-          />    , <a href="../package/JumpToSelf.dhall.html"
-          >../package/JumpToSelf.dhall</a
-          > ]<br
-          />in <a href="#var4-5" data-name="var4-5" class="name-use"
-          >selfs</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/JumpToSelf.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToSelf.dhall</span>
+</h2>
+<a data-path="/JumpToSelf.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>Althtough Dhall forbids cyclic imports, <code>dhall-docs</code> can handle them properly</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>Althtough Dhall forbids cyclic imports, `dhall-docs` can handle them properly<br>-}<br>let <span data-name="var4-5" id="var4-5" class="name-decl">selfs</span> =<br>    [ <a href="./JumpToSelf.dhall.html">./JumpToSelf.dhall</a>
+<br>    , <a href="../package/JumpToSelf.dhall.html">../package/JumpToSelf.dhall</a> ]<br>in <a href="#var4-5" data-name="var4-5" class="name-use">selfs</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
@@ -1,64 +1,48 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/JumpToUrls.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToUrls.dhall</span></h2
-      ><a data-path="/JumpToUrls.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >Example taken from <a href="https://docs.dhall-lang.org/tutorials/Language-Tour.html#prelude"
-          >dhall documentation</a></p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />Example taken from [dhall documentation](https://docs.dhall-lang.org/tutorials/Language-Tour.html#prelude)<br
-          />-}<br
-          /><br
-          /><br
-          />let <span data-name="var6-5" id="var6-5" class="name-decl"
-          >List/generate</span
-          > = <a href="https://prelude.dhall-lang.org/v15.0.0/List/generate"
-                 target="_blank"
-          >https://prelude.dhall-lang.org/v15.0.0/List/generate</a
-          ><br
-          /><br
-          />in <a href="#var6-5" data-name="var6-5" class="name-use"
-          >List/generate</a
-          > 10 Text (\(<span data-name="var8-29" id="var8-29"
-                             class="name-decl"
-          >n</span
-          > : Natural) -&gt; &quot;Result #${Natural/show <a href="#var8-29"
-                                                             data-name="var8-29" class="name-use"
-          >n</a
-          >}&quot;)<br
-          /><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/JumpToUrls.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToUrls.dhall</span>
+</h2>
+<a data-path="/JumpToUrls.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>Example taken from <a href="https://docs.dhall-lang.org/tutorials/Language-Tour.html#prelude">dhall documentation</a>
+</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>Example taken from [dhall documentation](https://docs.dhall-lang.org/tutorials/Language-Tour.html#prelude)<br>-}<br>
+<br>
+<br>let <span data-name="var6-5" id="var6-5" class="name-decl">List/generate</span> = <a href="https://prelude.dhall-lang.org/v15.0.0/List/generate" target="_blank">https://prelude.dhall-lang.org/v15.0.0/List/generate</a>
+<br>
+<br>in <a href="#var6-5" data-name="var6-5" class="name-use">List/generate</a> 10 Text (\(<span data-name="var8-29" id="var8-29" class="name-decl">n</span> : Natural) -&gt; &quot;Result #${Natural/show <a href="#var8-29" data-name="var8-29" class="name-use">n</a>}&quot;)<br>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
@@ -1,160 +1,95 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/MarkdownExample.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >MarkdownExample.dhall</span></h2
-      ><a data-path="/MarkdownExample.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><h1 id="heading-1"
-        >Heading 1</h1
-        >
-<h2 id="heading-2"
-        >Heading 2</h2
-        >
-<h3 id="heading-3"
-        >Heading 3</h3
-        >
-<h4 id="heading-4"
-        >Heading 4</h4
-        >
-<h5 id="heading-5"
-        >Heading 5</h5
-        >
-<h6 id="heading-6"
-        >Heading 6</h6
-        >
-<p
-          >Message data type for our <em
-          >messaging-system</em> config.</p
-        >
-<pre
-          ><code
-          >It is similar to the `kafka` message dto.
-</code></pre
-        >
-<p
-        >testing again another random text.</p
-        >
-<p
-          ><strong
-          >NOTE</strong>: This is really important to know</p
-        >
-<p
-        >This allows you to:</p
-        >
-<ul
-          >
-<li
-          >
+<html>
+<head>
+<title>/MarkdownExample.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">MarkdownExample.dhall</span>
+</h2>
+<a data-path="/MarkdownExample.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<h1 id="heading-1">Heading 1</h1>
+<h2 id="heading-2">Heading 2</h2>
+<h3 id="heading-3">Heading 3</h3>
+<h4 id="heading-4">Heading 4</h4>
+<h5 id="heading-5">Heading 5</h5>
+<h6 id="heading-6">Heading 6</h6>
+<p>Message data type for our <em>messaging-system</em> config.</p>
+<pre>
+<code>It is similar to the `kafka` message dto.
+</code>
+</pre>
+<p>testing again another random text.</p>
+<p>
+<strong>NOTE</strong>: This is really important to know</p>
+<p>This allows you to:</p>
+<ul>
+<li>
 Send messages
-</li
-          >
-<li
-            >
+</li>
+<li>
 Receive messages, knowing that:
-<ul
-              >
-<li
-              >
+<ul>
+<li>
 nothing works (?)
-</li
-              >
-<li
-              >
+</li>
+<li>
 weird huh
 </li>
 </ul>
 </li>
-</ul
-        >
-<p
-        >As somebody said,</p
-        >
-<blockquote
-          >
-<p
-          >The best way to code is to not code</p>
-</blockquote
-        >
-<p
-        >Here I show you some haskell code</p
-        >
-<pre
-          ><code class="language-haskell"
-          >main = putStrLn &quot;dhall rulez&quot;
-</code></pre>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          /># Heading 1<br
-          /><br
-          />## Heading 2<br
-          /><br
-          />### Heading 3<br
-          /><br
-          />#### Heading 4<br
-          /><br
-          />##### Heading 5<br
-          /><br
-          />###### Heading 6<br
-          /><br
-          />Message data type for our _messaging-system_ config.<br
-          /><br
-          />    It is similar to the `kafka` message dto.<br
-          />testing again another random text.<br
-          /><br
-          />**NOTE**: This is really important to know<br
-          /><br
-          />This allows you to:<br
-          /><br
-          />* Send messages<br
-          />* Receive messages, knowing that:<br
-          />    - nothing works (?)<br
-          />    - weird huh<br
-          /><br
-          />As somebody said,<br
-          /><br
-          />&gt; The best way to code is to not code<br
-          /><br
-          />Here I show you some haskell code<br
-          /><br
-          />```haskell<br
-          />main = putStrLn &quot;dhall rulez&quot;<br
-          />```<br
-          />-}<br
-          />{ remitent: Text                         --| Remitent name<br
-          />, deliveryStatus: <a href="./DeliveryStatus.dhall.html"
-          >./DeliveryStatus.dhall</a
-          > --| Status<br
-          />, body: Text                             --| Message body<br
-          />}<br/></pre></div></div></body></html>
+</ul>
+<p>As somebody said,</p>
+<blockquote>
+<p>The best way to code is to not code</p>
+</blockquote>
+<p>Here I show you some haskell code</p>
+<pre>
+<code class="language-haskell">main = putStrLn &quot;dhall rulez&quot;
+</code>
+</pre>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br># Heading 1<br>
+<br>## Heading 2<br>
+<br>### Heading 3<br>
+<br>#### Heading 4<br>
+<br>##### Heading 5<br>
+<br>###### Heading 6<br>
+<br>Message data type for our _messaging-system_ config.<br>
+<br>    It is similar to the `kafka` message dto.<br>testing again another random text.<br>
+<br>**NOTE**: This is really important to know<br>
+<br>This allows you to:<br>
+<br>* Send messages<br>* Receive messages, knowing that:<br>    - nothing works (?)<br>    - weird huh<br>
+<br>As somebody said,<br>
+<br>&gt; The best way to code is to not code<br>
+<br>Here I show you some haskell code<br>
+<br>```haskell<br>main = putStrLn &quot;dhall rulez&quot;<br>```<br>-}<br>{ remitent: Text                         --| Remitent name<br>, deliveryStatus: <a href="./DeliveryStatus.dhall.html">./DeliveryStatus.dhall</a> --| Status<br>, body: Text                             --| Message body<br>}<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/MultilineIndentationExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/MultilineIndentationExample.dhall.html
@@ -1,71 +1,58 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/MultilineIndentationExample.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >MultilineIndentationExample.dhall</span></h2
-      ><a data-path="/MultilineIndentationExample.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-        >Non indented text should remain as-is</p
-        >
-<pre
-          ><code
-          >indented code block
-</code></pre
-        >
-<ul
-          >
-<li
-            >
+<html>
+<head>
+<title>/MultilineIndentationExample.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">MultilineIndentationExample.dhall</span>
+</h2>
+<a data-path="/MultilineIndentationExample.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>Non indented text should remain as-is</p>
+<pre>
+<code>indented code block
+</code>
+</pre>
+<ul>
+<li>
 item 1
-<ul
-              >
-<li
-              >
+<ul>
+<li>
 item 2
 </li>
 </ul>
 </li>
 </ul>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />Non indented text should remain as-is<br
-          /><br
-          />    indented code block<br
-          /><br
-          />* item 1<br
-          />    - item 2<br
-          />-}<br
-          />{=} : {}<br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>Non indented text should remain as-is<br>
+<br>    indented code block<br>
+<br>* item 1<br>    - item 2<br>-}<br>{=} : {}<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/NoDoc.dhall.html
+++ b/dhall-docs/tasty/data/golden/NoDoc.dhall.html
@@ -1,39 +1,41 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/NoDoc.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >NoDoc.dhall</span></h2
-      ><a data-path="/NoDoc.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{=}<br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/NoDoc.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">NoDoc.dhall</span>
+</h2>
+<a data-path="/NoDoc.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{=}<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/NonDhallDocsCommentAfterValid.dhall.html
+++ b/dhall-docs/tasty/data/golden/NonDhallDocsCommentAfterValid.dhall.html
@@ -1,51 +1,43 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/NonDhallDocsCommentAfterValid.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >NonDhallDocsCommentAfterValid.dhall</span></h2
-      ><a data-path="/NonDhallDocsCommentAfterValid.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >This example shows that you can place non-dhall comments after a <em
-          >valid</em>
+<html>
+<head>
+<title>/NonDhallDocsCommentAfterValid.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">NonDhallDocsCommentAfterValid.dhall</span>
+</h2>
+<a data-path="/NonDhallDocsCommentAfterValid.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This example shows that you can place non-dhall comments after a <em>valid</em>
 dhall comment</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />    This example shows that you can place non-dhall comments after a _valid_<br
-          />    dhall comment -}<br
-          />{-<br
-          />    bar -}<br
-          />-- qux<br
-          />{=}<br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>    This example shows that you can place non-dhall comments after a _valid_<br>    dhall comment -}<br>{-<br>    bar -}<br>-- qux<br>{=}<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/OrdinaryAnnotation.dhall.html
+++ b/dhall-docs/tasty/data/golden/OrdinaryAnnotation.dhall.html
@@ -1,47 +1,43 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/OrdinaryAnnotation.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >OrdinaryAnnotation.dhall</span></h2
-      ><a data-path="/OrdinaryAnnotation.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-        >This file contains a Dhall expression with just a type annotation, which
+<html>
+<head>
+<title>/OrdinaryAnnotation.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">OrdinaryAnnotation.dhall</span>
+</h2>
+<a data-path="/OrdinaryAnnotation.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This file contains a Dhall expression with just a type annotation, which
 should be selected as the expression&#39;s type</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />This file contains a Dhall expression with just a type annotation, which<br
-          />should be selected as the expression&#39;s type<br
-          />-}<br
-          />1 : Natural<br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>This file contains a Dhall expression with just a type annotation, which<br>should be selected as the expression&#39;s type<br>-}<br>1 : Natural<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/Pair.dhall.html
+++ b/dhall-docs/tasty/data/golden/Pair.dhall.html
@@ -1,69 +1,47 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/Pair.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >Pair.dhall</span></h2
-      ><a data-path="/Pair.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >Just a <em
-          >Pair</em> right here</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          ><br
-          />{-|<br
-          />Just a *Pair* right here<br
-          />-}<br
-          /><br
-          />let <span data-name="var6-5" id="var6-5" class="name-decl"
-          >Pair</span
-          ><br
-          />  : forall(A: Type) -- | Type of first position<br
-          />  -&gt; forall(B: Type) -- | Type of second position<br
-          />  -&gt; Type<br
-          />  = λ(<span data-name="var10-7" id="var10-7" class="name-decl"
-          >A</span
-          >: Type) -&gt; λ(<span data-name="var10-21" id="var10-21"
-                                 class="name-decl"
-          >B</span
-          >: Type) -&gt; {first: <a href="#var10-7" data-name="var10-7"
-                                    class="name-use"
-          >A</a
-          >, second: <a href="#var10-21" data-name="var10-21"
-                        class="name-use"
-          >B</a
-          >}<br
-          /><br
-          />in <a href="#var6-5" data-name="var6-5" class="name-use"
-          >Pair</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/Pair.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">Pair.dhall</span>
+</h2>
+<a data-path="/Pair.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>Just a <em>Pair</em> right here</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>
+<br>{-|<br>Just a *Pair* right here<br>-}<br>
+<br>let <span data-name="var6-5" id="var6-5" class="name-decl">Pair</span>
+<br>  : forall(A: Type) -- | Type of first position<br>  -&gt; forall(B: Type) -- | Type of second position<br>  -&gt; Type<br>  = λ(<span data-name="var10-7" id="var10-7" class="name-decl">A</span>: Type) -&gt; λ(<span data-name="var10-21" id="var10-21" class="name-decl">B</span>: Type) -&gt; {first: <a href="#var10-7" data-name="var10-7" class="name-use">A</a>, second: <a href="#var10-21" data-name="var10-21" class="name-use">B</a>}<br>
+<br>in <a href="#var6-5" data-name="var6-5" class="name-use">Pair</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/RenderTypeIndexesExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/RenderTypeIndexesExample.dhall.html
@@ -1,57 +1,46 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/RenderTypeIndexesExample.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >RenderTypeIndexesExample.dhall</span></h2
-      ><a data-path="/RenderTypeIndexesExample.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >This example shows that <code
-          >dhall-docs</code> will find render the correct type on the
+<html>
+<head>
+<title>/RenderTypeIndexesExample.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">RenderTypeIndexesExample.dhall</span>
+</h2>
+<a data-path="/RenderTypeIndexesExample.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This example shows that <code>dhall-docs</code> will find render the correct type on the
 index respecting variable indices</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />This example shows that `dhall-docs` will find render the correct type on the<br
-          />index respecting variable indices<br
-          />-}<br
-          /><br
-          />let <span data-name="var6-5" id="var6-5" class="name-decl"
-          >x</span
-          > : Bool = True<br
-          />let x : Natural = 1<br
-          /><br
-          />in <a href="#var6-5" data-name="var6-5" class="name-use"
-          >x@1</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>This example shows that `dhall-docs` will find render the correct type on the<br>index respecting variable indices<br>-}<br>
+<br>let <span data-name="var6-5" id="var6-5" class="name-decl">x</span> : Bool = True<br>let x : Natural = 1<br>
+<br>in <a href="#var6-5" data-name="var6-5" class="name-use">x@1</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/TwoAnnotations.dhall.html
+++ b/dhall-docs/tasty/data/golden/TwoAnnotations.dhall.html
@@ -1,64 +1,47 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/TwoAnnotations.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >TwoAnnotations.dhall</span></h2
-      ><a data-path="/TwoAnnotations.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-          >This expression contains type annotations on both the <code
-          >let</code
-          > binding and on the
-body of the <code
-          >let</code> expression.  The documentation generator prefers to use the
+<html>
+<head>
+<title>/TwoAnnotations.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">TwoAnnotations.dhall</span>
+</h2>
+<a data-path="/TwoAnnotations.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This expression contains type annotations on both the <code>let</code> binding and on the
+body of the <code>let</code> expression.  The documentation generator prefers to use the
 latter annotation.</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />This expression contains type annotations on both the `let` binding and on the<br
-          />body of the `let` expression.  The documentation generator prefers to use the<br
-          />latter annotation.<br
-          />-}<br
-          />let <span data-name="var6-5" id="var6-5" class="name-decl"
-          >x</span
-          > = 1<br
-          /><br
-          />let <span data-name="var8-5" id="var8-5" class="name-decl"
-          >y</span
-          > = Natural<br
-          /><br
-          />in  <a href="#var6-5" data-name="var6-5" class="name-use"
-          >x</a
-          > : <a href="#var8-5" data-name="var8-5" class="name-use"
-          >y</a
-          ><br/></pre></div></div></body></html>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>This expression contains type annotations on both the `let` binding and on the<br>body of the `let` expression.  The documentation generator prefers to use the<br>latter annotation.<br>-}<br>let <span data-name="var6-5" id="var6-5" class="name-decl">x</span> = 1<br>
+<br>let <span data-name="var8-5" id="var8-5" class="name-decl">y</span> = Natural<br>
+<br>in  <a href="#var6-5" data-name="var6-5" class="name-use">x</a> : <a href="#var8-5" data-name="var8-5" class="name-use">y</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/a/JumpToParent.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/JumpToParent.dhall.html
@@ -1,53 +1,46 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/a/JumpToParent.dhall</title
-    ><link href="../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html" class="title-crumb"
-        >a</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToParent.dhall</span></h2
-      ><a data-path="/a/JumpToParent.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >let <span data-name="var1-5" id="var1-5" class="name-decl"
-          >parents</span
-          > =<br
-          />    [ <a href="../IndexesExample.dhall.html"
-          >../IndexesExample.dhall</a
-          ><br
-          />    ]<br
-          /><br
-          />in <a href="#var1-5" data-name="var1-5" class="name-use"
-          >parents</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/a/JumpToParent.dhall</title>
+<link href="../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="index.html" class="title-crumb">a</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToParent.dhall</span>
+</h2>
+<a data-path="/a/JumpToParent.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>let <span data-name="var1-5" id="var1-5" class="name-decl">parents</span> =<br>    [ <a href="../IndexesExample.dhall.html">../IndexesExample.dhall</a>
+<br>    ]<br>
+<br>in <a href="#var1-5" data-name="var1-5" class="name-use">parents</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/a/b.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b.dhall.html
@@ -1,51 +1,45 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/a/b.dhall</title
-    ><link href="../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html" class="title-crumb"
-        >a</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >b.dhall</span></h2
-      ><a data-path="/a/b.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-<br
-          />Hi there boys<br
-          />-}<br
-          /><br
-          />let <span data-name="var5-5" id="var5-5" class="name-decl"
-          >b</span
-          > = 1 in <a href="#var5-5" data-name="var5-5" class="name-use"
-          >b</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/a/b.dhall</title>
+<link href="../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="index.html" class="title-crumb">a</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">b.dhall</span>
+</h2>
+<a data-path="/a/b.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-<br>Hi there boys<br>-}<br>
+<br>let <span data-name="var5-5" id="var5-5" class="name-decl">b</span> = 1 in <a href="#var5-5" data-name="var5-5" class="name-use">b</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/a/b/JumpToGrandfather.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/JumpToGrandfather.dhall.html
@@ -1,58 +1,48 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/a/b/JumpToGrandfather.dhall</title
-    ><link href="../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html" class="title-crumb"
-        >a</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html" class="title-crumb"
-        >b</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >JumpToGrandfather.dhall</span></h2
-      ><a data-path="/a/b/JumpToGrandfather.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >let <span data-name="var1-5" id="var1-5" class="name-decl"
-          >parents</span
-          > =<br
-          />    [ <a href="../../IndexesExample.dhall.html"
-          >../../IndexesExample.dhall</a
-          ><br
-          />    ]<br
-          /><br
-          />in <a href="#var1-5" data-name="var1-5" class="name-use"
-          >parents</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/a/b/JumpToGrandfather.dhall</title>
+<link href="../../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="../index.html" class="title-crumb">a</a>
+<span class="crumb-divider">/</span>
+<a href="index.html" class="title-crumb">b</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">JumpToGrandfather.dhall</span>
+</h2>
+<a data-path="/a/b/JumpToGrandfather.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>let <span data-name="var1-5" id="var1-5" class="name-decl">parents</span> =<br>    [ <a href="../../IndexesExample.dhall.html">../../IndexesExample.dhall</a>
+<br>    ]<br>
+<br>in <a href="#var1-5" data-name="var1-5" class="name-use">parents</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/a/b/c.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c.dhall.html
@@ -1,55 +1,47 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/a/b/c.dhall</title
-    ><link href="../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html" class="title-crumb"
-        >a</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html" class="title-crumb"
-        >b</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >c.dhall</span></h2
-      ><a data-path="/a/b/c.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-<br
-          />Hi there boys<br
-          />-}<br
-          /><br
-          />let <span data-name="var5-5" id="var5-5" class="name-decl"
-          >c</span
-          > = 1 in <a href="#var5-5" data-name="var5-5" class="name-use"
-          >c</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/a/b/c.dhall</title>
+<link href="../../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="../index.html" class="title-crumb">a</a>
+<span class="crumb-divider">/</span>
+<a href="index.html" class="title-crumb">b</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">c.dhall</span>
+</h2>
+<a data-path="/a/b/c.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-<br>Hi there boys<br>-}<br>
+<br>let <span data-name="var5-5" id="var5-5" class="name-decl">c</span> = 1 in <a href="#var5-5" data-name="var5-5" class="name-use">c</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
@@ -1,59 +1,49 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/a/b/c/a.dhall</title
-    ><link href="../../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../../../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../../../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../index.html" class="title-crumb"
-        >a</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html" class="title-crumb"
-        >b</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html" class="title-crumb"
-        >c</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >a.dhall</span></h2
-      ><a data-path="/a/b/c/a.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-<br
-          />Hi there boys<br
-          />-}<br
-          /><br
-          />let <span data-name="var5-5" id="var5-5" class="name-decl"
-          >a</span
-          > = 1 in <a href="#var5-5" data-name="var5-5" class="name-use"
-          >a</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/a/b/c/a.dhall</title>
+<link href="../../../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../../../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../../../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../../../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="../../index.html" class="title-crumb">a</a>
+<span class="crumb-divider">/</span>
+<a href="../index.html" class="title-crumb">b</a>
+<span class="crumb-divider">/</span>
+<a href="index.html" class="title-crumb">c</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">a.dhall</span>
+</h2>
+<a data-path="/a/b/c/a.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-<br>Hi there boys<br>-}<br>
+<br>let <span data-name="var5-5" id="var5-5" class="name-decl">a</span> = 1 in <a href="#var5-5" data-name="var5-5" class="name-use">a</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/a/b/c/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/index.html
@@ -1,47 +1,44 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/a/b/c</title
-    ><link href="../../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../../../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../../../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../index.html" class="title-crumb"
-        >a</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html" class="title-crumb"
-        >b</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >c</span></h2
-      ><a data-path="/a/b/c" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><h3
-      >Exported files: </h3
-      ><ul
-        ><li
-          ><a href="a.dhall.html"
-          >a.dhall</a></li></ul></div></body></html>
+<html>
+<head>
+<title>/a/b/c</title>
+<link href="../../../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../../../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../../../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../../../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="../../index.html" class="title-crumb">a</a>
+<span class="crumb-divider">/</span>
+<a href="../index.html" class="title-crumb">b</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">c</span>
+</h2>
+<a data-path="/a/b/c" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<h3>Exported files: </h3>
+<ul>
+<li>
+<a href="a.dhall.html">a.dhall</a>
+</li>
+</ul>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/a/b/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/index.html
@@ -1,52 +1,51 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/a/b</title
-    ><link href="../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html" class="title-crumb"
-        >a</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >b</span></h2
-      ><a data-path="/a/b" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><h3
-      >Exported files: </h3
-      ><ul
-        ><li
-          ><a href="JumpToGrandfather.dhall.html"
-          >JumpToGrandfather.dhall</a></li
-        ><li
-          ><a href="c.dhall.html"
-          >c.dhall</a></li></ul
-      ><h3
-      >Exported packages: </h3
-      ><ul
-        ><li
-          ><a href="c/index.html"
-          >c/</a></li></ul></div></body></html>
+<html>
+<head>
+<title>/a/b</title>
+<link href="../../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="../index.html" class="title-crumb">a</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">b</span>
+</h2>
+<a data-path="/a/b" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<h3>Exported files: </h3>
+<ul>
+<li>
+<a href="JumpToGrandfather.dhall.html">JumpToGrandfather.dhall</a>
+</li>
+<li>
+<a href="c.dhall.html">c.dhall</a>
+</li>
+</ul>
+<h3>Exported packages: </h3>
+<ul>
+<li>
+<a href="c/index.html">c/</a>
+</li>
+</ul>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/a/index.html
+++ b/dhall-docs/tasty/data/golden/a/index.html
@@ -1,48 +1,49 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/a</title
-    ><link href="../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >a</span></h2
-      ><a data-path="/a" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><h3
-      >Exported files: </h3
-      ><ul
-        ><li
-          ><a href="JumpToParent.dhall.html"
-          >JumpToParent.dhall</a></li
-        ><li
-          ><a href="b.dhall.html"
-          >b.dhall</a></li></ul
-      ><h3
-      >Exported packages: </h3
-      ><ul
-        ><li
-          ><a href="b/index.html"
-          >b/</a></li></ul></div></body></html>
+<html>
+<head>
+<title>/a</title>
+<link href="../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">a</span>
+</h2>
+<a data-path="/a" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<h3>Exported files: </h3>
+<ul>
+<li>
+<a href="JumpToParent.dhall.html">JumpToParent.dhall</a>
+</li>
+<li>
+<a href="b.dhall.html">b.dhall</a>
+</li>
+</ul>
+<h3>Exported packages: </h3>
+<ul>
+<li>
+<a href="b/index.html">b/</a>
+</li>
+</ul>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
@@ -1,52 +1,49 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/deep/nested/folder</title
-    ><link href="../../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../../../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../../../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../index.html" class="title-crumb"
-        >deep</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html" class="title-crumb"
-        >nested</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >folder</span></h2
-      ><a data-path="/deep/nested/folder" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><h3
-      >Exported files: </h3
-      ><ul
-        ><li
-          ><a href="my-even.dhall.html"
-          >my-even.dhall</a
-          ><span class="of-type-token"
-          >:</span
-          ><span class="dhall-type source-code"
-            ><pre
-              >Natural → &lt; even | odd &gt;<br/></pre></span></li></ul></div></body></html>
+<html>
+<head>
+<title>/deep/nested/folder</title>
+<link href="../../../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../../../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../../../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../../../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="../../index.html" class="title-crumb">deep</a>
+<span class="crumb-divider">/</span>
+<a href="../index.html" class="title-crumb">nested</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">folder</span>
+</h2>
+<a data-path="/deep/nested/folder" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<h3>Exported files: </h3>
+<ul>
+<li>
+<a href="my-even.dhall.html">my-even.dhall</a>
+<span class="of-type-token">:</span>
+<span class="dhall-type source-code">
+<pre>Natural → &lt; even | odd &gt;<br>
+</pre>
+</span>
+</li>
+</ul>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
@@ -1,85 +1,58 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/deep/nested/folder/my-even.dhall</title
-    ><link href="../../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../../../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../../../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../index.html" class="title-crumb"
-        >deep</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html" class="title-crumb"
-        >nested</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html" class="title-crumb"
-        >folder</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >my-even.dhall</span></h2
-      ><a data-path="/deep/nested/folder/my-even.dhall"
-          class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-      /><h3
-      >Examples</h3
-      ><div class="source-code code-examples"
-        ><pre
-          >my-even 1 ≡ &lt; even | odd &gt;.odd<br/></pre
-        ><pre
-          >my-even 2 ≡ &lt; even | odd &gt;.even<br/></pre></div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-<br
-          />Check if a natural is even or not returning an union data-type<br
-          />-}<br
-          />let <span data-name="var4-5" id="var4-5" class="name-decl"
-          >my-even</span
-          ><br
-          />    : Natural → &lt; even | odd &gt;<br
-          />    = λ(<span data-name="var6-9" id="var6-9" class="name-decl"
-          >n</span
-          > : Natural) →<br
-          />        if Natural/even <a href="#var6-9" data-name="var6-9"
-                                       class="name-use"
-          >n</a
-          > then &lt; even | odd&gt;.even else &lt; even | odd &gt;.odd<br
-          /><br
-          />let example0 = assert : <a href="#var4-5" data-name="var4-5"
-                                       class="name-use"
-          >my-even</a
-          > 1 === &lt;even | odd&gt;.odd<br
-          />let example0 = assert : <a href="#var4-5" data-name="var4-5"
-                                       class="name-use"
-          >my-even</a
-          > 2 === &lt;even | odd&gt;.even<br
-          /><br
-          />in <a href="#var4-5" data-name="var4-5" class="name-use"
-          >my-even</a
-          ><br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/deep/nested/folder/my-even.dhall</title>
+<link href="../../../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../../../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../../../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../../../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="../../index.html" class="title-crumb">deep</a>
+<span class="crumb-divider">/</span>
+<a href="../index.html" class="title-crumb">nested</a>
+<span class="crumb-divider">/</span>
+<a href="index.html" class="title-crumb">folder</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">my-even.dhall</span>
+</h2>
+<a data-path="/deep/nested/folder/my-even.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Examples</h3>
+<div class="source-code code-examples">
+<pre>my-even 1 ≡ &lt; even | odd &gt;.odd<br>
+</pre>
+<pre>my-even 2 ≡ &lt; even | odd &gt;.even<br>
+</pre>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-<br>Check if a natural is even or not returning an union data-type<br>-}<br>let <span data-name="var4-5" id="var4-5" class="name-decl">my-even</span>
+<br>    : Natural → &lt; even | odd &gt;<br>    = λ(<span data-name="var6-9" id="var6-9" class="name-decl">n</span> : Natural) →<br>        if Natural/even <a href="#var6-9" data-name="var6-9" class="name-use">n</a> then &lt; even | odd&gt;.even else &lt; even | odd &gt;.odd<br>
+<br>let example0 = assert : <a href="#var4-5" data-name="var4-5" class="name-use">my-even</a> 1 === &lt;even | odd&gt;.odd<br>let example0 = assert : <a href="#var4-5" data-name="var4-5" class="name-use">my-even</a> 2 === &lt;even | odd&gt;.even<br>
+<br>in <a href="#var4-5" data-name="var4-5" class="name-use">my-even</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/deep/nested/index.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/index.html
@@ -1,43 +1,42 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/deep/nested</title
-    ><link href="../../index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="../../index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="../../dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../../index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="../index.html" class="title-crumb"
-        >deep</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >nested</span></h2
-      ><a data-path="/deep/nested" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><h3
-      >Exported packages: </h3
-      ><ul
-        ><li
-          ><a href="folder/index.html"
-          >folder/</a></li></ul></div></body></html>
+<html>
+<head>
+<title>/deep/nested</title>
+<link href="../../index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="../../index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="../../dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="../../index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<a href="../index.html" class="title-crumb">deep</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">nested</span>
+</h2>
+<a data-path="/deep/nested" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<h3>Exported packages: </h3>
+<ul>
+<li>
+<a href="folder/index.html">folder/</a>
+</li>
+</ul>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -1,184 +1,187 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"/></h2
-      ><a data-path="/" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><h3
-      >Exported files: </h3
-      ><ul
-        ><li
-          ><a href="ImportAsType.dhall.html"
-          >ImportAsType.dhall</a
-          ><span class="of-type-token"
-          >:</span
-          ><span class="dhall-type source-code"
-            ><pre
-              ><a href="./MarkdownExample.dhall.html"
-              >./MarkdownExample.dhall</a
-              ><br/></pre></span></li
-        ><li
-          ><a href="InvalidBlockComment.dhall.html"
-          >InvalidBlockComment.dhall</a></li
-        ><li
-          ><a href="InvalidConsecutiveComments.dhall.html"
-          >InvalidConsecutiveComments.dhall</a></li
-        ><li
-          ><a href="InvalidMarkdown.dhall.html"
-          >InvalidMarkdown.dhall</a></li
-        ><li
-          ><a href="JumpToDefOnUnused.dhall.html"
-          >JumpToDefOnUnused.dhall</a></li
-        ><li
-          ><a href="JumpToHereImports.dhall.html"
-          >JumpToHereImports.dhall</a></li
-        ><li
-          ><a href="JumpToLamBindingComplex.dhall.html"
-          >JumpToLamBindingComplex.dhall</a></li
-        ><li
-          ><a href="JumpToLamBindingSimple.dhall.html"
-          >JumpToLamBindingSimple.dhall</a></li
-        ><li
-          ><a href="JumpToLamBindingWithIndex.dhall.html"
-          >JumpToLamBindingWithIndex.dhall</a></li
-        ><li
-          ><a href="JumpToLamBindingWithQuotes.dhall.html"
-          >JumpToLamBindingWithQuotes.dhall</a></li
-        ><li
-          ><a href="JumpToLamBindingWithShadowing.dhall.html"
-          >JumpToLamBindingWithShadowing.dhall</a></li
-        ><li
-          ><a href="JumpToLetBindingSimple.dhall.html"
-          >JumpToLetBindingSimple.dhall</a></li
-        ><li
-          ><a href="JumpToLetBindingWithIndex.dhall.html"
-          >JumpToLetBindingWithIndex.dhall</a></li
-        ><li
-          ><a href="JumpToLetBindingWithQuotes.dhall.html"
-          >JumpToLetBindingWithQuotes.dhall</a></li
-        ><li
-          ><a href="JumpToLetBindingWithShadowing.dhall.html"
-          >JumpToLetBindingWithShadowing.dhall</a></li
-        ><li
-          ><a href="JumpToLetbindingComplex.dhall.html"
-          >JumpToLetbindingComplex.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenFieldDoesNotExist.dhall.html"
-          >JumpToRecordFieldWhenFieldDoesNotExist.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html"
-          >JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html"
-          >JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenVarIsOfRecordType.dhall.html"
-          >JumpToRecordFieldWhenVarIsOfRecordType.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html"
-          >JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html"
-          >JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html"
-          >JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html"
-          >JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html"
-          >JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall</a></li
-        ><li
-          ><a href="JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html"
-          >JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall</a></li
-        ><li
-          ><a href="JumpToSelf.dhall.html"
-          >JumpToSelf.dhall</a></li
-        ><li
-          ><a href="JumpToUrls.dhall.html"
-          >JumpToUrls.dhall</a></li
-        ><li
-          ><a href="MarkdownExample.dhall.html"
-          >MarkdownExample.dhall</a></li
-        ><li
-          ><a href="MultilineIndentationExample.dhall.html"
-          >MultilineIndentationExample.dhall</a
-          ><span class="of-type-token"
-          >:</span
-          ><span class="dhall-type source-code"
-            ><pre
-              >{}<br/></pre></span></li
-        ><li
-          ><a href="NoDoc.dhall.html"
-          >NoDoc.dhall</a></li
-        ><li
-          ><a href="NonDhallDocsCommentAfterValid.dhall.html"
-          >NonDhallDocsCommentAfterValid.dhall</a></li
-        ><li
-          ><a href="OrdinaryAnnotation.dhall.html"
-          >OrdinaryAnnotation.dhall</a
-          ><span class="of-type-token"
-          >:</span
-          ><span class="dhall-type source-code"
-            ><pre
-              >Natural<br/></pre></span></li
-        ><li
-          ><a href="Pair.dhall.html"
-          >Pair.dhall</a
-          ><span class="of-type-token"
-          >:</span
-          ><span class="dhall-type source-code"
-            ><pre
-              >∀(A : Type) → ∀(B : Type) → Type<br/></pre></span></li
-        ><li
-          ><a href="RenderTypeIndexesExample.dhall.html"
-          >RenderTypeIndexesExample.dhall</a
-          ><span class="of-type-token"
-          >:</span
-          ><span class="dhall-type source-code"
-            ><pre
-              >Bool<br/></pre></span></li
-        ><li
-          ><a href="TwoAnnotations.dhall.html"
-          >TwoAnnotations.dhall</a
-          ><span class="of-type-token"
-          >:</span
-          ><span class="dhall-type source-code"
-            ><pre
-              >y<br/></pre></span></li
-        ><li
-          ><a href="package.dhall.html"
-          >package.dhall</a></li></ul
-      ><h3
-      >Exported packages: </h3
-      ><ul
-        ><li
-          ><a href="a/index.html"
-          >a/</a></li></ul></div></body></html>
+<html>
+<head>
+<title>/</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">
+</span>
+</h2>
+<a data-path="/" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<h3>Exported files: </h3>
+<ul>
+<li>
+<a href="ImportAsType.dhall.html">ImportAsType.dhall</a>
+<span class="of-type-token">:</span>
+<span class="dhall-type source-code">
+<pre>
+<a href="./MarkdownExample.dhall.html">./MarkdownExample.dhall</a>
+<br>
+</pre>
+</span>
+</li>
+<li>
+<a href="InvalidBlockComment.dhall.html">InvalidBlockComment.dhall</a>
+</li>
+<li>
+<a href="InvalidConsecutiveComments.dhall.html">InvalidConsecutiveComments.dhall</a>
+</li>
+<li>
+<a href="InvalidMarkdown.dhall.html">InvalidMarkdown.dhall</a>
+</li>
+<li>
+<a href="JumpToDefOnUnused.dhall.html">JumpToDefOnUnused.dhall</a>
+</li>
+<li>
+<a href="JumpToHereImports.dhall.html">JumpToHereImports.dhall</a>
+</li>
+<li>
+<a href="JumpToLamBindingComplex.dhall.html">JumpToLamBindingComplex.dhall</a>
+</li>
+<li>
+<a href="JumpToLamBindingSimple.dhall.html">JumpToLamBindingSimple.dhall</a>
+</li>
+<li>
+<a href="JumpToLamBindingWithIndex.dhall.html">JumpToLamBindingWithIndex.dhall</a>
+</li>
+<li>
+<a href="JumpToLamBindingWithQuotes.dhall.html">JumpToLamBindingWithQuotes.dhall</a>
+</li>
+<li>
+<a href="JumpToLamBindingWithShadowing.dhall.html">JumpToLamBindingWithShadowing.dhall</a>
+</li>
+<li>
+<a href="JumpToLetBindingSimple.dhall.html">JumpToLetBindingSimple.dhall</a>
+</li>
+<li>
+<a href="JumpToLetBindingWithIndex.dhall.html">JumpToLetBindingWithIndex.dhall</a>
+</li>
+<li>
+<a href="JumpToLetBindingWithQuotes.dhall.html">JumpToLetBindingWithQuotes.dhall</a>
+</li>
+<li>
+<a href="JumpToLetBindingWithShadowing.dhall.html">JumpToLetBindingWithShadowing.dhall</a>
+</li>
+<li>
+<a href="JumpToLetbindingComplex.dhall.html">JumpToLetbindingComplex.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenFieldDoesNotExist.dhall.html">JumpToRecordFieldWhenFieldDoesNotExist.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html">JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html">JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenVarIsOfRecordType.dhall.html">JumpToRecordFieldWhenVarIsOfRecordType.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html">JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html">JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html">JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html">JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html">JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall</a>
+</li>
+<li>
+<a href="JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html">JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall</a>
+</li>
+<li>
+<a href="JumpToSelf.dhall.html">JumpToSelf.dhall</a>
+</li>
+<li>
+<a href="JumpToUrls.dhall.html">JumpToUrls.dhall</a>
+</li>
+<li>
+<a href="MarkdownExample.dhall.html">MarkdownExample.dhall</a>
+</li>
+<li>
+<a href="MultilineIndentationExample.dhall.html">MultilineIndentationExample.dhall</a>
+<span class="of-type-token">:</span>
+<span class="dhall-type source-code">
+<pre>{}<br>
+</pre>
+</span>
+</li>
+<li>
+<a href="NoDoc.dhall.html">NoDoc.dhall</a>
+</li>
+<li>
+<a href="NonDhallDocsCommentAfterValid.dhall.html">NonDhallDocsCommentAfterValid.dhall</a>
+</li>
+<li>
+<a href="OrdinaryAnnotation.dhall.html">OrdinaryAnnotation.dhall</a>
+<span class="of-type-token">:</span>
+<span class="dhall-type source-code">
+<pre>Natural<br>
+</pre>
+</span>
+</li>
+<li>
+<a href="Pair.dhall.html">Pair.dhall</a>
+<span class="of-type-token">:</span>
+<span class="dhall-type source-code">
+<pre>∀(A : Type) → ∀(B : Type) → Type<br>
+</pre>
+</span>
+</li>
+<li>
+<a href="RenderTypeIndexesExample.dhall.html">RenderTypeIndexesExample.dhall</a>
+<span class="of-type-token">:</span>
+<span class="dhall-type source-code">
+<pre>Bool<br>
+</pre>
+</span>
+</li>
+<li>
+<a href="TwoAnnotations.dhall.html">TwoAnnotations.dhall</a>
+<span class="of-type-token">:</span>
+<span class="dhall-type source-code">
+<pre>y<br>
+</pre>
+</span>
+</li>
+<li>
+<a href="package.dhall.html">package.dhall</a>
+</li>
+</ul>
+<h3>Exported packages: </h3>
+<ul>
+<li>
+<a href="a/index.html">a/</a>
+</li>
+</ul>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/package.dhall.html
+++ b/dhall-docs/tasty/data/golden/package.dhall.html
@@ -1,54 +1,45 @@
 <!DOCTYPE HTML>
-<html
-  ><head
-    ><title
-    >/package.dhall</title
-    ><link href="index.css" type="text/css" rel="stylesheet"
-    /><link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap"
-            type="text/css" rel="stylesheet"
-    /><script src="index.js" type="text/javascript"
-    /><meta charset="UTF-8"/></head
-  ><body
-    ><div class="nav-bar"
-      ><img src="dhall-icon.svg" class="dhall-icon"
-      /><p class="package-title"
-      >test-package</p
-      ><div class="nav-bar-content-divider"
-      /><a id="switch-light-dark-mode" class="nav-option"
-      >Switch Light/Dark Mode</a></div
-    ><div class="main-container"
-      ><h2 class="doc-title"
-        ><span class="crumb-divider"
-        >/</span
-        ><a href="index.html"
-        >test-package</a
-        ><span class="crumb-divider"
-        >/</span
-        ><span href="index.html" class="title-crumb"
-        >package.dhall</span></h2
-      ><a data-path="/package.dhall" class="copy-to-clipboard"
-        ><i
-          ><small
-          >Copy path to clipboard</small></i></a
-      ><br
-      /><div class="doc-contents"
-        ><p
-        >This is your package entrypoint documentation</p>
-</div
-      ><h3
-      >Source</h3
-      ><div class="source-code"
-        ><pre
-          >{-|<br
-          />This is your package entrypoint documentation<br
-          />-}<br
-          />{ Message = <a href="./Message.dhall.html"
-          >./Message.dhall</a
-          ><br
-          />, DeliveryStatus = <a href="./DeliveryStatus.dhall.html"
-          >./DeliveryStatus.dhall</a
-          ><br
-          />, Pair = <a href="./Pair.dhall.html"
-          >./Pair.dhall</a
-          ><br
-          />}<br/></pre></div></div></body></html>
+<html>
+<head>
+<title>/package.dhall</title>
+<link href="index.css" type="text/css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap" type="text/css" rel="stylesheet">
+<script src="index.js" type="text/javascript">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img src="dhall-icon.svg" class="dhall-icon">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span href="index.html" class="title-crumb">package.dhall</span>
+</h2>
+<a data-path="/package.dhall" class="copy-to-clipboard">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+<p>This is your package entrypoint documentation</p>
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>{-|<br>This is your package entrypoint documentation<br>-}<br>{ Message = <a href="./Message.dhall.html">./Message.dhall</a>
+<br>, DeliveryStatus = <a href="./DeliveryStatus.dhall.html">./DeliveryStatus.dhall</a>
+<br>, Pair = <a href="./Pair.dhall.html">./Pair.dhall</a>
+<br>}<br>
+</pre>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
HaXml is largely unmaintained, so removing the dependency may prevent
future trouble.