### PR TITLE
dhall-docs: Index non-dhall files

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -22,11 +22,13 @@ Category: Compiler
 Extra-Source-Files:
     CHANGELOG.md
     README.md
+    tasty/data/package/*.txt
     tasty/data/package/*.dhall
     tasty/data/package/a/*.dhall
     tasty/data/package/a/b/*.dhall
     tasty/data/package/a/b/c/*.dhall
     tasty/data/package/deep/nested/folder/*.dhall
+    tasty/data/golden/*.txt.html
     tasty/data/golden/*.dhall.html
     tasty/data/golden/a/*.dhall.html
     tasty/data/golden/a/b/*.dhall.html

--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -13,6 +13,7 @@
 
 module Dhall.Docs.Html
     ( dhallFileToHtml
+    , textFileToHtml
     , indexToHtml
     , DocParams(..)
     ) where
@@ -71,6 +72,28 @@ dhallFileToHtml filePath contents expr examples header params@DocParams{..} =
                         mapM_ (renderCodeSnippet characterSet AssertionExample) examples
                 h3_ "Source"
                 div_ [class_ "source-code"] $ renderCodeWithHyperLinks contents expr
+  where
+    breadcrumb = relPathToBreadcrumb filePath
+    htmlTitle = breadCrumbsToText breadcrumb
+    clipboardText = fold baseImportUrl <> htmlTitle
+
+-- | Generates an @`Html` ()@ with all the information about a dhall file
+textFileToHtml
+    :: Path Rel File            -- ^ Source file name, used to extract the title
+    -> Text                     -- ^ Contents of the file
+    -> DocParams                -- ^ Parameters for the documentation
+    -> Html ()
+textFileToHtml filePath contents params@DocParams{..} =
+    doctypehtml_ $ do
+        headContents htmlTitle params
+        body_ $ do
+            navBar params
+            mainContainer $ do
+                setPageTitle params NotIndex breadcrumb
+                copyToClipboardButton clipboardText
+                br_ []
+                h3_ "Source"
+                div_ [class_ "source-code"] (toHtml contents)
   where
     breadcrumb = relPathToBreadcrumb filePath
     htmlTitle = breadCrumbsToText breadcrumb

--- a/dhall-docs/tasty/data/golden/AsText.dhall.html
+++ b/dhall-docs/tasty/data/golden/AsText.dhall.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>/AsText.dhall</title>
+<link rel="stylesheet" type="text/css" href="index.css">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
+<script type="text/javascript" src="index.js">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img class="dhall-icon" src="dhall-icon.svg">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span class="title-crumb" href="index.html">AsText.dhall</span>
+</h2>
+<a class="copy-to-clipboard" data-path="/AsText.dhall">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>
+<a href="./Plain.txt.html">./Plain.txt as Text</a>
+<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/Plain.txt.html
+++ b/dhall-docs/tasty/data/golden/Plain.txt.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>/Plain.txt</title>
+<link rel="stylesheet" type="text/css" href="index.css">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
+<script type="text/javascript" src="index.js">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img class="dhall-icon" src="dhall-icon.svg">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span class="title-crumb" href="index.html">Plain.txt</span>
+</h2>
+<a class="copy-to-clipboard" data-path="/Plain.txt">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<div class="doc-contents">
+</div>
+<h3>Source</h3>
+<div class="source-code">
+<pre>A plain text file that is imported `as Text` by `./AsText.dhall`<br>
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -33,6 +33,9 @@
 <h3>Exported files: </h3>
 <ul>
 <li>
+<a href="AsText.dhall.html">AsText.dhall</a>
+</li>
+<li>
 <a href="ImportAsType.dhall.html">ImportAsType.dhall</a>
 <span class="of-type-token">:</span>
 <span class="dhall-type source-code">
@@ -155,6 +158,9 @@
 <pre>∀(A : Type) → ∀(B : Type) → Type<br>
 </pre>
 </span>
+</li>
+<li>
+<a href="Plain.txt.html">Plain.txt</a>
 </li>
 <li>
 <a href="RenderTypeIndexesExample.dhall.html">RenderTypeIndexesExample.dhall</a>

--- a/dhall-docs/tasty/data/package/AsText.dhall
+++ b/dhall-docs/tasty/data/package/AsText.dhall
@@ -1,0 +1,1 @@
+./Plain.txt as Text

--- a/dhall-docs/tasty/data/package/Plain.txt
+++ b/dhall-docs/tasty/data/package/Plain.txt
@@ -1,0 +1,1 @@
+A plain text file that is imported `as Text` by `./AsText.dhall`

--- a/dhall-docs/tasty/data/package/ShouldBeIgnoredToo
+++ b/dhall-docs/tasty/data/package/ShouldBeIgnoredToo
@@ -1,1 +1,0 @@
-Should be ignored because this file has no .dhall extension


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2395

`dhall-docs` now bundles any `Text` files that it encounters.  The
motivation for this change was so that relative `as Text` imports would
work correctly, but it can also be used to just browse non-Dhall files
like `README`s.