### PR TITLE
Fix compatibility with tasty-hspec 1.1.7

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -104,6 +104,7 @@ Test-Suite tests
     Build-Depends:
         base                                   ,
         haskell-lsp-types >= 0.19.0  && < 0.25 ,
+        hspec             >= 2.7     && < 2.9  ,
         lsp-test          >= 0.9     && < 0.13 ,
         tasty             >= 0.11.2  && < 1.5  ,
         tasty-hspec       >= 1.1     && < 1.2  ,

--- a/dhall-lsp-server/tests/Main.hs
+++ b/dhall-lsp-server/tests/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
@@ -16,6 +17,10 @@ import Language.Haskell.LSP.Types
     )
 import Test.Tasty
 import Test.Tasty.Hspec
+
+#if MIN_VERSION_tasty_hspec(1,1,7)
+import Test.Hspec
+#endif
 
 import qualified Data.Text       as T
 import qualified GHC.IO.Encoding


### PR DESCRIPTION
tasty-hspec no longer re-exports Test.Hspec since 1.1.7. Let's import
it ourselves.