### PR TITLE
Drop support for old encodings

### DIFF
--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -13,15 +13,11 @@
 -}
 
 module Dhall.Binary
-    ( -- * Standard versions
-      StandardVersion(..)
-    , renderStandardVersion
-
-    -- * Encoding and decoding
-    , encodeExpression
+    ( -- * Encoding and decoding
+      encodeExpression
     , decodeExpression
 
-    -- * Exceptions
+      -- * Exceptions
     , DecodingFailure(..)
     ) where
 
@@ -54,7 +50,6 @@ import Dhall.Syntax
     )
 
 import Data.Foldable (toList)
-import Data.Text     (Text)
 import Data.Void     (Void, absurd)
 import GHC.Float     (double2Float, float2Double)
 import Numeric.Half  (fromHalf, toHalf)
@@ -75,35 +70,6 @@ import qualified Dhall.Crypto
 import qualified Dhall.Map
 import qualified Dhall.Syntax          as Syntax
 import qualified Text.Printf           as Printf
-
-{-| Supported version strings
-
-    This exists primarily for backwards compatibility for expressions encoded
-    before Dhall removed version tags from the binary encoding
--}
-data StandardVersion
-    = NoVersion
-    -- ^ No version string
-    | V_5_0_0
-    -- ^ Version "5.0.0"
-    | V_4_0_0
-    -- ^ Version "4.0.0"
-    | V_3_0_0
-    -- ^ Version "3.0.0"
-    | V_2_0_0
-    -- ^ Version "2.0.0"
-    | V_1_0_0
-    -- ^ Version "1.0.0"
-    deriving (Enum, Bounded)
-
--- | Render a `StandardVersion` as `Data.Text.Text`
-renderStandardVersion :: StandardVersion -> Text
-renderStandardVersion NoVersion = "none"
-renderStandardVersion V_1_0_0   = "1.0.0"
-renderStandardVersion V_2_0_0   = "2.0.0"
-renderStandardVersion V_3_0_0   = "3.0.0"
-renderStandardVersion V_4_0_0   = "4.0.0"
-renderStandardVersion V_5_0_0   = "5.0.0"
 
 {-| Convert a function applied to multiple arguments to the base function and
     the list of arguments

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -167,7 +167,6 @@ import Data.List.NonEmpty               (NonEmpty (..))
 import Data.Text                        (Text)
 import Data.Typeable                    (Typeable)
 import Data.Void                        (Void, absurd)
-import Dhall.Binary                     (StandardVersion (..))
 
 import Dhall.Syntax
     ( Chunks (..)
@@ -200,7 +199,6 @@ import Dhall.Parser
     )
 import Lens.Family.State.Strict (zoom)
 
-import qualified Codec.CBOR.Encoding                         as Encoding
 import qualified Codec.CBOR.Write                            as Write
 import qualified Codec.Serialise
 import qualified Control.Monad.State.Strict                  as State
@@ -566,19 +564,24 @@ loadImportWithSemanticCache
         Nothing -> fetch
     where
         fetch = do
-            ImportSemantics { importSemantics } <- loadImportWithSemisemanticCache import_
+            ImportSemantics{ importSemantics } <- loadImportWithSemisemanticCache import_
 
-            let variants = map (\version -> encodeExpression version (Core.alphaNormalize importSemantics))
-                                [ minBound .. maxBound ]
-            case Data.Foldable.find ((== semanticHash). Dhall.Crypto.sha256Hash) variants of
-                Just bytes -> zoom cacheWarning (writeToSemanticCache semanticHash bytes)
-                Nothing -> do
-                    let expectedHash = semanticHash
-                    Status { _stack } <- State.get
-                    let actualHash = hashExpression (Core.alphaNormalize importSemantics)
-                    throwMissingImport (Imported _stack (HashMismatch {..}))
+            let bytes = encodeExpression (Core.alphaNormalize importSemantics)
 
-            return (ImportSemantics {..})
+            let actualHash = Dhall.Crypto.sha256Hash bytes
+
+            let expectedHash = semanticHash
+
+            if actualHash == expectedHash
+                then do
+                    zoom cacheWarning (writeToSemanticCache semanticHash bytes)
+
+                else do
+                    Status{ _stack } <- State.get
+
+                    throwMissingImport (Imported _stack HashMismatch{..})
+
+            return ImportSemantics{..}
 
 
 
@@ -600,7 +603,8 @@ writeExpressionToSemanticCache expression =
     -- with the old behavior
     State.evalStateT (writeToSemanticCache hash bytes) CacheWarned
   where
-    bytes = encodeExpression NoVersion expression
+    bytes = encodeExpression expression
+
     hash = Dhall.Crypto.sha256Hash bytes
 
 writeToSemanticCache
@@ -682,7 +686,7 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
                     let betaNormal =
                             Core.normalizeWith _normalizer substitutedExpr
 
-                    let bytes = encodeExpression NoVersion betaNormal
+                    let bytes = encodeExpression betaNormal
 
                     zoom cacheWarning (writeToSemisemanticCache semisemanticHash bytes)
 
@@ -1206,33 +1210,19 @@ loadRelativeToWithManager newManager rootDirectory semanticCacheMode expression 
         (loadWith expression)
         (emptyStatusWithManager newManager rootDirectory) { _semanticCacheMode = semanticCacheMode }
 
-encodeExpression
-    :: StandardVersion
-    -- ^ `NoVersion` means to encode without the version tag
-    -> Expr Void Void
-    -> Data.ByteString.ByteString
-encodeExpression _standardVersion expression = bytesStrict
+encodeExpression :: Expr Void Void -> Data.ByteString.ByteString
+encodeExpression expression = bytesStrict
   where
     intermediateExpression :: Expr Void Import
     intermediateExpression = fmap absurd expression
 
-    encoding =
-        case _standardVersion of
-            NoVersion ->
-                Codec.Serialise.encode intermediateExpression
-            s ->
-                    Encoding.encodeListLen 2
-                <>  Encoding.encodeString v
-                <>  Codec.Serialise.encode intermediateExpression
-              where
-                v = Dhall.Binary.renderStandardVersion s
+    encoding = Codec.Serialise.encode intermediateExpression
 
     bytesStrict = Write.toStrictByteString encoding
 
 -- | Hash a fully resolved expression
 hashExpression :: Expr Void Void -> Dhall.Crypto.SHA256Digest
-hashExpression expression =
-    Dhall.Crypto.sha256Hash (encodeExpression NoVersion expression)
+hashExpression = Dhall.Crypto.sha256Hash . encodeExpression
 
 {-| Convenience utility to hash a fully resolved expression and return the
     base-16 encoded hash with the @sha256:@ prefix


### PR DESCRIPTION
A while back we dropped the standard version from the binary encoding,
but we still wrote out old binary encodings for backwards compatibility.
However, by this point there are likely very few people using the old
encodings by this point and they should upgrade anyway.

The upside of dropping support for older encodings (besides simpler
code), is that now binary cache writes will be 6x faster since we
don't need to write out the same cache product 5 extra times for older
encodings.