### PR TITLE
Support GHC 9.4

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -243,7 +243,7 @@ Common common
         repline                     >= 0.4.0.0  && < 0.5 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
-        template-haskell            >= 2.13.0.0 && < 2.19,
+        template-haskell            >= 2.13.0.0 && < 2.20,
         text                        >= 0.11.1.0 && < 2.1 ,
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
         text-short                  >= 0.1      && < 0.2 ,

--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -124,8 +124,8 @@ dot = token Internal.dot
 equals :: Diff
 equals = token Internal.equals
 
-forall :: Diff
-forall = token (Internal.forall Internal.Unicode)
+forall_ :: Diff
+forall_ = token (Internal.forall_ Internal.Unicode)
 
 lambda :: Diff
 lambda = token (Internal.lambda Internal.Unicode)
@@ -737,7 +737,7 @@ diff l@(Pi {}) r@(Pi {}) =
             | same docA =
                 format mempty docB
             | otherwise =
-                    forall
+                    forall_
                 <>  lparen
                 <>  format " " docA
                 <>  colon

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -55,7 +55,7 @@ module Dhall.Pretty.Internal (
     , comma
     , dot
     , equals
-    , forall
+    , forall_
     , label
     , lambda
     , langle
@@ -310,9 +310,9 @@ lambda :: CharacterSet -> Doc Ann
 lambda Unicode = syntax "λ"
 lambda ASCII   = syntax "\\"
 
-forall :: CharacterSet -> Doc Ann
-forall Unicode = syntax "∀"
-forall ASCII   = syntax "forall "
+forall_ :: CharacterSet -> Doc Ann
+forall_ Unicode = syntax "∀"
+forall_ ASCII   = syntax "forall "
 
 rarrow :: CharacterSet -> Doc Ann
 rarrow Unicode = syntax "→"
@@ -798,7 +798,7 @@ prettyPrinters characterSet =
         docs (Pi _ "_" b c) = prettyOperatorExpression b : docs c
         docs (Pi _ a   b c) = Pretty.group (Pretty.flatAlt long short) : docs c
           where
-            long =  forall characterSet <> space
+            long =  forall_ characterSet <> space
                 <>  Pretty.align
                     (   lparen <> space
                     <>  prettyLabel a
@@ -809,7 +809,7 @@ prettyPrinters characterSet =
                     <>  rparen
                     )
 
-            short = forall characterSet <> lparen
+            short = forall_ characterSet <> lparen
                 <>  prettyLabel a
                 <>  space <> colon <> space
                 <>  prettyExpression b

--- a/dhall/src/Dhall/Pretty/Internal.hs
+++ b/dhall/src/Dhall/Pretty/Internal.hs
@@ -469,7 +469,7 @@ enclose beginShort beginLong sepShort sepLong endShort endLong docs =
     combineShort x y = x <> y
 
 {-| Format an expression that holds a variable number of elements without a
-    trailing document such as nested `let`, nested lambdas, or nested `forall`s
+    trailing document such as nested @let@, nested lambdas, or nested @forall@s
 -}
 enclose'
     :: Doc ann


### PR DESCRIPTION
dhall-nix and dhall-nixpkgs are blocked on hnix not being compatible yet.
dhall-lsp-server needs to become compatible with the latest lsp release first.

The renamings `forall` -> `forall_` are due to this warning:

    warning: [-Wforall-identifier]
    The use of ‘forall’ as an identifier
    will become an error in a future GHC release.
    Suggested fix:
      Consider using another name, such as
      ‘forAll’, ‘for_all’, or ‘forall_’.

----

TODO:

* [ ] Run the doctests once `doctest` is compatible (https://github.com/sol/doctest/pull/376).