### PR TITLE
Build against `turtle-1.6`

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -419,7 +419,7 @@ Test-Suite tasty
         tasty-quickcheck          >= 0.9.2    && < 0.11,
         tasty-silver                             < 3.4 ,
         temporary                 >= 1.2.1    && < 1.4 ,
-        turtle                                   < 1.6 ,
+        turtle                                   < 1.7 ,
     Default-Language: Haskell2010
 
 Test-Suite doctest

--- a/dhall/tests/Dhall/Test/Freeze.hs
+++ b/dhall/tests/Dhall/Test/Freeze.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Dhall.Test.Freeze where
 
 import Data.Text    (Text)

--- a/dhall/tests/Dhall/Test/Freeze.hs
+++ b/dhall/tests/Dhall/Test/Freeze.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+-- FIXME: Re-enable deprecation warnings after removing support for turtle < 1.6.
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Dhall.Test.Freeze where

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
+-- FIXME: Re-enable deprecation warnings after removing support for turtle < 1.6.
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Dhall.Test.Import where

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -2,16 +2,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Dhall.Test.Import where
 
-import Control.Exception         (SomeException)
-import Data.Foldable             (fold)
-import Data.Text                 (Text, isSuffixOf)
-import Data.Void                 (Void)
-import Filesystem.Path.CurrentOS (toText)
-import Prelude                   hiding (FilePath)
-import Test.Tasty                (TestTree)
-import Turtle                    (FilePath, (</>))
+import Control.Exception (SomeException)
+import Data.Foldable     (fold)
+import Data.Text         (Text, isSuffixOf)
+import Data.Void         (Void)
+import Prelude           hiding (FilePath)
+import Test.Tasty        (TestTree)
+import Turtle            (FilePath, toText, (</>))
 
 import qualified Control.Exception                as Exception
 import qualified Control.Monad                    as Monad


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/6613

I kept the deprecated functions so that we could also
support `turtle-1.5` for one release, to (hypothetically)
simplify migrations for reverse dependencies.  After publishing
one release with this change we can remove the deprecated
functions.