### PR TITLE
dhall.cabal: Use more globbing in Extra-Source-Files

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -1,8 +1,8 @@
+Cabal-Version: 2.4
 Name: dhall
 Version: 1.40.2
-Cabal-Version: 2.0
 Build-Type: Simple
-License: BSD3
+License: BSD-3-Clause
 License-File: LICENSE
 Copyright: 2017 Gabriel Gonzalez
 Author: Gabriel Gonzalez
@@ -24,10 +24,9 @@ Category: Compiler
 Data-Files:
     man/dhall.1
 Extra-Source-Files:
-    benchmark/deep-nested-large-record/*.dhall
-    benchmark/examples/*.dhall
-    benchmark/examples/normalize/*.dhall
     CHANGELOG.md
+    benchmark/**/*.dhall
+    dhall-lang/Prelude/**/*.dhall
     dhall-lang/Prelude/Bool/and
     dhall-lang/Prelude/Bool/build
     dhall-lang/Prelude/Bool/even
@@ -35,16 +34,10 @@ Extra-Source-Files:
     dhall-lang/Prelude/Bool/not
     dhall-lang/Prelude/Bool/odd
     dhall-lang/Prelude/Bool/or
-    dhall-lang/Prelude/Bool/package.dhall
     dhall-lang/Prelude/Bool/show
