### PR TITLE
Improve pretty-printing of `sha256`

### DIFF
--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -1083,7 +1083,15 @@ instance Pretty ImportHashed where
     pretty (ImportHashed  Nothing p) =
       Pretty.pretty p
     pretty (ImportHashed (Just h) p) =
-      Pretty.pretty p <> " sha256:" <> Pretty.pretty (show h)
+      Pretty.group (Pretty.flatAlt long short)
+      where
+        long =
+            Pretty.align
+                (   Pretty.pretty p <> Pretty.hardline
+                <>  "  sha256:" <> Pretty.pretty (show h)
+                )
+
+        short = Pretty.pretty p <> " sha256:" <> Pretty.pretty (show h)
 
 -- | Reference to an external resource
 data Import = Import

--- a/dhall/tests/format/ipfsB.dhall
+++ b/dhall/tests/format/ipfsB.dhall
@@ -11,7 +11,8 @@ let matchLabels =
       labels.{ `app.kubernetes.io/name`, `app.kubernetes.io/instance` }
 
 let k8s =
-      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ab28225a150498aef67c226d3c5f026c95b5a1e/package.dhall sha256:2c7ac35494f16b1f39afcf3467b2f3b0ab579edb0c711cddd2c93f1cbed358bd
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ab28225a150498aef67c226d3c5f026c95b5a1e/package.dhall
+        sha256:2c7ac35494f16b1f39afcf3467b2f3b0ab579edb0c711cddd2c93f1cbed358bd
 
 let serviceName = "ipfs"
 

--- a/dhall/tests/format/issue1400-2B.dhall
+++ b/dhall/tests/format/issue1400-2B.dhall
@@ -3,7 +3,8 @@ let Tagged
     = λ(a : Type) →
         { field : Text
         , nesting :
-              ./Nesting sha256:6284802edd41d5d725aa1ec7687e614e21ad1be7e14dd10996bfa9625105c335
+              ./Nesting
+                sha256:6284802edd41d5d725aa1ec7687e614e21ad1be7e14dd10996bfa9625105c335
             ? ./Nesting
         , contents : a
         }

--- a/dhall/tests/format/sha256PrintingB.dhall
+++ b/dhall/tests/format/sha256PrintingB.dhall
@@ -1,4 +1,5 @@
 let replicate =
-      https://raw.githubusercontent.com/dhall-lang/Prelude/c79c2bc3c46f129cc5b6d594ce298a381bcae92c/List/replicate sha256:cc856d59b63f7699881bdb8e4b1036ca4c0013827268040a50c1e1405f646a2c
+      https://raw.githubusercontent.com/dhall-lang/Prelude/c79c2bc3c46f129cc5b6d594ce298a381bcae92c/List/replicate
+        sha256:cc856d59b63f7699881bdb8e4b1036ca4c0013827268040a50c1e1405f646a2c
 
 in  replicate 5

--- a/dhall/tests/freeze/cachedB.dhall
+++ b/dhall/tests/freeze/cachedB.dhall
@@ -1,2 +1,3 @@
-  ./True.dhall sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
+  ./True.dhall
+    sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
 ? ./True.dhall

--- a/dhall/tests/freeze/incorrectHashB.dhall
+++ b/dhall/tests/freeze/incorrectHashB.dhall
@@ -1,2 +1,3 @@
-  ./True.dhall sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
+  ./True.dhall
+    sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
 ? ./True.dhall

--- a/dhall/tests/freeze/protectedB.dhall
+++ b/dhall/tests/freeze/protectedB.dhall
@@ -1,2 +1,3 @@
-  ./True.dhall sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
+  ./True.dhall
+    sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
 ? ./True.dhall

--- a/dhall/tests/freeze/unprotectedB.dhall
+++ b/dhall/tests/freeze/unprotectedB.dhall
@@ -1,2 +1,3 @@
-  ./True.dhall sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
+  ./True.dhall
+    sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
 ? ./True.dhall


### PR DESCRIPTION
… by printing it on a separate line when it spills over (which is
basically all the time)