### PR TITLE
Fix macOS release archive format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         os:
           - runner: 'macOS-latest'
             package: 'macos'
-            archive-command: 'tar --create --file'
+            archive-command: 'tar --create -j --file'
             file-extension: 'tar.bz2'
             executable-extension: ''
           - runner: 'ubuntu-latest'


### PR DESCRIPTION
macOS tar doesn't compress with bzip2 purely based on `tar.bz2` extension, `-j` must be provided.

Fixes #2366