-    dhall-lang/Prelude/Bool/*.dhall
-    dhall-lang/Prelude/Double/package.dhall
     dhall-lang/Prelude/Double/show
-    dhall-lang/Prelude/Double/*.dhall
     dhall-lang/Prelude/Function/compose
     dhall-lang/Prelude/Function/identity
-    dhall-lang/Prelude/Function/package.dhall
-    dhall-lang/Prelude/Function/*.dhall
     dhall-lang/Prelude/Integer/abs
     dhall-lang/Prelude/Integer/add
     dhall-lang/Prelude/Integer/clamp
@@ -58,20 +51,17 @@ Extra-Source-Files:
     dhall-lang/Prelude/Integer/negative
     dhall-lang/Prelude/Integer/nonNegative
     dhall-lang/Prelude/Integer/nonPositive
-    dhall-lang/Prelude/Integer/package.dhall
     dhall-lang/Prelude/Integer/positive
     dhall-lang/Prelude/Integer/show
     dhall-lang/Prelude/Integer/subtract
     dhall-lang/Prelude/Integer/toDouble
     dhall-lang/Prelude/Integer/toNatural
-    dhall-lang/Prelude/Integer/*.dhall
     dhall-lang/Prelude/JSON/Format
     dhall-lang/Prelude/JSON/Nesting
     dhall-lang/Prelude/JSON/Tagged
     dhall-lang/Prelude/JSON/Type
     dhall-lang/Prelude/JSON/array
     dhall-lang/Prelude/JSON/bool
-    dhall-lang/Prelude/JSON/core.dhall
     dhall-lang/Prelude/JSON/double
     dhall-lang/Prelude/JSON/integer
     dhall-lang/Prelude/JSON/keyText
@@ -81,16 +71,12 @@ Extra-Source-Files:
     dhall-lang/Prelude/JSON/number
     dhall-lang/Prelude/JSON/object
     dhall-lang/Prelude/JSON/omitNullFields
-    dhall-lang/Prelude/JSON/package.dhall
     dhall-lang/Prelude/JSON/render
     dhall-lang/Prelude/JSON/renderAs
-    dhall-lang/Prelude/JSON/renderCompact.dhall
-    dhall-lang/Prelude/JSON/renderInteger.dhall
     dhall-lang/Prelude/JSON/renderYAML
     dhall-lang/Prelude/JSON/string
     dhall-lang/Prelude/JSON/tagInline
     dhall-lang/Prelude/JSON/tagNested
-    dhall-lang/Prelude/JSON/*.dhall
     dhall-lang/Prelude/List/all
     dhall-lang/Prelude/List/any
     dhall-lang/Prelude/List/build
@@ -110,7 +96,6 @@ Extra-Source-Files:
     dhall-lang/Prelude/List/length
     dhall-lang/Prelude/List/map
     dhall-lang/Prelude/List/null
-    dhall-lang/Prelude/List/package.dhall
     dhall-lang/Prelude/List/partition
     dhall-lang/Prelude/List/replicate
     dhall-lang/Prelude/List/reverse
@@ -119,10 +104,7 @@ Extra-Source-Files:
     dhall-lang/Prelude/List/unpackOptionals
     dhall-lang/Prelude/List/unzip
     dhall-lang/Prelude/List/zip
-    dhall-lang/Prelude/List/*.dhall
     dhall-lang/Prelude/Location/Type
-    dhall-lang/Prelude/Location/package.dhall
-    dhall-lang/Prelude/Location/*.dhall
     dhall-lang/Prelude/Map/Entry
     dhall-lang/Prelude/Map/Type
     dhall-lang/Prelude/Map/empty
@@ -130,9 +112,7 @@ Extra-Source-Files:
     dhall-lang/Prelude/Map/keyValue
     dhall-lang/Prelude/Map/keys
     dhall-lang/Prelude/Map/map
-    dhall-lang/Prelude/Map/package.dhall
     dhall-lang/Prelude/Map/values
-    dhall-lang/Prelude/Map/*.dhall
     dhall-lang/Prelude/Monoid
     dhall-lang/Prelude/Natural/build
     dhall-lang/Prelude/Natural/enumerate
@@ -149,7 +129,6 @@ Extra-Source-Files:
     dhall-lang/Prelude/Natural/max
     dhall-lang/Prelude/Natural/min
     dhall-lang/Prelude/Natural/odd
-    dhall-lang/Prelude/Natural/package.dhall
     dhall-lang/Prelude/Natural/product
     dhall-lang/Prelude/Natural/show
     dhall-lang/Prelude/Natural/sort
@@ -157,9 +136,6 @@ Extra-Source-Files:
     dhall-lang/Prelude/Natural/sum
     dhall-lang/Prelude/Natural/toDouble
     dhall-lang/Prelude/Natural/toInteger
-    dhall-lang/Prelude/Natural/*.dhall
-    dhall-lang/Prelude/NonEmpty/*.dhall
-    dhall-lang/Prelude/Operator/package.dhall
     dhall-lang/Prelude/Optional/all
     dhall-lang/Prelude/Optional/any
     dhall-lang/Prelude/Optional/build
@@ -172,282 +148,33 @@ Extra-Source-Files:
     dhall-lang/Prelude/Optional/length
     dhall-lang/Prelude/Optional/map
     dhall-lang/Prelude/Optional/null
-    dhall-lang/Prelude/Optional/package.dhall
     dhall-lang/Prelude/Optional/toList
     dhall-lang/Prelude/Optional/unzip
-    dhall-lang/Prelude/Optional/*.dhall
     dhall-lang/Prelude/Text/concat
     dhall-lang/Prelude/Text/concatMap
     dhall-lang/Prelude/Text/concatMapSep
     dhall-lang/Prelude/Text/concatSep
     dhall-lang/Prelude/Text/default
     dhall-lang/Prelude/Text/defaultMap
-    dhall-lang/Prelude/Text/package.dhall
-    dhall-lang/Prelude/Text/replace.dhall
     dhall-lang/Prelude/Text/replicate
     dhall-lang/Prelude/Text/show
     dhall-lang/Prelude/Text/spaces
-    dhall-lang/Prelude/Text/*.dhall
     dhall-lang/Prelude/XML/Type
     dhall-lang/Prelude/XML/attribute
     dhall-lang/Prelude/XML/element
     dhall-lang/Prelude/XML/emptyAttributes
     dhall-lang/Prelude/XML/leaf
-    dhall-lang/Prelude/XML/package.dhall
     dhall-lang/Prelude/XML/render
     dhall-lang/Prelude/XML/text
-    dhall-lang/Prelude/XML/*.dhall
-    dhall-lang/Prelude/*.dhall
-    dhall-lang/Prelude/package.dhall
-    dhall-lang/tests/alpha-normalization/success/unit/*.dhall
-    dhall-lang/tests/alpha-normalization/success/regression/*.dhall
-    dhall-lang/tests/binary-decode/failure/unit/*.dhallb
-    dhall-lang/tests/binary-decode/success/unit/*.dhall
-    dhall-lang/tests/binary-decode/success/unit/*.dhallb
-    dhall-lang/tests/binary-decode/success/unit/imports/*.dhall
-    dhall-lang/tests/binary-decode/success/unit/imports/*.dhallb
+    dhall-lang/tests/**/*.dhall
+    dhall-lang/tests/**/*.dhallb
+    dhall-lang/tests/**/*.hash
+    dhall-lang/tests/**/*.txt
     dhall-lang/tests/import/cache/dhall/12203871180b87ecaba8b53fffb2a8b52d3fce98098fab09a6f759358b9e8042eedc
     dhall-lang/tests/import/cache/dhall/1220618f785ce8f3930a9144398f576f0a992544b51212bc9108c31b4e670dc6ed21
