### PR TITLE
change dhall-nix to generate FOD for URL imports

### DIFF
--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -27,11 +27,13 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                      >= 4.11.0.0 && < 5   ,
+        bytestring                                     ,
         containers                               < 0.7 ,
         data-fix                                 < 0.4 ,
         dhall                     >= 1.40     && < 1.41,
         hnix                      >= 0.7      && < 0.15,
         lens-family-core          >= 1.0.0    && < 2.2 ,
+        memory                                         ,
         neat-interpolation                       < 0.6 ,
         text                      >= 0.8.0.0  && < 1.3
     Exposed-Modules:

--- a/dhall-nix/exec/Main.hs
+++ b/dhall-nix/exec/Main.hs
@@ -48,14 +48,20 @@ main = handle (Dhall.detailed (do
         Left  err  -> Control.Exception.throwIO err
         Right expr -> return expr
 
-    expr' <- Dhall.Import.load expr
-    case Dhall.TypeCheck.typeOf expr' of
-        Left  err -> Control.Exception.throwIO err
-        Right _   -> return ()
+    -- expr' <- Dhall.Import.load expr
+    -- case Dhall.TypeCheck.typeOf expr' of
+    --     Left  err -> Control.Exception.throwIO err
+    --     Right _   -> return ()
 
-    nix <- case Dhall.Nix.dhallToNix expr' of
+    -- nix <- case Dhall.Nix.dhallToNix expr' of
+    --     Left err  -> Control.Exception.throwIO err
+    --     Right nix -> return nix
+
+    nix <- case Dhall.Nix.dhallToNix expr of
         Left err  -> Control.Exception.throwIO err
         Right nix -> return nix
+
+
     print (Nix.Pretty.prettyNix nix) ))
 
 handle :: IO a -> IO a

--- a/dhall-nix/src/Dhall/Nix.hs
+++ b/dhall-nix/src/Dhall/Nix.hs
@@ -739,7 +739,9 @@ dhallToNix e =
                             , ("postFetch",
                                 mkStrAntiquote
                                   [ Antiquoted "dhall"
-                                  , Plain "/bin/dhall encoded --file \"$downloadedFile\" > $out"
+                                  , Plain "/bin/dhall normalize --alpha --file \"$downloadedFile\" | "
+                                  , Antiquoted "dhall"
+                                  , Plain "/bin/dhall encode > $out"
                                   ]
                               )
                             ]

--- a/dhall-nix/src/Dhall/Nix.hs
+++ b/dhall-nix/src/Dhall/Nix.hs
@@ -739,7 +739,7 @@ dhallToNix e =
                             , ("postFetch",
                                 mkStrAntiquote
                                   [ Antiquoted "dhall"
-                                  , Plain "/bin/dhall normalize --alpha --file \"$downloadedFile\" | "
+                                  , Plain "/bin/dhall --alpha --plain --file \"$downloadedFile\" | "
                                   , Antiquoted "dhall"
                                   , Plain "/bin/dhall encode > $out"
                                   ]

--- a/dhall-nix/src/Dhall/Nix.hs
+++ b/dhall-nix/src/Dhall/Nix.hs
@@ -136,9 +136,11 @@ import Nix.Expr
     )
 import Nix.Expr.Shorthands
     ( attrsE
+    , inherit
     , letE
     , mkBool
     , mkFunction
+    , mkNonRecSet
     , mkParamset
     , mkSym
     , mkStr
@@ -254,6 +256,7 @@ dhallToNix e =
             (mkParamset
               [ ("dhallToNixUrlFOD", Nothing)
               , ("fetchurl", Nothing)
+              , ("runCommand", Nothing)
               , ("dhall", Nothing)
               ]
               False
@@ -750,6 +753,16 @@ dhallToNix e =
                             , Plain "\" > $out"
                             ]
                         )
+                      ) @@
+                      ( mkNonRecSet
+                          [ inherit
+                              [ "dhallToNixUrlFOD"
+                              , "fetchurl"
+                              , "runCommand"
+                              , "dhall"
+                              ]
+                              (Nix.SourcePos "unknown" (Nix.mkPos 1) (Nix.mkPos 1))
+                          ]
                       )
 
 mkStrAntiquote :: [ Antiquoted Text (Fix NExprF) ] -> Fix NExprF

--- a/example-purescript-package/.gitignore
+++ b/example-purescript-package/.gitignore
@@ -1,0 +1,10 @@
+/bower_components/
+/node_modules/
+/.pulp-cache/
+/output/
+/generated-docs/
+/.psc-package/
+/.psc*
+/.purs*
+/.psa*
+/.spago

--- a/example-purescript-package/packages.dhall
+++ b/example-purescript-package/packages.dhall
@@ -1,0 +1,4 @@
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20210905/packages.dhall sha256:140f3630801f2b02d5f3a405d4872e0af317e4ef187016a6b00f97d59d6275c6
+
+in  upstream

