### PR TITLE
fix dhall-lsp-server/default.nix to build lsp

### DIFF
--- a/dhall-lsp-server/default.nix
+++ b/dhall-lsp-server/default.nix
@@ -1,1 +1,1 @@
-(import ../nix/shared.nix {}).possibly-static.dhall
+(import ../nix/shared.nix { }).possibly-static.dhall-lsp-server


### PR DESCRIPTION
I fixed dhall-lsp-server/default.nix that was trying to build dhall instead of dhall-lsp-server.

P.S. The problem with https://github.com/dhall-lang/vscode-dhall-lsp-server/issues/37 is probably resolved in the current modified build. I haven't investigated it in detail, so it may not be exactly the same.