### PR TITLE
Implement "hashOf" keyword

### DIFF
--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -935,6 +935,7 @@ encodeExpressionInternal encodeEmbed = go
                 (go l)
                 (encodeList (fmap Encoding.encodeString ks))
                 (go r)
+        HashOf t -> encodeList2 (Encoding.encodeInt 30) (go t)
 
         Note _ b ->
             go b

--- a/dhall/src/Dhall/Import.hs-boot
+++ b/dhall/src/Dhall/Import.hs-boot
@@ -1,0 +1,6 @@
+module Dhall.Import where
+import Dhall.Syntax (Expr)
+import Data.Void (Void)
+import Dhall.Crypto (SHA256Digest)
+
+hashExpression :: Expr Void Void -> SHA256Digest

--- a/dhall/src/Dhall/Normalize.hs
+++ b/dhall/src/Dhall/Normalize.hs
@@ -174,6 +174,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
  where
  loop =  \case
     Const k -> pure (Const k)
+    HashOf v -> HashOf <$> loop v
     Var v -> pure (Var v)
     Lam cs (FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = _A }) b ->
         Lam cs <$> (Syntax.makeFunctionBinding x <$> _A') <*> b'
@@ -731,6 +732,7 @@ isNormalized e0 = loop (Syntax.denote e0)
   where
     loop e = case e of
       Const _ -> True
+      HashOf e' -> loop e'
       Var _ -> True
       Lam _ (FunctionBinding Nothing _ Nothing Nothing a) b -> loop a && loop b
       Lam _ _ _ -> False

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -387,10 +387,19 @@ parsers embedded = Parsers {..}
 
                     return (\a -> ToMap a Nothing, Just "argument to ❰toMap❱")
 
-            let alternative3 =
+            let alternative3 = do
+                    try (_hashOf *> nonemptyWhitespace)
+
+                    return (\a -> HashOf a, Just "argument to ❰hashOf❱")
+
+            let alternative4 =
                     return (id, Nothing)
 
-            (f, maybeMessage) <- alternative0 <|> alternative1 <|> alternative2 <|> alternative3
+            (f, maybeMessage) <- alternative0
+                              <|> alternative1
+                              <|> alternative2
+                              <|> alternative3
+                              <|> alternative4
 
             let adapt parser =
                     case maybeMessage of

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -38,6 +38,7 @@ module Dhall.Parser.Token (
     _using,
     _merge,
     _toMap,
+    _hashOf,
     _assert,
     _Some,
     _None,
@@ -840,6 +841,14 @@ _merge = keyword "merge"
 -}
 _toMap :: Parser ()
 _toMap = keyword "toMap"
+
+{-| Parse @hasOf@ keyword
+  -
+    This DO NOT correspont to the official grammar because it is quick
+    and dirty hack.
+-}
+_hashOf :: Parser ()
+_hashOf = keyword "hashOf"
 
 {-| Parse the @assert@ keyword
 

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -836,6 +836,7 @@ prettyPrinters characterSet =
             (  "  " <> keyword "assert"
             <> Pretty.hardline <> colon <> " " <> prettyExpression a
             )
+    prettyExpression (HashOf a) = Pretty.group (keyword "hashOf" <> " " <> prettyExpression a)
     prettyExpression a
         | Just doc <- preserveSource a =
             doc

--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -624,6 +624,8 @@ data Expr s a
     | ImportAlt (Expr s a) (Expr s a)
     -- | > Embed import                             ~  import
     | Embed a
+    -- | > Hash of expression                       ~  hashOf e
+    | HashOf (Expr s a)
     deriving (Foldable, Generic, Traversable, Show, Data, Lift, NFData)
 -- NB: If you add a constructor to Expr, please also update the Arbitrary
 -- instance in Dhall.Test.QuickCheck.
@@ -840,6 +842,7 @@ unsafeSubExpressions f (Prefer cs a b c) = Prefer cs <$> a' <*> f b <*> f c
 unsafeSubExpressions f (RecordCompletion a b) = RecordCompletion <$> f a <*> f b
 unsafeSubExpressions f (Merge a b t) = Merge <$> f a <*> f b <*> traverse f t
 unsafeSubExpressions f (ToMap a t) = ToMap <$> f a <*> traverse f t
+unsafeSubExpressions f (HashOf a) = HashOf <$> f a
 unsafeSubExpressions f (Project a b) = Project <$> f a <*> traverse f b
 unsafeSubExpressions f (Assert a) = Assert <$> f a
 unsafeSubExpressions f (Equivalent cs a b) = Equivalent cs <$> f a <*> f b

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -218,7 +218,7 @@ infer typer = loop
     loop ctx@Ctx{..} expression = case expression of
         Const c ->
             fmap VConst (axiom c)
-
+        HashOf _ -> Right $ VText
         Var (V x0 n0) -> do
             let go TypesEmpty _ =
                     die (UnboundVariable x0)


### PR DESCRIPTION
Implement "hashOf" keyword, that returns hash of expression as text.
I believe this keyword was already discussed previously, and was considered
unwanted since it breaks assumption that

f :: forall a. a -> Text

must be implemented as "f = const <some-constant-string>", but let me present
my use-case.

Consider expression that describes SQL index:

````
let Index = {
  unique : Bool,
  expressions : List Text
}
````

and I have list of indexes. I want to generate SQL code that would make
sure that table has these and only these indexes. For starters, index
must have name, and it is very convenient to auto-generate name based
on index properties. Hence the desire to get text hash of arbitrary
expression, to be able to write something like following:

````
let f = \(i: Index) ->
  let name = hashOf i
  let unique = if i.unique then "unique" else ""
  in ''
    create ${unique} index index_${name} on foo.bar(${i.expressions});
  ''
````

Technically, same result (modulo ergonomics) could be achived by
extending Dhall with function of type '\(a: Type) -> \(x: a) -> Text',
but it is not as convenient.

Here is prelimitary patch, that fails several tests. Any chance to get this
merged after being polished?
