### PR TITLE
Change dhall-hash argument to dhallHash for dhall-to-nixpkgs

### DIFF
--- a/dhall-nixpkgs/Main.hs
+++ b/dhall-nixpkgs/Main.hs
@@ -407,7 +407,7 @@ data Dependency = Dependency
       --   > buildDhallUrl {
       --   >   url = "https://some.url.to/a/dhall/file.dhall";
       --   >   hash = "sha256-ZTSiQUXpPbPfPvS8OeK6dDQE6j6NbP27ho1cg9YfENI=";
-      --   >   dhall-hash =
+      --   >   dhallHash =
       --   >     "sha256:6534a24145e93db3df3ef4bc39e2ba743404ea3e8d6cfdbb868d5c83d61f10d2";
       --   > }
     }
@@ -421,11 +421,11 @@ data Dependency = Dependency
 --   > buildDhallUrl {
 --   >   url = "https://some.url.to/a/dhall/file.dhall";
 --   >   hash = "sha256-ZTSiQUXpPbPfPvS8OeK6dDQE6j6NbP27ho1cg9YfENI=";
---   >   dhall-hash =
+--   >   dhallHash =
 --   >     "sha256:6534a24145e93db3df3ef4bc39e2ba743404ea3e8d6cfdbb868d5c83d61f10d2";
 --   > }
 --
--- The @hash@ argument is an SRI hash that Nix understands.  The @dhall-hash@
+-- The @hash@ argument is an SRI hash that Nix understands.  The @dhallHash@
 -- argument is a base-16-encoded hash that Dhall understands.
 dependencyToNixAsFOD :: URL -> SHA256Digest -> IO Dependency
 dependencyToNixAsFOD url (SHA256Digest shaBytes) = do
@@ -442,7 +442,7 @@ dependencyToNixAsFOD url (SHA256Digest shaBytes) = do
             @@  Nix.attrsE
                     [ ("url", Nix.mkStr $ Dhall.Core.pretty url)
                     , ("hash", Nix.mkStr $ Text.pack nixSRIHash)
-                    , ("dhall-hash", Nix.mkStr $ Text.pack dhallHash)
+                    , ("dhallHash", Nix.mkStr $ Text.pack dhallHash)
                     ]
 
     return Dependency{..}


### PR DESCRIPTION
Currently, `dhall-to-nixpkgs directory --fixed-output-derivations` produces a call to `buildDhallUrl` that uses the argument `dhall-hash`.

However, when adding the `buildDhallUrl` function to Nixpkgs, we decided that `dhallHash` would be a better argument name: https://github.com/NixOS/nixpkgs/pull/142825#discussion_r744340906

This PR updates `dhall-to-nixpkgs` to use the argument `dhallHash` instead of `dhall-hash`.