### PR TITLE
dhall-to-yaml{,-ng}: Add new `--preserve-header` option

### DIFF
--- a/dhall-json/src/Dhall/DhallToYaml/Main.hs
+++ b/dhall-json/src/Dhall/DhallToYaml/Main.hs
@@ -34,6 +34,7 @@ parseOptions =
             <*> optional parseFile
             <*> optional parseOutput
             <*> parseNoEdit
+            <*> parsePreserveHeader
             )
     <|> parseVersion
   where
@@ -70,6 +71,12 @@ parseOptions =
         Options.switch
            (   Options.long "generated-comment"
            <>  Options.help "Include a comment header warning not to edit the generated file"
+           )
+
+    parsePreserveHeader =
+        Options.switch
+           (   Options.long "preserve-header"
+           <>  Options.help "Translate any Dhall comment header to a YAML comment header"
            )
 
 parserInfo :: ParserInfo (Maybe Options)

--- a/dhall-yaml/tasty/Main.hs
+++ b/dhall-yaml/tasty/Main.hs
@@ -69,6 +69,10 @@ testTree =
             TestBoth
         , testYamlToDhall
             "./tasty/data/mergify"
+        , testDhallToYaml
+            Dhall.JSON.Yaml.defaultOptions{ preserveHeader = True }
+            "./tasty/data/preserve-header"
+            TestBoth
         ]
 
 testDhallToYaml :: Options -> String -> TestScope -> TestTree

--- a/dhall-yaml/tasty/data/preserve-header.dhall
+++ b/dhall-yaml/tasty/data/preserve-header.dhall
@@ -1,0 +1,6 @@
+-- Test header preservation
+--
+-- Line comments strip the leading `--`
+{- Block comments include the surrounding `{-` and `-}`
+  -}
+1

--- a/dhall-yaml/tasty/data/preserve-header.yaml
+++ b/dhall-yaml/tasty/data/preserve-header.yaml
@@ -1,0 +1,6 @@
+# Test header preservation
+#
+# Line comments strip the leading `--`
+#{- Block comments include the surrounding `{-` and `-}`
+#  -}
+1


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2375

This option preserves the original comment as a header