### PR TITLE
Allow doctest 0.19

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -122,7 +122,7 @@ Test-Suite doctest
         base                           ,
         directory,
         filepath                 < 1.5 ,
-        doctest    >= 0.7.0   && < 0.19
+        doctest    >= 0.7.0   && < 0.20
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010
 

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -92,7 +92,7 @@ Test-Suite doctest
         base                           ,
         directory  >= 1.3.1.5 && < 1.4 ,
         filepath                 < 1.5 ,
-        doctest    >= 0.7.0   && < 0.19,
+        doctest    >= 0.7.0   && < 0.20,
         QuickCheck
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -713,7 +713,7 @@ Test-Suite doctest
         directory                     ,
         filepath                < 1.5 ,
         mockery                 < 0.4 ,
-        doctest   >= 0.7.0   && < 0.19
+        doctest   >= 0.7.0   && < 0.20
     if os(windows)
       -- https://github.com/dhall-lang/dhall-haskell/issues/2237
       Buildable: False


### PR DESCRIPTION
https://hackage.haskell.org/package/doctest-0.19.0/changelog

The changelog mentions improvements for `cabal v2`. I couldn't find any
improvements with regard to https://github.com/dhall-lang/dhall-haskell/issues/1100 though.