### PR TITLE
'dhall text' support passing shell functions as `Text -> Text` arguments

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -238,6 +238,7 @@ Common common
         prettyprinter               >= 1.7.0    && < 1.8 ,
         prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
         pretty-simple                              < 4.2 ,
+        process                     >= 1.6.0    && < 1.7 ,
         profunctors                 >= 3.1.2    && < 5.7 ,
         repline                     >= 0.4.0.0  && < 0.5 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,


### PR DESCRIPTION
Context/discussion: https://discourse.dhall-lang.org/t/idea-for-dhall-text-tool-accept-arguments-including-shell-commands-as-text-text/568

For my use case, the dhall tool alone is probably 90% of the way to a full templating solution with multiple backends.

Currently, `dhall text` requires the expression to be `Text`.  But what if it was able to also render expressions of type `(Text -> Text) -> Text`, and be given a shell argument as the `Text -> Text` ?

```dhall
-- testfile.dhall
let text = https://raw.githubusercontent.com/dhall-lang/dhall-lang/v21.1.0/Prelude/Text/package.dhall
in  \(f : Text -> Text) -> text.concatMapSep "," Text f [ "hello", "world" ]
```

Would give:

```
$ dhall text --file testfile.dhall --argCmd cat
hello,world
$ dhall text --file testfile.dhall --argCmd "tr '[:lower:]' '[:upper:]'"
HELLO,WORLD
$ dhall text --file testfile.dhall --argCmd "pandoc -f markdown -t html"
<p>hello</p>
,<p>world</p>
$ dhall text --file testfile.dhall --argCmd "md5sum -z"
5d41402abc4b2a76b9719d911017c592  -,7d793037a0760186574b0282f2f435e7  -
```

Error messages:

```
$ dhall text --file testfile.dhall
Error: Expression doesn't match annotation

- Text
+ .. -> .. (a function type)
$ dhall text --file testfile.dhall --argCmd cat --argCmd cat
Error: Expression doesn't match annotation

- .. -> ..  (a function type)
+ Text
```

Supports multiple arguments as well:

```dhall
-- testfile2.dhall
let text = https://raw.githubusercontent.com/dhall-lang/dhall-lang/v21.1.0/Prelude/Text/package.dhall
in  \(f : Text -> Text) -> \(g : Text -> Text) -> text.concatMapSep "," Text f [ "hello", g "world" ]
```

```
$ dhall text --file testfile2.dhall --argCmd cat --argCmd "tr '[:lower:]' '[:upper:]'"
hello,WORLD
```

Let me know if this is too "heavy" or "opinionated" to make sense to have in the main tool!  I definitely don't want to add anything to the tool that would compromise the spirit and purpose of it.  I can probably also make this an external tool as well if that's the case.