### PR TITLE
Report input name in parsing errors

### DIFF
--- a/dhall/src/Dhall/Format.hs
+++ b/dhall/src/Dhall/Format.hs
@@ -72,18 +72,18 @@ format (Format { inputs = inputs0, transitivity = transitivity0, ..}) =
                     <>  Dhall.Pretty.prettyCharacterSet characterSet expr
                     <>  "\n")
 
-        (originalText, transitivity) <- case input of
+        (inputName, originalText, transitivity) <- case input of
             InputFile file -> do
                 text <- Data.Text.IO.readFile file
 
-                return (text, transitivity0)
+                return (file, text, transitivity0)
             StandardInput -> do
                 text <- Data.Text.IO.getContents
 
-                return (text, NonTransitive)
+                return ("(input)", text, NonTransitive)
 
 
-        headerAndExpr@(_, parsedExpression) <- Dhall.Util.getExpressionAndHeaderFromStdinText censor originalText
+        headerAndExpr@(_, parsedExpression) <- Dhall.Util.getExpressionAndHeaderFromStdinText censor inputName originalText
 
         case transitivity of
             Transitive ->

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -174,18 +174,18 @@ freezeWithManager newManager outputMode transitivity0 inputs scope intent chosen
 
         let status = Dhall.Import.emptyStatusWithManager newManager directory
 
-        (originalText, transitivity) <- case input of
+        (inputName, originalText, transitivity) <- case input of
             InputFile file -> do
                 text <- Text.IO.readFile file
 
-                return (text, transitivity0)
+                return (file, text, transitivity0)
 
             StandardInput -> do
                 text <- Text.IO.getContents
 
-                return (text, NonTransitive)
+                return ("(input)", text, NonTransitive)
 
-        (Header header, parsedExpression) <- Util.getExpressionAndHeaderFromStdinText censor originalText
+        (Header header, parsedExpression) <- Util.getExpressionAndHeaderFromStdinText censor inputName originalText
 
         let characterSet = fromMaybe (detectCharacterSet parsedExpression) chosenCharacterSet
 

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -848,18 +848,18 @@ command (Options {..}) = do
 
                 let status = Dhall.Import.emptyStatus directory
 
-                (originalText, transitivity) <- case input of
+                (inputName, originalText, transitivity) <- case input of
                     InputFile file -> do
                         text <- Data.Text.IO.readFile file
 
-                        return (text, transitivity0)
+                        return (file, text, transitivity0)
                     StandardInput -> do
                         text <- Data.Text.IO.getContents
 
-                        return (text, NonTransitive)
+                        return ("(input)", text, NonTransitive)
 
                 (Header header, parsedExpression) <-
-                    Dhall.Util.getExpressionAndHeaderFromStdinText censor originalText
+                    Dhall.Util.getExpressionAndHeaderFromStdinText censor inputName originalText
 
                 let characterSet = fromMaybe (detectCharacterSet parsedExpression) chosenCharacterSet
 

--- a/dhall/src/Dhall/Schemas.hs
+++ b/dhall/src/Dhall/Schemas.hs
@@ -68,11 +68,11 @@ data Schemas = Schemas
 -- | Implementation of the @dhall rewrite-with-schemas@ subcommand
 schemasCommand :: Schemas -> IO ()
 schemasCommand Schemas{..} = do
-    originalText <- case input of
-        InputFile file -> Text.IO.readFile file
-        StandardInput  -> Text.IO.getContents
+    (inputName, originalText) <- case input of
+        InputFile file -> (,) file <$> Text.IO.readFile file
+        StandardInput  -> (,) "(input)" <$> Text.IO.getContents
 
-    (Header header, expression) <- Util.getExpressionAndHeaderFromStdinText censor originalText
+    (Header header, expression) <- Util.getExpressionAndHeaderFromStdinText censor inputName originalText
 
     let characterSet = fromMaybe (detectCharacterSet expression) chosenCharacterSet
 

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -118,13 +118,13 @@ get parser censor input = do
         case input of
             Input_ (InputFile file) -> Data.Text.IO.readFile file
             Input_ StandardInput    -> Data.Text.IO.getContents
-            StdinText text          -> pure text
+            StdinText _ text        -> pure text
 
     let name =
             case input of
                 Input_ (InputFile file) -> file
                 Input_ StandardInput    -> "(input)"
-                StdinText _             -> "(input)"
+                StdinText inputName _   -> inputName
 
     let result = parser name inText
 
@@ -149,7 +149,11 @@ data Censor = NoCensor | Censor
 data Input = StandardInput | InputFile FilePath deriving (Eq)
 
 -- | Path to input or raw input text, necessary since we can't read STDIN twice
-data InputOrTextFromStdin = Input_ Input | StdinText Text
+data InputOrTextFromStdin
+    = Input_ Input
+    | StdinText String Text
+    -- ^ StdinText name text where name is a use-friendly name describing the
+    -- input expression, used in parsing error messages
 
 {-| Specifies whether or not an input's transitive dependencies should also be
     processed.  Transitive dependencies are restricted to relative file imports.
@@ -234,6 +238,6 @@ getExpressionAndHeader censor =
 -- | Convenient utility for retrieving an expression along with its header from
 -- | text already read from STDIN (so it's not re-read)
 getExpressionAndHeaderFromStdinText
-    :: Censor -> Text -> IO (Header, Expr Src Import)
-getExpressionAndHeaderFromStdinText censor =
-    get Dhall.Parser.exprAndHeaderFromText censor . StdinText
+    :: Censor -> String -> Text -> IO (Header, Expr Src Import)
+getExpressionAndHeaderFromStdinText censor inputName =
+    get Dhall.Parser.exprAndHeaderFromText censor . StdinText inputName

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -152,7 +152,7 @@ data Input = StandardInput | InputFile FilePath deriving (Eq)
 data InputOrTextFromStdin
     = Input_ Input
     | StdinText String Text
-    -- ^ StdinText name text where name is a use-friendly name describing the
+    -- ^ @StdinText name text@ where name is a user-friendly name describing the
     -- input expression, used in parsing error messages
 
 {-| Specifies whether or not an input's transitive dependencies should also be


### PR DESCRIPTION
Fixes #2194

Parser errors in `format`, `freeze`, `lint` didn't report which input they came from. This wasn't an issue until we started supporting multiple inputs.