### PR TITLE
dhall-docs: Allow path 0.9

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -74,7 +74,7 @@ Library
         mmark                >= 0.0.7.0   && < 0.8 ,
         megaparsec           >= 7         && < 9.1 ,
         memory                               < 0.17,
-        path                 >= 0.7.0     && < 0.9 ,
+        path                 >= 0.7.0     && < 0.10,
         path-io              >= 1.6.0     && < 1.7 ,
         prettyprinter        >= 1.5.1     && < 1.8 ,
         text                 >= 0.11.1.0  && < 1.3 ,


### PR DESCRIPTION
https://hackage.haskell.org/package/path-0.9.0/changelog