### PR TITLE
Allow transformers 0.6, mtl 2.3

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,32 @@
-packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-docs ./dhall-openapi ./dhall-nixpkgs ./dhall-csv ./dhall-toml ./dhall-lsp-server
+packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-openapi ./dhall-nixpkgs ./dhall-csv
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell/mtl.git
+    tag: 5d0f62b
+
+source-repository-package
+    type: git
+    location: https://github.com/ekmett/exceptions.git
+    tag: 28b9b49a51deb7c1343e003dafb4c69ef79f2e8b
+
+source-repository-package
+    type: git
+    location: https://github.com/Bodigrim/tasty.git
+    tag: aed32006bcab905a8b579ba45ce803fe257943d8
+    subdir: core
+
+source-repository-package
+    type: git
+    location: https://github.com/ekmett/free.git
+    tag: 63ccf73981002747e334fa38072235ce3eab7490
+
+source-repository-package
+    type: git
+    location: https://github.com/sjakobi/megaparsec.git
+    tag: 3c4c79ef7ec6be665380a61c67a3bf9cc52fad76
+
+source-repository-package
+    type: git
+    location: https://github.com/sjakobi/repline.git
+    tag: 803493033a55dc8c13358db66c4d162ba5fe11ad

--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,11 @@ packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-ope
 
 source-repository-package
     type: git
+    location: https://github.com/ekmett/exceptions.git
+    tag: 28b9b49a51deb7c1343e003dafb4c69ef79f2e8b
+
+source-repository-package
+    type: git
     location: https://github.com/Bodigrim/tasty.git
     tag: 3c5a521ca58d2f7f652593c1b1e27cb8dc22eca8
     subdir: core

--- a/cabal.project
+++ b/cabal.project
@@ -20,3 +20,8 @@ source-repository-package
     type: git
     location: https://github.com/sjakobi/HsYAML.git
     tag: 9117e8e806268c1ab2b6c7a1a0a2c7141f420bab
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell/random.git
+    tag: fddfef8816aae91c7d81a00a70e491cda607de4a

--- a/cabal.project
+++ b/cabal.project
@@ -2,11 +2,6 @@ packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-ope
 
 source-repository-package
     type: git
-    location: https://github.com/ekmett/exceptions.git
-    tag: 28b9b49a51deb7c1343e003dafb4c69ef79f2e8b
-
-source-repository-package
-    type: git
     location: https://github.com/Bodigrim/tasty.git
     tag: aed32006bcab905a8b579ba45ce803fe257943d8
     subdir: core

--- a/cabal.project
+++ b/cabal.project
@@ -7,10 +7,5 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/sjakobi/HsYAML.git
-    tag: 9117e8e806268c1ab2b6c7a1a0a2c7141f420bab
-
-source-repository-package
-    type: git
     location: https://github.com/ekmett/lens.git
     tag: 371a9410cb2876af14b9ac5864b1da420101136c

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-openapi ./dhall-csv ./dhall-toml
+packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-openapi ./dhall-csv ./dhall-toml ./dhall-docs
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -2,17 +2,6 @@ packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-openapi ./dhall
 
 source-repository-package
     type: git
-    location: git@github.com:UnkindPartition/tasty.git
-    tag: 3c5a521ca58d2f7f652593c1b1e27cb8dc22eca8
-    subdir: core
-
-source-repository-package
-    type: git
-    location: https://github.com/sjakobi/megaparsec.git
-    tag: bc1041e07553b04583ee11181bab7fa1f5559271
-
-source-repository-package
-    type: git
     location: https://github.com/sjakobi/repline.git
     tag: 803493033a55dc8c13358db66c4d162ba5fe11ad
 
@@ -20,8 +9,3 @@ source-repository-package
     type: git
     location: https://github.com/sjakobi/HsYAML.git
     tag: 9117e8e806268c1ab2b6c7a1a0a2c7141f420bab
-
-source-repository-package
-    type: git
-    location: https://github.com/haskell/random.git
-    tag: fddfef8816aae91c7d81a00a70e491cda607de4a

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,4 @@
-packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-openapi ./dhall-csv ./dhall-toml ./dhall-docs
--- ./dhall-lsp-server needs https://github.com/ekmett/lens/issues/1007
+packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-openapi ./dhall-csv ./dhall-toml ./dhall-docs ./dhall-lsp-server
 
 source-repository-package
     type: git
@@ -13,6 +12,5 @@ source-repository-package
 
 source-repository-package
     type: git
