### PR TITLE
Move types needed in Dhall.DirectoryTree to own module

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -353,6 +353,7 @@ Library
         Exposed-Modules:
           Dhall.Deriving
     Other-Modules:
+        Dhall.DirectoryTree.Types
         Dhall.Eval
         Dhall.Import.Types
         Dhall.Import.Headers

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE OverloadedLists    #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RecordWildCards    #-}
-{-# LANGUAGE TupleSections      #-}
-{-# LANGUAGE ViewPatterns       #-}
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -18,21 +18,18 @@ module Dhall.DirectoryTree
     , directoryTreeType
     ) where
 
-import Control.Applicative      (empty)
-import Control.Exception        (Exception)
-import Control.Monad            (unless, when)
-import Data.Either.Validation   (Validation (..))
-import Data.Functor.Identity    (Identity (..))
-import Data.Maybe               (fromMaybe)
-import Data.Sequence            (Seq)
-import Data.Text                (Text)
-import Data.Void                (Void)
+import Control.Applicative       (empty)
+import Control.Exception         (Exception)
+import Control.Monad             (unless, when)
+import Data.Either.Validation    (Validation (..))
+import Data.Functor.Identity     (Identity (..))
+import Data.Maybe                (fromMaybe)
+import Data.Sequence             (Seq)
+import Data.Text                 (Text)
+import Data.Void                 (Void)
 import Dhall.DirectoryTree.Types
-import Dhall.Marshal.Decode
-    ( Decoder (..)
-    , Expector
-    )
-import Dhall.Src                (Src)
+import Dhall.Marshal.Decode      (Decoder (..), Expector)
+import Dhall.Src                 (Src)
 import Dhall.Syntax
     ( Chunks (..)
     , Const (..)
@@ -40,8 +37,8 @@ import Dhall.Syntax
     , RecordField (..)
     , Var (..)
     )
-import System.FilePath          ((</>))
-import System.PosixCompat.Types (FileMode, GroupID, UserID)
+import System.FilePath           ((</>))
+import System.PosixCompat.Types  (FileMode, GroupID, UserID)
 
 import qualified Control.Exception           as Exception
 import qualified Data.Foldable               as Foldable

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -1,13 +1,6 @@
-{-# LANGUAGE DataKinds          #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingVia        #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedLists    #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE PatternSynonyms    #-}
 {-# LANGUAGE RecordWildCards    #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections      #-}
 {-# LANGUAGE ViewPatterns       #-}
 
@@ -32,20 +25,16 @@ import Data.Maybe               (fromMaybe)
 import Data.Sequence            (Seq)
 import Data.Text                (Text)
 import Data.Void                (Void)
+import Dhall.DirectoryTree.Types
 import Dhall.Marshal.Decode
     ( Decoder (..)
     , Expector
-    , FromDhall (..)
-    , Generic
-    , InputNormalizer
-    , InterpretOptions (..)
     )
 import Dhall.Src                (Src)
 import Dhall.Syntax
     ( Chunks (..)
     , Const (..)
     , Expr (..)
-    , FieldSelection (..)
     , RecordField (..)
     , Var (..)
     )
@@ -66,7 +55,6 @@ import qualified Prettyprinter.Render.String as Pretty
 import qualified System.Directory            as Directory
 import qualified System.FilePath             as FilePath
 import qualified System.PosixCompat.Files    as Posix
-import qualified System.PosixCompat.Types    as Posix
 import qualified System.PosixCompat.User     as Posix
 
 {-| Attempt to transform a Dhall record into a directory tree where:
@@ -269,131 +257,15 @@ makeType = Record . Map.fromList <$> sequenceA
         makeConstructor name dec = (name,) . Core.makeRecordField
             <$> (Pi Nothing "_" <$> expected dec <*> pure (Var (V "tree" 0)))
 
--- | Utility pattern synonym to match on filesystem entry constructors
-pattern Make :: Text -> Expr s a -> Expr s a
-pattern Make label entry <- App (Field (Var (V "_" 0)) (fieldSelectionLabel -> label)) entry
-
-type DirectoryEntry = Entry (Seq FilesystemEntry)
-
-type FileEntry = Entry Text
-
--- | A filesystem entry.
-data FilesystemEntry
-    = DirectoryEntry (Entry (Seq FilesystemEntry))
-    | FileEntry (Entry Text)
-    deriving Show
-
-instance FromDhall FilesystemEntry where
-    autoWith normalizer = Decoder
-        { expected = pure $ Var (V "tree" 0)
-        , extract = \case
-            Make "directory" entry ->
-                DirectoryEntry <$> extract (autoWith normalizer) entry
-            Make "file" entry ->
-                FileEntry <$> extract (autoWith normalizer) entry
-            expr -> Decode.typeError (expected (Decode.autoWith normalizer :: Decoder FilesystemEntry)) expr
-        }
-
--- | A generic filesystem entry. This type holds the metadata that apply to all
--- entries. It is parametric over the content of such an entry.
-data Entry a = Entry
-    { entryName :: String
-    , entryContent :: a
-    , entryUser :: Maybe User
-    , entryGroup :: Maybe Group
-    , entryMode :: Maybe (Mode Maybe)
-    }
-    deriving (Generic, Show)
-
-instance FromDhall a => FromDhall (Entry a) where
-    autoWith = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOptions
-        { fieldModifier = Text.toLower . Text.drop (Text.length "entry")
-        }
-
--- | A user identified either by id or name.
-data User
-    = UserId UserID
-    | UserName String
-    deriving (Generic, Show)
-
-instance FromDhall User
-
-instance FromDhall Posix.CUid where
-    autoWith normalizer = Posix.CUid <$> autoWith normalizer
-
 -- | Resolve a `User` to a numerical id.
 getUser :: User -> IO UserID
 getUser (UserId uid) = return uid
 getUser (UserName name) = Posix.userID <$> Posix.getUserEntryForName name
 
--- | A group identified either by id or name.
-data Group
-    = GroupId GroupID
-    | GroupName String
-    deriving (Generic, Show)
-
-instance FromDhall Group
-
-instance FromDhall Posix.CGid where
-    autoWith normalizer = Posix.CGid <$> autoWith normalizer
-
 -- | Resolve a `Group` to a numerical id.
 getGroup :: Group -> IO GroupID
 getGroup (GroupId gid) = return gid
 getGroup (GroupName name) = Posix.groupID <$> Posix.getGroupEntryForName name
-
--- | A filesystem mode. See chmod(1).
--- The parameter is meant to be instantiated by either `Identity` or `Maybe`
--- depending on the completeness of the information:
---  * For data read from the filesystem it will be `Identity`.
---  * For user-supplied data it will be `Maybe` as we want to be able to set
---    only specific bits.
-data Mode f = Mode
-    { modeUser :: f (Access f)
-    , modeGroup :: f (Access f)
-    , modeOther :: f (Access f)
-    }
-    deriving Generic
-
-deriving instance Eq (Mode Identity)
-deriving instance Eq (Mode Maybe)
-deriving instance Show (Mode Identity)
-deriving instance Show (Mode Maybe)
-
-instance FromDhall (Mode Identity) where
-    autoWith = modeDecoder
-
-instance FromDhall (Mode Maybe) where
-    autoWith = modeDecoder
-
-modeDecoder :: FromDhall (f (Access f)) => InputNormalizer -> Decoder (Mode f)
-modeDecoder = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOptions
-    { fieldModifier = Text.toLower . Text.drop (Text.length "mode")
-    }
-
--- | The permissions for a subject (user/group/other).
-data Access f = Access
-    { accessExecute :: f Bool
-    , accessRead :: f Bool
-    , accessWrite :: f Bool
-    }
-    deriving Generic
-
-deriving instance Eq (Access Identity)
-deriving instance Eq (Access Maybe)
-deriving instance Show (Access Identity)
-deriving instance Show (Access Maybe)
-
-instance FromDhall (Access Identity) where
-    autoWith = accessDecoder
-
-instance FromDhall (Access Maybe) where
-    autoWith = accessDecoder
-
-accessDecoder :: FromDhall (f Bool) => InputNormalizer -> Decoder (Access f)
-accessDecoder = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOptions
-    { fieldModifier = Text.toLower . Text.drop (Text.length "access")
-    }
 
 -- | Process a `FilesystemEntry`. Writes the content to disk and apply the
 -- metadata to the newly created item.

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -311,7 +311,7 @@ applyMetadata entry fp = do
 
     let mode' = maybe mode (updateModeWith mode) (entryMode entry)
     unless (mode' == mode) $
-        Posix.setFileMode fp $ modeToFileMode mode'
+        setFileModeOnUnix fp $ modeToFileMode mode'
 
 -- | Calculate the new `Mode` from the current mode and the changes specified by
 -- the user.

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -308,7 +308,7 @@ applyMetadata entry fp = do
 
     let mode' = maybe mode (updateModeWith mode) (entryMode entry)
     unless (mode' == mode) $
-        setFileModeOnUnix fp $ modeToFileMode mode'
+        setFileMode fp $ modeToFileMode mode'
 
 -- | Calculate the new `Mode` from the current mode and the changes specified by
 -- the user.

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -43,8 +43,11 @@ import qualified Dhall.Marshal.Decode as Decode
 #ifdef mingw32_HOST_OS
 import Data.Word (Word32)
 import System.IO (hPutStrLn, stderr)
+import System.PosixCompat.Types (CMode)
 
 import qualified Unsafe.Coerce
+
+type FileMode = CMode
 #else
 import System.PosixCompat.Types (FileMode)
 
@@ -189,8 +192,6 @@ accessDecoder = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOpt
 setFileModeOnUnix :: FilePath -> FileMode -> IO ()
 #ifdef mingw32_HOST_OS
 setFileModeOnUnix fp _ = hPutStrLn stderr $ "Warning: Feature is not supported on your platform; Failed to set permissions for " <> fp
-
-type FileMode = CMode
 #else
 setFileModeOnUnix fp mode = Posix.setFileMode fp mode
 #endif

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -210,10 +210,10 @@ setFileMode fp mode = Posix.setFileMode fp mode
 -- | Pretty-print a `FileMode`. The format is similar to the one ls(1):
 -- It is display as three blocks of three characters. The first block are the
 -- permissions of the user, the second one are the ones of the group and the
--- third one the ones of other subjects. A 'r' denotes that the file or
--- directory is readable by the subject, a 'w' denotes that it is writable and
--- an 'x' denotes that it is executable. Unset permissions are represented by
--- '-'.
+-- third one the ones of other subjects. A @r@ denotes that the file or
+-- directory is readable by the subject, a @w@ denotes that it is writable and
+-- an @x@ denotes that it is executable. Unset permissions are represented by
+-- @-@.
 prettyFileMode :: FileMode -> String
 prettyFileMode mode = userPP <> groupPP <> otherPP
     where

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE CPP                #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
-{-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE PatternSynonyms    #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE ViewPatterns       #-}
-{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE ViewPatterns               #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -35,15 +35,11 @@ import Dhall.Marshal.Decode
     , InputNormalizer
     , InterpretOptions (..)
     )
-import Dhall.Syntax
-    ( Expr (..)
-    , FieldSelection (..)
-    , Var (..)
-    )
+import Dhall.Syntax             (Expr (..), FieldSelection (..), Var (..))
 import System.PosixCompat.Types (GroupID, UserID)
 
-import qualified Data.Text                   as Text
-import qualified Dhall.Marshal.Decode        as Decode
+import qualified Data.Text            as Text
+import qualified Dhall.Marshal.Decode as Decode
 
 #ifdef mingw32_HOST_OS
 import Data.Word (Word32)

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -57,8 +57,10 @@ import qualified System.PosixCompat.Types as Posix
 pattern Make :: Text -> Expr s a -> Expr s a
 pattern Make label entry <- App (Field (Var (V "_" 0)) (fieldSelectionLabel -> label)) entry
 
+-- | A directory in the filesystem.
 type DirectoryEntry = Entry (Seq FilesystemEntry)
 
+-- | A file in the filesystem.
 type FileEntry = Entry Text
 
 -- | A filesystem entry.

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE LambdaCase         #-}
@@ -12,9 +13,9 @@
 
 -- | Types used by the implementation of the @to-directory-tree@ subcommand
 module Dhall.DirectoryTree.Types
-    ( DirectoryEntry
+    ( FilesystemEntry(..)
+    , DirectoryEntry
     , FileEntry
-    , FilesystemEntry(..)
     , Entry(..)
     , User(..)
     , Group(..)
@@ -61,7 +62,7 @@ type FileEntry = Entry Text
 data FilesystemEntry
     = DirectoryEntry (Entry (Seq FilesystemEntry))
     | FileEntry (Entry Text)
-    deriving Show
+    deriving (Eq, Generic, Ord, Show)
 
 instance FromDhall FilesystemEntry where
     autoWith normalizer = Decoder
@@ -83,7 +84,7 @@ data Entry a = Entry
     , entryGroup :: Maybe Group
     , entryMode :: Maybe (Mode Maybe)
     }
-    deriving (Generic, Show)
+    deriving (Eq, Generic, Ord, Show)
 
 instance FromDhall a => FromDhall (Entry a) where
     autoWith = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOptions
@@ -94,7 +95,7 @@ instance FromDhall a => FromDhall (Entry a) where
 data User
     = UserId UserID
     | UserName String
-    deriving (Generic, Show)
+    deriving (Eq, Generic, Ord, Show)
 
 instance FromDhall User
 
@@ -110,7 +111,7 @@ instance FromDhall Posix.CUid where
 data Group
     = GroupId GroupID
     | GroupName String
-    deriving (Generic, Show)
+    deriving (Eq, Generic, Ord, Show)
 
 instance FromDhall Group
 
@@ -137,6 +138,8 @@ data Mode f = Mode
 
 deriving instance Eq (Mode Identity)
 deriving instance Eq (Mode Maybe)
+deriving instance Ord (Mode Identity)
+deriving instance Ord (Mode Maybe)
 deriving instance Show (Mode Identity)
 deriving instance Show (Mode Maybe)
 
@@ -161,6 +164,8 @@ data Access f = Access
 
 deriving instance Eq (Access Identity)
 deriving instance Eq (Access Maybe)
+deriving instance Ord (Access Identity)
+deriving instance Ord (Access Maybe)
 deriving instance Show (Access Identity)
 deriving instance Show (Access Maybe)
 

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE PatternSynonyms    #-}
@@ -50,6 +51,8 @@ import System.IO (hPutStrLn, stderr)
 
 import qualified Unsafe.Coerce
 #else
+import System.PosixCompat.Types (FileMode)
+
 import qualified System.PosixCompat.Files as Posix
 import qualified System.PosixCompat.Types as Posix
 #endif
@@ -188,9 +191,14 @@ accessDecoder = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOpt
 
 
 -- | Set file permissions if we are not on Windows as it is currently not supported.
-setFileModeOnUnix :: FilePath -> Posix.FileMode -> IO ()
+setFileModeOnUnix :: FilePath -> FileMode -> IO ()
 #ifdef mingw32_HOST_OS
 setFileModeOnUnix fp _ = hPutStrLn stderr $ "Warning: Feature is not supported on your platform; Failed to set permissions for " <> fp
+
+type FileMode = CMode
+
+newtype CMode = CMode Word32
+    deriving (Eq, Ord, Enum, Num, Real, Show, Read, Bounded, Integral)
 #else
 setFileModeOnUnix fp mode = Posix.setFileMode fp mode
 #endif

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -43,6 +43,7 @@ import qualified Dhall.Marshal.Decode     as Decode
 import qualified System.PosixCompat.Files as Posix
 
 #ifdef mingw32_HOST_OS
+import Control.Monad            (unless)
 import Data.Word                (Word32)
 import System.IO                (hPutStrLn, stderr)
 import System.PosixCompat.Types (CMode)

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -93,7 +93,10 @@ data User
 
 instance FromDhall User
 
-#ifndef mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
+deriving instance FromDhall UserID
+deriving instance Generic UserID
+#else
 instance FromDhall Posix.CUid where
     autoWith normalizer = Posix.CUid <$> autoWith normalizer
 #endif
@@ -106,7 +109,10 @@ data Group
 
 instance FromDhall Group
 
-#ifndef mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
+deriving instance FromDhall GroupID
+deriving instance Generic GroupID
+#else
 instance FromDhall Posix.CGid where
     autoWith normalizer = Posix.CGid <$> autoWith normalizer
 #endif

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -1,13 +1,12 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE PatternSynonyms            #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE ViewPatterns       #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -192,9 +191,6 @@ setFileModeOnUnix :: FilePath -> FileMode -> IO ()
 setFileModeOnUnix fp _ = hPutStrLn stderr $ "Warning: Feature is not supported on your platform; Failed to set permissions for " <> fp
 
 type FileMode = CMode
-
-newtype CMode = CMode Word32
-    deriving (Eq, Ord, Enum, Num, Real, Show, Read, Bounded, Integral)
 #else
 setFileModeOnUnix fp mode = Posix.setFileMode fp mode
 #endif

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ViewPatterns       #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Types used by the implementation of the @to-directory-tree@ subcommand
+module Dhall.DirectoryTree.Types
+    ( DirectoryEntry
+    , FileEntry
+    , FilesystemEntry(..)
+    , Entry(..)
+    , User(..)
+    , Group(..)
+    , Mode(..)
+    , Access(..)
+    ) where
+
+import Data.Functor.Identity    (Identity (..))
+import Data.Sequence            (Seq)
+import Data.Text                (Text)
+import Dhall.Marshal.Decode
+    ( Decoder (..)
+    , FromDhall (..)
+    , Generic
+    , InputNormalizer
+    , InterpretOptions (..)
+    )
+import Dhall.Syntax
+    ( Expr (..)
+    , FieldSelection (..)
+    , Var (..)
+    )
+import System.PosixCompat.Types (GroupID, UserID)
+
+import qualified Data.Text                   as Text
+import qualified Dhall.Marshal.Decode        as Decode
+
+#ifndef mingw32_HOST_OS
+import qualified System.PosixCompat.Types    as Posix
+#endif
+
+pattern Make :: Text -> Expr s a -> Expr s a
+pattern Make label entry <- App (Field (Var (V "_" 0)) (fieldSelectionLabel -> label)) entry
+
+type DirectoryEntry = Entry (Seq FilesystemEntry)
+
+type FileEntry = Entry Text
+
+-- | A filesystem entry.
+data FilesystemEntry
+    = DirectoryEntry (Entry (Seq FilesystemEntry))
+    | FileEntry (Entry Text)
+    deriving Show
+
+instance FromDhall FilesystemEntry where
+    autoWith normalizer = Decoder
+        { expected = pure $ Var (V "tree" 0)
+        , extract = \case
+            Make "directory" entry ->
+                DirectoryEntry <$> extract (autoWith normalizer) entry
+            Make "file" entry ->
+                FileEntry <$> extract (autoWith normalizer) entry
+            expr -> Decode.typeError (expected (Decode.autoWith normalizer :: Decoder FilesystemEntry)) expr
+        }
+
+-- | A generic filesystem entry. This type holds the metadata that apply to all
+-- entries. It is parametric over the content of such an entry.
+data Entry a = Entry
+    { entryName :: String
+    , entryContent :: a
+    , entryUser :: Maybe User
+    , entryGroup :: Maybe Group
+    , entryMode :: Maybe (Mode Maybe)
+    }
+    deriving (Generic, Show)
+
+instance FromDhall a => FromDhall (Entry a) where
+    autoWith = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOptions
+        { fieldModifier = Text.toLower . Text.drop (Text.length "entry")
+        }
+
+-- | A user identified either by id or name.
+data User
+    = UserId UserID
+    | UserName String
+    deriving (Generic, Show)
+
+instance FromDhall User
+
+#ifndef mingw32_HOST_OS
+instance FromDhall Posix.CUid where
+    autoWith normalizer = Posix.CUid <$> autoWith normalizer
+#endif
+
+-- | A group identified either by id or name.
+data Group
+    = GroupId GroupID
+    | GroupName String
+    deriving (Generic, Show)
+
+instance FromDhall Group
+
+#ifndef mingw32_HOST_OS
+instance FromDhall Posix.CGid where
+    autoWith normalizer = Posix.CGid <$> autoWith normalizer
+#endif
+
+-- | A filesystem mode. See chmod(1).
+-- The parameter is meant to be instantiated by either `Identity` or `Maybe`
+-- depending on the completeness of the information:
+--  * For data read from the filesystem it will be `Identity`.
+--  * For user-supplied data it will be `Maybe` as we want to be able to set
+--    only specific bits.
+data Mode f = Mode
+    { modeUser :: f (Access f)
+    , modeGroup :: f (Access f)
+    , modeOther :: f (Access f)
+    }
+    deriving Generic
+
+deriving instance Eq (Mode Identity)
+deriving instance Eq (Mode Maybe)
+deriving instance Show (Mode Identity)
+deriving instance Show (Mode Maybe)
+
+instance FromDhall (Mode Identity) where
+    autoWith = modeDecoder
+
+instance FromDhall (Mode Maybe) where
+    autoWith = modeDecoder
+
+modeDecoder :: FromDhall (f (Access f)) => InputNormalizer -> Decoder (Mode f)
+modeDecoder = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOptions
+    { fieldModifier = Text.toLower . Text.drop (Text.length "mode")
+    }
+
+-- | The permissions for a subject (user/group/other).
+data Access f = Access
+    { accessExecute :: f Bool
+    , accessRead :: f Bool
+    , accessWrite :: f Bool
+    }
+    deriving Generic
+
+deriving instance Eq (Access Identity)
+deriving instance Eq (Access Maybe)
+deriving instance Show (Access Identity)
+deriving instance Show (Access Maybe)
+
+instance FromDhall (Access Identity) where
+    autoWith = accessDecoder
+
+instance FromDhall (Access Maybe) where
+    autoWith = accessDecoder
+
+accessDecoder :: FromDhall (f Bool) => InputNormalizer -> Decoder (Access f)
+accessDecoder = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOptions
+    { fieldModifier = Text.toLower . Text.drop (Text.length "access")
+    }

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -45,7 +45,7 @@ import qualified Dhall.Marshal.Decode        as Decode
 #ifdef mingw32_HOST_OS
 import Data.Word (Word32)
 
-import qualified Data.Coerce
+import qualified Unsafe.Coerce
 #else
 import qualified System.PosixCompat.Types as Posix
 #endif
@@ -100,7 +100,7 @@ instance FromDhall User
 
 #ifdef mingw32_HOST_OS
 instance FromDhall UserID where
-    autoWith normalizer = Data.Coerce.coerce <$> autoWith @Word32 normalizer
+    autoWith normalizer = Unsafe.Coerce.unsafeCoerce <$> autoWith @Word32 normalizer
 #else
 instance FromDhall Posix.CUid where
     autoWith normalizer = Posix.CUid <$> autoWith normalizer
@@ -116,7 +116,7 @@ instance FromDhall Group
 
 #ifdef mingw32_HOST_OS
 instance FromDhall GroupID where
-    autoWith normalizer = Data.Coerce.coerce <$> autoWith @Word32 normalizer
+    autoWith normalizer = Unsafe.Coerce.unsafeCoerce <$> autoWith @Word32 normalizer
 #else
 instance FromDhall Posix.CGid where
     autoWith normalizer = Posix.CGid <$> autoWith normalizer

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE PatternSynonyms    #-}
@@ -36,14 +37,10 @@ import Dhall.Syntax
     , FieldSelection (..)
     , Var (..)
     )
-import System.PosixCompat.Types (GroupID, UserID)
 
 import qualified Data.Text                   as Text
 import qualified Dhall.Marshal.Decode        as Decode
-
-#ifndef mingw32_HOST_OS
 import qualified System.PosixCompat.Types    as Posix
-#endif
 
 pattern Make :: Text -> Expr s a -> Expr s a
 pattern Make label entry <- App (Field (Var (V "_" 0)) (fieldSelectionLabel -> label)) entry
@@ -87,15 +84,14 @@ instance FromDhall a => FromDhall (Entry a) where
 
 -- | A user identified either by id or name.
 data User
-    = UserId UserID
+    = UserId Posix.UserID
     | UserName String
     deriving (Generic, Show)
 
 instance FromDhall User
 
 #ifdef mingw32_HOST_OS
-deriving instance FromDhall UserID
-deriving instance Generic UserID
+deriving instance FromDhall Posix.UserID
 #else
 instance FromDhall Posix.CUid where
     autoWith normalizer = Posix.CUid <$> autoWith normalizer
@@ -103,15 +99,14 @@ instance FromDhall Posix.CUid where
 
 -- | A group identified either by id or name.
 data Group
-    = GroupId GroupID
+    = GroupId Posix.GroupID
     | GroupName String
     deriving (Generic, Show)
 
 instance FromDhall Group
 
 #ifdef mingw32_HOST_OS
-deriving instance FromDhall GroupID
-deriving instance Generic GroupID
+deriving instance FromDhall Posix.GroupID
 #else
 instance FromDhall Posix.CGid where
     autoWith normalizer = Posix.CGid <$> autoWith normalizer

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -38,12 +38,13 @@ import Dhall.Marshal.Decode
 import Dhall.Syntax             (Expr (..), FieldSelection (..), Var (..))
 import System.PosixCompat.Types (GroupID, UserID)
 
-import qualified Data.Text            as Text
-import qualified Dhall.Marshal.Decode as Decode
+import qualified Data.Text                as Text
+import qualified Dhall.Marshal.Decode     as Decode
+import qualified System.PosixCompat.Files as Posix
 
 #ifdef mingw32_HOST_OS
-import Data.Word (Word32)
-import System.IO (hPutStrLn, stderr)
+import Data.Word                (Word32)
+import System.IO                (hPutStrLn, stderr)
 import System.PosixCompat.Types (CMode)
 
 import qualified Unsafe.Coerce
@@ -52,7 +53,6 @@ type FileMode = CMode
 #else
 import System.PosixCompat.Types (FileMode)
 
-import qualified System.PosixCompat.Files as Posix
 import qualified System.PosixCompat.Types as Posix
 #endif
 

--- a/dhall/src/Dhall/Pretty/Internal.hs-boot
+++ b/dhall/src/Dhall/Pretty/Internal.hs-boot
@@ -1,15 +1,15 @@
 module Dhall.Pretty.Internal where
 
-import Control.DeepSeq (NFData)
-import Data.Data (Data)
-import Data.Text (Text)
-import Prettyprinter (Pretty, Doc)
-import Dhall.Src (Src)
+import Control.DeepSeq            (NFData)
+import Data.Data                  (Data)
+import Data.Text                  (Text)
+import Dhall.Src                  (Src)
 import Language.Haskell.TH.Syntax (Lift)
+import Prettyprinter              (Doc, Pretty)
 
+import                Dhall.Syntax.Const
 import {-# SOURCE #-} Dhall.Syntax.Expr
-import Dhall.Syntax.Const
-import Dhall.Syntax.Var
+import                Dhall.Syntax.Var
 
 data Ann
 

--- a/dhall/tests/to-directory-tree/fixpoint-permissions.dhall
+++ b/dhall/tests/to-directory-tree/fixpoint-permissions.dhall
@@ -2,8 +2,6 @@ let User = (./fixpoint-helper.dhall).User
 
 let Group = (./fixpoint-helper.dhall).Group
 
-let Access = (./fixpoint-helper.dhall).Access
-
 let Make = (./fixpoint-helper.dhall).Make
 
 let no-access = { execute = Some False, read = Some False, write = Some False }

--- a/dhall/tests/to-directory-tree/fixpoint-usergroup.dhall
+++ b/dhall/tests/to-directory-tree/fixpoint-usergroup.dhall
@@ -1,0 +1,25 @@
+let User = (./fixpoint-helper.dhall).User
+
+let Group = (./fixpoint-helper.dhall).Group
+
+let Mode = (./fixpoint-helper.dhall).Mode
+
+let Make = (./fixpoint-helper.dhall).Make
+
+in  \(r : Type) ->
+    \(make : Make r) ->
+      [ make.file
+          { name = "ids"
+          , content = ""
+          , user = Some (User.UserId 0)
+          , group = Some (Group.GroupId 0)
+          , mode = None Mode
+          }
+      , make.file
+          { name = "names"
+          , content = ""
+          , user = Some (User.UserName "user")
+          , group = Some (Group.GroupName "group")
+          , mode = None Mode
+          }
+      ]


### PR DESCRIPTION
In order to fix the Windows builds observed in #2452 we only include the `FromDhall CUid` and `FromDhall CGid` instance only if we are on that platform. Those types are not available there which caused the CI failure.

Fixes #2452