### PR TITLE
Clean up build logs

### DIFF
--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -182,12 +182,13 @@ let
                       );
 
                     dhall =
-                      applyCoverage
-                        (haskellPackagesNew.callCabal2nix
-                          "dhall"
-                          (pkgsNew.sdist ../dhall)
-                          { }
-                        );
+                        (applyCoverage
+                          (haskellPackagesNew.callCabal2nix
+                            "dhall"
+                            (pkgsNew.sdist ../dhall)
+                            { }
+                          )
+                        ).overrideAttrs (old: { XDG_CACHE_HOME=".cache"; });
 
                     dhall-no-http =
                       # The import tests fail with HTTP support compiled out


### PR DESCRIPTION
… so that they don't keep spewing warnings like these:

```
Warning: The directory:

↳ /

... does not give you permission to read, write, or search files.

The directory's current permissions are:

• ✓ readable
• ✗ writable
• ✓ searchable

Warning: Could not get or create the default cache directory:

↳ /homeless-shelter/.cache/dhall-haskell

You can enable caching by creating it if needed and setting read,
write and search permissions on it or providing another cache base
directory by setting the $XDG_CACHE_HOME environment variable.
```

Fixes https://github.com/dhall-lang/dhall-haskell/issues/2180

The root cause appears to be that the Template Haskell logic in
`Dhall.Test.TH` was using the default cache directory of
`${HOME}/.cache`, which in a Nix build is `/homeless-shelter/.cache`.

We had already set `XDG_CACHE_HOME` for the test suites at run-time, but
we also need to set it at build-time, too, so that it's available for
Template Haskell.