-    location: https://github.com/sjakobi/conduit.git
-    tag: f026e6e
-    subdir: resourcet
+    location: https://github.com/ekmett/lens.git
+    tag: 371a9410cb2876af14b9ac5864b1da420101136c

--- a/cabal.project
+++ b/cabal.project
@@ -1,19 +1,1 @@
 packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-openapi ./dhall-csv ./dhall-toml ./dhall-docs ./dhall-lsp-server
-
-source-repository-package
-    type: git
-    location: https://github.com/haskell/lsp.git
-    tag: 67a168319169d7cf4679869ed2e0cfe217743a96
-    subdir: lsp
-
-source-repository-package
-    type: git
-    location: https://github.com/haskell/lsp.git
-    tag: 67a168319169d7cf4679869ed2e0cfe217743a96
-    subdir: lsp-test
-
-source-repository-package
-    type: git
-    location: https://github.com/haskell/lsp.git
-    tag: 67a168319169d7cf4679869ed2e0cfe217743a96
-    subdir: lsp-types

--- a/cabal.project
+++ b/cabal.project
@@ -1,27 +1,22 @@
-packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-openapi ./dhall-nixpkgs ./dhall-csv
+packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-openapi ./dhall-csv ./dhall-toml
 
 source-repository-package
     type: git
-    location: https://github.com/ekmett/exceptions.git
-    tag: 28b9b49a51deb7c1343e003dafb4c69ef79f2e8b
-
-source-repository-package
-    type: git
-    location: https://github.com/Bodigrim/tasty.git
+    location: git@github.com:UnkindPartition/tasty.git
     tag: 3c5a521ca58d2f7f652593c1b1e27cb8dc22eca8
     subdir: core
 
 source-repository-package
     type: git
-    location: https://github.com/ekmett/free.git
-    tag: 63ccf73981002747e334fa38072235ce3eab7490
-
-source-repository-package
-    type: git
     location: https://github.com/sjakobi/megaparsec.git
-    tag: 3c4c79ef7ec6be665380a61c67a3bf9cc52fad76
+    tag: bc1041e07553b04583ee11181bab7fa1f5559271
 
 source-repository-package
     type: git
     location: https://github.com/sjakobi/repline.git
     tag: 803493033a55dc8c13358db66c4d162ba5fe11ad
+
+source-repository-package
+    type: git
+    location: https://github.com/sjakobi/HsYAML.git
+    tag: 9117e8e806268c1ab2b6c7a1a0a2c7141f420bab

--- a/cabal.project
+++ b/cabal.project
@@ -2,10 +2,18 @@ packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-openapi ./dhall
 
 source-repository-package
     type: git
-    location: https://github.com/sjakobi/repline.git
-    tag: 803493033a55dc8c13358db66c4d162ba5fe11ad
+    location: https://github.com/haskell/lsp.git
+    tag: 67a168319169d7cf4679869ed2e0cfe217743a96
+    subdir: lsp
 
 source-repository-package
     type: git
-    location: https://github.com/ekmett/lens.git
-    tag: 371a9410cb2876af14b9ac5864b1da420101136c
+    location: https://github.com/haskell/lsp.git
+    tag: 67a168319169d7cf4679869ed2e0cfe217743a96
+    subdir: lsp-test
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell/lsp.git
+    tag: 67a168319169d7cf4679869ed2e0cfe217743a96
+    subdir: lsp-types

--- a/cabal.project
+++ b/cabal.project
@@ -2,11 +2,6 @@ packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-ope
 
 source-repository-package
     type: git
-    location: https://github.com/haskell/mtl.git
-    tag: 5d0f62b
-
-source-repository-package
-    type: git
     location: https://github.com/ekmett/exceptions.git
     tag: 28b9b49a51deb7c1343e003dafb4c69ef79f2e8b
 

--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,7 @@ packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-ope
 source-repository-package
     type: git
     location: https://github.com/Bodigrim/tasty.git
-    tag: aed32006bcab905a8b579ba45ce803fe257943d8
+    tag: 3c5a521ca58d2f7f652593c1b1e27cb8dc22eca8
     subdir: core
 
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,5 @@
 packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-openapi ./dhall-csv ./dhall-toml ./dhall-docs
+-- ./dhall-lsp-server needs https://github.com/ekmett/lens/issues/1007
 
 source-repository-package
     type: git
@@ -9,3 +10,9 @@ source-repository-package
     type: git
     location: https://github.com/sjakobi/HsYAML.git
     tag: 9117e8e806268c1ab2b6c7a1a0a2c7141f420bab
