### PR TITLE
Fix equivalence check for `Date`/`Time`/`TimeZone`

### DIFF
--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -981,6 +981,18 @@ conv !env t0 t0' =
             conv env t t'
         (VTextReplace a b c, VTextReplace a' b' c') ->
             conv env a a' && conv env b b' && conv env c c'
+        (VDate, VDate) ->
+            True
+        (VDateLiteral l, VDateLiteral r) ->
+            l == r
+        (VTime, VTime) ->
+            True
+        (VTimeLiteral tl pl, VTimeLiteral tr pr) ->
+            tl == tr && pl == pr
+        (VTimeZone, VTimeZone) ->
+            True
+        (VTimeZoneLiteral l, VTimeZoneLiteral r) ->
+            l == r
         (VList a, VList a') ->
             conv env a a'
         (VListLit _ xs, VListLit _ xs') ->

--- a/dhall/tests/Dhall/Test/TypeInference.hs
+++ b/dhall/tests/Dhall/Test/TypeInference.hs
@@ -97,6 +97,11 @@ successTest prefix = do
 
         Tasty.HUnit.assertEqual message resolvedExpectedType inferredType
 
+        -- We also add this to exercise the `Dhall.Eval.conv` code path, since
+        -- it's easy to forget to update it when adding new syntax
+        _ <- Core.throws (TypeCheck.typeOf (Core.Annot resolvedExpr resolvedExpectedType))
+        return ()
+
 failureTest :: Text -> TestTree
 failureTest prefix = do
     let expectedFailures =


### PR DESCRIPTION
This is fixing a bug where a temporal literal fails to type-check
when given a type annotation (or more generally, when the type-checker
checks it against an expected type).

For example, the expression `00:00:00 : Date` would not type-check.

The reason why is that `Dhall.Eval.conv` was missing cases for
the `Date` / `Time` / `TimeZone` types and their respective literals,
which this change fixes.

I also fixed the test suite to catch future issues like this.  We do
have standard tests that check that temporal literals against
expected types, but we were running the tests in such a way that we
were not exercising the `Dhall.Eval.conv` code path that had this
bug.

So I updated the test suite so that it now catches this issue and
future issues like this.  I verified that the updated test suite
now fails without this fix and passes with the fix.