### PR TITLE
Make IntOrString = Natural | Text if preferNaturalInt

### DIFF
--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:  >=1.11
 Name:           dhall-openapi
-Version:        1.0.2
+Version:        1.0.3
 Homepage:       https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi#dhall-openapi
 Author:         Fabrizio Ferrai
 Maintainer:     Gabriel439@gmail.com

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:  >=1.11
 Name:           dhall-openapi
-Version:        1.0.3
+Version:        1.0.2
 Homepage:       https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi#dhall-openapi
 Author:         Fabrizio Ferrai
 Maintainer:     Gabriel439@gmail.com

--- a/dhall-openapi/openapi-to-dhall/Main.hs
+++ b/dhall-openapi/openapi-to-dhall/Main.hs
@@ -229,12 +229,12 @@ parseOptions = Options <$> parseSkip <*> parseNaturalInt <*> parseNatIntExceptio
     parseNaturalInt =
       Options.Applicative.switch
         (  Options.Applicative.long "preferNaturalInt"
-        <> Options.Applicative.help "Render Swagger Integer as Dhall Natural unless negative numbers included in range"
+        <> Options.Applicative.help "Render Swagger Integer as Dhall Natural unless negative numbers included in range, and Swagger IntOrString as Dhall NatOrString"
         )
     parseNatIntExceptions' =
       option [] $ Options.Applicative.option parseNatIntExceptions
        (  Options.Applicative.long "natIntExceptions"
-        <> Options.Applicative.help "List of Type.field that should be treated the opposite way to preferNaturalInt; e.g.: ContainerStateTerminated.exitCode,ContainerStateTerminated.signal"
+        <> Options.Applicative.help "List of Integer and/or IntOrString Type.field that should be treated the opposite way to preferNaturalInt; e.g.: ContainerStateTerminated.exitCode,ContainerStateTerminated.signal"
         <> Options.Applicative.metavar "EXCEPTIONS"
        )
     parsePrefixMap' =
@@ -348,6 +348,9 @@ main = do
           (RecordLit
               [ ( "IntOrString"
                 , Dhall.makeRecordField $ Field (Embed (Convert.mkImport prefixMap [ ] "types.dhall")) $ Dhall.makeFieldSelection "IntOrString"
+                )
+              , ( "NatOrString"
+                , Dhall.makeRecordField $ Field (Embed (Convert.mkImport prefixMap [ ] "types.dhall")) $ Dhall.makeFieldSelection "NatOrString"
                 )
               , ( "Resource", mkEmbedField (Convert.mkImport prefixMap [ ] "typesUnion.dhall"))
               ]

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -552,8 +552,8 @@ toDefinition crd = fmap (\d -> (modelName, d)) definition
         , format               = v1JSONSchemaPropsFormat
         , minimum_             = v1JSONSchemaPropsMinimum
         , exclusiveMinimum     = v1JSONSchemaPropsExclusiveMinimum
-        , maximum_         = v1JSONSchemaPropsMaximum
-        , exclusiveMaximum = v1JSONSchemaPropsExclusiveMaximum
+        , maximum_             = v1JSONSchemaPropsMaximum
+        , exclusiveMaximum     = v1JSONSchemaPropsExclusiveMaximum
         , description          = v1JSONSchemaPropsDescription
         , items                = v1JSONSchemaPropsItems >>= parseMaybe parseJSON
         , properties           = fmap toProperties v1JSONSchemaPropsProperties

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -196,7 +196,7 @@ toTypes' prefixMap typeSplitter preferNaturalInt natIntExceptions definitions to
         intOrStringType = Dhall.Union $ Dhall.Map.fromList $ fmap (second Just)
           [ ("Int", Dhall.Integer), ("String", Dhall.Text) ]
         natOrStringType = Dhall.Union $ Dhall.Map.fromList $ fmap (second Just)
-          [ ("Nat", Dhall.Natural), ("String", Dhall.Text) ]
+          [ ("Int", Dhall.Natural), ("String", Dhall.Text) ]
 
         -- | Convert a single Definition to a Dhall Type, yielding any definitions to be split
         --   Note: model hierarchy contains the modelName of of the current definition as the last entry

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -33,6 +33,7 @@ import qualified Data.Tuple      as Tuple
 import qualified Dhall.Core      as Dhall
 import qualified Dhall.Map
 import qualified Dhall.Optics
+import qualified Data.Map as Map
 
 modelsToText :: ModelHierarchy -> [Text]
 modelsToText = List.map (\ (ModelName unModelName) -> unModelName)
@@ -79,10 +80,31 @@ requiredFields modelHierarchy required
         )
       ]
 