+
+source-repository-package
+    type: git
+    location: https://github.com/sjakobi/conduit.git
+    tag: f026e6e
+    subdir: resourcet

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -82,7 +82,7 @@ Library
         path-io              >= 1.6.0     && < 2 ,
         prettyprinter        >= 1.7.0     && < 1.8 ,
         text                 >= 0.11.1.0  && < 2.1 ,
-        transformers         >= 0.2.0.0  && < 0.6 ,
+        transformers         >= 0.2.0.0   && < 0.7 ,
         mtl                  >= 2.2.1     && < 2.3 ,
         optparse-applicative >= 0.14.0.0  && < 0.18
     Exposed-Modules:

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -116,19 +116,6 @@ Executable dhall-docs
     GHC-Options: -Wall
     Default-Language: Haskell2010
 
-Test-Suite doctest
-    Type: exitcode-stdio-1.0
-    Hs-Source-Dirs: doctest
-    Main-Is: Main.hs
-    GHC-Options: -Wall
-    Build-Depends:
-        base                           ,
-        directory,
-        filepath                 < 1.5 ,
-        doctest    >= 0.7.0
-    Other-Extensions: OverloadedStrings RecordWildCards
-    Default-Language: Haskell2010
-
 Test-Suite tasty
     Type: exitcode-stdio-1.0
     Hs-Source-Dirs: tasty

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -83,7 +83,7 @@ Library
         prettyprinter        >= 1.7.0     && < 1.8 ,
         text                 >= 0.11.1.0  && < 2.1 ,
         transformers         >= 0.2.0.0   && < 0.7 ,
-        mtl                  >= 2.2.1     && < 2.3 ,
+        mtl                  >= 2.2.1     && < 2.4 ,
         optparse-applicative >= 0.14.0.0  && < 0.18
     Exposed-Modules:
         Dhall.Docs

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -59,6 +59,7 @@ library
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     , megaparsec           >= 7.0.2    && < 10
     , mtl                  >= 2.2.2    && < 2.3
+    , mtl                  >= 2.2.2    && < 2.4
     , network-uri          >= 2.6.1.0  && < 2.7
     , prettyprinter        >= 1.7.0    && < 1.8
     , text                 >= 1.2.3.0  && < 2.1

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -83,20 +83,6 @@ executable dhall-lsp-server
   default-language: Haskell2010
   GHC-Options: -Wall -fwarn-incomplete-uni-patterns
 
-Test-Suite doctest
-    Type: exitcode-stdio-1.0
-    Hs-Source-Dirs: doctest
-    Main-Is: Main.hs
-    GHC-Options: -Wall
-    Build-Depends:
-        base                           ,
-        directory  >= 1.3.1.5 && < 1.4 ,
-        filepath                 < 1.5 ,
-        doctest    >= 0.7.0            ,
-        QuickCheck
-    Other-Extensions: OverloadedStrings RecordWildCards
-    Default-Language: Haskell2010
-
 Test-Suite tests
     Type: exitcode-stdio-1.0
     Hs-Source-Dirs: tests

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -58,7 +58,6 @@ library
     , lens                 >= 4.16.1   && < 5.2
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     , megaparsec           >= 7.0.2    && < 10
-    , mtl                  >= 2.2.2    && < 2.3
     , mtl                  >= 2.2.2    && < 2.4
     , network-uri          >= 2.6.1.0  && < 2.7
     , prettyprinter        >= 1.7.0    && < 1.8

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -62,7 +62,7 @@ library
     , network-uri          >= 2.6.1.0  && < 2.7
     , prettyprinter        >= 1.7.0    && < 1.8
     , text                 >= 1.2.3.0  && < 2.1
-    , transformers         >= 0.5.5.0  && < 0.6
+    , transformers         >= 0.5.5.0  && < 0.7
     , unordered-containers >= 0.2.9.0  && < 0.3
     , uri-encode           >= 1.5.0.5  && < 1.6
   default-language: Haskell2010

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -33,7 +33,7 @@ Executable dhall-to-nixpkgs
                      , optparse-applicative >= 0.14.0.0 && < 0.18
                      , prettyprinter        >= 1.7.0    && < 1.8
                      , text                 >= 0.11.1.0 && < 2.1
-                     , transformers         >= 0.2.0.0  && < 0.6
+                     , transformers         >= 0.2.0.0  && < 0.7
                      , turtle                              < 1.6
                      , network-uri                         < 2.8
   Default-Language:    Haskell2010

--- a/dhall-toml/dhall-toml.cabal
+++ b/dhall-toml/dhall-toml.cabal
@@ -83,15 +83,3 @@ Test-Suite dhall-toml-test
         tomland
     GHC-Options:      -Wall
     Default-Language: Haskell2010
