### PR TITLE
dhall:tasty: Run testsuite in parallel

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -412,6 +412,7 @@ Test-Suite tasty
         temporary                 >= 1.2.1    && < 1.4 ,
         turtle                                   < 1.6 ,
     Default-Language: Haskell2010
+    Ghc-Options: -threaded -rtsopts -with-rtsopts=-N
 
 Test-Suite doctest
     Import: common


### PR DESCRIPTION
This reduces runtime on my machine from about 23s to 6s.