### PR TITLE
Remove redundant dependency on transformers-compat

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -514,8 +514,7 @@ Library
         text                        >= 0.11.1.0 && < 1.3 ,
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
         th-lift-instances           >= 0.1.13   && < 0.2 ,
-        transformers                >= 0.2.0.0  && < 0.6 ,
-        transformers-compat         >= 0.6.2    && < 0.7 ,
+        transformers                >= 0.5.2.0  && < 0.6 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
         uri-encode                                 < 1.6 ,
         vector                      >= 0.11.0.0 && < 0.13

--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -18,15 +18,13 @@ import Control.Exception
     , displayException
     , throwIO
     )
-import Control.Monad              (forM_)
+import Control.Monad                       (forM_)
 #if !(MIN_VERSION_base(4,13,0))
-import Control.Monad.Fail         (MonadFail)
+import Control.Monad.Fail                  (MonadFail)
 #endif
-import Control.Monad.IO.Class     (MonadIO, liftIO)
-import Control.Monad.State.Class  (MonadState, get, modify)
-import Control.Monad.State.Strict (evalStateT)
--- For the MonadFail instance for StateT.
-import Control.Monad.Trans.Instances       ()
+import Control.Monad.IO.Class              (MonadIO, liftIO)
+import Control.Monad.State.Class           (MonadState, get, modify)
+import Control.Monad.State.Strict          (evalStateT)
 import Data.Char                           (isSpace)
 import Data.List
     ( dropWhileEnd


### PR DESCRIPTION
The dependency was added in https://github.com/dhall-lang/dhall-haskell/commit/4f9defec2516edab4707f85c1bfec7e1eac09f72 for


https://github.com/dhall-lang/dhall-haskell/blob/3167200e102ff46c3f06026d805a9359958f30d5/dhall/src/Dhall/Repl.hs#L22-L23

AFAIK we don't need backwards compatibility with `transformers < 0.5.2` (when the `MonadFail` instance for `StateT` was added) anymore, so we can get rid of the `transformers-compat` dependency now.