### PR TITLE
Fix dhall-openapi version

### DIFF
--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:  >=1.11
 Name:           dhall-openapi
-Version:        1.0.3
+Version:        1.0.4
 Homepage:       https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi#dhall-openapi
 Author:         Fabrizio Ferrai
 Maintainer:     Gabriel439@gmail.com


### PR DESCRIPTION
I had to bump the version again in order to upload to Hackage because
it was one version behind