### PR TITLE
Remove upper bounds on doctest

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -122,7 +122,7 @@ Test-Suite doctest
         base                           ,
         directory,
         filepath                 < 1.5 ,
-        doctest    >= 0.7.0   && < 0.20
+        doctest    >= 0.7.0
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010
 

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -92,7 +92,7 @@ Test-Suite doctest
         base                           ,
         directory  >= 1.3.1.5 && < 1.4 ,
         filepath                 < 1.5 ,
-        doctest    >= 0.7.0   && < 0.20,
+        doctest    >= 0.7.0            ,
         QuickCheck
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -713,7 +713,7 @@ Test-Suite doctest
         directory                     ,
         filepath                < 1.5 ,
         mockery                 < 0.4 ,
-        doctest   >= 0.7.0   && < 0.20
+        doctest   >= 0.7.0
     if os(windows)
       -- https://github.com/dhall-lang/dhall-haskell/issues/2237
       Buildable: False


### PR DESCRIPTION
…for compatibility with v0.20:

https://hackage.haskell.org/package/doctest-0.20.0/changelog

Doctest appears to be rather stable and unlikely to cause breakage in
this project. Even if a doctest update would cause tests to fail,
this is unlikely to affect users. Such breakage could be easily
repaired by adding bounds via Hackage revisions.