### PR TITLE
Support *ENV.dhall for import failure tests

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -682,6 +682,7 @@ Test-Suite tasty
         serialise                                      ,
         special-values                           < 0.2 ,
         spoon                                    < 0.4 ,
+        system-filepath                                ,
         tasty                     >= 0.11.2   && < 1.5 ,
         tasty-expected-failure                   < 0.13,
         tasty-hunit               >= 0.10     && < 0.11,


### PR DESCRIPTION
Required for https://github.com/dhall-lang/dhall-lang/pull/1229

Given that this will quietly ignore any *ENV.dhall test cases, I wonder if we should add a dot to the suffix to avoid any surprises (i.e. `testName.ENV.dhall` instead of `testNameENV.dhall`)