### PR TITLE
Allow megaparsec 9.1 and mmorph 1.2 in all the packages

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -72,7 +72,7 @@ Library
         lens-family-core     >= 1.0.0     && < 2.2 ,
         lucid                >= 2.9.12    && < 2.10,
         mmark                >= 0.0.7.0   && < 0.8 ,
-        megaparsec           >= 7         && < 9.1 ,
+        megaparsec           >= 7         && < 9.2 ,
         memory                               < 0.17,
         path                 >= 0.7.0     && < 0.10,
         path-io              >= 1.6.0     && < 1.7 ,

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -56,7 +56,7 @@ library
     , rope-utf16-splay     >= 0.3.1.0  && < 0.4
     , hslogger             >= 1.2.10   && < 1.4
     , lens                 >= 4.16.1   && < 5.1
-    , megaparsec           >= 7.0.2    && < 9.1
+    , megaparsec           >= 7.0.2    && < 9.2
     , mtl                  >= 2.2.2    && < 2.3
     , network-uri          >= 2.6.1.0  && < 2.7
     , prettyprinter        >= 1.5.1    && < 1.8

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -23,8 +23,8 @@ Executable dhall-to-nixpkgs
                      , foldl                               < 1.5
                      , hnix                 >= 0.10.1   && < 0.15
                      , lens-family-core     >= 1.0.0    && < 2.2
-                     , megaparsec           >= 7.0.0    && < 9.1
-                     , mmorph                              < 1.2
+                     , megaparsec           >= 7.0.0    && < 9.2
+                     , mmorph                              < 1.3
                      , neat-interpolation                  < 0.6
                      , optparse-applicative >= 0.14.0.0 && < 0.17
                      , prettyprinter        >= 1.5.1    && < 1.8

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -43,7 +43,7 @@ Executable openapi-to-dhall
     dhall                                          ,
     dhall-openapi                                  ,
     filepath                >= 1.4       && < 1.5  ,
-    megaparsec              >= 7.0       && < 9.1  ,
+    megaparsec              >= 7.0       && < 9.2  ,
     optparse-applicative    >= 0.14.3.0  && < 0.17 ,
     parser-combinators                             , 
     prettyprinter                                  ,


### PR DESCRIPTION
The affected packages build fine with
`--allow-newer='hnix:megaparsec,tomland:megaparsec'`.