### PR TITLE
Feature/dhall csv docs

### DIFF
--- a/dhall-csv/src/Dhall/Csv.hs
+++ b/dhall-csv/src/Dhall/Csv.hs
@@ -70,7 +70,7 @@
 
     Also, all Dhall expressions are normalized before translation to CSV:
 
-> $ dhall-to-csv <<< "[{ equailty = True == False }]"
+> $ dhall-to-csv <<< "[{ equality = True == False }]"
 > equality
 > false
 -}

--- a/dhall-csv/src/Dhall/Csv.hs
+++ b/dhall-csv/src/Dhall/Csv.hs
@@ -142,7 +142,8 @@ instance Exception CompileError where
             \The following Dhall expression could not be translated to CSV:                  \n\
             \                                                                                \n\
             \" <> insert e <>                                                               "\n\
-            \because it has type:                                                            \n\
+            \                                                                                \n\
+            \... because it has type:                                                        \n\
             \                                                                                \n\
             \" <> insert (fromRight e (TypeCheck.typeOf e))
 
@@ -157,7 +158,8 @@ instance Exception CompileError where
             \expression:                                                                     \n\
             \                                                                                \n\
             \" <> insert e <>                                                               "\n\
-            \which has type:                                                                 \n\
+            \                                                                                \n\
+            \... which has type:                                                             \n\
             \                                                                                \n\
             \" <> insert (fromRight e (TypeCheck.typeOf e))
 
@@ -171,7 +173,8 @@ instance Exception CompileError where
             \Expected a record but instead got the following expression:                     \n\
             \                                                                                \n\
             \" <> insert e <>                                                               "\n\
-            \which has type:                                                                 \n\
+            \                                                                                \n\
+            \... which has type:                                                             \n\
             \                                                                                \n\
             \" <> insert (fromRight e (TypeCheck.typeOf e))
 
@@ -179,9 +182,9 @@ instance Exception CompileError where
        Data.Text.unpack $
             _ERROR <> ": ❰None❱ is not valid on its own                                      \n\
             \                                                                                \n\
-            \Explanation: The conversion to JSON/YAML does not accept ❰None❱ in isolation as \n\
-            \a valid way to represent ❰null❱.  In Dhall, ❰None❱ is a function whose input is \n\
-            \a type and whose output is an ❰Optional❱ of that type.                          \n\
+            \Explanation: The conversion to CSV does not accept ❰None❱ in isolation as a     \n\
+            \valid way to represent a null value.  In Dhall, ❰None❱ is a function whose      \n\
+            \input is a type and whose output is an ❰Optional❱ of that type.                 \n\
             \                                                                                \n\
             \For example:                                                                    \n\
             \                                                                                \n\

--- a/dhall-csv/src/Dhall/Csv.hs
+++ b/dhall-csv/src/Dhall/Csv.hs
@@ -187,12 +187,12 @@ instance Exception CompileError where
             \                                                                                \n\
             \                                                                                \n\
             \                                                                                \n\
-            \The conversion to JSON/YAML only translates the fully applied form to ❰null❱.   "
+            \The conversion to CSV only translates the fully applied form to empty string.   "
 
 insert :: Pretty a => a -> Text
 insert = Pretty.renderStrict . Dhall.Pretty.layout . Dhall.Util.insert
 
