### PR TITLE
Improved to-directory-tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ docs
 result
 result-*
 report.html
+/dhall/tests/to-directory-tree/*.out/

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -250,6 +250,7 @@ Common common
         th-lift-instances           >= 0.1.13   && < 0.2 ,
         time                        >= 1.1.4    && < 1.13,
         transformers                >= 0.5.2.0  && < 0.6 ,
+        unix-compat                 >= 0.4.2    && < 0.7 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
         uri-encode                                 < 1.6 ,
         vector                      >= 0.11.0.0 && < 0.14
@@ -411,6 +412,7 @@ Test-Suite tasty
     Other-Modules:
         Dhall.Test.Dhall
         Dhall.Test.Diff
+        Dhall.Test.DirectoryTree
         Dhall.Test.Tags
         Dhall.Test.Format
         Dhall.Test.Freeze

--- a/dhall/examples/to-directory-tree.dhall
+++ b/dhall/examples/to-directory-tree.dhall
@@ -1,0 +1,119 @@
+-- This is an example on how to build a directory tree using the so-called
+-- fixpointed method. See the documenatation of the `Dhall.DirectoryTree` module
+-- for further information on it.
+
+-- First, define some types recognized by the `dhall to-directory-tree` command.
+
+-- A user, either identified by its numeric user id or its name.
+let User = < UserId : Natural | UserName : Text >
+
+-- Similarly, a group.
+let Group = < GroupId : Natural | GroupName : Text >
+
+-- The following two type aliases are a well-typed represenation of the bitmask
+-- for permissions used by the DAC access control found on Unix systems. See for
+-- example the chmod(5) manual entry.
+
+-- How much access we do grant...
+let Access =
+      { execute : Optional Bool, read : Optional Bool, write : Optional Bool }
+
+-- ... for whom.
+let Mode =
+      { user : Optional Access
+      , group : Optional Access
+      , other : Optional Access
+      }
+
+-- A generic file system entry. It consists of a name, an abstract content and
+-- some metadata which might be set (Some) or not (None).
+let Entry =
+      \(content : Type) ->
+        { name : Text
+        , content : content
+        , user : Optional User
+        , group : Optional Group
+        , mode : Optional Mode
+        }
+
+-- This is the main program constructing our directory tree. It is a fixpoint
+-- definition similar to how we deal with recursive types in arbitrary Dhall
+-- programs but specialised to our use case. The first argument is the type of a
+-- directory tree and the second one is a record where each field is a
+-- constructor for a specific filesystem entry.
+in  \(tree : Type) ->
+    \ ( make
+      : { directory : Entry (List tree) -> tree, file : Entry Text -> tree }
+      ) ->
+
+      -- Before we define the actual directory tree we define some Dhall schemas
+      -- and shortcuts for convenience.
+
+      -- A schema suitable for a directory...
+      let Directory =
+            { Type =
+                { name : Text
+                , content : List tree
+                , user : Optional User
+                , group : Optional Group
+                , mode : Optional Mode
+                }
+            , default =
+              { content = [] : List tree
+              , user = None User
+              , group = None Group
+              , mode = None Mode
+              }
+            }
+
+      -- ... and one for a file.
+      let File =
+            { Type =
+                { name : Text
+                , content : Text
+                , user : Optional User
+                , group : Optional Group
+                , mode : Optional Mode
+                }
+            , default =
+              { content = ""
+              , user = None User
+              , group = None Group
+              , mode = None Mode
+              }
+            }
+
+      -- Give someone full access to an filesystem entry.
+      let full_access
+          : Access
+          = { execute = Some True, read = Some True, write = Some True }
+
+      -- Give someone no access at all to an filesystem entry.
+      let no_access
+          : Access
+          = { execute = Some False, read = Some False, write = Some False }
+
+      -- These permissions
+      --  * grant full access to the user.
+      --  * retain the permissions of the primary group of the user.
+      --  * deny access to everyone else.
+      let semi_private
+          : Mode
+          = { user = Some full_access, group = None Access, other = Some no_access }
+
+      -- Now let's start with the directory tree ...
+      in    [ -- Some file with a gentle greeting. No metadata is set explicitly.
+              make.file File::{ name = "some file", content = "Hello world!" }
+              -- A directory with some metadata set explicitely.
+            , make.directory
+                Directory::{
+                , name = "my private directory"
+                  -- How owns the new directory: just_me
+                , user = Some (User.UserName "just_me")
+                  -- We stick with the user's default group here.
+                , group = None Group
+                , mode = Some semi_private
+                , content = [] : List tree
+                }
+            ]
+          : List tree

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE BangPatterns      #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedLists   #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms   #-}
-{-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE OverloadedLists    #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE QuasiQuotes        #-}
+{-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE ViewPatterns       #-}
 
 -- | Implementation of the @dhall to-directory-tree@ subcommand
 module Dhall.DirectoryTree
@@ -16,17 +16,24 @@ module Dhall.DirectoryTree
     , FilesystemError(..)
     ) where
 
-import Control.Applicative (empty)
-import Control.Exception   (Exception)
-import Control.Monad       (when, unless)
-import Data.Either         (isRight)
-import Data.Maybe          (fromMaybe)
-import Data.Functor.Identity (Identity(..))
-import Data.Sequence       (Seq)
-import Data.Text           (Text)
-import Data.Void           (Void)
-import Dhall.Syntax        (Chunks (..), Expr (..), FieldSelection(..), FunctionBinding(..), RecordField(..), Var(..))
-import System.FilePath     ((</>))
+import Control.Applicative      (empty)
+import Control.Exception        (Exception)
+import Control.Monad            (unless, when)
+import Data.Either              (isRight)
+import Data.Functor.Identity    (Identity (..))
+import Data.Maybe               (fromMaybe)
+import Data.Sequence            (Seq)
+import Data.Text                (Text)
+import Data.Void                (Void)
+import Dhall.Syntax
+    ( Chunks (..)
+    , Expr (..)
+    , FieldSelection (..)
+    , FunctionBinding (..)
+    , RecordField (..)
+    , Var (..)
+    )
+import System.FilePath          ((</>))
 import System.PosixCompat.Types (FileMode, GroupID, UserID)
 
 import qualified Control.Exception           as Exception

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -174,8 +174,8 @@ import qualified System.PosixCompat.User     as Posix
 
     __NOTE__: This utility does not take care of type-checking and normalizing
     the provided expression. This will raise a `FilesystemError` exception or a
-    `DhallErrors` exception upon encountering an expression that cannot be
-    converted as-is.
+    `Dhall.Marshal.Decode.DhallErrors` exception upon encountering an expression
+    that cannot be converted as-is.
 -}
 toDirectoryTree
     :: Bool -- ^ Whether to allow path separators in file names or not

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -79,7 +79,7 @@ import qualified System.PosixCompat.User     as Posix
 
     * @Optional@ values are omitted if @None@
 
-    * There is a more advanced way construction directory trees using a fixpoint
+    * There is a more advanced way to construct directory trees using a fixpoint
       encoding. See the documentation below on that.
 
     For example, the following Dhall record:

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -110,7 +110,7 @@ import qualified System.PosixCompat.User     as Posix
 
     /Advanced construction of directory trees/
 
-    In addition to the ways described above using 'simple' Dhall values to
+    In addition to the ways described above using "simple" Dhall values to
     construct the directory tree there is one based on a fixpoint encoding. It
     works by passing a value of the following type to the interpreter:
 
@@ -275,7 +275,8 @@ extractFilesystemEntry _ expr = Exception.throw (FilesystemError expr)
 extractFilesystemEntryList :: Text -> Expr Void Void -> Seq FilesystemEntry
 extractFilesystemEntryList make = extractList (extractFilesystemEntry make)
 
--- | A generic filesystem entry parameterized over the content.
+-- | A generic filesystem entry. This type holds the metadata that apply to all entries.
+-- It is parametric over the content of such an entry.
 data Entry a = Entry
     { entryName :: String
     , entryContent :: a
@@ -352,7 +353,10 @@ getGroup (GroupName name) = Posix.groupID <$> Posix.getGroupEntryForName name
 
 -- | A filesystem mode. See chmod(1).
 -- The parameter is meant to be instantiated by either `Identity` or `Maybe`
--- depending on the completeness of the information.
+-- depending on the completeness of the information:
+--  * For data read from the filesystem it will be `Identity`.
+--  * For user-supplied data it will be `Maybe` as we want to be able to set
+--    only specific bits.
 data Mode f = Mode
     { modeUser :: f (Access f)
     , modeGroup :: f (Access f)
@@ -402,7 +406,7 @@ extractAccess (RecordLit (Map.toList ->
     }
 extractAccess expr = Exception.throw (FilesystemError expr)
 
--- | Helper function to extract a `Bool` value.
+-- | Helper function to extract a `Prelude.Bool` value.
 extractBool :: Expr Void Void -> Bool
 extractBool (BoolLit b) = b
 extractBool expr = Exception.throw (FilesystemError expr)
@@ -421,11 +425,11 @@ extractMaybe _ (App None _) = Nothing
 extractMaybe f (Some expr) = Just (f expr)
 extractMaybe _ expr = Exception.throw (FilesystemError expr)
 
--- | Helper function to extract a `String` value.
+-- | Helper function to extract a `Prelude.String` value.
 extractString :: Expr Void Void -> String
 extractString = Text.unpack . extractText
 
--- | Helper function to extract a `Text` value.
+-- | Helper function to extract a `Text.Text` value.
 extractText :: Expr Void Void -> Text
 extractText (TextLit (Chunks [] text)) = text
 extractText expr = Exception.throw (FilesystemError expr)

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -156,13 +156,13 @@ import qualified System.PosixCompat.User     as Posix
     >         , mode : Optional Mode
     >         }
     >
-    > in  forall (r : Type) ->
+    > in  forall (tree : Type) ->
     >     forall  ( make
-    >             : { directory : Entry (List r) -> r
-    >               , file : Entry Text -> r
+    >             : { directory : Entry (List tree) -> tree
+    >               , file : Entry Text -> tree
     >               }
     >             ) ->
-    >       List r
+    >       List tree
 
     The fact that the metadata for filesystem entries is modeled after the POSIX
     permission model comes with the unfortunate downside that it might not apply

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -159,7 +159,7 @@ data Mode
     | Encode { file :: Input, json :: Bool }
     | Decode { file :: Input, json :: Bool, quiet :: Bool }
     | Text { file :: Input, output :: Output }
-    | DirectoryTree { file :: Input, path :: FilePath }
+    | DirectoryTree { allowSeparators :: Bool, file :: Input, path :: FilePath }
     | Schemas { file :: Input, outputMode :: OutputMode, schemas :: Text }
     | SyntaxTree { file :: Input, noted :: Bool }
 
@@ -269,7 +269,7 @@ parseMode =
             Generate
             "to-directory-tree"
             "Convert nested records of Text literals into a directory tree"
-            (DirectoryTree <$> parseFile <*> parseDirectoryTreeOutput)
+            (DirectoryTree <$> parseDirectoryTreeAllowSeparators <*> parseFile <*> parseDirectoryTreeOutput)
     <|> subcommand
             Interpret
             "resolve"
@@ -531,6 +531,12 @@ parseMode =
             (   Options.Applicative.long "schemas"
             <>  Options.Applicative.help "A record of schemas"
             <>  Options.Applicative.metavar "EXPR"
+            )
+
+    parseDirectoryTreeAllowSeparators =
+        Options.Applicative.switch
+            (   Options.Applicative.long "allow-path-separators"
+            <>  Options.Applicative.help "Whether to allow path separators in file names"
             )
 
     parseDirectoryTreeOutput =
@@ -997,7 +1003,7 @@ command (Options {..}) = do
 
             let normalizedExpression = Dhall.Core.normalize resolvedExpression
 
-            DirectoryTree.toDirectoryTree path normalizedExpression
+            DirectoryTree.toDirectoryTree allowSeparators path normalizedExpression
 
         Dhall.Main.Schemas{..} ->
             Dhall.Schemas.schemasCommand Dhall.Schemas.Schemas{ input = file, ..}

--- a/dhall/src/Dhall/Marshal/Decode.hs
+++ b/dhall/src/Dhall/Marshal/Decode.hs
@@ -146,6 +146,7 @@ import Data.Functor.Contravariant
     , Op (..)
     , Predicate (..)
     )
+import Data.Functor.Identity            (Identity (..))
 import Data.Hashable                    (Hashable)
 import Data.List.NonEmpty               (NonEmpty (..))
 import Data.Typeable                    (Proxy (..), Typeable)
@@ -313,6 +314,9 @@ instance FromDhall Data.Text.Lazy.Text where
 
 instance FromDhall Text where
     autoWith _ = strictText
+
+instance FromDhall a => FromDhall (Identity a) where
+    autoWith opts = Identity <$> autoWith opts
 
 instance FromDhall a => FromDhall (Maybe a) where
     autoWith opts = maybe (autoWith opts)

--- a/dhall/tests/Dhall/Test/DirectoryTree.hs
+++ b/dhall/tests/Dhall/Test/DirectoryTree.hs
@@ -1,0 +1,89 @@
+module Dhall.Test.DirectoryTree (tests) where
+
+import Control.Monad
+import Data.Either (partitionEithers)
+import Lens.Family (set)
+import System.FilePath ((</>))
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Data.Text.IO
+import qualified Dhall
+import qualified Dhall.Core
+import qualified Dhall.DirectoryTree
+import qualified System.Directory as Directory
+import qualified System.FilePath as FilePath
+import qualified System.PosixCompat.Files as Files
+
+tests :: TestTree
+tests = testGroup "to-directory-tree"
+    [ testGroup "fixpointed"
+        [ fixpointedEmpty
+        , fixpointedSimple
+        , fixpointedMetadata
+        ]
+    ]
+
+fixpointedEmpty :: TestTree
+fixpointedEmpty = testCase "empty" $ do
+    let outDir = "./tests/to-directory-tree/fixpoint-empty.out"
+        path = "./tests/to-directory-tree/fixpoint-empty.dhall"
+    entries <- runDirectoryTree False outDir path
+    entries @?= [Directory outDir]
+
+fixpointedSimple :: TestTree
+fixpointedSimple = testCase "simple" $ do
+    let outDir = "./tests/to-directory-tree/fixpoint-simple.out"
+        path = "./tests/to-directory-tree/fixpoint-simple.dhall"
+    entries <- runDirectoryTree False outDir path
+    entries @?=
+        [ Directory outDir
+        , File $ outDir </> "file"
+        , Directory $ outDir </> "directory"
+        ]
+
+fixpointedMetadata :: TestTree
+fixpointedMetadata = testCase "metadata" $ do
+    let outDir = "./tests/to-directory-tree/fixpoint-metadata.out"
+        path = "./tests/to-directory-tree/fixpoint-metadata.dhall"
+    entries <- runDirectoryTree False outDir path
+    entries @?=
+        [ Directory outDir
+        , File $ outDir </> "file"
+        ]
+    s <- Files.getFileStatus $ outDir </> "file"
+    let mode = Files.fileMode s `Files.intersectFileModes` Files.accessModes
+    mode @?= Files.ownerModes
+
+runDirectoryTree :: Bool -> FilePath -> FilePath -> IO [FilesystemEntry]
+runDirectoryTree allowSeparators outDir path = do
+    doesOutDirExist <- Directory.doesDirectoryExist outDir
+    when doesOutDirExist $
+        Directory.removeDirectoryRecursive outDir
+    Directory.createDirectoryIfMissing True outDir
+
+    text <- Data.Text.IO.readFile path
+    let inputSettings
+            = set Dhall.rootDirectory (FilePath.takeDirectory path)
+            . set Dhall.sourceName path
+            $ Dhall.defaultInputSettings
+    expr <- Dhall.inputExprWithSettings inputSettings text
+
+    Dhall.DirectoryTree.toDirectoryTree allowSeparators outDir $ Dhall.Core.denote expr
+
+    walkFsTree outDir
+
+data FilesystemEntry
+    = Directory FilePath
+    | File FilePath
+    deriving (Eq, Show)
+
+walkFsTree :: FilePath -> IO [FilesystemEntry]
+walkFsTree dir = do
+    entries <- Directory.listDirectory dir
+    (ds, fs) <- fmap partitionEithers $ forM entries $ \path -> do
+        let path' = dir </> path
+        isDirectory <- Directory.doesDirectoryExist path'
+        return $ if isDirectory then Left path' else Right (File path')
+    entries' <- traverse walkFsTree ds
+    return $ Directory dir : fs <> concat entries'

--- a/dhall/tests/Dhall/Test/DirectoryTree.hs
+++ b/dhall/tests/Dhall/Test/DirectoryTree.hs
@@ -2,6 +2,7 @@ module Dhall.Test.DirectoryTree (tests) where
 
 import Control.Monad
 import Data.Either (partitionEithers)
+import Data.Either.Validation
 import Lens.Family (set)
 import System.FilePath ((</>))
 import Test.Tasty
@@ -18,11 +19,22 @@ import qualified System.PosixCompat.Files as Files
 tests :: TestTree
 tests = testGroup "to-directory-tree"
     [ testGroup "fixpointed"
-        [ fixpointedEmpty
+        [ fixpointedType
+        , fixpointedEmpty
         , fixpointedSimple
         , fixpointedMetadata
         ]
     ]
+
+fixpointedType :: TestTree
+fixpointedType = testCase "Type is as expected" $ do
+    let file = "./tests/to-directory-tree/type.dhall"
+    text <- Data.Text.IO.readFile file
+    ref <- Dhall.inputExpr text
+    expected' <- case Dhall.DirectoryTree.directoryTreeType of
+        Failure e -> assertFailure $ show e
+        Success expr -> return expr
+    assertBool "Type mismatch" $ expected' `Dhall.Core.judgmentallyEqual` ref
 
 fixpointedEmpty :: TestTree
 fixpointedEmpty = testCase "empty" $ do

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -5,6 +5,7 @@ import Test.Tasty      (TestTree)
 
 import qualified Dhall.Test.Dhall
 import qualified Dhall.Test.Diff
+import qualified Dhall.Test.DirectoryTree
 import qualified Dhall.Test.Format
 import qualified Dhall.Test.Freeze
 import qualified Dhall.Test.Import
@@ -62,6 +63,7 @@ getAllTests = do
                 , tagsTests
                 , freezeTests
                 , schemaTests
+                , Dhall.Test.DirectoryTree.tests
                 , Dhall.Test.Regression.tests
                 , Dhall.Test.Tutorial.tests
                 , Dhall.Test.QuickCheck.tests

--- a/dhall/tests/to-directory-tree/fixpoint-empty.dhall
+++ b/dhall/tests/to-directory-tree/fixpoint-empty.dhall
@@ -1,0 +1,3 @@
+let Make = (./fixpoint-helper.dhall).Make
+
+in  \(r : Type) -> \(make : Make r) -> [] : List r

--- a/dhall/tests/to-directory-tree/fixpoint-helper.dhall
+++ b/dhall/tests/to-directory-tree/fixpoint-helper.dhall
@@ -1,0 +1,26 @@
+let User = < UserId : Natural | UserName : Text >
+
+let Group = < GroupId : Natural | GroupName : Text >
+
+let Access =
+      { execute : Optional Bool, read : Optional Bool, write : Optional Bool }
+
+let Mode =
+      { user : Optional Access
+      , group : Optional Access
+      , other : Optional Access
+      }
+
+let Entry =
+      \(content : Type) ->
+        { name : Text
+        , content : content
+        , user : Optional User
+        , group : Optional Group
+        , mode : Optional Mode
+        }
+
+let Make =
+      \(r : Type) -> { directory : Entry (List r) -> r, file : Entry Text -> r }
+
+in  { User, Group, Access, Mode, Entry, Make }

--- a/dhall/tests/to-directory-tree/fixpoint-metadata.dhall
+++ b/dhall/tests/to-directory-tree/fixpoint-metadata.dhall
@@ -1,0 +1,26 @@
+let User = (./fixpoint-helper.dhall).User
+
+let Group = (./fixpoint-helper.dhall).Group
+
+let Access = (./fixpoint-helper.dhall).Access
+
+let Make = (./fixpoint-helper.dhall).Make
+
+let no-access = { execute = Some False, read = Some False, write = Some False }
+
+let full-access = { execute = Some True, read = Some True, write = Some True }
+
+in  \(r : Type) ->
+    \(make : Make r) ->
+      [ make.file
+          { name = "file"
+          , content = ""
+          , user = None User
+          , group = None Group
+          , mode = Some
+            { user = Some full-access
+            , group = Some no-access
+            , other = Some no-access
+            }
+          }
+      ]

--- a/dhall/tests/to-directory-tree/fixpoint-simple.dhall
+++ b/dhall/tests/to-directory-tree/fixpoint-simple.dhall
@@ -1,0 +1,25 @@
+let User = (./fixpoint-helper.dhall).User
+
+let Group = (./fixpoint-helper.dhall).Group
+
+let Mode = (./fixpoint-helper.dhall).Mode
+
+let Make = (./fixpoint-helper.dhall).Make
+
+in  \(r : Type) ->
+    \(make : Make r) ->
+        [ make.file
+            { name = "file"
+            , content = ""
+            , user = None User
+            , group = None Group
+            , mode = None Mode
+            }
+        , make.directory
+            { name = "directory"
+            , content = [] : List r
+            , user = None User
+            , group = None Group
+            , mode = None Mode
+            }
+        ]

--- a/dhall/tests/to-directory-tree/type.dhall
+++ b/dhall/tests/to-directory-tree/type.dhall
@@ -1,0 +1,31 @@
+let User = < UserId : Natural | UserName : Text >
+
+let Group = < GroupId : Natural | GroupName : Text >
+
+let Access =
+      { execute : Optional Bool, read : Optional Bool, write : Optional Bool }
+
+let Mode =
+      { user : Optional Access
+      , group : Optional Access
+      , other : Optional Access
+      }
+
+let Entry =
+      \(content : Type) ->
+        { name : Text
+        , content : content
+        , user : Optional User
+        , group : Optional Group
+        , mode : Optional Mode
+        }
+
+in  forall (result : Type) ->
+      let DirectoryEntry = Entry (List result)
+
+      let FileEntry = Entry Text
+
+      let Make =
+            { directory : DirectoryEntry -> result, file : FileEntry -> result }
+
+      in  forall (make : Make) -> List result


### PR DESCRIPTION
 * Added a new command line flag --allow-path-separators for the
   to-directory-tree command. This flag controls whether path separators
   in names are allowed. In that case we also create all parent
   directories of a file.
 * Added a new way building directory trees using a fixpoint approach.
   Using it allows one to set the user, group and permissions (for some OS).
   The values accepted need to have the type given in the issue description of #2436 .
 * Added unix-compat as a new dependency of the dhall package
 * Added some tests for to-directory-tree
 * Added a `FromDhall` instance for `Identity`

Fixes #2436 
Fixes #1633 