### PR TITLE
Explicit bzip2 format for linux artifacts.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
       matrix:
         os:
           - runner: 'macOS-latest'
-            archive-command: 'tar --create -j --file'
+            archive-command: 'tar --create --bzip2 --file'
             file-extension: 'tar.bz2'
             executable-extension: ''
           - runner: 'ubuntu-latest'
-            archive-command: 'tar --create --file'
+            archive-command: 'tar --create --bzip2 --file'
             file-extension: 'tar.bz2'
             executable-extension: ''
           - runner: 'windows-latest'


### PR DESCRIPTION
Fixes #2438 .
At the moment `tar` does not compress linux artifacts, this can be observer by artifacts file sizes for `1.41.2`:
```
<!DOCTYPE html>
dhall-Linux.tar.bz2 | 435 MB |  
-- | -- | --
dhall-Windows.zip | 96.9 MB |  
dhall-macOS.tar.bz2 | 43.5 MB
[dhall-Linux.tar.bz2](https://github.com/dhall-lang/dhall-haskell/suites/7819800437/artifacts/330389439)
435 MB	
[dhall-Windows.zip](https://github.com/dhall-lang/dhall-haskell/suites/7819800437/artifacts/330389442)
96.9 MB	
[dhall-macOS.tar.bz2](https://github.com/dhall-lang/dhall-haskell/suites/7819800437/artifacts/330389441)
43.5 MB
```

This PR add explicit bzip2 compression for Linux and unifies MacOs and Linux compression commands.