### PR TITLE
Provide multiple files to various CLI subcommands

### DIFF
--- a/dhall-openapi/openapi-to-dhall/Main.hs
+++ b/dhall-openapi/openapi-to-dhall/Main.hs
@@ -75,10 +75,9 @@ writeDhall path expr = do
 
   let outputMode = Dhall.Util.Write
 
-  let input =
-        Dhall.Util.PossiblyTransitiveInputFile
-            path
-            Dhall.Util.NonTransitive
+  let inputs = pure (Dhall.Util.InputFile path)
+
+  let transitivity = Dhall.Util.NonTransitive
 
   let formatOptions = Dhall.Format.Format{..}
 

--- a/dhall/src/Dhall/Format.hs
+++ b/dhall/src/Dhall/Format.hs
@@ -26,6 +26,7 @@ import Dhall.Util
     , Input (..)
     , OutputMode (..)
     , Transitivity (..)
+    , mapMThrowCheckFailed
     )
 
 import qualified Control.Exception
@@ -53,7 +54,7 @@ data Format = Format
 -- | Implementation of the @dhall format@ subcommand
 format :: Format -> IO ()
 format (Format { inputs = inputs0, transitivity = transitivity0, ..}) =
-    mapM_ go inputs0
+    mapMThrowCheckFailed go inputs0
   where
     go input = do
         let directory = case input of

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -38,7 +38,7 @@ import Dhall.Util
     , Input (..)
     , OutputMode (..)
     , Transitivity (..)
-    , mapMThrowCheckFailed
+    , handleMultipleChecksFailed
     )
 import System.Console.ANSI (hSupportsANSI)
 
@@ -163,7 +163,7 @@ freezeWithManager
     -> Censor
     -> IO ()
 freezeWithManager newManager outputMode transitivity0 inputs scope intent chosenCharacterSet censor =
-    mapMThrowCheckFailed go inputs
+    handleMultipleChecksFailed "freeze" "frozen" go inputs
   where
     go input = do
         let directory = case input of
@@ -231,15 +231,13 @@ freezeWithManager newManager outputMode transitivity0 inputs scope intent chosen
                            else
                              Pretty.renderIO System.IO.stdout unAnnotated
 
+                return (Right ())
+
             Check ->
-                if originalText == modifiedText
-                    then return ()
-                    else do
-                        let command = "freeze"
-
-                        let modified = "frozen"
-
-                        Exception.throwIO CheckFailed{..}
+                return $
+                    if originalText == modifiedText
+                        then Right ()
+                        else Left CheckFailed{..}
 
 {-| Slightly more pure version of the `freeze` function
 

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -38,6 +38,7 @@ import Dhall.Util
     , Input (..)
     , OutputMode (..)
     , Transitivity (..)
+    , mapMThrowCheckFailed
     )
 import System.Console.ANSI (hSupportsANSI)
 
@@ -162,7 +163,7 @@ freezeWithManager
     -> Censor
     -> IO ()
 freezeWithManager newManager outputMode transitivity0 inputs scope intent chosenCharacterSet censor =
-    mapM_ go inputs
+    mapMThrowCheckFailed go inputs
   where
     go input = do
         let directory = case input of

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -436,13 +436,10 @@ parseMode =
             <>  Options.Applicative.action "file"
             )
 
-    parseTransitiveSwitch = fmap f (Options.Applicative.switch
+    parseTransitiveSwitch = Options.Applicative.flag NonTransitive Transitive
         (   Options.Applicative.long "transitive"
         <>  Options.Applicative.help "Modify the input and its transitive relative imports in-place"
-        ))
-        where
-            f False = NonTransitive
-            f True = Transitive
+        )
 
     parseInplaceNonTransitive =
             fmap InputFile parseInplace

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -65,7 +65,6 @@ import Dhall.Util
     , Input (..)
     , Output (..)
     , OutputMode (..)
-    , PossiblyTransitiveInput (..)
     , Transitivity (..)
     )
 
@@ -448,18 +447,6 @@ parseMode =
     parseInplaceNonTransitive =
             fmap InputFile parseInplace
         <|> pure StandardInput
