### PR TITLE
Remove `Tested-With`-stanzas from cabal files

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -2,7 +2,6 @@ Name: dhall-bash
 Version: 1.0.37
 Cabal-Version: >=1.10
 Build-Type: Simple
-Tested-With: GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -2,7 +2,6 @@ Name: dhall-docs
 Version: 1.0.6
 Cabal-Version: >=1.10
 Build-Type: Simple
-Tested-With: GHC == 8.6.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2020 Germán Robayo

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -2,7 +2,6 @@ Name: dhall-json
 Version: 1.7.7
 Cabal-Version: >=1.10
 Build-Type: Simple
-Tested-With: GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -2,7 +2,6 @@ Name: dhall-nix
 Version: 1.1.21
 Cabal-Version: >=1.10
 Build-Type: Simple
-Tested-With: GHC == 8.0.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -2,7 +2,6 @@ Name: dhall-yaml
 Version: 1.2.7
 Cabal-Version: >=1.10
 Build-Type: Simple
-Tested-With: GHC == 8.4.3, GHC == 8.6.1
 License: GPL-3
 License-File: LICENSE
 Copyright: 2019 Gabriel Gonzalez

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -2,7 +2,6 @@ Name: dhall
 Version: 1.39.0
 Cabal-Version: 2.0
 Build-Type: Simple
-Tested-With: GHC == 8.4.3, GHC == 8.6.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez


### PR DESCRIPTION
All of these stanzas provided outdated information. Instead of
vowing to keep this information up-to-date in the future, I think
we should simply remove it.