### PR TITLE
Support GHC 9.2

### DIFF
--- a/dhall-docs/src/Dhall/Docs/Comment.hs
+++ b/dhall-docs/src/Dhall/Docs/Comment.hs
@@ -189,7 +189,7 @@ parseDhallDocsText (BlockComment blockComment) =
         Just e -> DhallDocsText e
   where
     joinedText = Data.Text.strip $ Data.Text.unlines reIndentedLines
-    (_ : commentLines) = Data.Text.lines blockComment
+    commentLines = tail $ Data.Text.lines blockComment
 
     leadingSpaces = Data.Text.takeWhile isSpace
         where

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -511,7 +511,7 @@ Library
         repline                     >= 0.4.0.0  && < 0.5 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
-        template-haskell            >= 2.13.0.0 && < 2.18,
+        template-haskell            >= 2.13.0.0 && < 2.19,
         text                        >= 0.11.1.0 && < 1.3 ,
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
         th-lift-instances           >= 0.1.13   && < 0.2 ,


### PR DESCRIPTION
Some dependencies aren't compatible yet, so I'm currently using this incantation:

```
cabal build all -O0 -w ghc-9.2 --allow-newer=basement:base,aeson:ghc-prim,aeson:template-haskell,modern-uri:template-haskell,relude:base,relude:ghc-prim,aeson-yaml:aeson,hnix:template-haskell,hnix:time,turtle:bytestring,tomland:base,validation-selective:base
```

…and this patch (due to https://github.com/dhall-lang/dhall-haskell/issues/2270):

```diff
--- a/cabal.project
+++ b/cabal.project
@@ -1 +1 @@
-packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-lsp-server ./dhall-nix ./dhall-docs ./dhall-openapi ./dhall-nixpkgs ./dhall-csv ./dhall-toml
+packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-docs ./dhall-openapi ./dhall-nixpkgs ./dhall-csv ./dhall-toml
```

Blocked on:

* [ ] https://github.com/haskell-foundation/foundation/pull/555
* [ ] https://github.com/haskell/aeson/issues/885
* [x] https://github.com/chrisdone/lucid/pull/118
* [ ] https://github.com/mrkkrp/modern-uri/pull/43 (via `mmark` via `dhall-docs`)
* [ ] https://github.com/kowainik/relude/issues/388 (via `hnix`)
* [ ] https://github.com/clovyr/aeson-yaml/issues/16#issuecomment-940502676
* [x] https://github.com/DanBurton/lens-family-th/issues/19
* [ ] https://github.com/Gabriel439/Haskell-Turtle-Library/issues/410
* [ ] https://github.com/kowainik/tomland/issues/395
* [ ] https://github.com/Lysxia/generic-random/issues/32