### PR TITLE
Nitpicky grammar fix for COC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, political belief or sexual identity and orientation.
+appearance, race, religion, political belief, or sexual identity and orientation.
 
 ## Our Standards
 


### PR DESCRIPTION
#1619 (accidentally) eliminated the Oxford comma in the COC, which should be re-added, for consistency with the rest of the document (as well as to eliminate potentially ambiguous wording).