### PR TITLE
Modifying field names in generated Haskell types

### DIFF
--- a/dhall/src/Dhall/Marshal/Decode.hs
+++ b/dhall/src/Dhall/Marshal/Decode.hs
@@ -90,6 +90,7 @@ module Dhall.Marshal.Decode
     , GenericFromDhallUnion(..)
     , genericAuto
     , genericAutoWith
+    , genericAutoWithInputNormalizer
 
     -- * Decoding errors
     , DhallErrors(..)
@@ -221,8 +222,8 @@ fromList [("a",False),("b",True)]
     implement `Generic`.  This does not auto-generate an instance for recursive
     types.
 
-    The default instance can be tweaked using 'genericAutoWith' and custom
-    'InterpretOptions', or using
+    The default instance can be tweaked using 'genericAutoWith'/'genericAutoWithInputNormalizer'
+    and custom 'InterpretOptions', or using
     [DerivingVia](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-DerivingVia)
     and 'Dhall.Deriving.Codec' from "Dhall.Deriving".
 -}
@@ -687,7 +688,13 @@ genericAuto = genericAutoWith defaultInterpretOptions
 {-| `genericAutoWith` is a configurable version of `genericAuto`.
 -}
 genericAutoWith :: (Generic a, GenericFromDhall a (Rep a)) => InterpretOptions -> Decoder a
-genericAutoWith options = withProxy (\p -> fmap to (evalState (genericAutoWithNormalizer p defaultInputNormalizer options) 1))
+genericAutoWith options = genericAutoWithInputNormalizer options defaultInputNormalizer
+
+{-| `genericAutoWithInputNormalizer` is like `genericAutoWith`, but instead of
+    using the `defaultInputNormalizer` it expects an custom `InputNormalizer`.
+-}
+genericAutoWithInputNormalizer :: (Generic a, GenericFromDhall a (Rep a)) => InterpretOptions -> InputNormalizer -> Decoder a
+genericAutoWithInputNormalizer options inputNormalizer = withProxy (\p -> fmap to (evalState (genericAutoWithNormalizer p inputNormalizer options) 1))
     where
         withProxy :: (Proxy a -> Decoder a) -> Decoder a
         withProxy f = f Proxy

--- a/dhall/src/Dhall/Marshal/Encode.hs
+++ b/dhall/src/Dhall/Marshal/Encode.hs
@@ -41,6 +41,7 @@ module Dhall.Marshal.Encode
     , GenericToDhall(..)
     , genericToDhall
     , genericToDhallWith
+    , genericToDhallWithInputNormalizer
     , InterpretOptions(..)
     , SingletonConstructors(..)
     , defaultInterpretOptions
@@ -127,8 +128,8 @@ instance Contravariant Encoder where
     implement `Generic`.  This does not auto-generate an instance for recursive
     types.
 
-    The default instance can be tweaked using 'genericToDhallWith' and custom
-    'InterpretOptions', or using
+    The default instance can be tweaked using 'genericToDhallWith'/'genericToDhallWithInputNormalizer'
+    and custom 'InterpretOptions', or using
     [DerivingVia](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-DerivingVia)
     and 'Dhall.Deriving.Codec' from "Dhall.Deriving".
 -}
@@ -725,8 +726,16 @@ want to define orphan instances for.
 -}
 genericToDhallWith
   :: (Generic a, GenericToDhall (Rep a)) => InterpretOptions -> Encoder a
-genericToDhallWith options
-    = contramap GHC.Generics.from (evalState (genericToDhallWithNormalizer defaultInputNormalizer options) 1)
+genericToDhallWith options = genericToDhallWithInputNormalizer options defaultInputNormalizer
+
+{-| `genericToDhallWithInputNormalizer` is like `genericToDhallWith`, but
+    instead of using the `defaultInputNormalizer` it expects an custom
+    `InputNormalizer`.
+-}
+genericToDhallWithInputNormalizer
+  :: (Generic a, GenericToDhall (Rep a)) => InterpretOptions -> InputNormalizer -> Encoder a
+genericToDhallWithInputNormalizer options inputNormalizer
+    = contramap GHC.Generics.from (evalState (genericToDhallWithNormalizer inputNormalizer options) 1)
 
 
 

