### PR TITLE
Add `--base-import-url` flag to `dhall-docs`

### DIFF
--- a/dhall-docs/src/Dhall/Docs/Core.hs
+++ b/dhall-docs/src/Dhall/Docs/Core.hs
@@ -288,14 +288,14 @@ resolveRelativePath currentDir =
         "." -> ""
         _ -> "../" <> resolveRelativePath (Path.parent currentDir)
 
-{-| Generates `Text` from the HTML representation of a `DhallFile`
--}
+-- | Generates `Text` from the HTML representation of a `DhallFile`
 makeHtml
-    :: Text                 -- ^ Package name
+    :: Maybe Text           -- ^ Base import URL
+    -> Text                 -- ^ Package name
     -> CharacterSet         -- ^ Output encoding
     -> DhallFile            -- ^ Parsed header
     -> GeneratedDocs Text
-makeHtml packageName characterSet DhallFile {..} = do
+makeHtml baseImportUrl packageName characterSet DhallFile {..} = do
     let relativeResourcesPath = resolveRelativePath $ Path.parent path
     let strippedHeader = Maybe.maybe "" unDhallDocsText (headerComment fileComments)
     headerAsHtml <-
@@ -311,7 +311,7 @@ makeHtml packageName characterSet DhallFile {..} = do
             expr
             examples
             headerAsHtml
-            DocParams { relativeResourcesPath, packageName, characterSet }
+            DocParams { relativeResourcesPath, packageName, characterSet, baseImportUrl }
 
     return htmlAsText
 
@@ -333,8 +333,13 @@ makeHtml packageName characterSet DhallFile {..} = do
     @a/b/c@ and no @index.html@ should be generated inside of `a/` or
     `a/b/`, but yes on `a/b/c/` in the last one there is the @b.dhall@ file
 -}
-createIndexes :: Text -> CharacterSet -> [DhallFile] -> [(Path Rel File, Text)]
-createIndexes packageName characterSet dhallFiles = map toIndex dirToDirsAndFilesMapAssocs
+createIndexes
+    :: Maybe Text
+    -> Text
+    -> CharacterSet
+    -> [DhallFile]
+    -> [(Path Rel File, Text)]
+createIndexes baseImportUrl packageName characterSet dhallFiles = map toIndex dirToDirsAndFilesMapAssocs
   where
     -- Files grouped by their directory
     dirToFilesMap :: Map (Path Rel Dir) [DhallFile]
@@ -377,7 +382,7 @@ createIndexes packageName characterSet dhallFiles = map toIndex dirToDirsAndFile
             indexDir
             (map (\DhallFile{..} -> (stripPrefix $ addHtmlExt path, mType)) files)
             (map stripPrefix dirs)
-            DocParams { relativeResourcesPath = resolveRelativePath indexDir, packageName, characterSet }
+            DocParams { relativeResourcesPath = resolveRelativePath indexDir, packageName, characterSet, baseImportUrl }
 
         stripPrefix :: Path Rel a -> Path Rel a
         stripPrefix relpath =
@@ -416,14 +421,15 @@ fileAnIssue titleName =
 generateDocs
     :: Path Abs Dir -- ^ Input directory
     -> Path Abs Dir -- ^ Link to be created to the generated documentation
+    -> Maybe Text   -- ^ Base import URL
     -> Text         -- ^ Package name, used in some HTML titles
     -> CharacterSet -- ^ Output encoding
     -> IO ()
-generateDocs inputDir outLink packageName characterSet = do
+generateDocs inputDir outLink baseImportUrl packageName characterSet = do
     (_, absFiles) <- Path.IO.listDirRecur inputDir
     contents <- mapM (Data.ByteString.readFile . Path.fromAbsFile) absFiles
     strippedFiles <- mapM (Path.stripProperPrefix inputDir) absFiles
-    let GeneratedDocs warnings docs = generateDocsPure packageName characterSet $ zip strippedFiles contents
+    let GeneratedDocs warnings docs = generateDocsPure baseImportUrl packageName characterSet $ zip strippedFiles contents
     mapM_ print warnings
     if null docs then
         putStrLn $
@@ -461,15 +467,16 @@ generateDocs inputDir outLink packageName characterSet = do
     If you want the `IO` version of this function, check `generateDocs`
 -}
 generateDocsPure
