### PR TITLE
stack.yaml: Remove old extra-deps

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -11,12 +11,9 @@ packages:
   - dhall-toml
   - dhall-yaml
 extra-deps:
-  - haskell-lsp-0.23.0.0@sha256:b782cb24ca62510f4eb698f778f7e6dac6419a5ac8fb8dc67bdffe4ae04ae42d,5315
-  - haskell-lsp-types-0.23.0.0@sha256:b15d9c2aff8b8145797f5fa6771910b986d2456eccb30c3de69b75d4768cd12d,3027
   - hnix-0.13.1@sha256:50748fdddbdb2dc04c2d0b71fe708cde3c50258291c5db8839f76c85d9fdb505,21066
   - hnix-store-core-0.4.3.0@sha256:82397e5afb9b095626fd72e92d0ae42df02b2107df2de275d99e9968fa41ed65,2766
   - hnix-store-remote-0.4.3.1@sha256:1ec3ce04cbe381b4dcba736f10b1bf30812533cffc1e7997571ee0d377f1df78,2263
-  - lsp-test-0.14.0.0
   - lucid-2.11.0
   - relude-1.0.0.1@sha256:35bcdaf14018e79f11e712b0e2314c1aac79976f28f4adc179985457493557d5,11569
   - semialign-1.2@sha256:9afb6eb7e50db7ca34d7c4108aec0f643dae2caaaa80394b44ffdd643315685c,2721


### PR DESCRIPTION
* We don't use haskell-lsp[-types] anymore.
* lsp-test-0.14.0.0 is already included in the Stackage snapshot.