### PR TITLE
add tomland dependency and bump stackage snapshot

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,7 @@ in
       dhall-openapi
       dhall-nix
       dhall-nixpkgs
+      dhall-toml
       dhall-yaml
     ;
 

--- a/dhall-toml/dhall-to-toml/Main.hs
+++ b/dhall-toml/dhall-to-toml/Main.hs
@@ -1,8 +1,6 @@
 module Main where
 
-import qualified Dhall.Toml (someFunc)
+import Dhall.Toml (dhallToToml)
 
 main :: IO ()
-main = do
-  putStrLn "Hello, Haskell!"
-  Dhall.Toml.someFunc
+main = dhallToToml

--- a/dhall-toml/dhall-toml.cabal
+++ b/dhall-toml/dhall-toml.cabal
@@ -34,8 +34,10 @@ Source-Repository head
 Library
     Hs-Source-Dirs:   src
     Build-Depends:
-        base  >= 4.12   && < 5    ,
-        dhall >= 1.39.0 && < 1.40
+        base    >= 4.12    && < 5    ,
+        dhall   >= 1.39.0  && < 1.40 ,
+        tomland >= 1.3.2.0 && < 1.4  ,
+        text    >= 1.2.4.1 && < 1.3
     Exposed-Modules:
         Dhall.Toml
     GHC-Options:      -Wall

--- a/dhall-toml/dhall-toml.cabal
+++ b/dhall-toml/dhall-toml.cabal
@@ -34,10 +34,10 @@ Source-Repository head
 Library
     Hs-Source-Dirs:   src
     Build-Depends:
-        base    >= 4.12    && < 5    ,
-        dhall   >= 1.39.0  && < 1.40 ,
-        tomland >= 1.3.2.0 && < 1.4  ,
-        text    >= 1.2.4.1 && < 1.3
+        base    >= 4.12     && < 5    ,
+        dhall   >= 1.39.0   && < 1.40 ,
+        tomland >= 1.3.2.0  && < 1.4  ,
+        text    >= 0.11.1.0 && < 1.3
     Exposed-Modules:
         Dhall.Toml
     GHC-Options:      -Wall

--- a/dhall-toml/src/Dhall/Toml.hs
+++ b/dhall-toml/src/Dhall/Toml.hs
@@ -1,4 +1,35 @@
-module Dhall.Toml (someFunc) where
+{-# LANGUAGE OverloadedStrings #-}
 
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"
+module Dhall.Toml
+    ( tomlToDhall
+    , dhallToToml
+    ) where
+
+import Prelude hiding (putStr, putStrLn)
+
+import Data.Text
+import Data.Text.IO (putStrLn)
+import Toml (TomlCodec, (.=))
+import qualified Toml
+
+data SomeTable = SomeTable
+    { boolItem :: Bool
+    , textItem  :: Text
+    }
+
+someTableCodec :: TomlCodec SomeTable
+someTableCodec = SomeTable
+    <$> Toml.bool "bool-item" .= boolItem
+    <*> Toml.text "text-item" .= textItem
+
+dhallToToml :: IO ()
+dhallToToml = putStrLn $ Toml.encode
+    someTableCodec
+    (SomeTable
+        { boolItem = True
+        , textItem = "hello"
+        })
+
+tomlToDhall :: IO ()
+tomlToDhall = putStrLn "not implemented"
+

--- a/dhall-toml/toml-to-dhall/Main.hs
+++ b/dhall-toml/toml-to-dhall/Main.hs
@@ -1,8 +1,6 @@
 module Main where
 
-import qualified Dhall.Toml (someFunc)
+import Dhall.Toml (tomlToDhall)
 
 main :: IO ()
-main = do
-  putStrLn "Hello, Haskell!"
-  Dhall.Toml.someFunc
+main = tomlToDhall

--- a/nix/packages/tomland.nix
+++ b/nix/packages/tomland.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, base, bytestring, containers, deepseq, directory
+, hashable, hedgehog, hspec, hspec-golden, hspec-hedgehog
+, hspec-megaparsec, lib, markdown-unlit, megaparsec, mtl
+, parser-combinators, text, time, transformers
+, unordered-containers, validation-selective
+}:
+mkDerivation {
+  pname = "tomland";
+  version = "1.3.2.0";
+  sha256 = "cc4e959be89b368f7e1619bf53c73bc56cfa32f543a3113396638f4f604d437a";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring containers deepseq hashable megaparsec mtl
+    parser-combinators text time transformers unordered-containers
+    validation-selective
+  ];
+  executableHaskellDepends = [
+    base bytestring containers hashable text time unordered-containers
+  ];
+  executableToolDepends = [ markdown-unlit ];
+  testHaskellDepends = [
+    base bytestring containers directory hashable hedgehog hspec
+    hspec-golden hspec-hedgehog hspec-megaparsec megaparsec text time
+    unordered-containers
+  ];
+  homepage = "https://github.com/kowainik/tomland";
+  description = "Bidirectional TOML serialization";
+  license = lib.licenses.mpl20;
+}

--- a/nix/packages/validation-selective.nix
+++ b/nix/packages/validation-selective.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, deepseq, doctest, hedgehog, hspec
+, hspec-hedgehog, selective, stdenv, text
+}:
+mkDerivation {
+  pname = "validation-selective";
+  version = "0.1.0.1";
+  sha256 = "eb7373511c40549b3440ffeb732db86e6c098589ff183ea0a7122f507321b200";
+  libraryHaskellDepends = [ base deepseq selective ];
+  testHaskellDepends = [
+    base doctest hedgehog hspec hspec-hedgehog selective text
+  ];
+  homepage = "https://github.com/kowainik/validation-selective";
+  description = "Lighweight pure data validation based on Applicative and Selective functors";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.27
+resolver: lts-18.0
 packages:
   - dhall
   - dhall-bash

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.0
+resolver: lts-14.27
 packages:
   - dhall
   - dhall-bash
@@ -35,6 +35,7 @@ extra-deps:
   - semialign-indexed-1.1@sha256:bc375898351fea11ab3f4279844fcfc00aa42c90182eedfc28c4754098da3e0e,2026
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - tasty-silver-3.1.15@sha256:f40b3f59dfabe14f185b5d27fdb8aa8b7c75458aa7999f8aa244b9dcbaf8dc31,2328
+  - tomland-1.3.2.0
 nix:
   packages:
     - ncurses

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,6 +36,7 @@ extra-deps:
   - some-1.0.1@sha256:26e5bab7276f48b25ea8660d3fd1166c0f20fd497dac879a40f408e23211f93e,2055
   - tasty-silver-3.1.15@sha256:f40b3f59dfabe14f185b5d27fdb8aa8b7c75458aa7999f8aa244b9dcbaf8dc31,2328
   - tomland-1.3.2.0
+  - validation-selective-0.1.0.1@sha256:9a5aa8b801efc6a4ffb120e1b28e80c5f7d090043be56bba11222cd20c393044,3621
 nix:
   packages:
     - ncurses


### PR DESCRIPTION
The stackage snapshot version was updated to get the an update version of
tomland. The old snapshot had version 1.1.0.1 and the latest snapshot
has version 1.3.2.0. Version [1.3.0.0](https://github.com/kowainik/tomland/blob/main/CHANGELOG.md#1300--may-19-2020) had a relatively large change to the
package organization as well as bug fixes.