### PR TITLE
Re-enable remaining CORS tests

### DIFF
--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -84,10 +84,7 @@ successTest prefix = do
 
     let directoryString = FilePath.takeDirectory inputPath
 
-    let expectedFailures =
-            [ importDirectory </> "success/unit/cors/TwoHops"
-            , importDirectory </> "success/unit/cors/OnlyGithub"
-            ]
+    let expectedFailures = [ ]
 
     Test.Util.testCase prefix expectedFailures (do
 


### PR DESCRIPTION
Now that https://github.com/dhall-lang/dhall-lang/pull/1272 is
merged these tests pass