### PR TITLE
<>| is accepted as empty union type 

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -1066,8 +1066,6 @@ parsers embedded = Parsers{..}
             let emptyUnionType = do
                     try (optional (_bar *> whitespace) *> _closeAngle)
 
-                    _ <- optional (_bar *> whitespace)
-
                     return (Union mempty)
 
             nonEmptyUnionType <|> emptyUnionType ) <?> "literal"


### PR DESCRIPTION
When reading through the dhall-haskell sources I found that an optional bar `|` is accepted after an empty union type (probably some left-over code from a refactoring):

```
Welcome to the Dhall v1.40.1 REPL! Type :help for more information.
⊢ <>|

<>
```
This is is not accepted by the dhall grammar or the standard implementation: 

```
<>|
dhall: user error ((input):1:3:
  |
1 | <>|
  |   ^
unexpected '|'
expecting "!=", "&&", "++", "--", "//", "//\\", "/\", "::", "==", "===", "{-", "||", '#', '*', '+', '.', ':', '?', '∧', '≡', '⩓', '⫽', crlf newline, end of input, newline, space, or tab
)
```