### PR TITLE
Build against `mmorph-1.2.0`

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -497,7 +497,7 @@ Library
         lens-family-core            >= 1.0.0    && < 2.2 ,
         megaparsec                  >= 7        && < 9.2 ,
         memory                      >= 0.14     && < 0.17,
-        mmorph                                     < 1.2 ,
+        mmorph                                     < 1.3 ,
         mtl                         >= 2.2.1    && < 2.3 ,
         network-uri                 >= 2.6      && < 2.7 ,
         optparse-applicative        >= 0.14.0.0 && < 0.17,


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/6122