### PR TITLE
Marshal Data.Text.Short.ShortText

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -246,6 +246,7 @@ Common common
         template-haskell            >= 2.13.0.0 && < 2.19,
         text                        >= 0.11.1.0 && < 2.1 ,
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
+        text-short                  >= 0.1      && < 0.2 ,
         th-lift-instances           >= 0.1.13   && < 0.2 ,
         time                        >= 1.1.4    && < 1.13,
         transformers                >= 0.5.2.0  && < 0.6 ,

--- a/dhall/src/Dhall/Marshal/Decode.hs
+++ b/dhall/src/Dhall/Marshal/Decode.hs
@@ -55,6 +55,7 @@ module Dhall.Marshal.Decode
     , string
     , lazyText
     , strictText
+    , shortText
       -- ** Time
     , timeOfDay
     , day
@@ -176,6 +177,7 @@ import qualified Data.Sequence
 import qualified Data.Set
 import qualified Data.Text
 import qualified Data.Text.Lazy
+import qualified Data.Text.Short
 import qualified Data.Time            as Time
 import qualified Data.Vector
 import qualified Dhall.Core           as Core
@@ -302,6 +304,9 @@ instance FromDhall Double where
 
 instance {-# OVERLAPS #-} FromDhall [Char] where
     autoWith _ = string
+
+instance FromDhall Data.Text.Short.ShortText where
+    autoWith _ = shortText
 
 instance FromDhall Data.Text.Lazy.Text where
     autoWith _ = lazyText
@@ -911,6 +916,14 @@ double = Decoder {..}
     extract  expr                       = typeError expected expr
 
     expected = pure Double
+
+{-| Decode `Data.Text.Short.ShortText`.
+
+>>> input shortText "\"Test\""
+"Test"
+-}
+shortText :: Decoder Data.Text.Short.ShortText
+shortText = fmap Data.Text.Short.fromText strictText
 
 {-| Decode lazy `Data.Text.Text`.
 

--- a/dhall/src/Dhall/Marshal/Encode.hs
+++ b/dhall/src/Dhall/Marshal/Encode.hs
@@ -83,6 +83,7 @@ import qualified Data.Sequence
 import qualified Data.Set
 import qualified Data.Text
 import qualified Data.Text.Lazy
+import qualified Data.Text.Short
 import qualified Data.Time            as Time
 import qualified Data.Vector
 import qualified Data.Void
@@ -165,6 +166,14 @@ instance ToDhall Bool where
         embed = BoolLit
 
         declared = Bool
+
+instance ToDhall Data.Text.Short.ShortText where
+    injectWith _ = Encoder {..}
+      where
+        embed text =
+            TextLit (Chunks [] (Data.Text.Short.toText text))
+
+        declared = Text
 
 instance ToDhall Data.Text.Lazy.Text where
     injectWith _ = Encoder {..}


### PR DESCRIPTION
...so that proto3-suite can use it as a string
representation within generated Haskell code
while still supporting Dhall marshaling.