+-- Special types: the first is a union found in the k8s swagger;
+-- the second is a parallel union we construct for distinguishing
+-- signed and unsigned intergers on the dhall side
+intOrStringK8sType :: Text
+intOrStringK8sType = "io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+natOrStringK8sType :: Text
+natOrStringK8sType = "io.k8s.apimachinery.pkg.util.intstr.NatOrString"
 
--- | Get a filename from a Swagger ref
-pathFromRef :: Ref -> Text
-pathFromRef (Ref r) = (Text.split (== '/') r) List.!! 2
+intOrStringDhallType :: Dhall.Expr s a
+intOrStringDhallType = Dhall.Union $ Dhall.Map.fromList $ fmap (second Just)
+  [ ("Int", Dhall.Integer), ("String", Dhall.Text) ]
+natOrStringDhallType :: Dhall.Expr s a
+natOrStringDhallType = Dhall.Union $ Dhall.Map.fromList $ fmap (second Just)
+  [ ("Nat", Dhall.Natural), ("String", Dhall.Text) ]
+
+-- | Get a filename from a Swagger ref, also handling when we need to split
+-- | NatOrString from IntOrString
+pathFromRef :: Bool -> Ref -> Text
+pathFromRef prefNatInt (Ref r) =
+  if prefNatInt && qualType == intOrStringK8sType then
+    natOrStringK8sType
+  else
+    qualType
+  where
+    qualType = (Text.split (== '/') r) List.!! 2
 
 -- | Build an import from path components (note: they need to be in reverse order)
 --   and a filename
@@ -163,7 +185,10 @@ pathSplitter pathsAndModels modelHierarchy definition
     like "should this key be optional"
 -}
 toTypes :: Data.Map.Map Prefix Dhall.Import -> ([ModelName] -> Definition -> Maybe ModelName) -> Bool -> [(String,String)] -> Data.Map.Map ModelName Definition -> Data.Map.Map ModelName Expr
-toTypes prefixMap typeSplitter preferNaturalInt natIntExceptions definitions = toTypes' prefixMap typeSplitter preferNaturalInt natIntExceptions definitions Data.Map.empty
+toTypes prefixMap typeSplitter preferNaturalInt natIntExceptions definitions =
+    Map.insert (ModelName natOrStringK8sType) natOrStringDhallType types
+  where
+    types = toTypes' prefixMap typeSplitter preferNaturalInt natIntExceptions definitions Data.Map.empty
 
 toTypes' :: Data.Map.Map Prefix Dhall.Import -> ([ModelName] -> Definition -> Maybe ModelName) -> Bool -> [(String,String)] -> Data.Map.Map ModelName Definition -> Data.Map.Map ModelName Expr -> Data.Map.Map ModelName Expr
 toTypes' prefixMap typeSplitter preferNaturalInt natIntExceptions definitions toMerge
@@ -193,10 +218,6 @@ toTypes' prefixMap typeSplitter preferNaturalInt natIntExceptions definitions to
        
         kvList = Dhall.App Dhall.List $ Dhall.Record $ Dhall.Map.fromList
           [ ("mapKey", Dhall.makeRecordField Dhall.Text), ("mapValue", Dhall.makeRecordField Dhall.Text) ]
-        intOrStringType = Dhall.Union $ Dhall.Map.fromList $ fmap (second Just)
-          [ ("Int", Dhall.Integer), ("String", Dhall.Text) ]
-        natOrStringType = Dhall.Union $ Dhall.Map.fromList $ fmap (second Just)
-          [ ("Int", Dhall.Natural), ("String", Dhall.Text) ]
 
         -- | Convert a single Definition to a Dhall Type, yielding any definitions to be split
         --   Note: model hierarchy contains the modelName of of the current definition as the last entry
@@ -205,7 +226,7 @@ toTypes' prefixMap typeSplitter preferNaturalInt natIntExceptions definitions to
           | Just splitModelName <- typeSplitter modelHierarchy definition =
             ( Dhall.Embed $ mkImport prefixMap [] ((unModelName splitModelName) <> ".dhall"), Data.Map.singleton splitModelName definition)
           -- If we point to a ref we just reference it via Import
