### PR TITLE
Add `FromDhall`/`ToDhall` for `LocalTime`/`ZonedTime`/`UTCTime`

### DIFF
--- a/dhall/src/Dhall/Marshal/Encode.hs
+++ b/dhall/src/Dhall/Marshal/Encode.hs
@@ -333,6 +333,26 @@ instance ToDhall Time.TimeZone where
 
         declared = TimeZone
 
+instance ToDhall Time.LocalTime where
+    injectWith _ = recordEncoder $
+      adapt
+        >$< encodeField "date"
+        >*< encodeField "time"
+      where
+        adapt (Time.LocalTime date time) = (date, time)
+
+instance ToDhall Time.ZonedTime where
+    injectWith _ = recordEncoder $
+      adapt
+        >$< encodeField "date"
+        >*< encodeField "time"
+        >*< encodeField "timeZone"
+      where
+        adapt (Time.ZonedTime (Time.LocalTime date time) timeZone) = (date, (time, timeZone))
+
+instance ToDhall Time.UTCTime where
+    injectWith = contramap (Time.utcToZonedTime Time.utc) . injectWith
+
 {-| Note that the output list will be sorted.
 
 >>> let x = Data.Set.fromList ["mom", "hi" :: Text]


### PR DESCRIPTION
Follow up to #2286.

One thing to discuss is how to handle decoding `UTCTime`. Right now, any input timezone is accepted, and then converted to UTC. One could also argue that only the `00:00` input timezone should be accepted, with an error thrown otherwise. I would be fine with both approaches.