-
-    parseInplaceTransitive =
-            fmap (\f -> PossiblyTransitiveInputFile f NonTransitive) parseInplace
-        <|> fmap (\f -> PossiblyTransitiveInputFile f    Transitive) parseTransitive
-        <|> pure NonTransitiveStandardInput
-      where
-        parseTransitive = Options.Applicative.strOption
-            (   Options.Applicative.long "transitive"
-            <>  Options.Applicative.help "Modify the specified file and its transitive relative imports in-place"
-            <>  Options.Applicative.metavar "FILE"
-            <>  Options.Applicative.action "file"
-            )
 
     parseInput = fmap f (optional p)
       where

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -144,7 +144,7 @@ data Mode
     | Normalize { file :: Input , alpha :: Bool }
     | Repl
     | Format { transitivity :: Transitivity, outputMode :: OutputMode, inputs :: NonEmpty Input }
-    | Freeze { possiblyTransitiveInput :: PossiblyTransitiveInput, all_ :: Bool, cache :: Bool, outputMode :: OutputMode }
+    | Freeze { transitivity :: Transitivity, all_ :: Bool, cache :: Bool, outputMode :: OutputMode, inputs :: NonEmpty Input }
     | Hash { file :: Input, cache :: Bool }
     | Diff { expr1 :: Text, expr2 :: Text }
     | Lint { possiblyTransitiveInput :: PossiblyTransitiveInput, outputMode :: OutputMode }
@@ -247,7 +247,7 @@ parseMode =
             Manipulate
             "freeze"
             "Add integrity checks to remote import statements of an expression"
-            (Freeze <$> parseInplaceTransitive <*> parseAllFlag <*> parseCacheFlag <*> parseCheck "frozen")
+            (Freeze <$> parseTransitiveSwitch <*> parseAllFlag <*> parseCacheFlag <*> parseCheck "frozen" <*> parseFiles)
     <|> subcommand
             Manipulate
             "lint"
@@ -818,7 +818,7 @@ command (Options {..}) = do
 
             let intent = if cache then Cache else Secure
 
-            Dhall.Freeze.freeze outputMode possiblyTransitiveInput scope intent chosenCharacterSet censor
+            Dhall.Freeze.freeze outputMode transitivity inputs scope intent chosenCharacterSet censor
 
         Hash {..} -> do
             expression <- getExpression file

--- a/dhall/src/Dhall/Schemas.hs
+++ b/dhall/src/Dhall/Schemas.hs
@@ -27,7 +27,7 @@ import Dhall.Src           (Src)
 import Dhall.Syntax        (Expr (..), Import, Var (..))
 import Dhall.Util
     ( Censor (..)
-    , CheckFailed (..)
+    , MultipleCheckFailed (..)
     , Header (..)
     , Input (..)
     , OutputMode (..)
@@ -115,7 +115,9 @@ schemasCommand Schemas{..} = do
 
                     let modified = "rewritten"
 
-                    Exception.throwIO CheckFailed{..}
+                    let inputs = pure input
+
+                    Exception.throwIO MultipleCheckFailed{..}
 
 decodeSchema :: Expr s Void -> Maybe (Expr s Void, Map Text (Expr s Void))
 decodeSchema (RecordLit m)

--- a/dhall/src/Dhall/Tutorial.hs
+++ b/dhall/src/Dhall/Tutorial.hs
@@ -1619,7 +1619,7 @@ import Dhall
 -- > let replicate = https://prelude.dhall-lang.org/List/replicate
 -- > in  replicate 5
 -- > $
--- > $ dhall freeze --inplace ./foo.dhall
+-- > $ dhall freeze ./foo.dhall
 -- > $ cat ./foo.dhall
 -- > let replicate =
 -- >       https://prelude.dhall-lang.org/List/replicate sha256:d4250b45278f2d692302489ac3e78280acb238d27541c837ce46911ff3baa347
@@ -1744,10 +1744,9 @@ import Dhall
 -- >       (List (List Natural))
 -- >       (replicate 5 (List Natural) (replicate 5 Natural 1))
 --
--- You can also use the formatter to modify files in place using the
--- @--inplace@ flag (i.e. for formatting source code):
+-- You can also use the formatter to modify files in place:
 --
--- > $ dhall format --inplace ./unformatted
+-- > $ dhall format ./unformatted
 --
 -- Carefully note that the code formatter does not preserve all comments.
 -- Currently, the formatter only preserves two types of comments:

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -185,7 +185,7 @@ instance Show CheckFailed where
         command_ = Data.Text.unpack command
 
         input_ = case input of
-            StandardInput -> "(stdin)"
+            StandardInput -> "(input)"
             InputFile file -> "\"" <> file <> "\""
 
 -- | Exception thrown when the @--check@ flag to a command-line subcommand fails

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -169,6 +169,9 @@ data Output = StandardOutput | OutputFile FilePath
 -}
 data OutputMode = Write | Check
 
