### PR TITLE
feat(dhall-csv): skeleton to provide golden testing for the package

### DIFF
--- a/dhall-csv/dhall-csv.cabal
+++ b/dhall-csv/dhall-csv.cabal
@@ -33,7 +33,8 @@ Source-Repository head
 Library
     Hs-Source-Dirs: src
     Build-Depends:
-        base                      >= 4.12.0.0  && < 5
+        base                 >= 4.12.0.0  && < 5   ,
+        bytestring                           < 0.12
     Exposed-Modules:
         Dhall.Csv
         Dhall.CsvToDhall
@@ -61,4 +62,21 @@ Executable csv-to-dhall
     Other-Modules:
         Paths_dhall_csv
     GHC-Options: -Wall
+    Default-Language: Haskell2010
+
+Test-Suite tasty
+    Type:             exitcode-stdio-1.0
+    Hs-Source-Dirs:   tasty
+    Main-Is:          Main.hs
+    Build-Depends:
+        base                ,
+        bytestring          ,
+        dhall               ,
+        dhall-csv           ,
+        filepath            ,
+        tasty        <  1.5 ,
+        tasty-silver <  3.3 ,
+        tasty-hunit  >= 0.2 ,
+        text
+    GHC-Options:      -Wall
     Default-Language: Haskell2010

--- a/dhall-csv/tasty/Main.hs
+++ b/dhall-csv/tasty/Main.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Test.Tasty           (TestTree)
+import Test.Tasty.Silver    (findByExtension)
+import System.FilePath      (takeBaseName, replaceExtension)
+
+import qualified Data.Text.IO
+import qualified GHC.IO.Encoding
+import qualified Test.Tasty
+import qualified Test.Tasty.Silver as Silver
+
+
+main :: IO ()
+main = do
+    GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
+
+    testTree <- goldenTests
+    Test.Tasty.defaultMain testTree
+
+goldenTests :: IO TestTree
+goldenTests = do
+    dhallToCsvTree <- dhallToCsvGolden
+    csvToDhallTree <- csvToDhallGolden
+    return $ Test.Tasty.testGroup "dhall-csv"
+        [ dhallToCsvTree
+        , csvToDhallTree
+        ]
+
+dhallToCsvGolden :: IO TestTree
+dhallToCsvGolden = do
+    dhallFiles <- findByExtension [".dhall"] "./tasty/data/dhall-to-csv"
+    return $ Test.Tasty.testGroup "dhall-to-csv"
+        [ Silver.goldenVsAction
+            (takeBaseName dhallFile)
+            csvFile
+            (Data.Text.IO.readFile dhallFile)
+            id
+        | dhallFile <- dhallFiles
+        , let csvFile = replaceExtension dhallFile ".csv"
+        ]
+
+csvToDhallGolden :: IO TestTree
+csvToDhallGolden = do
+    csvFiles <- findByExtension [".csv"] "./tasty/data/csv-to-dhall"
+    return $ Test.Tasty.testGroup "csv-to-dhall"
+        [ Silver.goldenVsAction
+            (takeBaseName csvFile)
+            dhallFile
+            (Data.Text.IO.readFile dhallFile)
+            id
+        | csvFile <- csvFiles
+        , let dhallFile = replaceExtension csvFile ".dhall"
+        ]

--- a/dhall-csv/tasty/data/csv-to-dhall/dummy.csv
+++ b/dhall-csv/tasty/data/csv-to-dhall/dummy.csv
@@ -1,0 +1,1 @@
+Dummy test CSV to Dhall

--- a/dhall-csv/tasty/data/csv-to-dhall/dummy.dhall
+++ b/dhall-csv/tasty/data/csv-to-dhall/dummy.dhall
@@ -1,0 +1,1 @@
+Dummy test CSV to Dhall

--- a/dhall-csv/tasty/data/dhall-to-csv/dummy.csv
+++ b/dhall-csv/tasty/data/dhall-to-csv/dummy.csv
@@ -1,0 +1,1 @@
+Dummy test Dhall to CSV

--- a/dhall-csv/tasty/data/dhall-to-csv/dummy.dhall
+++ b/dhall-csv/tasty/data/dhall-to-csv/dummy.dhall
@@ -1,0 +1,1 @@
+Dummy test Dhall to CSV


### PR DESCRIPTION
I created a skeleton testing tool using `tasty` that allows you to add new tests only by adding new files to the desired test directory. 

As it is right now it doesn't make any processing to the input file and compares it is the same as the expected output. When the conversion functions are implemented we can replace `id` with the according function. 