### PR TITLE
dhall-openapi: Fix handling of additionalProperties

### DIFF
--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -217,6 +217,9 @@ toTypes' prefixMap typeSplitter definitions toMerge
                   adaptRecordList = Dhall.Map.mapMaybe (Just . Dhall.makeRecordField)
 
               in (Dhall.Record $ adaptRecordList $ Dhall.Map.fromList $ fmap (first $ unModelName) allFields, newPropDefs)
+          | Just props <- additionalProperties definition
+          , let (mapValue, rest) = convertToType modelHierarchy props =
+              (Dhall.App Dhall.List (Dhall.Record (Dhall.Map.fromList [ ("mapKey", Dhall.makeRecordField Dhall.Text), ("mapValue", Dhall.makeRecordField mapValue) ])), rest)
             -- This is another way to declare an intOrString
           | Maybe.isJust $ intOrString definition = (intOrStringType, Data.Map.empty)
             -- Otherwise - if we have a 'type' - it's a basic type
@@ -438,6 +441,7 @@ data V1JSONSchemaProps =
         , v1JSONSchemaPropsExclusiveMinimum :: Maybe Bool
         , v1JSONSchemaPropsItems :: Maybe Value
         , v1JSONSchemaPropsProperties :: Maybe (Data.Map.Map String V1JSONSchemaProps)
+        , v1JSONSchemaPropsAdditionalProperties :: Maybe V1JSONSchemaProps
         , v1JSONSchemaPropsRequired :: Maybe [Text]
         , v1JSONSchemaPropsType :: Maybe Text
         , v1JSONSchemaPropsIntOrString :: Maybe Bool
@@ -456,6 +460,7 @@ mkV1JSONSchemaProps =
         , v1JSONSchemaPropsExclusiveMinimum = Nothing
         , v1JSONSchemaPropsItems = Nothing
         , v1JSONSchemaPropsProperties = Nothing
+        , v1JSONSchemaPropsAdditionalProperties = Nothing
         , v1JSONSchemaPropsRequired = Nothing
         , v1JSONSchemaPropsType = Nothing
         , v1JSONSchemaPropsIntOrString = Nothing
@@ -519,17 +524,18 @@ toDefinition crd = fmap (\d -> (modelName, d)) definition
     propsToDefinition :: V1JSONSchemaProps -> Maybe BaseData -> Definition
     propsToDefinition V1JSONSchemaProps{..} basedata =
       Definition
