### PR TITLE
Fix `dhall freeze --cache` to support v21.0.0

### DIFF
--- a/dhall/tests/freeze/cachedB.dhall
+++ b/dhall/tests/freeze/cachedB.dhall
@@ -1,3 +1,3 @@
-  ./True.dhall
+  missing
     sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
 ? ./True.dhall

--- a/dhall/tests/freeze/incorrectHashB.dhall
+++ b/dhall/tests/freeze/incorrectHashB.dhall
@@ -1,3 +1,3 @@
-  ./True.dhall
+  missing
     sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
 ? ./True.dhall

--- a/dhall/tests/freeze/protectedB.dhall
+++ b/dhall/tests/freeze/protectedB.dhall
@@ -1,3 +1,3 @@
-  ./True.dhall
+  missing
     sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
 ? ./True.dhall

--- a/dhall/tests/freeze/unprotectedB.dhall
+++ b/dhall/tests/freeze/unprotectedB.dhall
@@ -1,3 +1,3 @@
-  ./True.dhall
+  missing
     sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
 ? ./True.dhall

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,3 +24,6 @@ nix:
   packages:
     - ncurses
     - zlib
+flags:
+  mintty:
+    Win32-2-13-1: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,5 +25,6 @@ nix:
     - ncurses
     - zlib
 flags:
+  # https://github.com/RyanGlScott/mintty/issues/4
   mintty:
     Win32-2-13-1: false


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2347

This now uses `missing sha256:…` for the frozen import so that the
import still succeeds even if the hash doesn't match (which was the
original intention of the `--cached` flag; otherwise it would be
useless).