### PR TITLE
dhall-lsp-server: Support newer dependency versions

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -42,7 +42,7 @@ library
       src
   default-extensions: RecordWildCards OverloadedStrings
   build-depends:
-      aeson                >= 1.3.1.1  && < 1.6
+      aeson                >= 1.3.1.1  && < 2.1
     , aeson-pretty         >= 0.8.7    && < 0.9
     , base                 >= 4.11     && < 5
     , bytestring           >= 0.10.8.2 && < 0.12
@@ -52,7 +52,7 @@ library
     , dhall                >= 1.38.0   && < 1.42
     , dhall-json           >= 1.4      && < 1.8
     , filepath             >= 1.4.2    && < 1.5
-    , lsp                  >= 1.2.0.0  && < 1.4
+    , lsp                  >= 1.2.0.0  && < 1.5
     , rope-utf16-splay     >= 0.3.1.0  && < 0.4
     , hslogger             >= 1.2.10   && < 1.4
     , lens                 >= 4.16.1   && < 5.2
@@ -104,7 +104,7 @@ Test-Suite tests
     GHC-Options: -Wall
     Build-Depends:
         base                                    ,
-        lsp-types         >= 1.2.0.0  && < 1.4  ,
+        lsp-types         >= 1.2.0.0  && < 1.5  ,
         hspec             >= 2.7      && < 2.10 ,
         lsp-test          >= 0.13.0.0 && < 0.15 ,
         tasty             >= 0.11.2   && < 1.5  ,


### PR DESCRIPTION
The main change is that in newer versions of `lsp-types` there is a `UInt` instead of an `Int` in various places.  However, the code is still compatible with older versions through the use of `fromIntegral` since both `UInt` and `Int` implement `Integral`