### PR TITLE
Require whitespace before with

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -253,7 +253,7 @@ parsers embedded = Parsers {..}
                         _          -> empty
 
                     bs <- some (do
-                        try (whitespace *> _with *> nonemptyWhitespace)
+                        try (nonemptyWhitespace *> _with *> nonemptyWhitespace)
 
                         keys <- Combinators.NonEmpty.sepBy1 anyLabel (try (whitespace *> _dot) *> whitespace)
 


### PR DESCRIPTION
Quick fix for #2212.