--- a/dhall/src/Dhall/TH.hs
+++ b/dhall/src/Dhall/TH.hs
@@ -194,7 +194,7 @@ derivingGenericClause = DerivClause (Just StockStrategy) [ ConT ''Generic ]
 -- | Generates a `FromDhall` instances.
 fromDhallInstance
     :: Syntax.Name -- ^ The name of the type the instances is for
-    -> Q Exp       -- ^ A TH splice generating some `InterpretOptions`
+    -> Q Exp       -- ^ A TH splice generating some `Dhall.InterpretOptions`
     -> Q [Dec]
 fromDhallInstance n interpretOptions = [d|
     instance FromDhall $(pure $ ConT n) where
@@ -204,7 +204,7 @@ fromDhallInstance n interpretOptions = [d|
 -- | Generates a `ToDhall` instances.
 toDhallInstance
     :: Syntax.Name -- ^ The name of the type the instances is for
-    -> Q Exp       -- ^ A TH splice generating some `InterpretOptions`
+    -> Q Exp       -- ^ A TH splice generating some `Dhall.InterpretOptions`
     -> Q [Dec]
 toDhallInstance n interpretOptions = [d|
     instance ToDhall $(pure $ ConT n) where
@@ -416,8 +416,8 @@ defaultGenerateOptions = GenerateOptions
 
 -- | This function generates `Dhall.InterpretOptions` that can be used for the
 --   marshalling of the Haskell type generated according to the `GenerateOptions`.
---   I.e. those `InterpretOptions` reflect the mapping done by `constructorModifier`
---   and `fieldModifier` on the value level.
+--   I.e. those `Dhall.InterpretOptions` reflect the mapping done by
+--   `constructorModifier` and `fieldModifier` on the value level.
 generateToInterpretOptions :: GenerateOptions -> HaskellType (Expr s a) -> Q Exp
 generateToInterpretOptions GenerateOptions{..} haskellType = [| Dhall.InterpretOptions
     { Dhall.fieldModifier = \ $(pure nameP) ->

--- a/dhall/src/Dhall/TH.hs
+++ b/dhall/src/Dhall/TH.hs
@@ -442,7 +442,7 @@ generateToInterpretOptions GenerateOptions{..} haskellType = [| Dhall.InterpretO
 
         toCases :: (Text -> Text) -> [Text] -> Q Exp
         toCases f xs = do
-            err <- [| error $ "SHOULD NEVER HAPPEN: Unmatched " <> show $(pure nameE) |]
+            err <- [| Core.internalError $ "Unmatched " <> show $(pure nameE) |]
             pure $ CaseE nameE $ map mkMatch xs <> [Match WildP (NormalB err) []]
             where
                 mkMatch n = Match (textToPat $ f n) (NormalB $ textToExp n) []

--- a/dhall/src/Dhall/TH.hs
+++ b/dhall/src/Dhall/TH.hs
@@ -313,7 +313,7 @@ toConstructor GenerateOptions{..} haskellTypes outerTypeName (constructorName, m
             let process (key, dhallFieldType) = do
                     haskellFieldType <- toNestedHaskellType haskellTypes dhallFieldType
 
-                    return (Syntax.mkName (Text.unpack key), bang, haskellFieldType)
+                    return (Syntax.mkName (Text.unpack $ fieldModifier key), bang, haskellFieldType)
 
             varBangTypes <- traverse process (Dhall.Map.toList $ Core.recordFieldValue <$> kts)
 
@@ -399,7 +399,7 @@ defaultGenerateOptions = GenerateOptions
     { constructorModifier = id
     , fieldModifier = id
     , generateFromDhallInstance = True
-    , generateToDhallInstance = False
+    , generateToDhallInstance = True
     }
 
 generateToInterpretOptions :: GenerateOptions -> HaskellType (Expr s a) -> Q Exp

--- a/dhall/src/Dhall/TH.hs
+++ b/dhall/src/Dhall/TH.hs
@@ -442,7 +442,7 @@ generateToInterpretOptions GenerateOptions{..} haskellType = [| Dhall.InterpretO
 
         toCases :: (Text -> Text) -> [Text] -> Q Exp
         toCases f xs = do
-            err <- [| Core.internalError $ "Unmatched " <> show $(pure nameE) |]
+            err <- [| Core.internalError $ "Unmatched " <> Text.pack (show $(pure nameE)) |]
             pure $ CaseE nameE $ map mkMatch xs <> [Match WildP (NormalB err) []]
             where
                 mkMatch n = Match (textToPat $ f n) (NormalB $ textToExp n) []

--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -21,8 +21,8 @@ deriving instance Eq   T
 deriving instance Show T
 
 Dhall.TH.makeHaskellTypes
-    [ MultipleConstructors "Department" "./tests/th/Department.dhall"
-    , SingleConstructor "Employee" "MakeEmployee" "./tests/th/Employee.dhall"
+    [ MultipleConstructors "Department" True True "./tests/th/Department.dhall"
+    , SingleConstructor "Employee" "MakeEmployee" True True "./tests/th/Employee.dhall"
     ]
 
 deriving instance Eq   Department
@@ -32,9 +32,9 @@ deriving instance Eq   Employee
 deriving instance Show Employee
 
 Dhall.TH.makeHaskellTypes
-  [ SingleConstructor "Bar" "MakeBar" "(./tests/th/issue2066.dhall).Bar"
-  , SingleConstructor "Foo" "MakeFoo" "(./tests/th/issue2066.dhall).Foo"
-  , MultipleConstructors "Qux" "(./tests/th/issue2066.dhall).Qux"
+  [ SingleConstructor "Bar" "MakeBar" True True "(./tests/th/issue2066.dhall).Bar"
+  , SingleConstructor "Foo" "MakeFoo" True True "(./tests/th/issue2066.dhall).Foo"
+  , MultipleConstructors "Qux" True True "(./tests/th/issue2066.dhall).Qux"
   ]
 
 deriving instance Eq   Bar

--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -7,9 +7,12 @@
 
 module Dhall.Test.TH where
 
+import Control.Exception (throwIO)
+import Data.Either.Validation (Validation(..))
 import Dhall.TH   (HaskellType (..))
 import Test.Tasty (TestTree)
 
+import qualified Data.Text
 import qualified Dhall
 import qualified Dhall.TH
 import qualified Test.Tasty       as Tasty
@@ -70,3 +73,83 @@ makeHaskellTypeFromUnion = Tasty.HUnit.testCase "makeHaskellTypeFromUnion" $ do
     qux <- Dhall.input Dhall.auto "let T = ./tests/th/issue2066.dhall in T.Qux.Foo { foo = +2, bar = { baz = +3 } }"
 
     Tasty.HUnit.assertEqual "" qux (Foo MakeFoo{ foo = 2, bar = MakeBar{ baz = 3 } })
+
+Dhall.TH.makeHaskellTypesWith (Dhall.TH.defaultGenerateOptions
+    { Dhall.TH.constructorModifier = ("My" <>)
+    , Dhall.TH.fieldModifier = ("my" <>) . Data.Text.toTitle
+    })
+    [ MultipleConstructors "MyT" "./tests/th/example.dhall"
+    , MultipleConstructors "MyDepartment" "./tests/th/Department.dhall"
+    , SingleConstructor "MyEmployee" "Employee" "./tests/th/Employee.dhall"
+    ]
+
+deriving instance Eq   MyT
+deriving instance Eq   MyDepartment
+deriving instance Eq   MyEmployee
+deriving instance Show MyT
+deriving instance Show MyDepartment
+deriving instance Show MyEmployee
+
+testMakeHaskellTypesWith :: TestTree
+testMakeHaskellTypesWith = Tasty.HUnit.testCase "makeHaskellTypesWith" $ do
+    let text0 = "let T = ./tests/th/example.dhall in T.A { x = True, y = [] : List Text }"
+        ref0 = MyA{ myX = True, myY = [] }
+    myTest text0 ref0
+
+    let text1 = "let T = ./tests/th/example.dhall in T.B (None (List Natural))"
+        ref1 = MyB Nothing
+    myTest text1 ref1
+
+    let text2 = "let T = ./tests/th/example.dhall in T.C"
+        ref2 = MyC
+    myTest text2 ref2
+
+    let textDepartment = "let T = ./tests/th/Department.dhall in T.Sales"
+        refDepartment = MySales
+    myTest textDepartment refDepartment
+
+    let textEmployee = "let T = ./tests/th/Department.dhall in T.Sales"
+        refEmployee = MyEmployee{ myName = "", myDepartment = MySales }
+    myTest textEmployee refEmployee
+    where
+        myTest text ref = do
+            expr <- Dhall.inputExpr text
+            t <- case Dhall.extract Dhall.auto expr of
+                Failure e -> throwIO e
+                Success t -> return t
+
+            Tasty.HUnit.assertEqual "" t ref
+            Tasty.HUnit.assertEqual "" expr $ Dhall.embed Dhall.inject ref
+
+Dhall.TH.makeHaskellTypesWith (Dhall.TH.defaultGenerateOptions
+    { Dhall.TH.constructorModifier = ("NoFromDhall" <>)
+    , Dhall.TH.fieldModifier = ("noFromDhall" <>) . Data.Text.toTitle
+    , Dhall.TH.generateFromDhallInstance = False
+    })
+    [ MultipleConstructors "NoFromDhallT" "./tests/th/example.dhall"
+    ]
+
+instance Dhall.FromDhall NoFromDhallT
+
+Dhall.TH.makeHaskellTypesWith (Dhall.TH.defaultGenerateOptions
+    { Dhall.TH.constructorModifier = ("NoToDhall" <>)
+    , Dhall.TH.fieldModifier = ("noToDhall" <>) . Data.Text.toTitle
+    , Dhall.TH.generateToDhallInstance = False
+    })
+    [ MultipleConstructors "NoToDhallT" "./tests/th/example.dhall"
+    ]
+
+instance Dhall.ToDhall NoToDhallT
+
+Dhall.TH.makeHaskellTypesWith (Dhall.TH.defaultGenerateOptions
+    { Dhall.TH.constructorModifier = ("NoInstances" <>)
+    , Dhall.TH.fieldModifier = ("noInstances" <>) . Data.Text.toTitle
+    , Dhall.TH.generateFromDhallInstance = False
+    , Dhall.TH.generateToDhallInstance = False
+    })
+    [ MultipleConstructors "NoInstancesT" "./tests/th/example.dhall"
+    ]
+
+deriving instance Dhall.Generic NoInstancesT
+instance Dhall.FromDhall NoInstancesT
+instance Dhall.ToDhall NoInstancesT

--- a/dhall/tests/Dhall/Test/TH.hs
+++ b/dhall/tests/Dhall/Test/TH.hs
@@ -21,8 +21,8 @@ deriving instance Eq   T
 deriving instance Show T
 
 Dhall.TH.makeHaskellTypes
-    [ MultipleConstructors "Department" True True "./tests/th/Department.dhall"
-    , SingleConstructor "Employee" "MakeEmployee" True True "./tests/th/Employee.dhall"
+    [ MultipleConstructors "Department" "./tests/th/Department.dhall"
+    , SingleConstructor "Employee" "MakeEmployee" "./tests/th/Employee.dhall"
     ]
 
 deriving instance Eq   Department
@@ -32,9 +32,9 @@ deriving instance Eq   Employee
 deriving instance Show Employee
 
 Dhall.TH.makeHaskellTypes
-  [ SingleConstructor "Bar" "MakeBar" True True "(./tests/th/issue2066.dhall).Bar"
-  , SingleConstructor "Foo" "MakeFoo" True True "(./tests/th/issue2066.dhall).Foo"
-  , MultipleConstructors "Qux" True True "(./tests/th/issue2066.dhall).Qux"
+  [ SingleConstructor "Bar" "MakeBar" "(./tests/th/issue2066.dhall).Bar"
+  , SingleConstructor "Foo" "MakeFoo" "(./tests/th/issue2066.dhall).Foo"
+  , MultipleConstructors "Qux" "(./tests/th/issue2066.dhall).Qux"
   ]
 
 deriving instance Eq   Bar


### PR DESCRIPTION
This commit adds two fields to both constructors of
`Dhall.TH.HaskellType`:
- One flag to control whether a `FromDhall`
instance will be generated.
- The other one controls whether a `ToDhall` instance will be generated.

Fixes: #2262 