-        { typ              = v1JSONSchemaPropsType
-        , ref              = Ref <$> v1JSONSchemaPropsRef
-        , format           = v1JSONSchemaPropsFormat
-        , minimum_         = v1JSONSchemaPropsMinimum
-        , exclusiveMinimum = v1JSONSchemaPropsExclusiveMinimum
-        , description      = v1JSONSchemaPropsDescription
-        , items            = v1JSONSchemaPropsItems >>= parseMaybe parseJSON
-        , properties       = fmap toProperties v1JSONSchemaPropsProperties
-        , required         = fmap (Set.fromList . fmap FieldName) v1JSONSchemaPropsRequired
-        , baseData         = basedata
-        , intOrString      = v1JSONSchemaPropsIntOrString
+        { typ                  = v1JSONSchemaPropsType
+        , ref                  = Ref <$> v1JSONSchemaPropsRef
+        , format               = v1JSONSchemaPropsFormat
+        , minimum_             = v1JSONSchemaPropsMinimum
+        , exclusiveMinimum     = v1JSONSchemaPropsExclusiveMinimum
+        , description          = v1JSONSchemaPropsDescription
+        , items                = v1JSONSchemaPropsItems >>= parseMaybe parseJSON
+        , properties           = fmap toProperties v1JSONSchemaPropsProperties
+        , additionalProperties = fmap (\p -> propsToDefinition p Nothing) v1JSONSchemaPropsAdditionalProperties
+        , required             = fmap (Set.fromList . fmap FieldName) v1JSONSchemaPropsRequired
+        , baseData             = basedata
+        , intOrString          = v1JSONSchemaPropsIntOrString
         }
 
     toProperties :: Data.Map.Map String V1JSONSchemaProps -> Data.Map.Map ModelName Definition

--- a/dhall-openapi/src/Dhall/Kubernetes/Data.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Data.hs
@@ -14,12 +14,16 @@ patchCyclicImports Definition{ properties = oldProps, .. } = Definition{..}
     toRemove =
       Set.fromList $
         (   ModelName
-        <$> [ "allOf"
+        <$> [ "additionalItems"
+            , "additionalProperties"
+            , "allOf"
             , "anyOf"
+            , "definitions"
+            , "dependencies"
+            , "items"
             , "not"
             , "oneOf"
-            , "additionalItems"
-            , "additionalProperties"
-            , "items"
+            , "properties"
+            , "patternProperties"
             ]
         )

--- a/dhall-openapi/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Types.hs
@@ -39,32 +39,34 @@ instance FromJSON Swagger
 
 
 data Definition = Definition
-  { typ              :: Maybe Text
-  , ref              :: Maybe Ref
-  , format           :: Maybe Text
-  , minimum_         :: Maybe Scientific -- Avoid shadowing with Prelude.minimum
-  , exclusiveMinimum :: Maybe Bool
-  , description      :: Maybe Text
-  , items            :: Maybe Definition
-  , properties       :: Maybe (Map ModelName Definition)
-  , required         :: Maybe (Set FieldName)
-  , baseData         :: Maybe BaseData
-  , intOrString      :: Maybe Bool
+  { typ                  :: Maybe Text
+  , ref                  :: Maybe Ref
+  , format               :: Maybe Text
+  , minimum_             :: Maybe Scientific -- Avoid shadowing with Prelude.minimum
+  , exclusiveMinimum     :: Maybe Bool
+  , description          :: Maybe Text
+  , items                :: Maybe Definition
+  , properties           :: Maybe (Map ModelName Definition)
+  , additionalProperties :: Maybe Definition
+  , required             :: Maybe (Set FieldName)
+  , baseData             :: Maybe BaseData
+  , intOrString          :: Maybe Bool
   } deriving (Generic, Show, Eq)
 
 instance FromJSON Definition where
   parseJSON = withObject "definition" $ \o -> do
-    typ              <- o .:? "type"
-    ref              <- o .:? "$ref"
-    format           <- o .:? "format"
-    minimum_         <- o .:? "minimum"
-    exclusiveMinimum <- o .:? "exclusiveMinimum"
-    properties       <- o .:? "properties"
-    required         <- o .:? "required"
-    items            <- o .:? "items"
-    description      <- o .:? "description"
-    baseData         <- fmap join $ optional (o .:? "x-kubernetes-group-version-kind")
-    intOrString      <- o .:? "x-kubernetes-int-or-string"
+    typ                  <- o .:? "type"
+    ref                  <- o .:? "$ref"
+    format               <- o .:? "format"
+    minimum_             <- o .:? "minimum"
+    exclusiveMinimum     <- o .:? "exclusiveMinimum"
+    properties           <- o .:? "properties"
+    additionalProperties <- o .:? "additionalProperties"
+    required             <- o .:? "required"
+    items                <- o .:? "items"
+    description          <- o .:? "description"
+    baseData             <- fmap join $ optional (o .:? "x-kubernetes-group-version-kind")
+    intOrString          <- o .:? "x-kubernetes-int-or-string"
     pure Definition{..}
 
 


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2337

Basically, `additionalProperties` is analogous to
`Map Text` in `dhall`, which this change codifies.

Before this change, an `object` with an `additionalProperties`
field would get encoded as `Map Text Text`, regardless of what
the property type was.  Now the property type is correctly
respected by the conversion code.