### PR TITLE
Fix `dhall-openapi.cabal`

### DIFF
--- a/dhall-openapi/LICENSE
+++ b/dhall-openapi/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2019 Fabrizio Ferrai
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the author nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -1,22 +1,28 @@
-cabal-version:  >=1.10
-name:           dhall-openapi
-version:        1.0.0
-homepage:       https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi#dhall-openapi
-author:         Fabrizio Ferrai
-maintainer:     Gabriel439@gmail.com
-copyright:      2019 Fabrizio Ferrai
-license:        BSD3
-build-type:     Simple
+Cabal-Version:  >=1.10
+Name:           dhall-openapi
+Version:        1.0.0
+Homepage:       https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi#dhall-openapi
+Author:         Fabrizio Ferrai
+Maintainer:     Gabriel439@gmail.com
+Copyright:      2019 Fabrizio Ferrai
+License:        BSD3
+License-File:   LICENSE
+Build-Type:     Simple
+Category:       Compiler
+Description:
+    This package provides an `openapi-to-dhall` program that converts an
+    OpenAPI specification to a Dhall package containing types, defaults, and
+    schemas for that API.
 
-source-repository head
-  type: git
-  location: https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi
+Source-Repository head
+  Type: git
+  Location: https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi
 
-executable openapi-to-dhall
-  main-is: Main.hs
-  hs-source-dirs:
+Executable openapi-to-dhall
+  Main-Is: Main.hs
+  Hs-Source-Dirs:
       openapi-to-dhall
-  default-extensions:
+  Default-Extensions:
     DuplicateRecordFields
     GeneralizedNewtypeDeriving
     LambdaCase
@@ -27,8 +33,8 @@ executable openapi-to-dhall
     ConstraintKinds
     ApplicativeDo
     TupleSections
-  ghc-options: -Wall
-  build-depends:
+  Ghc-Options: -Wall
+  Build-Depends:
     base                                           ,
     aeson                                          ,
     containers                                     ,
@@ -43,16 +49,16 @@ executable openapi-to-dhall
     sort                                           ,
     text                                           ,
     vector
-  default-language: Haskell2010
+  Default-Language: Haskell2010
 
-library
-  exposed-Modules:
+Library
+  Exposed-Modules:
       Dhall.Kubernetes.Convert
       Dhall.Kubernetes.Data
       Dhall.Kubernetes.Types
-  hs-source-dirs:
+  Hs-Source-Dirs:
       src
-  default-extensions:
+  Default-Extensions:
     DeriveDataTypeable
     DeriveGeneric
     DerivingStrategies
@@ -66,8 +72,8 @@ library
     ConstraintKinds
     ApplicativeDo
     TupleSections
-  ghc-options: -Wall
-  build-depends:
+  Ghc-Options: -Wall
+  Build-Depends:
     base                    >= 4.11.0.0  && < 5    ,
     aeson                   >= 1.0.0.0   && < 1.6  ,
     containers              >= 0.5.8.0   && < 0.7  ,
@@ -77,4 +83,4 @@ library
     sort                    >= 1.0       && < 1.1  ,
     text                    >= 0.11.1.0  && < 1.3  ,
     vector                  >= 0.11.0.0  && < 0.13
-  default-language: Haskell2010
+  Default-Language: Haskell2010

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -9,6 +9,7 @@ License:        BSD3
 License-File:   LICENSE
 Build-Type:     Simple
 Category:       Compiler
+Synopsis:       Convert an OpenAPI specification to a Dhall package
 Description:
     This package provides an `openapi-to-dhall` program that converts an
     OpenAPI specification to a Dhall package containing types, defaults, and


### PR DESCRIPTION
There were a few issues with the `.cabal` file that prevented me from
uploading this to Hackage.

Note that really only `Version` needs to be capitalized (so that the `.cabal`
file plays well with the release script), but I went ahead and capitalized
everything else for consistency with the other `.cabal` files.

Once this is merged I'll attempt the upload again.