### PR TITLE
cabal.project: Re-add dhall-lsp-server

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,1 @@
-packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-docs ./dhall-openapi ./dhall-nixpkgs ./dhall-csv ./dhall-toml
+packages: ./dhall ./dhall-bash ./dhall-json ./dhall-yaml ./dhall-nix ./dhall-docs ./dhall-openapi ./dhall-nixpkgs ./dhall-csv ./dhall-toml ./dhall-lsp-server


### PR DESCRIPTION
This reverts a change that was prematurely merged in
https://github.com/dhall-lang/dhall-haskell/pull/2356.