### PR TITLE
Add hints for type errors where the user might have meant `{=}` instead of `{}`

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveDataTypeable  #-}
-{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -1382,7 +1381,8 @@ data TypeMessage s a
     deriving (Show)
 
 formatHints :: [Doc Ann] -> Doc Ann
-formatHints hints = vsep (map format hints) where
+formatHints hints = vsep (map format hints)
+  where
     format hint = "\n\n\ESC[1;33mHint\ESC[0m: " <> hint
 
 shortTypeMessage :: (Eq a, Pretty a) => TypeMessage s a -> Doc Ann
@@ -2633,7 +2633,7 @@ prettyTypeMessage (ListAppendMismatch expr0 expr1) = ErrorMessages {..}
         txt1 = insert expr1
 
 prettyTypeMessage (CompletionSchemaMustBeARecord expr0 expr1) = ErrorMessages {..}
- where
+  where
     short = "The completion schema must be a record"
 
     hints = []
@@ -2659,7 +2659,7 @@ prettyTypeMessage (CompletionSchemaMustBeARecord expr0 expr1) = ErrorMessages {.
         txt1 = insert expr1
 
 prettyTypeMessage (InvalidRecordCompletion fieldName expr0) = ErrorMessages {..}
- where
+  where
     short = "Completion schema is missing a field: " <> pretty fieldName
 
     hints = []


### PR DESCRIPTION
I thought https://github.com/dhall-lang/dhall-lang/issues/1024 would make for a good first use case of context-specific hints next to errors, much like `rustc`. The idea is that if you have a type error involving `{}`, and it's a context where `{=}` could work, we include a hint in the error output:

```
$ echo '{ x = 1 } // {}' | ./dist/build/Dhall/dhall

Use "dhall --explain" for detailed errors

Error: You can only override records

Hint: {} is the empty record type, use {=} for the empty record value

1│ { x = 1 } // {}

(input):1:1
```

This hint appears for the following type errors:

 - `({Type = { x: Natural }, default={ x = 1 }})::{}`
 - `{} // { x = 1 }`
 - `{} /\ { x = 1 }`
 - `(\(x: Natural) -> x + 1) {}`

The hint is only shown when the erroneous value in question is literally `{}` so it should have a fairly high relevance. In the final example `{=}` would _also_ be the wrong type though, so it's not 100%.

The only issue I had is when `{}` is on the right hand side of a combine operation, i.e. `{ x = 1 } /\ {}`

The `--explain` text for this one actually looks incorrect to me, it ends in:

```
You supplied this expression as one of the arguments:

↳ { x = 1 }

... which is not a record, but is actually a:

↳ Type
```

My hint shows up when I reverse the operands, so it seems like maybe the code constructing this error is always passing in the left hand side, rather than the expression matching the non-record type.