### PR TITLE
Allow `Some` in `with` expression

### DIFF
--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -385,7 +385,7 @@ parsers embedded = Parsers{..}
                     bs <- some (do
                         try (nonemptyWhitespace *> _with *> nonemptyWhitespace)
 
-                        keys <- Combinators.NonEmpty.sepBy1 anyLabel (try (whitespace *> _dot) *> whitespace)
+                        keys <- Combinators.NonEmpty.sepBy1 anyLabelOrSome (try (whitespace *> _dot) *> whitespace)
 
                         whitespace
 


### PR DESCRIPTION
Fix for small discrepancy between `dhall-haskell` and the reference implementation/[standard](https://github.com/dhall-lang/dhall-lang/blob/502856d9d09b555044e140a87ab34e120a1869d4/standard/dhall.abnf#L859).

Before:
```
⊢ { Some = 0 } with Some = 1

Error: Invalid input

(input):1:23:
  |
1 | { Some = 0 } with Some = 1
  |                       ^
expecting any label or whitespace
```

After:
```
⊢ { Some = 0 } with Some = 1

{ Some = 1 }
```