--- a/example-purescript-package/spago.dhall
+++ b/example-purescript-package/spago.dhall
@@ -1,0 +1,17 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+
+Need help? See the following resources:
+- Spago documentation: https://github.com/purescript/spago
+- Dhall language tour: https://docs.dhall-lang.org/tutorials/Language-Tour.html
+
+When creating a new Spago project, you can use
+`spago init --no-comments` or `spago init -C`
+to generate this file without the comments in this block.
+-}
+{ name = "my-project"
+, dependencies = [ "console", "effect", "prelude", "psci-support" ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/example-purescript-package/spago2.dhall
+++ b/example-purescript-package/spago2.dhall
@@ -1,0 +1,6 @@
+{ name = "my-project"
+, dependencies = [ "console", "effect", "prelude", "psci-support" ]
+, packages = https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20210905/packages.dhall sha256:140f3630801f2b02d5f3a405d4872e0af317e4ef187016a6b00f97d59d6275c6
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}
+

--- a/example-purescript-package/src/Main.purs
+++ b/example-purescript-package/src/Main.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+
+main :: Effect Unit
+main = do
+  log "🍝"

--- a/example-purescript-package/test/Main.purs
+++ b/example-purescript-package/test/Main.purs
@@ -1,0 +1,11 @@
+module Test.Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Class.Console (log)
+
+main :: Effect Unit
+main = do
+  log "🍝"
+  log "You should add some tests."

--- a/example.nix
+++ b/example.nix
@@ -1,0 +1,53 @@
+with import <nixpkgs> {};
+
+
+# spago:
+# { name = "my-project"
+# , dependencies = [ "console", "effect", "prelude", "psci-support" ]
+# , packages = https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20210905/packages.dhall sha256:140f3630801f2b02d5f3a405d4872e0af317e4ef187016a6b00f97d59d6275c6
+# , sources = [ "src/**/*.purs", "test/**/*.purs" ]
+# }
+
+# turns into nix:
+# {
+#   dependencies = [ "console" "effect" "prelude" "psci-support" ];
+#   name = "my-project";
+#   packages = {};
+#   packages =
+#     dhallToNixUrlFOD (
+#       let
+#         packageSet = fetchurl {
+#           url = "https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20210905/packages.dhall";
+#           hash = "sha256-FA82MIAfKwLV86QF1IcuCvMX5O8YcBamsA+X1Z1idcY=";
+#           downloadToTemp = true;
+#           postFetch = ''
+#             ${dhall}/bin/dhall encode --file "$downloadedFile" > $out
+#           '';
+#         };
+#       in
+#         runCommand "decodedPackageSet" {} ''
+#           ${dhall}/bin/dhall decode --file "${packageSet}" > $out
+#         '';
+#     )
+#   sources = [ "src/**/*.purs" "test/**/*.purs" ];
+# }
+
+let
+  _dhallToNixUrlFOD = dhallFile:
+    let
+      drv = stdenv.mkDerivation {
+        name = "dhall-compiled.nix";
+
+        buildCommand = ''
+          dhall-to-nix <<< "${dhallFile}" > $out
+        '';
+
+        buildInputs = [ dhall-nix ];
+      };
+    in
+      import drv;
+
+  dhallToNixUrlFOD = _dhallToNixUrlFOD;
+in
+
+dhallToNixUrlFOD ~/temp/temp-purescript-pacakge/spago2.dhall

--- a/example.nix
+++ b/example.nix
@@ -33,43 +33,10 @@ let
 
   dhallToNixUrlFOD = _dhallToNixUrlFOD;
 
-  xxx =
-    { dhallToNixUrlFOD, fetchurl, runCommand, dhall }:
-    {
-      dependencies = [ "console" "effect" "prelude" "psci-support" ];
-      name = "my-project";
-      packages =
-        dhallToNixUrlFOD (
-          let
-            packageSet =
-              (fetchurl {
-                url = "https://gist.githubusercontent.com/cdepillabout/2683131f078753fd24723ab8bf1e1b74/raw/0de0be4b0238974a33aac07580338105fa5c42e1/example-remote-import.dhall";
-                hash = "sha256-W1WfXQXIvufW57F5N7fxqRvi/YMBdvlnwlFn4eMyVLc=";
-                downloadToTemp = true;
-                postFetch = ''
-                  env | sort
-                  ${dhall}/bin/dhall --alpha --plain --file "$downloadedFile" | ${dhall}/bin/dhall encode > $out
-                '';
-              }).overrideAttrs (oldAttrs: {
-                SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-                NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-                nativeBuildInputs = (oldAttrs.nativeBuildInputs or []) ++ [ cacert ];
-              });
-          in runCommand "decodedPackageSet" {} "${dhall}/bin/dhall decode --file \"${packageSet}\" > \$out") {
-        inherit dhallToNixUrlFOD fetchurl runCommand dhall;
-      };
-      sources = [ "src/**/*.purs" "test/**/*.purs" ];
-    };
-
 in
 
-# dhallToNixUrlFOD ./example-purescript-package/spago2.dhall {
+dhallToNixUrlFOD ./example-purescript-package/spago2.dhall {
 # dhallToNixUrlFOD ./example-spago2.dhall {
-#   inherit dhallToNixUrlFOD fetchurl runCommand;
-#   dhall = myDhall;
-# }
-
-xxx {
-  inherit dhallToNixUrlFOD fetchurl runCommand;
+  inherit dhallToNixUrlFOD cacert fetchurl runCommand;
   dhall = myDhall;
 }


### PR DESCRIPTION
I'd like to be able to sue `dhall-nix` to generate Nix code from a derivation, and then recursively import it (IFD).  The problem with this is that remote URL imports in Dhall can't be resolved in a Nix derivation unless you make it a fixed-output derivation.

Luckily, if remote URL imports in Dhall have an integrity check, then we can make them into fixed-output derivation.

Currently, this PR modifies `dhall-nix` to generate Nix code that turns remote imports with an integrity check into fixed output derivations.  It then recursively imports them.

For example, imagine the following Dhall file:

`example-remote-import.dhall`:

```dhall
[   1
  + https://gist.githubusercontent.com/cdepillabout/2683131f078753fd24723ab8bf1e1b74/raw/7e1b26ff812000e868a4ff108b33a21d03a9a591/example-normal.dhall
      sha256:15f52ecf91c94c1baac02d5a4964b2ed8fa401641a2c8a95e8306ec7c1e3b8d2
, 3
]
```

If you look at https://gist.githubusercontent.com/cdepillabout/2683131f078753fd24723ab8bf1e1b74/raw/7e1b26ff812000e868a4ff108b33a21d03a9a591/example-normal.dhall, it is just:

```dhall
List/length Natural [ 100, 200, 300 ]
```

Running `nix-dhall` from this PR on `example-remote-import.dhall` will produce an output like the following:

```nix
{ dhallToNixUrlFOD, cacert, dhall, fetchurl, runCommand }:
  [
    (1 + dhallToNixUrlFOD (let
      packageSet = (fetchurl {
        url = "https://gist.githubusercontent.com/cdepillabout/2683131f078753fd24723ab8bf1e1b74/raw/7e1b26ff812000e868a4ff108b33a21d03a9a591/example-normal.dhall";
        hash = "sha256-FfUuz5HJTBuqwC1aSWSy7Y+kAWQaLIqV6DBux8HjuNI=";
        downloadToTemp = true;
        postFetch = "${dhall}/bin/dhall --alpha --plain --file \"\$downloadedFile\" | ${dhall}/bin/dhall encode > \$out";
        }).overrideAttrs (oldAttrs:
        {
          nativeBuildInputs = (oldAttrs.nativeBuildInputs or []) ++ [ cacert ];
          });
    in runCommand "decodedPackageSet" {} "${dhall}/bin/dhall decode --file \"${packageSet}\" > \$out") {
      inherit dhallToNixUrlFOD cacert dhall fetchurl runCommand;
      })
    3
    ]
```

There are two new things here:

1. With the current code in this PR, `dhall-nix` now produces a function that takes the following arguments:

    ```nix
    { dhallToNixUrlFOD, cacert, dhall, fetchurl, runCommand }:
    ```

    These values are used in the code for recursively importing remote URLs from Dhall.

1. Remote URLs with an integrity check in Dhall are generated into an expression like the following:

    ```nix
    dhallToNixUrlFOD
      ( let
          packageSet =
            (fetchurl {
              url = "https://gist.githubusercontent.com/cdepillabout/2683131f078753fd24723ab8bf1e1b74/raw/7e1b26ff812000e868a4ff108b33a21d03a9a591/example-normal.dhall";
              hash = "sha256-FfUuz5HJTBuqwC1aSWSy7Y+kAWQaLIqV6DBux8HjuNI=";
            downloadToTemp = true;
              postFetch = "${dhall}/bin/dhall --alpha --plain --file \"\$downloadedFile\" | ${dhall}/bin/dhall encode > \$out";
            }).overrideAttrs (oldAttrs: {
              nativeBuildInputs = (oldAttrs.nativeBuildInputs or []) ++ [ cacert ];
            });
        in
        runCommand "decodedPackageSet" {} "${dhall}/bin/dhall decode --file \"${packageSet}\" > \$out"
      )
      { inherit dhallToNixUrlFOD cacert dhall fetchurl runCommand; }
    ```

    The code in this PR changes Dhall integrity checks into a hash that Nix understands, and throws it into a call to `fetchurl`.  It normalizes the result and encodes it so the hash matches.  It then decodes it.

    This derivation is then passed into a function I'm calling `dhallToNixUrlFOD`.

    You can find a proof-of-concept definition of `dhallToNixUrlFOD` in the file `example.nix` in this PR.  It is basically the same as [`dhallToNix` in Nixpkgs](https://github.com/NixOS/nixpkgs/blob/9a8850aea97840dca1cc1087447ed89dbfe183dc/pkgs/build-support/dhall-to-nix.nix).