### PR TITLE
Fixes to haddocks

### DIFF
--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -1900,7 +1900,8 @@ layoutOpts =
     Pretty.defaultLayoutOptions
         { Pretty.layoutPageWidth = Pretty.AvailablePerLine 80 1.0 }
 
-{-| Convert an expression representing a temporal value to `Text`, if possible
+{-| Convert an expression representing a temporal value to `Data.Text.Text`, if
+    possible
 
     This is used by downstream integrations (e.g. `dhall-json` for treating
     temporal values as strings

--- a/dhall/src/Dhall/Tutorial.hs
+++ b/dhall/src/Dhall/Tutorial.hs
@@ -1968,6 +1968,7 @@ import Dhall
 -- $substitutions
 --
 -- Substitutions are another way to extend the language.
+--
 -- Suppose we have the following Haskell datatype:
 --
 -- > data Result = Failure Integer | Success String
@@ -1985,22 +1986,9 @@ import Dhall
 -- Right now it is quite easy to keep these two definitions (the one in Haskell source and the one in the Dhall file) synchronized:
 -- If we implement a new feature in the Haskell source we update the corresponding type in the Dhall file.
 -- But what happens if our application is growing and our Result type contains e.g. 10 unions with possible types embedded in it?
--- Maintaining the code will get tedious. Luckily we can extract the correct Dhall type from the Haskell definition:
 --
--- > resultDecoder :: Dhall.Decoder Result
--- > resultDecoder = Dhall.auto
--- >
--- > resultType :: Expr Src Void
--- > resultType = maximum $ Dhall.expected resultDecoder
--- >
--- > resultTypeString :: String
--- > resultTypeString = show $ pretty resultType
---
--- Now we just have to inject that type into the Dhall code and we are done. One common way to do that is to wrap the import of example.dhall in a let expression:
---
--- > Dhall.input (Dhall.auto :: Dhall.Decoder Result) ("let Result = " <> Data.Text.pack resultTypeString <> " in ./example.dhall")
---
--- Now we can omit the definition of Result in our example.dhall file. While this will work perfectly Dhall provides a cleaner solution for our \"injection problem\":
+-- We can override the interpreter's @evaluateSettings@ with a custom set of
+-- substitutions, like this:
 --
 -- > {-# LANGUAGE OverloadedStrings #-}
 -- >


### PR DESCRIPTION
The main change is to remove the stringly-typed example for
substitutions, not only because I don't want to encourage that
pattern, but also because it contains a confusing use of the
`maximum` function where it's being used as a partial
`fromSuccess :: Expector a -> a` function by abusing the
`Foldable` instance for `Validation`