+-- | A check failure corresponding to a single input.
+-- This type is intended to be used with 'MultipleCheckFailed' for error
+-- reporting.
 newtype CheckFailed = CheckFailed { input :: Input }
 
 -- | Exception thrown when the @--check@ flag to a command-line subcommand fails

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -10,7 +10,6 @@ module Dhall.Util
     , _ERROR
     , Censor(..)
     , Input(..)
-    , PossiblyTransitiveInput(..)
     , Transitivity(..)
     , OutputMode(..)
     , Output(..)
@@ -144,13 +143,6 @@ data Input = StandardInput | InputFile FilePath deriving (Eq)
 
 -- | Path to input or raw input text, necessary since we can't read STDIN twice
 data InputOrTextFromStdin = Input_ Input | StdinText Text
-
-{-| For utilities that may want to process transitive dependencies, like
-    @dhall freeze@
--}
-data PossiblyTransitiveInput
-    = NonTransitiveStandardInput
-    | PossiblyTransitiveInputFile FilePath Transitivity
 
 {-| Specifies whether or not an input's transitive dependencies should also be
     processed.  Transitive dependencies are restricted to relative file imports.

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -140,7 +140,7 @@ throws (Right r) = return r
 data Censor = NoCensor | Censor
 
 -- | Path to input
-data Input = StandardInput | InputFile FilePath
+data Input = StandardInput | InputFile FilePath deriving (Eq)
 
 -- | Path to input or raw input text, necessary since we can't read STDIN twice
 data InputOrTextFromStdin = Input_ Input | StdinText Text

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -163,13 +163,13 @@ data Output = StandardOutput | OutputFile FilePath
 data OutputMode = Write | Check
 
 -- | Exception thrown when the @--check@ flag to a command-line subcommand fails
-data CheckFailed = CheckFailed { command :: Text, modified :: Text }
+data CheckFailed = CheckFailed { command :: Text, modified :: Text, input :: Input }
 
 instance Exception CheckFailed
 
 instance Show CheckFailed where
     show CheckFailed{..} =
-         _ERROR <> ": ❰dhall " <> command_ <> " --check❱ failed\n\
+         _ERROR <> ": ❰dhall " <> command_ <> " --check❱ failed on " <> input_ <> "\n\
         \\n\
         \You ran ❰dhall " <> command_ <> " --check❱, but the input appears to have not\n\
         \been " <> modified_ <> " before, or was changed since the last time the input\n\
@@ -178,6 +178,10 @@ instance Show CheckFailed where
         modified_ = Data.Text.unpack modified
 
         command_ = Data.Text.unpack command
+
+        input_ = case input of
+            StandardInput -> "(stdin)"
+            InputFile file -> "\"" <> file <> "\""
 
 -- | Convenient utility for retrieving an expression
 getExpression :: Censor -> Input -> IO (Expr Src Import)


### PR DESCRIPTION
This PR makes it possible to provide multiple files as argument to the `format`, `freeze`, and `lint` subcommands.
These subcommands already had to deal with potentially multiple files via the use of the `transitive` flag.

# Motivation

It is common in unix tools for the CLI to accept multiple file arguments as input, so it would be great if `dhall` could do the same where possible/it makes sense.
A more concrete motivation is that I would like `dhall format` to be easily usable with formatting tools/managers such as https://github.com/numtide/treefmt. `treefmt` has a specification of sorts for what basic API formatters should expose as part of their CLI: https://numtide.github.io/treefmt/docs/formatters-spec.html. This specification requires the ability for a formatter to take multiple file arguments.

Providing multiple files as argument as opposed to calling these subcommands in a loop in `bash` (or with `xargs -n1`) has some performance benefits since we don't have to start a new process for every file.

# Changes

This PR make `inplace` implicit for file arguments (so that flag is removed). That was already kind of the case for these 3 subcommands as the only way to provide a file argument was `inplace` or `transitive` which implied `inplace`.

This PR changed the `transitive` flag from a flag that takes a file path to a switch that applies to all the input files.

Stdin is still supported, in 2 ways now: no file arguments, or a file argument `"-"`. This should enable applying the subcommands to both stdin and input files at the same time.
Note: stdin is still a non-transitive input even when the `transitive` switch is on.

---

Other subcommands might benefit from taking multiple files as input as well, I simply started with the ones I thought needed it the most.