### PR TITLE
Assume Swagger integer is Dhall Natural unless evidence to contrary

### DIFF
--- a/dhall-openapi/openapi-to-dhall/Main.hs
+++ b/dhall-openapi/openapi-to-dhall/Main.hs
@@ -182,9 +182,9 @@ parseNatIntExceptions =
     bimap errorBundlePretty id $ result (pack s)
   where
     parser = do
-      typ <- some (alphaNumChar)
+      typ <- some alphaNumChar
       char '.'
-      fld <- some (alphaNumChar)
+      fld <- some alphaNumChar
       return (typ, fld)
     result = parse ((Dhall.Parser.unParser parser `sepBy1` char ',') <* eof) "EXCEPTIONS"
 

--- a/dhall-openapi/openapi-to-dhall/Main.hs
+++ b/dhall-openapi/openapi-to-dhall/Main.hs
@@ -215,7 +215,7 @@ parseSplits =
         mo <- parseModel
         return mo
       return (path, model)
-    result = parse ((Dhall.Parser.unParser parser `sepBy1` char ',') <* eof) "MAPPING"
+    result = parse ((Dhall.Parser.unParser parser `sepBy1` char ',') <* eof) "SPLITS"
 
 
 parseOptions :: Options.Applicative.Parser Options
@@ -248,7 +248,7 @@ parseOptions = Options <$> parseSkip <*> parseNaturalInt <*> parseNatIntExceptio
         (  Options.Applicative.long "splitPaths"
         <> Options.Applicative.help
           "Specifiy path and model name pairs with paths being delimited by '.' and pairs separated by '=' for which \
-          \definitions should be aritifically split with a ref: \n\
+          \definitions should be artificially split with a ref: \n\
           \'(com.example.v1.Certificate).spec=com.example.v1.CertificateSpec'\n\
           \When the model name is omitted, a guess will be made based on the first word of the definition's \
           \description. Also note that top level model names in a path must use () when the name contains '.'"

--- a/dhall-openapi/openapi-to-dhall/Main.hs
+++ b/dhall-openapi/openapi-to-dhall/Main.hs
@@ -60,6 +60,7 @@ import qualified Text.Megaparsec.Char.Lexer as Megaparsec.Lexer
 -- | Top-level program options
 data Options = Options
     { skipDuplicates :: Bool
+    , preferNaturalInt :: Bool
     , prefixMap :: Data.Map.Map Prefix Dhall.Import
     , splits :: Data.Map.Map ModelHierarchy (Maybe ModelName)
     , filename :: String
@@ -205,12 +206,17 @@ parseSplits =
 
 
 parseOptions :: Options.Applicative.Parser Options
-parseOptions = Options <$> parseSkip <*> parsePrefixMap' <*> parseSplits' <*> fileArg <*> crdArg
+parseOptions = Options <$> parseSkip <*> parseNaturalInt <*> parsePrefixMap' <*> parseSplits' <*> fileArg <*> crdArg
   where
     parseSkip =
       Options.Applicative.switch
         (  Options.Applicative.long "skipDuplicates"
         <> Options.Applicative.help "Skip types with the same name when aggregating types"
+        )
+    parseNaturalInt =
+      Options.Applicative.switch
+        (  Options.Applicative.long "preferNaturalInt"
+        <> Options.Applicative.help "Render Swagger Integer as Dhall Natural unless negative numbers included in range"
         )
     parsePrefixMap' =
       option Data.Map.empty $ Options.Applicative.option parsePrefixMap
@@ -288,7 +294,7 @@ main = do
         ) defs
 
   -- Convert to Dhall types in a Map
-  let types = Convert.toTypes prefixMap (Convert.pathSplitter splits) fixedDefs
+  let types = Convert.toTypes prefixMap (Convert.pathSplitter splits) preferNaturalInt fixedDefs
 
   -- Output to types
   Directory.createDirectoryIfMissing True "types"

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -232,9 +232,9 @@ toTypes' prefixMap typeSplitter definitions toMerge
               "string"  -> (Dhall.Text, Data.Map.empty)
               "boolean" -> (Dhall.Bool, Data.Map.empty)
               "integer" -> case (minimum_ definition, exclusiveMinimum definition) of
-                (Just min_, Just True) | min_ >= -1 -> (Dhall.Natural, Data.Map.empty)
-                (Just min_, _)         | min_ >= 0 -> (Dhall.Natural, Data.Map.empty)
-                _                      -> (Dhall.Integer, Data.Map.empty)
+                (Just min_, Just True) | min_ < -1 -> (Dhall.Integer, Data.Map.empty)
+                (Just min_, _)         | min_ < 0 -> (Dhall.Integer, Data.Map.empty)
+                _                      -> (Dhall.Natural, Data.Map.empty)
               "number"  -> (Dhall.Double, Data.Map.empty)
               other     -> error $ "Found missing Swagger type: " <> Text.unpack other
             -- There are empty schemas that only have a description, so we return empty record

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -231,9 +231,12 @@ toTypes' prefixMap typeSplitter definitions toMerge
               "string"  | format definition == Just "int-or-string" -> (intOrStringType, Data.Map.empty)
               "string"  -> (Dhall.Text, Data.Map.empty)
               "boolean" -> (Dhall.Bool, Data.Map.empty)
-              "integer" -> case (minimum_ definition, exclusiveMinimum definition) of
+              "integer" -> case (minimum_ definition, exclusiveMinimum definition,
+                                 maximum_ definition, exclusiveMaximum definition) of
                 (Just min_, Just True) | min_ < -1 -> (Dhall.Integer, Data.Map.empty)
                 (Just min_, _)         | min_ < 0 -> (Dhall.Integer, Data.Map.empty)
+                (Just max_, Just True) | max_ < 1 -> (Dhall.Integer, Data.Map.empty)
+                (Just max_, _)         | max_ < 0 -> (Dhall.Integer, Data.Map.empty)
                 _                      -> (Dhall.Natural, Data.Map.empty)
               "number"  -> (Dhall.Double, Data.Map.empty)
               other     -> error $ "Found missing Swagger type: " <> Text.unpack other

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -233,10 +233,10 @@ toTypes' prefixMap typeSplitter definitions toMerge
               "boolean" -> (Dhall.Bool, Data.Map.empty)
               "integer" -> case (minimum_ definition, exclusiveMinimum definition,
                                  maximum_ definition, exclusiveMaximum definition) of
-                (Just min_, Just True) | min_ < -1 -> (Dhall.Integer, Data.Map.empty)
-                (Just min_, _)         | min_ < 0 -> (Dhall.Integer, Data.Map.empty)
-                (Just max_, Just True) | max_ < 1 -> (Dhall.Integer, Data.Map.empty)
-                (Just max_, _)         | max_ < 0 -> (Dhall.Integer, Data.Map.empty)
+                (Just min_, Just True, _, _) | min_ < -1 -> (Dhall.Integer, Data.Map.empty)
+                (Just min_, _, _, _)         | min_ < 0 -> (Dhall.Integer, Data.Map.empty)
+                (_, _, Just max_, Just True) | max_ < 1 -> (Dhall.Integer, Data.Map.empty)
+                (_, _, Just max_, _)         | max_ < 0 -> (Dhall.Integer, Data.Map.empty)
                 _                      -> (Dhall.Natural, Data.Map.empty)
               "number"  -> (Dhall.Double, Data.Map.empty)
               other     -> error $ "Found missing Swagger type: " <> Text.unpack other
@@ -442,6 +442,8 @@ data V1JSONSchemaProps =
         , v1JSONSchemaPropsFormat :: Maybe Text
         , v1JSONSchemaPropsMinimum :: Maybe Scientific
         , v1JSONSchemaPropsExclusiveMinimum :: Maybe Bool
+        , v1JSONSchemaPropsMaximum :: Maybe Scientific
+        , v1JSONSchemaPropsExclusiveMaximum :: Maybe Bool
         , v1JSONSchemaPropsItems :: Maybe Value
         , v1JSONSchemaPropsProperties :: Maybe (Data.Map.Map String V1JSONSchemaProps)
         , v1JSONSchemaPropsAdditionalProperties :: Maybe V1JSONSchemaProps
@@ -461,6 +463,8 @@ mkV1JSONSchemaProps =
         , v1JSONSchemaPropsFormat = Nothing
         , v1JSONSchemaPropsMinimum = Nothing
         , v1JSONSchemaPropsExclusiveMinimum = Nothing
+        , v1JSONSchemaPropsMaximum = Nothing
+        , v1JSONSchemaPropsExclusiveMaximum = Nothing
         , v1JSONSchemaPropsItems = Nothing
         , v1JSONSchemaPropsProperties = Nothing
         , v1JSONSchemaPropsAdditionalProperties = Nothing
@@ -532,6 +536,8 @@ toDefinition crd = fmap (\d -> (modelName, d)) definition
         , format               = v1JSONSchemaPropsFormat
         , minimum_             = v1JSONSchemaPropsMinimum
         , exclusiveMinimum     = v1JSONSchemaPropsExclusiveMinimum
+        , maximum_         = v1JSONSchemaPropsMaximum
+        , exclusiveMaximum = v1JSONSchemaPropsExclusiveMaximum
         , description          = v1JSONSchemaPropsDescription
         , items                = v1JSONSchemaPropsItems >>= parseMaybe parseJSON
         , properties           = fmap toProperties v1JSONSchemaPropsProperties

--- a/dhall-openapi/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Types.hs
@@ -44,6 +44,8 @@ data Definition = Definition
   , format               :: Maybe Text
   , minimum_             :: Maybe Scientific -- Avoid shadowing with Prelude.minimum
   , exclusiveMinimum     :: Maybe Bool
+  , maximum_         :: Maybe Scientific -- Avoid shadowing with Prelude.maximum
+  , exclusiveMaximum :: Maybe Bool
   , description          :: Maybe Text
   , items                :: Maybe Definition
   , properties           :: Maybe (Map ModelName Definition)
@@ -60,6 +62,8 @@ instance FromJSON Definition where
     format               <- o .:? "format"
     minimum_             <- o .:? "minimum"
     exclusiveMinimum     <- o .:? "exclusiveMinimum"
+    maximum_         <- o .:? "maximum"
+    exclusiveMaximum <- o .:? "exclusiveMaximum"
     properties           <- o .:? "properties"
     additionalProperties <- o .:? "additionalProperties"
     required             <- o .:? "required"


### PR DESCRIPTION
This PR reverses the assumption made when converting a Swagger spec to Dhall types about the signedness of integers. In most cases when dealing with configuration, an "integer" is meant to be a nonnegative number, be it a timeout, a port number, a count, or some other real-world quantity. Thus rather than requiring a range _excluding_ negative numbers to make a Natural, we require a range explicitly _including_ them to make an Integer.