-{-| Convert a Dhall Expression (with resolved imports) to an equivalent
+{-| Convert a Dhall expression (with resolved imports) to an
     sequence of CSV @NamedRecord@s.
 -}
 dhallToCsv

--- a/dhall-csv/src/Dhall/Csv.hs
+++ b/dhall-csv/src/Dhall/Csv.hs
@@ -1,7 +1,7 @@
 {-#LANGUAGE OverloadedStrings#-}
 
 {-| This library exports two functions: `dhallToCsv` and `codeToValue`.
-    The former converts a Dhall Expression (with imports resolved already) into a
+    The former converts a Dhall expression (with imports resolved already) into a
     sequence of CSV `NamedRecord`s (from the @cassava@ library) while the latter
     converts a `Text` containing Dhall code into a list of CSV `NamedRecord`s.
 

--- a/dhall-csv/src/Dhall/Csv.hs
+++ b/dhall-csv/src/Dhall/Csv.hs
@@ -2,9 +2,8 @@
 
 {-| This library exports two functions: `dhallToCsv` and `codeToValue`.
     The former converts a Dhall Expression (with imports resolved already) into a
-    sequence of CSV `NamedRecord` (from the @cassava@ library) while the latter
-    converts a Text containing Dhall code into a list of CSV `NamedRecord` wrapped
-    in the `IO` Monad (because of the import resolution).
+    sequence of CSV `NamedRecord`s (from the @cassava@ library) while the latter
+    converts a `Text` containing Dhall code into a list of CSV `NamedRecord`s.
 
     Not all Dhall expressions can be converted to CSV since CSV is not a
     programming language.  The only things you can convert are @List@s of

--- a/dhall-csv/src/Dhall/Csv.hs
+++ b/dhall-csv/src/Dhall/Csv.hs
@@ -15,8 +15,8 @@
     * @Integer@s
     * @Double@s
     * @Text@ values
-    * @Optional@ values (one of these types)
-    * unions (of these types)
+    * @Optional@ (of valid field types)
+    * unions (of empty alternatives or valid record field types)
 
     Dhall @Bool@s translate to either `"true"` or `"false"` in all lowercase letters:
 

--- a/dhall-csv/src/Dhall/Csv.hs
+++ b/dhall-csv/src/Dhall/Csv.hs
@@ -131,7 +131,7 @@ instance Show CompileError where
             \● ❰Integer❱                                                                     \n\
             \● ❰Double❱                                                                      \n\
             \● ❰Text❱                                                                        \n\
-            \● ❰Optional❱ tp (where tp is a valid record field type)                         \n\
+            \● ❰Optional t❱ (where ❰t❱ is a valid record field type)                         \n\
             \● Unions *                                                                      \n\
             \                                                                                \n\
             \* Unions can have empty alternatives or alternatives with valid                 \n\

--- a/dhall-csv/src/Dhall/Csv.hs
+++ b/dhall-csv/src/Dhall/Csv.hs
@@ -1,12 +1,91 @@
 {-#LANGUAGE OverloadedStrings#-}
 
+{-| This library exports two functions: `dhallToCsv` and `codeToValue`.
+    The former converts a Dhall Expression (with imports resolved already) into a
+    sequence of CSV `NamedRecord` (from the @cassava@ library) while the latter
+    converts a Text containing Dhall code into a list of CSV `NamedRecord` wrapped
+    in the `IO` Monad (because of the import resolution).
+
+    Not all Dhall expressions can be converted to CSV since CSV is not a
+    programming language.  The only things you can convert are @List@s of
+    records where each field is one of the following types:
+
+    * @Bool@s
+    * @Natural@s
+    * @Integer@s
+    * @Double@s
+    * @Text@ values
+    * @Optional@ values (one of these types)
+    * unions (of these types)
+
+    Dhall @Bool@s translate to either `"true"` or `"false"` in all lowercase letters:
+
+> $ dhall-to-csv <<< '[{ exampleBool = True }]'
+> exampleBool
+> true
+> $ dhall-to-csv <<< '[{ exampleBool = False }]'
+> exampleBool
+> false
+
+    Dhall numbers translate to their string representations:
+
+> $ dhall-to-csv <<< '[{ exampleInteger = +2 }]'
+> exampleInteger
+> 2
+> $ dhall-to-csv <<< '[{ exampleNatural = 2 }]'
+> exampleNatural
+> 2
+> $ dhall-to-csv <<< '[{ exampleDouble = 2.3 }]'
+> exampleDouble
+> 2.3
+
+    Dhall @Text@ translates directly to CSV. Special CSV characters
+    are enclosed by double quotes:
+
+> $ dhall-to-csv <<< '[{ exampleText = "ABC" }]'
+> exampleText
+> ABC
+> $ dhall-to-csv <<< '[{ exampleText = "ABC,ABC" }]'
+> exampleText
+> "ABC,ABC"
+
+    Dhall @Optional@ values translate to the empty string if absent and the unwrapped
+    value otherwise:
+
+> $ dhall-to-csv <<< '[{ exampleOptional = None Natural }]'
+> exampleInt,exampleOptional
+>
+> $ dhall-to-csv <<< '[{ exampleOptional = Some 1 }]'
+> exampleOptional
+> 1
+
+    Dhall unions translate to the wrapped value or the name of the field
+    (in case it is an empty field):
+
+> $ dhall-to-csv <<< "[{ exampleUnion = < Left | Right : Natural>.Left }]"
+> exampleUnion
+> Left
+> $ dhall-to-csv <<< "[{ exampleUnion = < Left | Right : Natural>.Right 2 }]"
+> exampleUnion
+> 2
+
+    Also, all Dhall expressions are normalized before translation to CSV:
+
+> $ dhall-to-csv <<< "[{ equailty = True == False }]"
+> equality
+> false
+-}
+
 module Dhall.Csv (
       dhallToCsv
     , codeToValue
+
+    -- * Exceptions
+    , CompileError
     ) where
 
 import Control.Exception            (Exception, throwIO)
-import Data.Csv                     (ToField (..))
+import Data.Csv                     (NamedRecord, ToField (..))
 import Data.Maybe                   (fromMaybe)
 import Data.Sequence                (Seq)
 import Data.Text                    (Text)
@@ -29,6 +108,12 @@ import qualified Dhall.TypeCheck
 import qualified Dhall.Util
 import qualified System.FilePath
 
+{-| This is the exception type for errors that can arise when converting from
+    Dhall to CSV.
+
+    It contains information on the specific cases that might
+    fail to give a better insight.
+-}
 data CompileError = Unsupported (Expr Void Void)
 
 instance Show CompileError where
@@ -48,15 +133,18 @@ instance Exception CompileError
 insert :: Pretty a => a -> Text
 insert = Pretty.renderStrict . Dhall.Pretty.layout . Dhall.Util.insert
 
+{-| Convert a Dhall Expression (with resolved imports) to an equivalent
+    sequence of CSV @NamedRecord@s.
+-}
 dhallToCsv
     :: Expr s Void
-    -> Either CompileError (Seq Data.Csv.NamedRecord)
+    -> Either CompileError (Seq NamedRecord)
 dhallToCsv e0 = listConvert $ Core.normalize e0
   where
-    listConvert :: Expr Void Void -> Either CompileError (Seq Data.Csv.NamedRecord)
+    listConvert :: Expr Void Void -> Either CompileError (Seq NamedRecord)
     listConvert (Core.ListLit _ a) = traverse recordConvert a
     listConvert e = Left $ Unsupported e
-    recordConvert :: Expr Void Void -> Either CompileError Data.Csv.NamedRecord
+    recordConvert :: Expr Void Void -> Either CompileError NamedRecord
     recordConvert (Core.RecordLit a) = do
         a' <- traverse (fieldConvert . Core.recordFieldValue) a
         return $ Data.Csv.toNamedRecord $ Dhall.Map.toMap a'
@@ -74,10 +162,12 @@ dhallToCsv e0 = listConvert $ Core.normalize e0
     fieldConvert (Core.App Core.None _) = return $ toField ("" :: Text)
     fieldConvert e = Left $ Unsupported e
 
+{-| Convert a @Text@ with Dhall code to a list of @NamedRecord@s.
+-}
 codeToValue
     :: Maybe FilePath
     -> Text
-    -> IO [Data.Csv.NamedRecord]
+    -> IO [NamedRecord]
 codeToValue mFilePath code = do
     parsedExpression <- Core.throws (Dhall.Parser.exprFromText (fromMaybe "(input)" mFilePath) code)
 

--- a/dhall-csv/src/Dhall/Csv/Util.hs
+++ b/dhall-csv/src/Dhall/Csv/Util.hs
@@ -4,6 +4,7 @@ module Dhall.Csv.Util (encodeCsvDefault, decodeCsvDefault) where
 
 import Data.List      (sort)
 import Data.Text      (Text)
+import Data.Csv       (NamedRecord, Record)
 
 import qualified Data.ByteString.Lazy       as ByteString
 import qualified Data.ByteString.Lazy.Char8 as ByteString.Char8
@@ -12,29 +13,34 @@ import qualified Data.HashMap.Strict        as HashMap
 import qualified Data.Text.Encoding
 import qualified Data.Vector                as Vector
 
-encodeCsvDefault :: [Data.Csv.NamedRecord] -> Text
+{-| Utility to convert a list of @NamedRecord@ to Text formatted as a CSV.
+-}
+encodeCsvDefault :: [NamedRecord] -> Text
 encodeCsvDefault csv = Data.Text.Encoding.decodeUtf8 $ ByteString.toStrict $ Data.Csv.encodeByName header csv
   where
     header = case csv of
         [] -> Vector.empty
         (m:_) -> Vector.fromList $ sort $ HashMap.keys m
 
-decodeCsvDefault :: Bool -> Text -> Either String [Data.Csv.NamedRecord]
+{-| Utility to decode a CSV into a list of records.
+    Must specify whether the CSV to decode has header or not.
+-}
+decodeCsvDefault :: Bool -> Text -> Either String [NamedRecord]
 decodeCsvDefault hasHeader
     | hasHeader = decodeCsvWithHeader
     | otherwise = decodeCsvNoHeader
 
-decodeCsvWithHeader :: Text -> Either String [Data.Csv.NamedRecord]
+decodeCsvWithHeader :: Text -> Either String [NamedRecord]
 decodeCsvWithHeader txt = do
     (_, vec) <- Data.Csv.decodeByName $ ByteString.fromStrict $ Data.Text.Encoding.encodeUtf8 txt
     return $ Vector.toList vec
 
-decodeCsvNoHeader :: Text -> Either String [Data.Csv.NamedRecord]
+decodeCsvNoHeader :: Text -> Either String [NamedRecord]
 decodeCsvNoHeader txt = do
     vec <- Data.Csv.decode Data.Csv.NoHeader $ ByteString.fromStrict $ Data.Text.Encoding.encodeUtf8 txt
     return $ map addDefaultHeader $ Vector.toList vec
 
-addDefaultHeader :: Data.Csv.Record -> Data.Csv.NamedRecord
+addDefaultHeader :: Record -> NamedRecord
 addDefaultHeader = HashMap.fromList . (zip headerBS) . Vector.toList
   where
     header = map (('_' :) . show) ([1..] :: [Int])

--- a/dhall-csv/src/Dhall/CsvToDhall.hs
+++ b/dhall-csv/src/Dhall/CsvToDhall.hs
@@ -481,14 +481,14 @@ instance Exception CompileError where
             \Explanation: Fields present in CSV header are not present in schema.            \n\
             \You may turn off the --strict-recs flag to ignore this error.                   "
 
-    displayException (Mismatch tp field key) =
+    displayException (Mismatch t field key) =
         Data.Text.unpack $
             _ERROR <> ": Type mismatch at field: " <> key <>                               "\n\
             \                                                                                \n\
             \Explanation: Could not parse CSV field " <> field <>                           "\n\
             \into the expected Dhall type:                                                   \n\
             \                                                                                \n\
-            \" <> insert tp
+            \" <> insert t
 
     displayException (ContainsUnion e) =
         Data.Text.unpack $
@@ -502,7 +502,7 @@ instance Exception CompileError where
             \                                                                                \n\
             \" <> insert e
 
-    displayException (UndecidableUnion tp field key opts) =
+    displayException (UndecidableUnion t field key opts) =
         Data.Text.unpack $
             _ERROR <> ": A union typed field can be parsed in more than one way.             \n\
             \                                                                                \n\
@@ -514,13 +514,15 @@ instance Exception CompileError where
             \                                                                                \n\
             \Expected union type:                                                            \n\
             \                                                                                \n\
-            \" <> insert tp <>
-            "\nField can be parsed as the following expressions: \n"
-            <> Data.Text.intercalate
+            \" <> insert t <>                                                              "\n\
+            \                                                                                \n\
+            \... field can be parsed as the following expressions:                           \n\
+            \                                                                                \n\
+            \" <> Data.Text.intercalate
             "\n------------------------------------------------------------------------------\n"
             (map insert opts)
 
-    displayException (UndecidableMissingUnion tp key opts) =
+    displayException (UndecidableMissingUnion t key opts) =
         Data.Text.unpack $
             _ERROR <> ": A union typed field can be parsed in more than one way.             \n\
             \                                                                                \n\
@@ -533,8 +535,10 @@ instance Exception CompileError where
             \                                                                                \n\
             \Expected union type:                                                            \n\
             \                                                                                \n\
-            \" <> insert tp <>
-            "\nMissing field can be parsed as the following expressions:                     \n\
+            \" <> insert t <>                                                              "\n\
+            \                                                                                \n\
+            \... missing field can be parsed as the following expressions:                   \n\
+            \                                                                                \n\
             \" <> Data.Text.intercalate
             "\n------------------------------------------------------------------------------\n"
             (map insert opts)

--- a/dhall-csv/src/Dhall/CsvToDhall.hs
+++ b/dhall-csv/src/Dhall/CsvToDhall.hs
@@ -540,10 +540,7 @@ instance Show CompileError where
 
     show (UnicodeError e) = show e
 
-    show _ = undefined
-
 instance Exception CompileError
-
 
 insert :: Pretty a => a -> Text
 insert = Pretty.renderStrict . Dhall.Pretty.layout . Dhall.Util.insert

--- a/dhall-csv/src/Dhall/CsvToDhall.hs
+++ b/dhall-csv/src/Dhall/CsvToDhall.hs
@@ -1,6 +1,132 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 
+{-| Convert CSV data to Dhall providing an expected Dhall Type necessary
+    to know which type will be interpreted.
+
+    The translation process will produce a Dhall Expression where
+    its type is a @List@ of records and the type of each field of the
+    records is one of the following:
+
+    * @Bool@s
+    * @Natural@s
+    * @Integer@s
+    * @Double@s
+    * @Text@s
+    * @Optional@s (of valid field types)
+    * unions (of empty alternatives or valid record field types)
+
+    It is exactly the same as @dhall-to-csv@ supported input types.
+
+    You can use this code as a library (this module) or as an executable
+    named @csv-to-dhall@, which is used in the examples below.
+
+    For now, @csv-to-dhall@ does not support type inference so you must
+    always specify the Dhall type you expect.
+
+> $ cat example.csv
+> example
+> 1
+> $ csv-to-dhall 'List { example : Integer }' < example.csv
+> [{ example = +1 }]
+
+    When using the @csv-to-dhall@ executable you can specify that the CSV
+    you want to translate does not have a header with the flag `--no-header`.
+    In this case the resulting record fields will be named `_1`, `_2`, ...
+    in the same order they where in the input CSV. You must still provide the
+    expected Dhall type taking this into consideration.
+
+> $ cat no-header-example.csv
+> 1,3.14,Hello
+> -1,2.68,Goodbye
+> $ csv-to-dhall --no-header 'List { _1 : Integer, _2 : Double, _3 : Text } < no-header-example.csv
+> [ { _1 = +1, _2 = 3.14, _3 = "Hello" }
+> , { _1 = -1, _2 = 2.68, _3 = "Goodbye" }
+> ]
+
+== Primitive types
+
+    Strings 'true' and 'false' can translate to Dhall @Bool@s
+
+> $ cat example.csv
+> exampleBool
+> true
+> false
+> $ csv-to-dhall 'List { exampleBool : Bool }' < example.csv
+> [ { exampleBool = True }, { exampleBool = False } ]
+
+    Numeric strings can translate to Dhall numbers:
+
+> $ cat example.csv
+> exampleNatural,exampleInt,exampleDouble
+> 1,2,3
+> 0,-2,3.14
+> 0,+2,-3.14
+> $ csv-to-dhall 'List { exampleNatural : Natural, exampleInt : Integer, exampleDouble : Double }' < example.csv
+> [ { exampleNatural = 1, exampleInt = +2, exampleDouble = 3.0 }
+> , { exampleNatural = 0, exampleInt = -2, exampleDouble = 3.14 }
+> , { exampleNatural = 0, exampleInt = +2, exampleDouble = -3.14 }
+> ]
+
+    Every CSV Field can translate directly to Dhall @Text@:
+
+> $ cat example.csv
+> exampleText
+> Hello
+> false
+>
+> ","
+> $ csv-to-dhall 'List { exampleText : Text }' < example.csv
+> [ { exampleText = "Hello" }
+> , { exampleText = "false" }
+> , { exampleText = "" }
+> , { exampleText = "," }
+> ]
+
+== Unions and Optionals
+
+    By default, when a union is expected, the first alternative that
+    matches the CSV field is chosen. With the `--unions-strict` flag
+    one can make sure that only one alternative matches. With the
+    `--unions-none` unions are not allowed.
+
+    An union alternative matches a CSV field if
+
+    * It's an empty alternative and the name is the same as the text in the CSV field.
+    * It's a non-empty alternative and the CSV field can be converted to the underlying type.
+
+> $ cat example.csv
+> exampleUnion
+> Hello
+> 1
+> 1.11
+> $ csv-to-dhall 'List { exampleUnion : <Hello | Nat : Natural | Dob : Double> }' < example.csv
+> [ { exampleUnion = <Hello | Nat : Natural | Dob : Double>.Hello }
+> , { exampleUnion = <Hello | Nat : Natural | Dob : Double>.Nat 1 }
+> , { exampleUnion = <Hello | Nat : Natural | Dob : Double>.Dob 1.11 }
+> ]
+
+    Optional values can be either missing or have the expected value.
+    The missing value is represented by the empty string.
+    If a field's expected value is an Optional and the field is not
+    in the CSV, then all the values will be None unless `--records-strict`
+    flag is specified, in that case it will throw an error if there
+    is any missign field.
+
+> $ cat example.csv
+> exampleOptional
+> 1
+>
+> 3
+> $ csv-to-dhall 'List { exampleOptional : Optional Natural, exampleMissing : Optional Natural }' < example.csv
+> [ { exampleOptional = Some 1, exampleMissing = None Natural }
+> , { exampleOptional = None Natural, exampleMissing = None Natural }
+> , { exampleOptional = Some 3, exampleMissing = None Natural }
+> ]
+
+-}
+
+
 module Dhall.CsvToDhall (
     -- * CSV to Dhall
       dhallFromCsv
@@ -17,6 +143,7 @@ module Dhall.CsvToDhall (
 import Control.Applicative      ((<|>))
 import Control.Exception        (Exception, throwIO)
 import Control.Monad.Catch      (MonadCatch, throwM)
+import Data.Csv                 (NamedRecord)
 import Data.Either              (lefts, rights)
 import Data.Either.Combinators  (mapRight)
 import Data.Foldable            (toList)
@@ -44,7 +171,7 @@ import qualified Options.Applicative         as O
 -- Conversion
 -- ----------
 
--- | JSON-to-dhall translation options
+-- | CSV-to-dhall translation options
 data Conversion = Conversion
     { strictRecs :: Bool
     , unions     :: UnionConv
@@ -113,6 +240,7 @@ resolveSchemaExpr code = do
         Right parsedExpression -> return parsedExpression
     Dhall.Import.load parsedExpression
 
+-- | Check that the Dhall type expression actually has type 'Type'
 typeCheckSchemaExpr :: (Exception e, MonadCatch m)
                     => (CompileError -> e) -> ExprX -> m ExprX
 typeCheckSchemaExpr compileException expr =
@@ -123,18 +251,21 @@ typeCheckSchemaExpr compileException expr =
       _              -> throwM . compileException $ BadDhallType t expr
 
 
-dhallFromCsv :: Conversion -> ExprX -> [Data.Csv.NamedRecord] -> Either CompileError ExprX
+{-| Convert a list of CSV @NameRecord@ to a Dhall expression given the expected Dhall Type
+    of the output.
+-}
+dhallFromCsv :: Conversion -> ExprX -> [NamedRecord] -> Either CompileError ExprX
 dhallFromCsv Conversion{..} typeExpr = listConvert (Core.normalize typeExpr)
   where
-    listConvert :: ExprX -> [Data.Csv.NamedRecord] -> Either CompileError ExprX
+    listConvert :: ExprX -> [NamedRecord] -> Either CompileError ExprX
     listConvert (Core.App Core.List recordType@(Core.Record _)) [] = return $ Core.ListLit (Just recordType) Sequence.empty
-    listConvert (Core.App Core.List recordType) [] = Left $ Unsupported recordType
+    listConvert (Core.App Core.List recordType) [] = Left $ NotARecord recordType
     listConvert (Core.App Core.List recordType) csv = do
         a <- traverse (recordConvert recordType) csv
         return $ Core.ListLit Nothing $ Sequence.fromList a
-    listConvert e _ = Left $ Unsupported e
+    listConvert e _ = Left $ NotAList e
 
-    recordConvert :: ExprX -> Data.Csv.NamedRecord -> Either CompileError ExprX
+    recordConvert :: ExprX -> NamedRecord -> Either CompileError ExprX
     recordConvert (Core.Record record) csvRecord
         | badKeys <- lefts (map decodeUtf8' (HashMap.keys csvRecord))
         , not (null badKeys)
@@ -147,7 +278,7 @@ dhallFromCsv Conversion{..} typeExpr = listConvert (Core.normalize typeExpr)
             let f k v = fieldConvert k (Core.recordFieldValue v) (HashMap.lookup (encodeUtf8 k) csvRecord)
             a <- Map.traverseWithKey (\k v -> mapRight Core.makeRecordField (f k v)) record
             return $ Core.RecordLit a
-    recordConvert e _ = Left $ Unsupported e
+    recordConvert e _ = Left $ NotARecord e
 
     fieldConvert :: Text -> ExprX -> Maybe Data.Csv.Field -> Either CompileError ExprX
     -- Unions
@@ -231,8 +362,17 @@ dhallFromCsv Conversion{..} typeExpr = listConvert (Core.normalize typeExpr)
 
     fieldConvert _ t _ = Left $ Unsupported t
 
+
+{-| This is the exception type for errors that can arise when converting from
+    CSV to Dhall.
+
+    It contains information on the specific cases that might
+    fail to give a better insight.
+-}
 data CompileError
     = Unsupported ExprX
+    | NotAList ExprX
+    | NotARecord ExprX
     | TypeError (TypeCheck.TypeError Src Void)
     | BadDhallType
         ExprX -- Expression type

--- a/dhall-csv/src/Dhall/CsvToDhall.hs
+++ b/dhall-csv/src/Dhall/CsvToDhall.hs
@@ -109,9 +109,7 @@
     Optional values can be either missing or have the expected value.
     The missing value is represented by the empty string.
     If a field's expected value is an Optional and the field is not
-    in the CSV, then all the values will be None unless `--records-strict`
-    flag is specified, in that case it will throw an error if there
-    is any missign field.
+    in the CSV, then all the values will be None.
 
 > $ cat example.csv
 > exampleOptional
@@ -140,32 +138,38 @@ module Dhall.CsvToDhall (
     , CompileError(..)
     ) where
 
-import Control.Applicative      ((<|>))
-import Control.Exception        (Exception, throwIO)
-import Control.Monad.Catch      (MonadCatch, throwM)
-import Data.Csv                 (NamedRecord)
-import Data.Either              (lefts, rights)
-import Data.Either.Combinators  (mapRight)
-import Data.Foldable            (toList)
-import Data.List                ((\\))
-import Data.Text                (Text)
-import Data.Text.Encoding       (decodeUtf8, decodeUtf8', encodeUtf8)
-import Data.Text.Encoding.Error (UnicodeException)
-import Data.Text.Read           (decimal, double, signed)
-import Data.Void                (Void)
-import Dhall.Core               (Expr)
-import Dhall.Src                (Src)
-import Options.Applicative      (Parser)
+import Control.Applicative          ((<|>))
+import Control.Exception            (Exception, throwIO)
+import Control.Monad.Catch          (MonadCatch, throwM)
+import Data.Csv                     (NamedRecord)
+import Data.Either                  (lefts, rights)
+import Data.Either.Combinators      (mapRight)
+import Data.Foldable                (toList)
+import Data.List                    ((\\))
+import Data.Text                    (Text)
+import Data.Text.Encoding           (decodeUtf8, decodeUtf8', encodeUtf8)
+import Data.Text.Encoding.Error     (UnicodeException)
+import Data.Text.Prettyprint.Doc    (Pretty)
+import Data.Text.Read               (decimal, double, signed)
+import Data.Void                    (Void)
+import Dhall.Core                   (Expr)
+import Dhall.Src                    (Src)
+import Dhall.Util                   (_ERROR)
+import Options.Applicative          (Parser)
 
 import qualified Data.Csv
-import qualified Data.HashMap.Strict         as HashMap
-import qualified Data.Sequence               as Sequence
-import qualified Dhall.Core                  as Core
+import qualified Data.HashMap.Strict                    as HashMap
+import qualified Data.Sequence                          as Sequence
+import qualified Data.Text
+import qualified Data.Text.Prettyprint.Doc.Render.Text  as Pretty
+import qualified Dhall.Core                             as Core
 import qualified Dhall.Import
-import qualified Dhall.Map                   as Map
+import qualified Dhall.Map                              as Map
 import qualified Dhall.Parser
-import qualified Dhall.TypeCheck             as TypeCheck
-import qualified Options.Applicative         as O
+import qualified Dhall.Pretty
+import qualified Dhall.TypeCheck                        as TypeCheck
+import qualified Dhall.Util
+import qualified Options.Applicative                    as O
 
 -- ----------
 -- Conversion
@@ -292,16 +296,16 @@ dhallFromCsv Conversion{..} typeExpr = listConvert (Core.normalize typeExpr)
                             Right _field ->
                                 if _field == unionKey
                                 then Right $ Core.Field t $ Core.makeFieldSelection unionKey
-                                else Left $ Mismatch t field recordKey
+                                else Left $ Mismatch t _field recordKey
             f unionKey (Just _type) = do
                 expression <- fieldConvert recordKey _type maybeField
                 return (Core.App (Core.Field t $ Core.makeFieldSelection unionKey) expression)
 
         case (unions, rights (toList (Map.mapWithKey f tm)), maybeField) of
             (UNone  , _         , _         ) -> Left $ ContainsUnion t
-            (UStrict, xs@(_:_:_), Just field) -> Left $ UndecidableUnion t field xs
-            (UStrict, xs@(_:_:_), Nothing   ) -> Left $ UndecidableMissingUnion t xs
-            (_      , []        , Just field) -> Left $ Mismatch t field recordKey
+            (UStrict, xs@(_:_:_), Just field) -> Left $ UndecidableUnion t (decodeUtf8 field) recordKey xs
+            (UStrict, xs@(_:_:_), Nothing   ) -> Left $ UndecidableMissingUnion t recordKey xs
+            (_      , []        , Just field) -> Left $ Mismatch t (decodeUtf8 field) recordKey
             (_      , []        , Nothing   ) -> Left $ MissingKey recordKey
             (UFirst , x:_       , _         ) -> Right $ x
             (UStrict, [x]       , _         ) -> Right $ x
@@ -314,10 +318,13 @@ dhallFromCsv Conversion{..} typeExpr = listConvert (Core.normalize typeExpr)
 
     -- Bools
     fieldConvert key Core.Bool (Just field) =
-        case field of
-            "true"  -> Right (Core.BoolLit True)
-            "false" -> Right (Core.BoolLit False)
-            _ -> Left $ Mismatch Core.Bool field key
+        case decodeUtf8' field of
+            Left err -> Left $ UnicodeError err
+            Right _field ->
+                case _field of
+                    "true"  -> Right (Core.BoolLit True)
+                    "false" -> Right (Core.BoolLit False)
+                    _ -> Left $ Mismatch Core.Bool _field key
 
     -- Naturals
     fieldConvert key Core.Natural (Just field) =
@@ -325,8 +332,8 @@ dhallFromCsv Conversion{..} typeExpr = listConvert (Core.normalize typeExpr)
             Left err -> Left $ UnicodeError err
             Right _field ->
                 case decimal _field of
-                    Right (v, "") -> Right $ Core.NaturalLit v           -- What to do when there is more text left to read?
-                    _ -> Left $ Mismatch Core.Natural field key
+                    Right (v, "") -> Right $ Core.NaturalLit v
+                    _ -> Left $ Mismatch Core.Natural _field key
 
     -- Integers
     fieldConvert key Core.Integer (Just field) =
@@ -334,8 +341,8 @@ dhallFromCsv Conversion{..} typeExpr = listConvert (Core.normalize typeExpr)
             Left err -> Left $ UnicodeError err
             Right _field ->
                 case (signed decimal) _field of
-                    Right (v, "") -> Right $ Core.IntegerLit v           -- What to do when there is more text left to read?
-                    _ -> Left $ Mismatch Core.Integer field key
+                    Right (v, "") -> Right $ Core.IntegerLit v
+                    _ -> Left $ Mismatch Core.Integer _field key
 
     -- Doubles
     fieldConvert _ Core.Double (Just field) =
@@ -381,17 +388,162 @@ data CompileError
     | UnhandledKeys [Text] -- Keys in CSV but not in schema
     | Mismatch
         ExprX           -- Expected Dhall Type
-        Data.Csv.Field  -- Actual field
+        Text            -- Actual field
         Text            -- Record key
     | ContainsUnion ExprX
     | UndecidableUnion
         ExprX           -- Expected Type
-        Data.Csv.Field  -- CSV Field
+        Text            -- CSV Field
+        Text            -- Record Key
         [ExprX]         -- Multiple conversions
     | UndecidableMissingUnion
         ExprX           -- Expected Type
+        Text            -- Record Key
         [ExprX]         -- Multiple Conversions
     | UnicodeError UnicodeException
-    deriving Show
+
+instance Show CompileError where
+    show (Unsupported e) =
+        Data.Text.unpack $
+            _ERROR <> ": Invalid record field type                                           \n\
+            \                                                                                \n\
+            \Explanation: Only the following types of record fields are valid:               \n\
+            \                                                                                \n\
+            \● ❰Bool❱                                                                        \n\
+            \● ❰Natural❱                                                                     \n\
+            \● ❰Integer❱                                                                     \n\
+            \● ❰Double❱                                                                      \n\
+            \● ❰Text❱                                                                        \n\
+            \● ❰Optional❱ tp (where tp is a valid record field type)                         \n\
+            \● Unions *                                                                      \n\
+            \                                                                                \n\
+            \* Unions can have empty alternatives or alternatives with valid                 \n\
+            \  record field types                                                            \n\
+            \                                                                                \n\
+            \Expected one of the previous types but instead got:                             \n\
+            \                                                                                \n\
+            \" <> insert e
+
+    show (NotAList e) =
+        Data.Text.unpack $
+            _ERROR <> ": Top level object must be of type ❰List❱                             \n\
+            \                                                                                \n\
+            \Explanation: Translation from CSV only returns ❰List❱s of records.              \n\
+            \Other types can not be translated.                                              \n\
+            \                                                                                \n\
+            \Expected type List {...} but instead got the following type:                    \n\
+            \                                                                                \n\
+            \" <> insert e
+
+    show (NotARecord e) =
+        Data.Text.unpack $
+            _ERROR <> ": Elements of the top-level list must be records                      \n\
+            \                                                                                \n\
+            \Explanation: Translation from CSV only returns ❰List❱s of records.              \n\
+            \Other types can not be translated.                                              \n\
+            \                                                                                \n\
+            \Expected a record type but instead got the following type:                      \n\
+            \                                                                                \n\
+            \" <> insert e
+
+    show (TypeError e) = show e
+
+    show (BadDhallType t e) =
+        Data.Text.unpack $
+            _ERROR <> ": Schema expression parsed successfully but has wrong Dhall type.     \n\
+            \                                                                                \n\
+            \Expected Dhall type: Type                                                       \n\
+            \                                                                                \n\
+            \Actual Dhall type:                                                              \n\
+            \" <> insert t <>
+            "                                                                                \n\
+            \                                                                                \n\
+            \Parsed Expression:                                                              \n\
+            \" <> insert e
+
+    show (MissingKey key) =
+        Data.Text.unpack $
+            _ERROR <> ": Missing key: \'" <> key <> "\'.                                     \n\
+            \                                                                                \n\
+            \Explanation: Key present in Dhall type (and not optional) is not provided       \n\
+            \in CSV. Please make sure every field key (non-optional) in Dhall type is        \n\
+            \present in CSV header.                                                          \n\
+            \                                                                                \n\
+            \If working with headerless CSVs, fields in Dhall type should have keys          \n\
+            \_1, _2, _3, ... and so forth                                                    "
+
+    show (UnhandledKeys keys) =
+        Data.Text.unpack $
+            _ERROR <> ": Following key(s): " <> (Data.Text.intercalate ", " keys) <>        "\n\
+            \are not handled.                                                                \n\
+            \                                                                                \n\
+            \Explanation: Keys present in CSV header are not present in Dhall type.          \n\
+            \You may turn off the --strict-recs flag to ignore this error.                   "
+
+    show (Mismatch tp field key) =
+        Data.Text.unpack $
+            _ERROR <> ": Type Mismtatch with key: " <> key <>                               "\n\
+            \                                                                                \n\
+            \Explanation: Could not parse CSV field " <> field <>                           "\n\
+            \into the expected Dhall type:                                                   \n\
+            \                                                                                \n\
+            \" <> insert tp
+
+    show (ContainsUnion e) =
+        Data.Text.unpack $
+            _ERROR <> ": Dhall type contains a Union type.                                   \n\
+            \                                                                                \n\
+            \Explanation: Dhall type contains a Union type for one of the record fields.     \n\
+            \This error occurs because flag --unions-none is turned on. If it is desired to  \n\
+            \have unions in the parsed expression, disable --unions-none flag.               \n\
+            \                                                                                \n\
+            \Expected no unions but got the following type in schema:                        \n\
+            \                                                                                \n\
+            \" <> insert e
+
+    show (UndecidableUnion tp field key opts) =
+        Data.Text.unpack $
+            _ERROR <> ": A union typed field can be parsed in more than one way.             \n\
+            \                                                                                \n\
+            \Explanation: The CSV field " <> field <>                                       "\n\
+            \             with key " <> key <>                                              "\n\
+            \can be converted in more than one of the expected union type alternatives.      \n\
+            \This error occurs because flag --unions-strict is turned on. You may turn off   \n\
+            \this flag to select the first valid alternative found.                          \n\
+            \                                                                                \n\
+            \Expected union type:                                                            \n\
+            \                                                                                \n\
+            \" <> insert tp <>
+            "\nField can be parsed as the following expressions: \n"
+            <> Data.Text.intercalate
+            "\n------------------------------------------------------------------------------\n"
+            (map insert opts)
+
+    show (UndecidableMissingUnion tp key opts) =
+        Data.Text.unpack $
+            _ERROR <> ": A union typed field can be parsed in more than one way.             \n\
+            \                                                                                \n\
+            \Explanation: The record field key " <> key <>                                  "\n\
+            \             missing in CSV                                                     \n\
+            \can be converted in more than one of the expected union type alternatives.      \n\
+            \That is to say, there are more than one alternatives with Optional types.       \n\
+            \This error occurs because flag --unions-strict is turned on. You may turn off   \n\
+            \this flag to select the first valid alternative found.                          \n\
+            \                                                                                \n\
+            \Expected union type:                                                            \n\
+            \                                                                                \n\
+            \" <> insert tp <>
+            "\nMissing field can be parsed as the following expressions:                     \n\
+            \" <> Data.Text.intercalate
+            "\n------------------------------------------------------------------------------\n"
+            (map insert opts)
+
+    show (UnicodeError e) = show e
+
+    show _ = undefined
 
 instance Exception CompileError
+
+
+insert :: Pretty a => a -> Text
+insert = Pretty.renderStrict . Dhall.Pretty.layout . Dhall.Util.insert

--- a/dhall-csv/src/Dhall/CsvToDhall.hs
+++ b/dhall-csv/src/Dhall/CsvToDhall.hs
@@ -482,7 +482,7 @@ instance Show CompileError where
 
     show (Mismatch tp field key) =
         Data.Text.unpack $
-            _ERROR <> ": Type Mismtatch with key: " <> key <>                               "\n\
+            _ERROR <> ": Type mismatch at field: " <> key <>                               "\n\
             \                                                                                \n\
             \Explanation: Could not parse CSV field " <> field <>                           "\n\
             \into the expected Dhall type:                                                   \n\

--- a/dhall-csv/src/Dhall/CsvToDhall.hs
+++ b/dhall-csv/src/Dhall/CsvToDhall.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 
-{-| Convert CSV data to Dhall providing an expected Dhall Type necessary
+{-| Convert CSV data to Dhall providing an expected Dhall type necessary
     to know which type will be interpreted.
 
     The translation process will produce a Dhall Expression where

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -177,6 +177,7 @@ let
                 failOnMissingHaddocksExtension =
                   mass failOnMissingHaddocks [
                     "dhall"
+                    "dhall-csv"
                   ];
 
                 extension =

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -177,7 +177,6 @@ let
                 failOnMissingHaddocksExtension =
                   mass failOnMissingHaddocks [
                     "dhall"
-                    "dhall-csv"
                   ];
 
                 extension =


### PR DESCRIPTION
I created haddocks on all the exported functions and types of the libraries and I added the verification of missing haddocks in `dhall-csv` to ci in `nix/shared.nix`.

I also improved (a lot) the error messages, both on `dhall-to-csv` and `csv-to-dhall`, mostly the latter but because those messages were worse before. I'm open to any suggestion on the error messages because I found it very hard to create descriptive and helpful messages haha.

EDIT: Removed verification for CI because I can't find where are the missing Haddocks and Hydra log only reports "Incomplete Haddocks"