### PR TITLE
Allow aeson 2.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,17 +1,1 @@
-packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-docs ./dhall-openapi ./dhall-csv ./dhall-toml
-
-source-repository-package
-    type: git
-    location: https://github.com/sjakobi/cborg
-    tag: 2e6e616
-    subdir: cborg-json
-
-source-repository-package
-    type: git
-    location: https://github.com/clovyr/aeson-yaml
-    tag: edabce7
-
-source-repository-package
-    type: git
-    location: https://github.com/hasufell/HsYAML-aeson
-    tag: b4b4ab8
+packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-lsp-server ./dhall-nix ./dhall-docs ./dhall-openapi ./dhall-nixpkgs ./dhall-csv ./dhall-toml

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,17 @@
-packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-lsp-server ./dhall-nix ./dhall-docs ./dhall-openapi ./dhall-nixpkgs ./dhall-csv ./dhall-toml
+packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-docs ./dhall-openapi ./dhall-csv ./dhall-toml
+
+source-repository-package
+    type: git
+    location: https://github.com/sjakobi/cborg
+    tag: 2e6e616
+    subdir: cborg-json
+
+source-repository-package
+    type: git
+    location: https://github.com/clovyr/aeson-yaml
+    tag: edabce7
+
+source-repository-package
+    type: git
+    location: https://github.com/hasufell/HsYAML-aeson
+    tag: b4b4ab8

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -38,7 +38,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                      >= 4.11.0.0  && < 5   ,
-        aeson                     >= 1.4.6.0   && < 1.6 ,
+        aeson                     >= 1.4.6.0   && < 2.1 ,
         aeson-pretty                              < 0.9 ,
         aeson-yaml                >= 1.1.0     && < 1.2 ,
         bytestring                                < 0.12,
@@ -59,6 +59,7 @@ Library
         Dhall.JSON.Yaml
         Dhall.DhallToYaml.Main
     Other-Modules:
+        Dhall.JSON.Compat
         Dhall.JSON.Util
     GHC-Options: -Wall
     Default-Language: Haskell2010

--- a/dhall-json/src/Dhall/JSON.hs
+++ b/dhall-json/src/Dhall/JSON.hs
@@ -230,7 +230,6 @@ import Prettyprinter       (Pretty)
 
 import qualified Data.Aeson                as Aeson
 import qualified Data.Foldable             as Foldable
-import qualified Data.HashMap.Strict       as HashMap
 import qualified Data.List
 import qualified Data.Map
 import qualified Data.Ord
@@ -238,6 +237,7 @@ import qualified Data.Text
 import qualified Data.Vector               as Vector
 import qualified Dhall.Core                as Core
 import qualified Dhall.Import
+import qualified Dhall.JSON.Compat         as JSON.Compat
 import qualified Dhall.Map
 import qualified Dhall.Optics
 import qualified Dhall.Parser
@@ -536,7 +536,7 @@ dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
 
                         ys <- traverse inner (Foldable.toList xs)
 
-                        return (Aeson.Object (HashMap.fromList ys))
+                        return (Aeson.Object (JSON.Compat.objectFromList ys))
                     outer (Core.App (Core.Field (V 0) (FA "number")) (Core.DoubleLit (DhallDouble n))) =
                         return (Aeson.toJSON n)
                     outer (Core.App (Core.Field (V 0) (FA "string")) (Core.TextLit (Core.Chunks [] text))) =
@@ -581,7 +581,7 @@ dhallToJSON e0 = loop (Core.alphaNormalize (Core.normalize e0))
 
                         ys <- traverse inner (Foldable.toList xs)
 
-                        return (Aeson.Object (HashMap.fromList ys))
+                        return (Aeson.Object (JSON.Compat.objectFromList ys))
                     outer (Core.App (Core.Field (V 0) (FA "double")) (Core.DoubleLit (DhallDouble n))) =
                         return (Aeson.toJSON n)
                     outer (Core.App (Core.Field (V 0) (FA "integer")) (Core.IntegerLit n)) =
@@ -635,7 +635,7 @@ toOrderedList =
 omitNull :: Value -> Value
 omitNull (Object object) = Object fields
   where
-    fields =HashMap.filter (/= Null) (fmap omitNull object)
+    fields = JSON.Compat.filterObject (/= Null) (fmap omitNull object)
 omitNull (Array array) =
     Array (fmap omitNull array)
 omitNull (String string) =
@@ -654,7 +654,7 @@ omitEmpty :: Value -> Value
 omitEmpty (Object object) =
     if null fields then Null else Object fields
   where
-    fields = HashMap.filter (/= Null) (fmap omitEmpty object)
+    fields = JSON.Compat.filterObject (/= Null) (fmap omitEmpty object)
 omitEmpty (Array array) =
     if null elems then Null else Array elems
   where

