### PR TITLE
Re-enable some CORS tests

### DIFF
--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -86,9 +86,6 @@ successTest prefix = do
 
     let expectedFailures =
             [ importDirectory </> "success/unit/cors/TwoHops"
-            , importDirectory </> "success/unit/cors/SelfImportAbsolute"
-            , importDirectory </> "success/unit/cors/AllowedAll"
-            , importDirectory </> "success/unit/cors/SelfImportRelative"
             , importDirectory </> "success/unit/cors/OnlyGithub"
             ]
 


### PR DESCRIPTION
These tests now work correctly after upstream fixes to
`test.dhall-lang.org`