### PR TITLE
Allow turtle 1.6 also for dhall-docs

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -150,7 +150,7 @@ Test-Suite tasty
         tasty        < 1.5                ,
         tasty-silver < 3.4                ,
         tasty-hunit  >= 0.10     && < 0.11,
-        turtle       < 1.6                ,
+        turtle       < 1.7                ,
         text
     GHC-Options: -Wall
     Default-Language: Haskell2010


### PR DESCRIPTION
Builds fine and all tests pass.