### PR TITLE
Fix bug in pretty-printing `with` expressions

### DIFF
--- a/dhall/tests/format/withQuestionA.dhall
+++ b/dhall/tests/format/withQuestionA.dhall
@@ -1,0 +1,1 @@
+λ(x : Optional Natural) → x with ? = 2

--- a/dhall/tests/format/withQuestionB.dhall
+++ b/dhall/tests/format/withQuestionB.dhall
@@ -1,0 +1,1 @@
+λ(x : Optional Natural) → x with ? = 2


### PR DESCRIPTION
Before this change the question mark would be escaped by the
pretty-printer