--- a/dhall-json/src/Dhall/JSON/Compat.hs
+++ b/dhall-json/src/Dhall/JSON/Compat.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE CPP #-}
+
+-- | Compatibility helpers for the @aeson-2@ migration.
+module Dhall.JSON.Compat (
+      objectFromList
+    , mapToAscList
+    , filterObject
+    , lookupObject
+    , traverseObjectWithKey
+    , objectKeys
+    , textToKey
+    ) where
+
+import Data.Aeson (Object, Value)
+import Data.Text  (Text)
+
+#if MIN_VERSION_aeson(2,0,0)
+import           Data.Aeson.Key    (Key)
+import qualified Data.Aeson.Key    as Key
+import           Data.Aeson.KeyMap (KeyMap)
+import qualified Data.Aeson.KeyMap as KeyMap
+import           Data.Bifunctor    (first)
+#else
+import           Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.List           as List
+#endif
+
+objectFromList :: [(Text, Value)] -> Object
+#if MIN_VERSION_aeson(2,0,0)
+objectFromList = KeyMap.fromList . map (first Key.fromText)
+#else
+objectFromList = HashMap.fromList
+#endif
+
+filterObject :: (Value -> Bool) -> Object -> Object
+#if MIN_VERSION_aeson(2,0,0)
+filterObject = KeyMap.filter
+#else
+filterObject = HashMap.filter
+#endif
+
+#if MIN_VERSION_aeson(2,0,0)
+mapToAscList :: KeyMap a -> [(Text, a)]
+mapToAscList = map (first Key.toText) . KeyMap.toAscList
+#else
+mapToAscList :: HashMap Text a -> [(Text, a)]
+mapToAscList = List.sortOn fst . HashMap.toList
+#endif
+
+lookupObject :: Text -> Object -> Maybe Value
+#if MIN_VERSION_aeson(2,0,0)
+lookupObject k = KeyMap.lookup (Key.fromText k)
+#else
+lookupObject = HashMap.lookup
+#endif
+
+objectKeys :: Object -> [Text]
+#if MIN_VERSION_aeson(2,0,0)
+objectKeys = map (Key.toText) . KeyMap.keys
+#else
+objectKeys = HashMap.keys
+#endif
+
+#if MIN_VERSION_aeson(2,0,0)
+textToKey :: Text -> Key
+textToKey = Key.fromText
+#else
+textToKey :: Text -> Text
+textToKey = id
+#endif
+
+#if MIN_VERSION_aeson(2,0,0)
+traverseObjectWithKey :: Applicative f => (Key -> v1 -> f v2) -> KeyMap v1 -> f (KeyMap v2)
+traverseObjectWithKey = KeyMap.traverseWithKey
+#else
+traverseObjectWithKey :: Applicative f => (Text -> v1 -> f v2) -> HashMap Text v1 -> f (HashMap Text v2)
+traverseObjectWithKey = HashMap.traverseWithKey
+#endif

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -17,7 +17,7 @@ Build-Type:          Simple
 Executable dhall-to-nixpkgs
   Main-Is:             Main.hs
   Build-Depends:       base                 >= 4.11     && < 5
-                     , aeson                >= 1.0.0.0  && < 1.6
+                     , aeson                >= 1.0.0.0  && < 2.1
                      , bytestring                          < 0.12
                      , data-fix
                      , dhall                >= 1.32.0   && < 1.41

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -77,7 +77,7 @@ Library
   Ghc-Options: -Wall
   Build-Depends:
     base                    >= 4.11.0.0  && < 5    ,
-    aeson                   >= 1.0.0.0   && < 1.6  ,
+    aeson                   >= 1.0.0.0   && < 2.1  ,
     containers              >= 0.5.8.0   && < 0.7  ,
     dhall                   >= 1.38.0    && < 1.41 ,
     prettyprinter           >= 1.7.0     && < 1.8  ,

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -34,7 +34,7 @@ Library
         HsYAML                    >= 0.2       && < 0.3 ,
         HsYAML-aeson              >= 0.2       && < 0.3 ,
         base                      >= 4.11.0.0  && < 5   ,
-        aeson                     >= 1.0.0.0   && < 1.6 ,
+        aeson                     >= 1.0.0.0   && < 2.1 ,
         bytestring                                < 0.12,
         dhall                     >= 1.31.0    && < 1.41,
         dhall-json                >= 1.6.0     && < 1.8 ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -473,7 +473,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                        >= 4.11.0.0 && < 5   ,
-        aeson                       >= 1.0.0.0  && < 1.6 ,
+        aeson                       >= 1.0.0.0  && < 2.1 ,
         aeson-pretty                               < 0.9 ,
         ansi-terminal               >= 0.6.3.1  && < 0.12,
         atomic-write                >= 0.2.0.7  && < 0.3 ,


### PR DESCRIPTION
https://hackage.haskell.org/package/aeson-2.0.0.0/changelog

---

Blocked on:

* Required by `dhall`:
  * [x] https://github.com/informatikr/aeson-pretty/issues/36
  * [x] https://github.com/snoyberg/yaml/issues/201
   * [x] https://github.com/well-typed/cborg/pull/270
* Required by other packages:
  * [ ] https://github.com/clovyr/aeson-yaml/issues/16 (needs release)
  * [ ] https://github.com/haskell-hvr/HsYAML-aeson/issues/11
  * [ ] https://github.com/haskell-nix/hnix/issues/991 (needs another release. v0.15.0 is deprecated)

