### PR TITLE
dhall-lsp-server: Allow rope-utf16-splay-0.4, text-2.0

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -53,7 +53,7 @@ library
     , dhall-json           >= 1.4      && < 1.8
     , filepath             >= 1.4.2    && < 1.5
     , lsp                  >= 1.2.0.0  && < 1.5
-    , rope-utf16-splay     >= 0.3.1.0  && < 0.4
+    , rope-utf16-splay     >= 0.3.1.0  && < 0.5
     , hslogger             >= 1.2.10   && < 1.4
     , lens                 >= 4.16.1   && < 5.2
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
@@ -61,7 +61,7 @@ library
     , mtl                  >= 2.2.2    && < 2.3
     , network-uri          >= 2.6.1.0  && < 2.7
     , prettyprinter        >= 1.7.0    && < 1.8
-    , text                 >= 1.2.3.0  && < 1.3
+    , text                 >= 1.2.3.0  && < 2.1
     , transformers         >= 0.5.5.0  && < 0.6
     , unordered-containers >= 0.2.9.0  && < 0.3
     , uri-encode           >= 1.5.0.5  && < 1.6
@@ -109,6 +109,6 @@ Test-Suite tests
         lsp-test          >= 0.13.0.0 && < 0.15 ,
         tasty             >= 0.11.2   && < 1.5  ,
         tasty-hspec       >= 1.1      && < 1.3  ,
-        text              >= 0.11     && < 1.3
+        text              >= 0.11     && < 2.1
     Build-Tool-Depends: dhall-lsp-server:dhall-lsp-server
     Default-Language: Haskell2010


### PR DESCRIPTION
https://hackage.haskell.org/package/rope-utf16-splay-0.4.0.0/changelog
https://hackage.haskell.org/package/text-2.0/changelog