### PR TITLE
Fix `dhall-openapi.cabal`

### DIFF
--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -1,4 +1,4 @@
-Cabal-Version:  >=1.11
+Cabal-Version:  1.11
 Name:           dhall-openapi
 Version:        1.0.5
 Homepage:       https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-openapi#dhall-openapi


### PR DESCRIPTION
This is a small fix that I needed to make in order to upload the
package to Hackage