### PR TITLE
Fix tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*B.dhall binary

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -688,6 +688,7 @@ Test-Suite tasty
         tasty-quickcheck          >= 0.9.2    && < 0.11,
         tasty-silver                             < 3.3 ,
         template-haskell                               ,
+        temporary                 >= 1.2.1    && < 1.3 ,
         text                      >= 0.11.1.0 && < 1.3 ,
         transformers                                   ,
         turtle                                   < 1.6 ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -688,7 +688,7 @@ Test-Suite tasty
         tasty-quickcheck          >= 0.9.2    && < 0.11,
         tasty-silver                             < 3.3 ,
         template-haskell                               ,
-        temporary                 >= 1.2.1    && < 1.3 ,
+        temporary                 >= 1.2.1    && < 1.4 ,
         text                      >= 0.11.1.0 && < 1.3 ,
         transformers                                   ,
         turtle                                   < 1.6 ,

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -21,6 +21,7 @@ import qualified Dhall.Test.Util                  as Test.Util
 import qualified Network.HTTP.Client              as HTTP
 import qualified Network.HTTP.Client.TLS          as HTTP
 import qualified System.FilePath                  as FilePath
+import qualified System.IO.Temp                   as Temp
 import qualified Test.Tasty                       as Tasty
 import qualified Test.Tasty.HUnit                 as Tasty.HUnit
 import qualified Turtle
@@ -112,7 +113,7 @@ successTest path = do
                 not (null (Turtle.match (Turtle.ends path') (Test.Util.toDhallPath path)))
 
         let buildNewCache = do
-                tempdir <- Turtle.mktempdir "/tmp" "dhall-cache"
+                tempdir <- fmap Turtle.decodeString (Turtle.managed (Temp.withSystemTempDirectory "dhall-cache"))
                 Turtle.liftIO (Turtle.cptree originalCache tempdir)
                 return tempdir
 


### PR DESCRIPTION
This should hopefully fix the tests on Windows

The main issue was the `B.dhall` test files using the wrong
line-ending, which is fixed by telling `git` to check them out as if
they are binary files (and therefore preserving the Unix line endings).

The second issue was the use of a non-existent `/tmp` directory on
Windows.