### PR TITLE
Switch from `haskell-lsp` to `lsp` package

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -52,7 +52,7 @@ library
     , dhall                >= 1.38.0   && < 1.42
     , dhall-json           >= 1.4      && < 1.8
     , filepath             >= 1.4.2    && < 1.5
-    , haskell-lsp          >= 0.21.0.0 && < 0.25
+    , lsp                  >= 1.2.0.0  && < 1.5
     , rope-utf16-splay     >= 0.3.1.0  && < 0.4
     , hslogger             >= 1.2.10   && < 1.4
     , lens                 >= 4.16.1   && < 5.2
@@ -104,11 +104,11 @@ Test-Suite tests
     GHC-Options: -Wall
     Build-Depends:
         base                                   ,
-        haskell-lsp-types >= 0.19.0  && < 0.25 ,
-        hspec             >= 2.7     && < 2.10 ,
-        lsp-test          >= 0.9     && < 0.13 ,
-        tasty             >= 0.11.2  && < 1.5  ,
-        tasty-hspec       >= 1.1     && < 1.3  ,
-        text              >= 0.11    && < 1.3
+        lsp-types         >= 1.3.0.1  && < 1.5  ,
+        hspec             >= 2.7      && < 2.10 ,
+        lsp-test          >= 0.14.0.1 && < 0.15 ,
+        tasty             >= 0.11.2   && < 1.5  ,
+        tasty-hspec       >= 1.1      && < 1.3  ,
+        text              >= 0.11     && < 1.3
     Build-Tool-Depends: dhall-lsp-server:dhall-lsp-server
     Default-Language: Haskell2010

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
@@ -35,17 +35,17 @@ import System.FilePath
     , takeFileName
     )
 
-import qualified Data.Graph                 as Graph
-import qualified Data.Map.Strict            as Map
-import qualified Data.Set                   as Set
-import qualified Data.Text                  as Text
-import qualified Dhall.Core                 as Dhall
-import qualified Dhall.Import               as Dhall
+import qualified Data.Graph         as Graph
+import qualified Data.Map.Strict    as Map
+import qualified Data.Set           as Set
+import qualified Data.Text          as Text
+import qualified Dhall.Core         as Dhall
+import qualified Dhall.Import       as Dhall
 import qualified Dhall.Map
-import qualified Dhall.Parser               as Dhall
-import qualified Dhall.TypeCheck            as Dhall
-import qualified Language.Haskell.LSP.Types as LSP.Types
-import qualified Network.URI                as URI
+import qualified Dhall.Parser       as Dhall
+import qualified Dhall.TypeCheck    as Dhall
+import qualified Language.LSP.Types as LSP.Types
+import qualified Network.URI        as URI
 
 
 -- | A @FileIdentifier@ represents either a local file or a remote url.

--- a/dhall-lsp-server/tests/Main.hs
+++ b/dhall-lsp-server/tests/Main.hs
@@ -4,8 +4,8 @@
 
 import Control.Monad.IO.Class     (liftIO)
 import Data.Maybe                 (fromJust)
-import Language.Haskell.LSP.Test
-import Language.Haskell.LSP.Types
+import Language.LSP.Test
+import Language.LSP.Types
     ( CompletionItem (..)
     , Diagnostic (..)
     , DiagnosticSeverity (..)


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2270

Related to https://github.com/NixOS/nixpkgs/pull/160733

The `haskell-lsp` package is deprecated in favor of the `lsp` package