-
-Test-Suite doctest
-    Type:             exitcode-stdio-1.0
-    Hs-Source-Dirs:   doctest
-    Main-Is:          Main.hs
-    Build-Depends:
-        base      ,
-        directory ,
-        filepath  ,
-        doctest
-    GHC-Options:      -Wall
-    Default-Language: Haskell2010

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -462,6 +462,7 @@ Test-Suite doctest
       -- https://github.com/dhall-lang/dhall-haskell/issues/2237
       Buildable: False
     Default-Language: Haskell2010
+    buildable: False
 
 Benchmark dhall-parser
     Import: common

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -249,7 +249,7 @@ Common common
         text-short                  >= 0.1      && < 0.2 ,
         th-lift-instances           >= 0.1.13   && < 0.2 ,
         time                        >= 1.1.4    && < 1.13,
-        transformers                >= 0.5.2.0  && < 0.6 ,
+        transformers                >= 0.5.2.0  && < 0.7 ,
         unix-compat                 >= 0.4.2    && < 0.7 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
         uri-encode                                 < 1.6 ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -231,7 +231,7 @@ Common common
         -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
         megaparsec                  >= 8        && < 10  ,
         mmorph                                     < 1.3 ,
-        mtl                         >= 2.2.1    && < 2.3 ,
+        mtl                         >= 2.2.1    && < 2.4 ,
         network-uri                 >= 2.6      && < 2.7 ,
         optparse-applicative        >= 0.14.0.0 && < 0.18,
         parsers                     >= 0.12.4   && < 0.13,


### PR DESCRIPTION
https://hackage.haskell.org/package/transformers-0.6.0.0/changelog

Build command as of 2022-07-14:

```
cabal test all -w ghc-8.10 --constraint 'transformers >= 0.6' --allow-newer=haskeline:transformers,tomland:mtl,lsp,lsp-test,lsp-types --enable-tests
```

Blocked on:

* [x] https://github.com/haskell/primitive/issues/310
* [x] ~~https://github.com/ekmett/transformers-compat/issues/48~~ (see https://github.com/dhall-lang/dhall-haskell/pull/2257)
* [x] https://github.com/ekmett/profunctors/issues/98
* [x] https://github.com/pcapriotti/optparse-applicative/issues/427
* [x] https://github.com/haskell/mtl/issues/88 (needs [release](https://github.com/haskell/mtl/issues/86))
* [x] `lens-family-core` (contacted via email)
* [x] https://github.com/judah/haskeline/issues/165
* [x] https://github.com/ekmett/parsers/pull/86
* [x] https://github.com/Gabriel439/Haskell-MMorph-Library/pull/69
* [x] https://github.com/ekmett/semigroupoids/issues/109 (via `either`)
* [x] https://github.com/ekmett/exceptions/issues/82
* [x] https://github.com/Gabriel439/Haskell-Optparse-Generic-Library/pull/82
* [x] https://github.com/mrkkrp/path-io/issues/64
* [x] https://github.com/fpco/unliftio/issues/85 (via `yaml` via `mmark`)
* [x] https://github.com/Gabriel439/Haskell-Foldl-Library/pull/172 (via `mmark`)
* [x] https://github.com/mainland/ref-tf/issues/6 (via `hnix`)
* [x] https://github.com/snowleopard/selective/issues/44 (via `tomland`)
* [x] https://github.com/Gabriel439/Haskell-Managed-Library/pull/22
* [x] https://github.com/sdiehl/repline/pull/38
* [x] https://github.com/mrkkrp/megaparsec/pull/471
* [x] https://github.com/haskell/parsec/issues/148 (via `network-uri`)
* [x] https://github.com/kowainik/validation-selective/issues/64 (via `tomland`)
* [x] https://github.com/haskell-tls/hs-certificate/issues/129 (via `http-client-tls`) (workaround: `-f-use-http-client-tls`)
* [x] https://github.com/haskell-hvr/HsYAML/pull/60
* [x] https://github.com/phile314/tasty-silver/issues/35
* [x] https://github.com/snoyberg/conduit/issues/484 (via `conduit` via `yaml`)
* [x] https://github.com/UnkindPartition/tasty/issues/333
* [x] https://github.com/ekmett/lens/issues/1007
* [x] https://github.com/k0ral/conduit-parse/issues/4 (via `lsp-test`)
* [x] https://github.com/haskell/lsp/issues/430
* [x] https://github.com/kowainik/tomland/issues/406
* [x] https://github.com/fpco/safe-exceptions/issues/39 (via `lsp-test`)
* [ ] #2428 