### PR TITLE
dhall-nix{,pkgs}: cabal: dep: allow hnix 0.13

### DIFF
--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -31,7 +31,7 @@ Library
         containers                               < 0.7 ,
         data-fix                                 < 0.4 ,
         dhall                     >= 1.38     && < 1.39,
-        hnix                      >= 0.7      && < 0.13,
+        hnix                      >= 0.7      && < 0.14,
         lens-family-core          >= 1.0.0    && < 2.2 ,
         neat-interpolation                       < 0.6 ,
         text                      >= 0.8.0.0  && < 1.3

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -21,7 +21,7 @@ Executable dhall-to-nixpkgs
                      , data-fix
                      , dhall                >= 1.32.0   && < 1.39
                      , foldl                               < 1.5
-                     , hnix                 >= 0.10.1   && < 0.13
+                     , hnix                 >= 0.10.1   && < 0.14
                      , lens-family-core     >= 1.0.0    && < 2.2
                      , megaparsec           >= 7.0.0    && < 9.1
                      , mmorph                              < 1.2


### PR DESCRIPTION
Looked into the use of the HNix modules in both projects.

Despite a huge [changelog](https://hackage.haskell.org/package/hnix/changelog) of the HNix release, there were no changes in `Shorthands` or `Pretty` that Dhall relies on. Therefore the straight-forward update.