### PR TITLE
Exclude dhall-nix on Ubuntu from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,15 @@ jobs:
               bin/dhall-to-yaml-ng
               bin/yaml-to-dhall
         exclude:
+          # Temporarily exclude dhall-nix on Ubuntu due to build failure
+          # See: https://github.com/dhall-lang/dhall-haskell/runs/2920388542
+          - os:
+              runner: ubuntu-latest
+              package: null
+            package:
+              name: dhall-nix
+              assets: >
+                bin/dhall-to-nix
           - os:
               runner: windows-latest
               package: windows


### PR DESCRIPTION
The dhall-nix build on Ubuntu [fails](https://github.com/dhall-lang/dhall-haskell/runs/2920388542) with LTS 18.0. The reason is that `libsodium`, which is an external dependency of `saltine` is not found. This PR removes dhall-nix/Ubuntu from the build matrix. While it is in general a Bad Idea to "fix" failing CI jobs by removing them it is IMHO not a big deal in this case: We already cover the Linux builds with Hydra which handles external dependencies correctly. The inclusion of Ubuntu in the build matrix was therefore highly optional in the first place.