### PR TITLE
Use indexed-traversable for type-checking list literals

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -226,6 +226,7 @@ Common common
         half                        >= 0.2.2.3  && < 0.4 ,
         haskeline                   >= 0.7.2.1  && < 0.9 ,
         hashable                    >= 1.2      && < 1.5 ,
+        indexed-traversable                        < 0.2 ,
         lens-family-core            >= 1.0.0    && < 2.2 ,
         -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
         megaparsec                  >= 8        && < 10  ,

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -35,7 +35,7 @@ import Control.Monad.Trans.Writer.Strict (execWriterT, tell)
 import Data.List.NonEmpty                (NonEmpty (..))
 import Data.Monoid                       (Endo (..))
 import Data.Semigroup                    (Max (..))
-import Data.Sequence                     (Seq, ViewL (..))
+import Data.Sequence                     (ViewL (..))
 import Data.Set                          (Set)
 import Data.Text                         (Text)
 import Data.Typeable                     (Typeable)
@@ -65,6 +65,7 @@ import Dhall.Syntax
     )
 
 import qualified Data.Foldable               as Foldable
+import qualified Data.Foldable.WithIndex     as Foldable.WithIndex
 import qualified Data.List.NonEmpty          as NonEmpty
 import qualified Data.Map
 import qualified Data.Sequence
@@ -92,9 +93,6 @@ import qualified Prettyprinter.Render.String as Pretty
 -}
 type X = Void
 {-# DEPRECATED X "Use Data.Void.Void instead" #-}
-
-traverseWithIndex_ :: Applicative f => (Int -> a -> f b) -> Seq a -> f ()
-traverseWithIndex_ k xs = Foldable.sequenceA_ (Data.Sequence.mapWithIndex k xs)
 
 axiom :: Const -> Either (TypeError s a) Const
 axiom Type = return Kind
@@ -631,7 +629,7 @@ infer typer = loop
 
                                     Left (TypeError context t₁ err)
 
-                    traverseWithIndex_ process ts₁
+                    Foldable.WithIndex.itraverse_ process ts₁
 
                     return (VList _T₀')
 


### PR DESCRIPTION
itraverse_ for Seq is implemented via Data.Sequence.foldMapWithIndex
and manages to perform the traversal in one pass.
The previous implementation involved first mapping over the Seq and
then reducing the resulting Seq.

indexed-traversable is used in aeson, so it's already a transitive
dependency.