### PR TITLE
Fix `:hash` REPL command to α-normalize input

### DIFF
--- a/dhall/src/Dhall/Repl.hs
+++ b/dhall/src/Dhall/Repl.hs
@@ -294,7 +294,8 @@ hashBinding src = do
 
   normalizedExpression <- normalize loadedExpression
 
-  writeOutputHandle $ hashExpressionToCode normalizedExpression
+  writeOutputHandle
+    (hashExpressionToCode (Dhall.Core.alphaNormalize normalizedExpression))
 
 saveFilePrefix :: FilePath
 saveFilePrefix = ".dhall-repl"


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/issues/1285