### PR TITLE
Always parenthesize custom headers

### DIFF
--- a/dhall/src/Dhall/Syntax.hs
+++ b/dhall/src/Dhall/Syntax.hs
@@ -1028,7 +1028,7 @@ instance Pretty URL where
         <>  foldMap prettyHeaders headers
       where
         prettyHeaders h =
-          " using " <> Pretty.unAnnotate (prettyImportExpression h)
+          " using (" <> Pretty.unAnnotate (Pretty.pretty h) <> ")"
 
         File {..} = path
 

--- a/dhall/tests/format/parenthesizeUsingA.dhall
+++ b/dhall/tests/format/parenthesizeUsingA.dhall
@@ -1,0 +1,6 @@
+-- https://github.com/dhall-lang/dhall-haskell/issues/2273
+let MyPackage =
+      https://server.test/package.dhall using (./headers.dhall)
+        sha256:03a6e298ff140d430cea8b387fad886ce9f5bee24622c7d1102115cc08ed9cf8
+
+in  MyPackage

--- a/dhall/tests/format/parenthesizeUsingB.dhall
+++ b/dhall/tests/format/parenthesizeUsingB.dhall
@@ -1,0 +1,6 @@
+-- https://github.com/dhall-lang/dhall-haskell/issues/2273
+let MyPackage =
+      https://server.test/package.dhall using (./headers.dhall)
+        sha256:03a6e298ff140d430cea8b387fad886ce9f5bee24622c7d1102115cc08ed9cf8
+
+in  MyPackage


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2273

This avoids ambiguous parses for expressions like:

```dhall
https://example.com using ./headers.dhall sha256:…
```

… where the integrity check could be modifying either the original
import or the custom headers.