### PR TITLE
Allow text-2.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,1 @@
-packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-lsp-server ./dhall-nix ./dhall-docs ./dhall-openapi ./dhall-nixpkgs ./dhall-csv ./dhall-toml
+packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-docs ./dhall-openapi ./dhall-nixpkgs ./dhall-csv ./dhall-toml

--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -33,7 +33,7 @@ Library
         dhall                     >= 1.40.0   && < 1.41,
         neat-interpolation                       < 0.6 ,
         shell-escape                             < 0.3 ,
-        text                      >= 0.2      && < 1.3
+        text                      >= 0.2      && < 2.1
     Exposed-Modules: Dhall.Bash
     GHC-Options: -Wall
     Default-Language: Haskell2010

--- a/dhall-csv/dhall-csv.cabal
+++ b/dhall-csv/dhall-csv.cabal
@@ -42,7 +42,7 @@ Library
         filepath                             < 1.5 ,
         optparse-applicative                       ,
         prettyprinter        >= 1.7.0     && < 1.8 ,
-        text                 >= 0.11.1.0  && < 1.3 ,
+        text                 >= 0.11.1.0  && < 2.1 ,
         unordered-containers                 < 0.3 ,
         vector               >= 0.12      && < 0.13
     Exposed-Modules:

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -78,7 +78,7 @@ Library
         path                 >= 0.7.0     && < 0.10,
         path-io              >= 1.6.0     && < 1.7 ,
         prettyprinter        >= 1.7.0     && < 1.8 ,
-        text                 >= 0.11.1.0  && < 1.3 ,
+        text                 >= 0.11.1.0  && < 2.1 ,
         transformers         >= 0.2.0.0  && < 0.6 ,
         mtl                  >= 2.2.1     && < 2.3 ,
         optparse-applicative >= 0.14.0.0  && < 0.17

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -50,7 +50,7 @@ Library
         optparse-applicative      >= 0.14.0.0  && < 0.17,
         prettyprinter             >= 1.7.0     && < 1.8 ,
         scientific                >= 0.3.0.0   && < 0.4 ,
-        text                      >= 0.11.1.0  && < 1.3 ,
+        text                      >= 0.11.1.0  && < 2.1 ,
         unordered-containers                      < 0.3 ,
         vector
     Exposed-Modules:
@@ -106,7 +106,7 @@ Executable json-to-dhall
         optparse-applicative                             ,
         prettyprinter                                    ,
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
-        text                                       < 1.3
+        text
     Other-Modules:
         Paths_dhall_json
     GHC-Options: -Wall

--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -33,7 +33,7 @@ Library
         hnix                      >= 0.7      && < 0.15,
         lens-family-core          >= 1.0.0    && < 2.2 ,
         neat-interpolation                       < 0.6 ,
-        text                      >= 0.8.0.0  && < 1.3
+        text                      >= 0.8.0.0  && < 2.1
     Exposed-Modules:
         Dhall.Nix
     GHC-Options: -Wall

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -32,7 +32,7 @@ Executable dhall-to-nixpkgs
                      , neat-interpolation                  < 0.6
                      , optparse-applicative >= 0.14.0.0 && < 0.17
                      , prettyprinter        >= 1.7.0    && < 1.8
-                     , text                 >= 0.11.1.0 && < 1.3
+                     , text                 >= 0.11.1.0 && < 2.1
                      , transformers         >= 0.2.0.0  && < 0.6
                      , turtle                              < 1.6
                      , network-uri                         < 2.8

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -83,6 +83,6 @@ Library
     prettyprinter           >= 1.7.0     && < 1.8  ,
     scientific              >= 0.3.0.0   && < 0.4  ,
     sort                    >= 1.0       && < 1.1  ,
-    text                    >= 0.11.1.0  && < 1.3  ,
+    text                    >= 0.11.1.0  && < 2.1  ,
     vector                  >= 0.11.0.0  && < 0.13
   Default-Language: Haskell2010

--- a/dhall-toml/dhall-toml.cabal
+++ b/dhall-toml/dhall-toml.cabal
@@ -37,7 +37,7 @@ Library
         base                 >= 4.12     && < 5    ,
         dhall                >= 1.39.0   && < 1.41 ,
         tomland              >= 1.3.2.0  && < 1.4  ,
-        text                 >= 0.11.1.0 && < 1.3  ,
+        text                 >= 0.11.1.0 && < 2.1  ,
         containers           >= 0.5.9    && < 0.7  ,
         unordered-containers >= 0.2      && < 0.3  ,
         prettyprinter        >= 1.7.0    && < 1.8

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -39,7 +39,7 @@ Library
         dhall                     >= 1.31.0    && < 1.41,
         dhall-json                >= 1.6.0     && < 1.8 ,
         optparse-applicative      >= 0.14.0.0  && < 0.17,
-        text                      >= 0.11.1.0  && < 1.3 ,
+        text                      >= 0.11.1.0  && < 2.1 ,
         vector
     Exposed-Modules:
         Dhall.Yaml
@@ -74,7 +74,7 @@ Executable yaml-to-dhall
         optparse-applicative                             ,
         prettyprinter               >= 1.7.0             ,
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
-        text                                       < 1.3
+        text
     Other-Modules:
         Paths_dhall_yaml
     GHC-Options: -Wall

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -238,7 +238,7 @@ Common common
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
         template-haskell            >= 2.13.0.0 && < 2.19,
-        text                        >= 0.11.1.0 && < 1.3 ,
+        text                        >= 0.11.1.0 && < 2.1 ,
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
         th-lift-instances           >= 0.1.13   && < 0.2 ,
         time                        >= 1.1.4    && < 1.13,


### PR DESCRIPTION
https://hackage.haskell.org/package/text-2.0/changelog

---

Build command that works around the bounds issues:

```
cabal build all --enable-tests --constraint 'text >= 2.0' --allow-newer=blaze-builder:text,uri-encode:text,serialise:text,parsers:text,megaparsec:text,cborg-json:text,uuid-types:text,aeson:text,scientific:text,strict:text,text-short:text,optparse-generic:text,cassava:text,path:hashable,mmark:text,text-metrics:text,modern-uri:text,html-entity-map:text,foldl:text,aeson-yaml:text,lens:text,hnix:hashable,hnix:text,neat-interpolation:text,relude:hashable,relude:text,regex-tdfa:text,nix-derivation:text,turtle:text,tomland:text,HsYAML-aeson:text,HsYAML:text,special-values:text,quickcheck-instances:text -j20
```

This is blocked on the following packages that currently show build failures:

* [ ] `aeson`
* [ ] https://github.com/brendanhay/text-manipulate/pull/5
* [x] https://github.com/mrkkrp/text-metrics/pull/23

---

Happy holidays, everyone! :)