### PR TITLE
Re-enable GHA dhall build on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,16 +74,6 @@ jobs:
               name: dhall-nix
               assets: >
                 bin/dhall-to-nix
-          # Temporarily exclude dhall on Windows due to
-          # https://github.com/dhall-lang/dhall-haskell/issues/2237
-          - os:
-              runner: windows-latest
-              package: windows
-            package:
-              name: dhall
-              assets: >
-                bin/dhall
-                share/man/man1/dhall.1
       fail-fast: false
     name: ${{ matrix.package.name }} on ${{ matrix.os.runner }}
     runs-on: ${{ matrix.os.runner }}

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -711,6 +711,9 @@ Test-Suite doctest
         filepath                < 1.5 ,
         mockery                 < 0.4 ,
         doctest   >= 0.7.0   && < 0.19
+    if os(windows)
+      -- https://github.com/dhall-lang/dhall-haskell/issues/2237
+      Buildable: False
     Default-Language: Haskell2010
 
 Benchmark dhall-parser


### PR DESCRIPTION
…but keep the problematic doctests disabled.

This reverts commit 06dac3d229073779f4594e6d96feb8bf016c69b5.

Context: #2237 