### PR TITLE
dhall: Add `Data` instance to `Import`

### DIFF
--- a/dhall/CHANGELOG.md
+++ b/dhall/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+
+* [Add `Data` instances for `Import` and various other types](https://github.com/dhall-lang/dhall-haskell/pull/2462)
+
 1.41.2
 
 * [BUG FIX: Fix `:hash` REPL command to α-normalize input](https://github.com/dhall-lang/dhall-haskell/pull/2420)
@@ -1049,7 +1053,7 @@
     * This allows the `dhall` package to be built without using
       `TemplateHaskell`
     * See: https://github.com/dhall-lang/dhall-haskell/pull/928
-* Increase lines of context for error messages 
+* Increase lines of context for error messages
     * Error messages now provide at least 20 lines of context instead of 3
       before truncating large expressions
     * See: https://github.com/dhall-lang/dhall-haskell/pull/916
@@ -1432,7 +1436,7 @@
       expression
     * You can pin the new hashes by supplying the `--protocol-version 1.0`
       option on the command line until you need support for newer language
-      features 
+      features
     * This also includes a breaking change to `ImportType` in the API
 * BREAKING CHANGE TO THE LANGUAGE: Disallow combining records of terms and
   types

--- a/dhall/ghc-src/Dhall/Crypto.hs
+++ b/dhall/ghc-src/Dhall/Crypto.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -14,6 +15,7 @@ module Dhall.Crypto (
 
 import Control.DeepSeq         (NFData)
 import Data.ByteString         (ByteString)
+import Data.Data               (Data)
 import GHC.Generics            (Generic)
 
 import qualified Crypto.Hash.SHA256
@@ -23,7 +25,7 @@ import qualified Data.ByteString.Char8  as ByteString.Char8
 
 -- | A SHA256 digest
 newtype SHA256Digest = SHA256Digest { unSHA256Digest :: ByteString }
-  deriving (Eq, Generic, Ord, NFData)
+  deriving (Data, Eq, Generic, Ord, NFData)
 
 instance Show SHA256Digest where
   show = toString

--- a/dhall/ghcjs-src/Dhall/Crypto.hs
+++ b/dhall/ghcjs-src/Dhall/Crypto.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE JavaScriptFFI              #-}
@@ -14,6 +15,7 @@ module Dhall.Crypto (
 
 import Control.DeepSeq                   (NFData)
 import Data.ByteString                   (ByteString)
+import Data.Data                         (Data)
 import GHC.Generics                      (Generic)
 import JavaScript.TypedArray.ArrayBuffer (ArrayBuffer)
 import System.IO.Unsafe                  (unsafePerformIO)
@@ -25,7 +27,7 @@ import qualified GHCJS.Buffer           as Buffer
 
 -- | A SHA256 digest
 newtype SHA256Digest = SHA256Digest { unSHA256Digest :: ByteString }
-  deriving (Eq, Generic, Ord, NFData)
+  deriving (Data, Eq, Generic, Ord, NFData)
 
 instance Show SHA256Digest where
   show (SHA256Digest bytes) = ByteString.Char8.unpack $ Base16.encode bytes

--- a/dhall/src/Dhall/Syntax/Expr.hs
+++ b/dhall/src/Dhall/Syntax/Expr.hs
@@ -245,7 +245,7 @@ data Expr s a
     | ImportAlt (Expr s a) (Expr s a)
     -- | > Embed import                             ~  import
     | Embed a
-    deriving Generic
+    deriving (Generic)
 -- NB: If you add a constructor to Expr, please also update the Arbitrary
 -- instance in Dhall.Test.QuickCheck.
 

--- a/dhall/src/Dhall/Syntax/Import.hs
+++ b/dhall/src/Dhall/Syntax/Import.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
 
 module Dhall.Syntax.Import
     ( Directory(..)
@@ -14,9 +15,11 @@ module Dhall.Syntax.Import
     , Scheme(..)
     ) where
 
+import Data.Data                      (Data)
 import Data.Text                      (Text)
 import Dhall.Src                      (Src (..))
 import Dhall.Syntax.Expr              (Expr (..))
+import Dhall.Syntax.Instances.Data    ()
 import Dhall.Syntax.Instances.Functor ()
 import GHC.Generics                   (Generic)
 
@@ -29,7 +32,7 @@ import qualified Dhall.Crypto
     @Directory { components = [ "baz", "bar", "foo" ] }@
 -}
 newtype Directory = Directory { components :: [Text] }
-    deriving Generic
+    deriving (Data, Generic)
 
 {-| A `File` is a `directory` followed by one additional path component
     representing the `file` name
@@ -37,7 +40,7 @@ newtype Directory = Directory { components :: [Text] }
 data File = File
     { directory :: Directory
     , file      :: Text
-    } deriving Generic
+    } deriving (Data, Generic)
 
 -- | The beginning of a file path which anchors subsequent path components
 data FilePrefix
@@ -49,11 +52,11 @@ data FilePrefix
     -- ^ Path relative to @..@
     | Home
     -- ^ Path relative to @~@
-    deriving Generic
+    deriving (Data, Generic)
 
 -- | The URI scheme
 data Scheme = HTTP | HTTPS
-    deriving Generic
+    deriving (Data, Generic)
 
 -- | This type stores all of the components of a remote import
 data URL = URL
@@ -62,7 +65,7 @@ data URL = URL
     , path      :: File
     , query     :: Maybe Text
     , headers   :: Maybe (Expr Src Import)
-    } deriving Generic
+    } deriving (Data, Generic)
 
 -- | The type of import (i.e. local vs. remote vs. environment)
 data ImportType
@@ -73,23 +76,23 @@ data ImportType
     | Env  Text
     -- ^ Environment variable
     | Missing
-    deriving Generic
+    deriving (Data, Generic)
 
 -- | How to interpret the import's contents (i.e. as Dhall code or raw text)
 data ImportMode = Code | RawText | Location
-  deriving Generic
+  deriving (Data, Generic)
 
 -- | A `ImportType` extended with an optional hash for semantic integrity checks
 data ImportHashed = ImportHashed
     { hash       :: Maybe Dhall.Crypto.SHA256Digest
     , importType :: ImportType
-    } deriving Generic
+    } deriving (Data, Generic)
 
 -- | Reference to an external resource
 data Import = Import
     { importHashed :: ImportHashed
     , importMode   :: ImportMode
-    } deriving Generic
+    } deriving (Data, Generic)
 
 
 


### PR DESCRIPTION
This allows (among other things) the rewriting of Dhall expressions that contain imports, using the tools in [`Data.Data.Lens`](https://hackage.haskell.org/package/lens-5.2/docs/Data-Data-Lens.html).