-          | Just r <- ref definition = ( Dhall.Embed $ mkImport prefixMap [] (pathFromRef r <> ".dhall"), Data.Map.empty)
+          | Just r <- ref definition = ( Dhall.Embed $ mkImport prefixMap [] (pathFromRef prefNatInt r <> ".dhall"), Data.Map.empty)
           | Just props <- properties definition =
               let
                   shouldBeRequired :: ModelHierarchy -> FieldName -> Bool
@@ -232,15 +253,14 @@ toTypes' prefixMap typeSplitter preferNaturalInt natIntExceptions definitions to
               (Dhall.App Dhall.List (Dhall.Record (Dhall.Map.fromList [ ("mapKey", Dhall.makeRecordField Dhall.Text), ("mapValue", Dhall.makeRecordField mapValue) ])), rest)
             -- This is another way to declare an intOrString
           | Maybe.isJust $ intOrString definition =
-             (if prefNatInt then natOrStringType else intOrStringType, Data.Map.empty)
+             (if prefNatInt then natOrStringDhallType else intOrStringDhallType, Data.Map.empty)
             -- Otherwise - if we have a 'type' - it's a basic type
           | Just basic <- typ definition = case basic of
               "object"  -> (kvList, Data.Map.empty)
               "array"   | Just item <- items definition ->
                 let (e, tm) = convertToType (modelHierarchy) item prefNatInt
                 in (Dhall.App Dhall.List e, tm)
-              "string"  | format definition == Just "int-or-string" ->
-                (if prefNatInt then natOrStringType else intOrStringType, Data.Map.empty)
+              "string"  | format definition == Just "int-or-string" -> (intOrStringDhallType, Data.Map.empty)
               "string"  -> (Dhall.Text, Data.Map.empty)
               "boolean" -> (Dhall.Bool, Data.Map.empty)
               "integer" -> if prefNatInt then case (minimum_ definition, exclusiveMinimum definition,

--- a/dhall-openapi/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Types.hs
@@ -44,8 +44,8 @@ data Definition = Definition
   , format               :: Maybe Text
   , minimum_             :: Maybe Scientific -- Avoid shadowing with Prelude.minimum
   , exclusiveMinimum     :: Maybe Bool
-  , maximum_         :: Maybe Scientific -- Avoid shadowing with Prelude.maximum
-  , exclusiveMaximum :: Maybe Bool
+  , maximum_             :: Maybe Scientific -- Avoid shadowing with Prelude.maximum
+  , exclusiveMaximum     :: Maybe Bool
   , description          :: Maybe Text
   , items                :: Maybe Definition
   , properties           :: Maybe (Map ModelName Definition)
@@ -62,8 +62,8 @@ instance FromJSON Definition where
     format               <- o .:? "format"
     minimum_             <- o .:? "minimum"
     exclusiveMinimum     <- o .:? "exclusiveMinimum"
-    maximum_         <- o .:? "maximum"
-    exclusiveMaximum <- o .:? "exclusiveMaximum"
+    maximum_             <- o .:? "maximum"
+    exclusiveMaximum     <- o .:? "exclusiveMaximum"
     properties           <- o .:? "properties"
     additionalProperties <- o .:? "additionalProperties"
     required             <- o .:? "required"


### PR DESCRIPTION
#2316 added support for optionally translating Swagger `Int` to Dhall `Natural`, however as mentioned in https://github.com/dhall-lang/dhall-kubernetes/pull/178 this leads to a mismatch with IntOrString fields which were still translated to a union of Integer and String. This PR changes this to translate IntOrString to a new NatOrString union when `--preferNaturalInt` is active.

The `--natIntExceptions` argument applies to IntOrString as it applies to Integer. That is, named fields are rendered as IntOrString when `--prefNaturalInt` is active, and NatOrString when it is inactive.

For the case of dhall-kubernetes, in the openapi specs from 1.12 to 1.22, IntOrString is used either for ports (where a string port or service name can be used instead), or nonnegative amounts (where a percentage can be given instead, e.g., "25%"). Thus, no new exceptions are needed for dhall-kubernetes.

Testing done: diff of generated files against previous is limited to IntOrString fields, running various combinations of `--prefNaturalInt` and `--natIntExceptions` generates expected results.