### PR TITLE
Version 1.38.0 → 1.38.1

### DIFF
--- a/dhall-docs/CHANGELOG.md
+++ b/dhall-docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+1.0.5
+
+* [BUG FIX: Fix index generation](https://github.com/dhall-lang/dhall-haskell/pull/2150)
+    * Indices are now created for intermediate directories without `.dhall` files
+    * `dhall-docs` no longer hangs when the top-level directory has no `.dhall` files
+* [Fix lower bound on `dhall`](https://github.com/dhall-lang/dhall-haskell/pull/2147/)
+* [Allow doctest-0.18](https://github.com/dhall-lang/dhall-haskell/pull/2148)
+* [Allow bytestring-0.11](https://github.com/dhall-lang/dhall-haskell/pull/2144)
+* [Add `README` to tarball](https://github.com/dhall-lang/dhall-haskell/pull/2145)
+* [Remove test dependency on HaXml](https://github.com/dhall-lang/dhall-haskell/pull/2156)
+
 1.0.4
 
 * Build against `dhall-1.38.0`, `tasty-1.4`, `tasty-silver-3.2`, and

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -1,5 +1,5 @@
 Name: dhall-docs
-Version: 1.0.4
+Version: 1.0.5
 Cabal-Version: >=1.10
 Build-Type: Simple
 Tested-With: GHC == 8.6.1

--- a/dhall-json/CHANGELOG.md
+++ b/dhall-json/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.7.6
+
+* [Fix `hashable`-related test failures](https://github.com/dhall-lang/dhall-haskell/pull/2152)
+* [Fix lower bound on `dhall`](https://github.com/dhall-lang/dhall-haskell/pull/2147)
+* [Allow bytestring-0.11](https://github.com/dhall-lang/dhall-haskell/pull/2144)
+* [Fix typos in `json-to-dhall --help` output](https://github.com/dhall-lang/dhall-haskell/pull/2160)
+
 1.7.5
 
 * Build against `dhall-1.38.0`, `tasty-1.4`, and `tasty-silver-3.2`

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -1,5 +1,5 @@
 Name: dhall-json
-Version: 1.7.5
+Version: 1.7.6
 Cabal-Version: >=1.10
 Build-Type: Simple
 Tested-With: GHC == 8.4.3, GHC == 8.6.1

--- a/dhall-lsp-server/ChangeLog.md
+++ b/dhall-lsp-server/ChangeLog.md
@@ -1,7 +1,0 @@
-# Changelog for dhall-lsp-server
-
-## unreleased
-  - whole document formatting
-  - correctly show location of import errors
-## 0.0.1.0
-  - diagnostic output

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -1,5 +1,5 @@
 name:           dhall-lsp-server
-Version:        1.0.13
+Version:        1.0.14
 cabal-version:  1.12
 synopsis:       Language Server Protocol (LSP) server for Dhall
 homepage:       https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-lsp-server#readme
@@ -12,7 +12,6 @@ license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     README.md
-    ChangeLog.md
     tests/fixtures/completion/*.dhall
     tests/fixtures/diagnostics/*.dhall
     tests/fixtures/linting/*.dhall

--- a/dhall-openapi/README.md
+++ b/dhall-openapi/README.md
@@ -1,7 +1,5 @@
 # `dhall-openapi`
 
-:construction: **This tool is on development phase yet**
-
 For installation or development instructions, see:
 
 * [`dhall-haskell` - `README`](https://github.com/dhall-lang/dhall-haskell/blob/master/README.md)
@@ -9,4 +7,5 @@ For installation or development instructions, see:
 ## Introduction
 
 This `dhall-openapi` package provides an OpenAPI to Dhall compiler.
+
 The `openapi-to-dhall` executable generates the Dhall types from an OpenAPI specification.

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -1,10 +1,9 @@
-cabal-version:  >=1.10
+cabal-version:  >=0.10
 name:           dhall-openapi
-version:        0.1.2
-category:       Code Generation
-homepage:       https://github.com/dhall-lang/dhall-haskell
+version:        1.0.0
+homepage:       https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi#dhall-openapi
 author:         Fabrizio Ferrai
-maintainer:     fabrizio@ferrai.io
+maintainer:     Gabriel439@gmail.com
 copyright:      2019 Fabrizio Ferrai
 license:        BSD3
 build-type:     Simple
@@ -17,7 +16,17 @@ executable openapi-to-dhall
   main-is: Main.hs
   hs-source-dirs:
       openapi-to-dhall
-  default-extensions: DuplicateRecordFields GeneralizedNewtypeDeriving LambdaCase RecordWildCards ScopedTypeVariables OverloadedStrings FlexibleInstances ConstraintKinds ApplicativeDo TupleSections
+  default-extensions:
+    DuplicateRecordFields
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    RecordWildCards
+    ScopedTypeVariables
+    OverloadedStrings
+    FlexibleInstances
+    ConstraintKinds
+    ApplicativeDo
+    TupleSections
   ghc-options: -Wall
   build-depends:
     base                                           ,
@@ -43,7 +52,20 @@ library
       Dhall.Kubernetes.Types
   hs-source-dirs:
       src
-  default-extensions: DeriveDataTypeable DeriveGeneric DerivingStrategies DuplicateRecordFields GeneralizedNewtypeDeriving LambdaCase RecordWildCards ScopedTypeVariables OverloadedStrings FlexibleInstances ConstraintKinds ApplicativeDo TupleSections
+  default-extensions:
+    DeriveDataTypeable
+    DeriveGeneric
+    DerivingStrategies
+    DuplicateRecordFields
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    RecordWildCards
+    ScopedTypeVariables
+    OverloadedStrings
+    FlexibleInstances
+    ConstraintKinds
+    ApplicativeDo
+    TupleSections
   ghc-options: -Wall
   build-depends:
     base                    >= 4.11.0.0  && < 5    ,

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -1,4 +1,4 @@
-cabal-version:  >=0.10
+cabal-version:  >=1.10
 name:           dhall-openapi
 version:        1.0.0
 homepage:       https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi#dhall-openapi

--- a/dhall-yaml/CHANGELOG.md
+++ b/dhall-yaml/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.2.6
+
+* [Allow bytestring-0.11](https://github.com/dhall-lang/dhall-haskell/pull/2144)
+
 1.2.5
 
 * Build against `dhall-1.38.0`, `tasty-1.4`, and `tasty-silver-3.2`

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -1,5 +1,5 @@
 Name: dhall-yaml
-Version: 1.2.5
+Version: 1.2.6
 Cabal-Version: >=1.10
 Build-Type: Simple
 Tested-With: GHC == 8.4.3, GHC == 8.6.1

--- a/dhall/CHANGELOG.md
+++ b/dhall/CHANGELOG.md
@@ -1,5 +1,7 @@
 1.38.1
 
+* [Add `INLINABLE` annotations in more places](https://github.com/dhall-lang/dhall-haskell/pull/2164)
+    * This may improve performance by enabling more specializations
 * [Fix `hashable`-related test failures](https://github.com/dhall-lang/dhall-haskell/pull/2152)
 * [Fix support for GHC 8.4.4](https://github.com/dhall-lang/dhall-haskell/pull/2143)
     * … by using `GeneralizedNewtypeDeriving` (with a `z`)

--- a/dhall/CHANGELOG.md
+++ b/dhall/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.38.1
+
+* [Fix `hashable`-related test failures](https://github.com/dhall-lang/dhall-haskell/pull/2152)
+* [Fix support for GHC 8.4.4](https://github.com/dhall-lang/dhall-haskell/pull/2143)
+    * … by using `GeneralizedNewtypeDeriving` (with a `z`)
+* [Allow doctest-0.18](https://github.com/dhall-lang/dhall-haskell/pull/2148)
+* [Allow bytestring-0.11](https://github.com/dhall-lang/dhall-haskell/pull/2144)
+
 1.38.0
 
 * [BREAKING CHANGE: Detect preferred character set from input](https://github.com/dhall-lang/dhall-haskell/pull/2108)

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -1,5 +1,5 @@
 Name: dhall
-Version: 1.38.0
+Version: 1.38.1
 Cabal-Version: 2.0
 Build-Type: Simple
 Tested-With: GHC == 8.4.3, GHC == 8.6.1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -42,6 +42,6 @@ function release {
 
 git submodule update
 
-for package in dhall-lsp-server dhall-json dhall-yaml dhall-bash dhall-nix dhall-nixpkgs dhall dhall-docs; do
+for package in dhall-lsp-server dhall-openapi dhall-json dhall-yaml dhall-bash dhall-nix dhall-nixpkgs dhall-docs dhall; do
   release "${package}"
 done


### PR DESCRIPTION
Note that this will be the first official release of `dhall-openapi` (including a Hackage release and release binaries)