-    :: Text                    -- ^ Package name
+    :: Maybe Text              -- ^ Base import URL
+    -> Text                    -- ^ Package name
     -> CharacterSet            -- ^ Output encoding
     -> [(Path Rel File, ByteString)] -- ^ (Input file, contents)
     -> GeneratedDocs [(Path Rel File, Text)]
-generateDocsPure packageName characterSet inputFiles = go
+generateDocsPure baseImportUrl packageName characterSet inputFiles = go
   where
     go :: GeneratedDocs [(Path Rel File, Text)]
     go = do
         dhallFiles <- getAllDhallFiles inputFiles
-        htmls <- mapM (makeHtml packageName characterSet) dhallFiles
-        let indexes = createIndexes packageName characterSet dhallFiles
+        htmls <- mapM (makeHtml baseImportUrl packageName characterSet) dhallFiles
+        let indexes = createIndexes baseImportUrl packageName characterSet dhallFiles
         return (zip (map (addHtmlExt . path) dhallFiles) htmls <> indexes)

--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -17,6 +17,7 @@ module Dhall.Docs.Html
     , DocParams(..)
     ) where
 
+import Data.Foldable           (fold)
 import Data.Text               (Text)
 import Data.Void               (Void)
 import Dhall.Core              (Expr, Import)
@@ -42,6 +43,8 @@ data DocParams = DocParams
                                         --   front-end files
     , packageName :: Text               -- ^ Name of the package
     , characterSet :: CharacterSet      -- ^ Render code as `ASCII` or `Unicode`
+    , baseImportUrl :: Maybe Text       -- ^ Address that the root of the
+                                        --   documentation is hosted on
     }
 
 -- | Generates an @`Html` ()@ with all the information about a dhall file
@@ -60,7 +63,7 @@ dhallFileToHtml filePath contents expr examples header params@DocParams{..} =
             navBar params
             mainContainer $ do
                 setPageTitle params NotIndex breadcrumb
-                copyToClipboardButton htmlTitle
+                copyToClipboardButton clipboardText
                 br_ []
                 div_ [class_ "doc-contents"] header
                 Control.Monad.unless (null examples) $ do
@@ -72,6 +75,7 @@ dhallFileToHtml filePath contents expr examples header params@DocParams{..} =
   where
     breadcrumb = relPathToBreadcrumb filePath
     htmlTitle = breadCrumbsToText breadcrumb
+    clipboardText = fold baseImportUrl <> htmlTitle
 
 -- | Generates an index @`Html` ()@ that list all the dhall files in that folder
 indexToHtml
@@ -86,7 +90,7 @@ indexToHtml indexDir files dirs params@DocParams{..} = doctypehtml_ $ do
         navBar params
         mainContainer $ do
             setPageTitle params Index breadcrumbs
-            copyToClipboardButton htmlTitle
+            copyToClipboardButton clipboardText
             br_ []
             Control.Monad.unless (null files) $ do
                 h3_ "Exported files: "
@@ -121,6 +125,7 @@ indexToHtml indexDir files dirs params@DocParams{..} = doctypehtml_ $ do
 
     breadcrumbs = relPathToBreadcrumb indexDir
     htmlTitle = breadCrumbsToText breadcrumbs
+    clipboardText = fold baseImportUrl <> htmlTitle
 
 copyToClipboardButton :: Text -> Html ()
 copyToClipboardButton filePath =

--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -43,8 +43,7 @@ data DocParams = DocParams
                                         --   front-end files
     , packageName :: Text               -- ^ Name of the package
     , characterSet :: CharacterSet      -- ^ Render code as `ASCII` or `Unicode`
-    , baseImportUrl :: Maybe Text       -- ^ Address that the root of the
-                                        --   documentation is hosted on
+    , baseImportUrl :: Maybe Text       -- ^ Base import URL
     }
 
 -- | Generates an @`Html` ()@ with all the information about a dhall file

--- a/dhall-docs/tasty/Main.hs
+++ b/dhall-docs/tasty/Main.hs
@@ -35,7 +35,8 @@ main = do
     GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
 
     input <- getPackageContents
-    let GeneratedDocs _ docs = generateDocsPure "test-package" Unicode input
+    let GeneratedDocs _ docs =
+            generateDocsPure Nothing "test-package" Unicode input
     let docsMap = Map.fromList docs
     commentTests <- getCommentTests
     let testTree = Test.Tasty.testGroup "dhall-docs"


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/issues/1183

This allows paths copied to the clipboard to be valid URLs that can be
pasted into Dhall code