### PR TITLE
Fix MustCombineARecord explanation

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -774,7 +774,7 @@ infer typer = loop
 
             _R' <- loop ctx r
 
-            let r'' = quote names (eval values l)
+            let r'' = quote names (eval values r)
 
             xLs' <- case _L' of
                 VRecord xLs' ->


### PR DESCRIPTION
This bug manifested as an incorrect type error explanation:

    You supplied this expression as one of the arguments:

    ↳ { x = 1 }

    ... which is not a record, but is actually a:

    ↳ Type

    ────────────────────────────────────────────────────────────────────────────────

    1│ { x = 1 } /\ {}

This issue was reported in https://github.com/dhall-lang/dhall-haskell/pull/2238.