-    dhall-lang/tests/import/data/*.dhall
-    dhall-lang/tests/import/data/*.txt
-    dhall-lang/tests/import/failure/*.dhall
-    dhall-lang/tests/import/failure/unit/*.dhall
-    dhall-lang/tests/import/success/*.dhall
-    dhall-lang/tests/import/success/unit/*.dhall
-    dhall-lang/tests/import/success/unit/asLocation/*.dhall
-    dhall-lang/tests/normalization/success/*.dhall
-    dhall-lang/tests/normalization/success/haskell-tutorial/access/*.dhall
-    dhall-lang/tests/normalization/success/haskell-tutorial/combineTypes/*.dhall
-    dhall-lang/tests/normalization/success/haskell-tutorial/prefer/*.dhall
-    dhall-lang/tests/normalization/success/haskell-tutorial/projection/*.dhall
-    dhall-lang/tests/normalization/success/regression/*.dhall
-    dhall-lang/tests/normalization/success/simple/*.dhall
-    dhall-lang/tests/normalization/success/simplifications/*.dhall
-    dhall-lang/tests/normalization/success/unit/*.dhall
-    dhall-lang/tests/parser/failure/*.dhall
-    dhall-lang/tests/parser/failure/spacing/*.dhall
-    dhall-lang/tests/parser/failure/unit/*.dhall
-    dhall-lang/tests/parser/success/*.dhall
-    dhall-lang/tests/parser/success/*.dhallb
-    dhall-lang/tests/parser/success/text/*.dhall
-    dhall-lang/tests/parser/success/text/*.dhallb
-    dhall-lang/tests/parser/success/unit/*.dhall
-    dhall-lang/tests/parser/success/unit/*.dhallb
-    dhall-lang/tests/parser/success/unit/operators/*.dhall
-    dhall-lang/tests/parser/success/unit/operators/*.dhallb
-    dhall-lang/tests/parser/success/unit/import/*.dhall
-    dhall-lang/tests/parser/success/unit/import/*.dhallb
-    dhall-lang/tests/parser/success/unit/import/urls/*.dhall
-    dhall-lang/tests/parser/success/unit/import/urls/*.dhallb
-    dhall-lang/tests/semantic-hash/success/*.dhall
-    dhall-lang/tests/semantic-hash/success/*.hash
-    dhall-lang/tests/semantic-hash/success/haskell-tutorial/access/*.dhall
-    dhall-lang/tests/semantic-hash/success/haskell-tutorial/access/*.hash
-    dhall-lang/tests/semantic-hash/success/haskell-tutorial/combineTypes/*.dhall
-    dhall-lang/tests/semantic-hash/success/haskell-tutorial/combineTypes/*.hash
-    dhall-lang/tests/semantic-hash/success/haskell-tutorial/prefer/*.dhall
-    dhall-lang/tests/semantic-hash/success/haskell-tutorial/prefer/*.hash
-    dhall-lang/tests/semantic-hash/success/haskell-tutorial/projection/*.dhall
-    dhall-lang/tests/semantic-hash/success/haskell-tutorial/projection/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/and/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/and/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/build/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/build/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/even/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/even/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/fold/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/fold/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/not/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/not/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/odd/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/odd/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/or/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/or/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/show/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Bool/show/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Double/show/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Double/show/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Integer/show/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Integer/show/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Integer/toDouble/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Integer/toDouble/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/all/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/all/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/any/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/any/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/build/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/build/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/concat/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/concat/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/concatMap/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/concatMap/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/filter/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/filter/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/fold/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/fold/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/generate/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/generate/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/head/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/head/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/indexed/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/indexed/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/iterate/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/iterate/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/last/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/last/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/length/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/length/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/map/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/map/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/null/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/null/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/replicate/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/replicate/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/reverse/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/reverse/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/shifted/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/shifted/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/List/unzip/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/List/unzip/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/build/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/build/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/enumerate/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/enumerate/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/even/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/even/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/fold/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/fold/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/isZero/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/isZero/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/odd/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/odd/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/product/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/product/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/show/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/show/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/sum/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/sum/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/toDouble/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/toDouble/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/toInteger/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Natural/toInteger/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/all/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/all/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/any/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/any/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/build/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/build/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/concat/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/concat/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/filter/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/filter/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/fold/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/fold/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/head/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/head/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/last/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/last/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/length/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/length/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/map/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/map/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/null/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/null/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/toList/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/toList/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/unzip/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Optional/unzip/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Text/concat/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Text/concat/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Text/concatMap/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Text/concatMap/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Text/concatMapSep/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Text/concatMapSep/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Text/concatSep/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Text/concatSep/*.hash
-    dhall-lang/tests/semantic-hash/success/prelude/Text/show/*.dhall
-    dhall-lang/tests/semantic-hash/success/prelude/Text/show/*.hash
-    dhall-lang/tests/semantic-hash/success/simple/*.dhall
-    dhall-lang/tests/semantic-hash/success/simple/*.hash
-    dhall-lang/tests/semantic-hash/success/simplifications/*.dhall
-    dhall-lang/tests/semantic-hash/success/simplifications/*.hash
-    dhall-lang/tests/type-inference/failure/*.dhall
-    dhall-lang/tests/type-inference/success/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Bool/and/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Bool/build/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Bool/even/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Bool/fold/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Bool/not/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Bool/odd/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Bool/or/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Bool/show/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Double/show/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Integer/show/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Integer/toDouble/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/all/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/any/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/build/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/concat/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/concatMap/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/filter/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/fold/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/generate/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/head/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/indexed/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/iterate/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/last/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/length/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/map/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/null/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/replicate/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/reverse/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/shifted/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/List/unzip/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Monoid/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/build/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/enumerate/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/even/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/fold/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/isZero/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/odd/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/product/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/show/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/sum/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/toDouble/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Natural/toInteger/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/all/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/any/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/build/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/concat/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/filter/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/fold/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/head/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/last/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/length/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/map/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/null/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/toList/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Optional/unzip/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Text/concat/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Text/concatMap/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Text/concatMapSep/*.dhall
-    dhall-lang/tests/type-inference/success/prelude/Text/concatSep/*.dhall
-    dhall-lang/tests/type-inference/success/regression/*.dhall
-    dhall-lang/tests/type-inference/success/simple/*.dhall
-    dhall-lang/tests/type-inference/success/simple/access/*.dhall
-    dhall-lang/tests/type-inference/success/unit/*.dhall
-    tests/diff/*.dhall
-    tests/diff/*.txt
-    tests/format/*.dhall
-    tests/freeze/*.dhall
-    tests/lint/success/*.dhall
-    tests/recursive/*.dhall
-    tests/regression/*.dhall
-    tests/schemas/*.dhall
-    tests/tags/*.dhall
-    tests/tags/*.tags
-    tests/th/*.dhall
-    tests/tutorial/*.dhall
+    tests/**/*.dhall
+    tests/**/*.tags
+    tests/**/*.txt
 
 Source-Repository head
     Type: git


### PR DESCRIPTION
…which requires bumping the Cabal-Version to 2.4.

This adds some test files to the source distribution:

    $ diff --brief --recursive _master/ _branch/
    Files _master/dhall-1.40.2/dhall.cabal and _branch/dhall-1.40.2/dhall.cabal differ
    Only in _branch/dhall-1.40.2/dhall-lang/tests/import/data: cors
    Only in _branch/dhall-1.40.2/dhall-lang/tests/import/failure/unit: cors
    Only in _branch/dhall-1.40.2/dhall-lang/tests/import/success/unit: cors
    Only in _branch/dhall-1.40.2/dhall-lang/tests/parser/failure: time
    Only in _branch/dhall-1.40.2/dhall-lang/tests/parser/success: time
    Only in _branch/dhall-1.40.2/dhall-lang/tests/type-inference/failure: unit
    Only in _branch/dhall-1.40.2/dhall-lang/tests/type-inference/success/unit: time