### PR TITLE
dhall-toml: support integers

### DIFF
--- a/dhall-toml/src/Dhall/DhallToToml.hs
+++ b/dhall-toml/src/Dhall/DhallToToml.hs
@@ -265,6 +265,7 @@ toToml :: TOML -> Key -> Expr Void Void -> Either CompileError TOML
 toToml toml key expr  = case expr of
     Core.BoolLit a -> return $ insertPrim (Toml.Value.Bool a)
     Core.NaturalLit a -> return $ insertPrim (Toml.Value.Integer $ toInteger a)
+    Core.IntegerLit a -> return $ insertPrim (Toml.Value.Integer a)
     Core.DoubleLit (DhallDouble a) -> return $ insertPrim (Toml.Value.Double a)
     Core.TextLit (Core.Chunks [] a) -> return $ insertPrim (Toml.Value.Text a)
     Core.App Core.None _ -> return toml
@@ -327,6 +328,7 @@ toToml toml key expr  = case expr of
         -- be represented as inline tables.
         isInline v = case v of
             Core.BoolLit _    -> True
+            Core.IntegerLit _ -> True
             Core.NaturalLit _ -> True
             Core.DoubleLit _  -> True
             Core.TextLit _    -> True
@@ -348,6 +350,7 @@ toToml toml key expr  = case expr of
         toAny :: Expr Void Void -> Either CompileError Toml.AnyValue.AnyValue
         toAny e = case e of
             Core.BoolLit x                  -> rightAny $ Toml.Value.Bool x
+            Core.IntegerLit x               -> rightAny $ Toml.Value.Integer x
             Core.NaturalLit x               -> rightAny $ Toml.Value.Integer $ toInteger x
             Core.DoubleLit (DhallDouble x)  -> rightAny $ Toml.Value.Double x
             Core.TextLit (Core.Chunks [] x) -> rightAny $ Toml.Value.Text x

--- a/dhall-toml/src/Dhall/TomlToDhall.hs
+++ b/dhall-toml/src/Dhall/TomlToDhall.hs
@@ -171,6 +171,7 @@ tomlToDhall schema toml = toDhall (Core.normalize schema) (tomlToObject toml)
 tomlValueToDhall :: Expr Src Void -> Value t -> Either CompileError (Expr Src Void)
 tomlValueToDhall exprType v = case (exprType, v) of
     (Core.Bool                , Value.Bool a   ) -> Right $ Core.BoolLit a
+    (Core.Integer             , Value.Integer a) -> Right $ Core.IntegerLit a
     (Core.Natural             , Value.Integer a) -> Right $ Core.NaturalLit $ fromInteger a
     (Core.Double              , Value.Double a ) -> Right $ Core.DoubleLit $ DhallDouble a
     (Core.Text                , Value.Text a   ) -> Right $ Core.TextLit $ Core.Chunks [] a

--- a/dhall-toml/tasty/data/inline-list-schema.dhall
+++ b/dhall-toml/tasty/data/inline-list-schema.dhall
@@ -3,6 +3,7 @@
 , lists : List (List Natural)
 , nested :
     { floats : List Double
+    , ints : List Integer
     , moreLists : List (List Natural)
     }
 , nested1 :

--- a/dhall-toml/tasty/data/inline-list.dhall
+++ b/dhall-toml/tasty/data/inline-list.dhall
@@ -3,6 +3,7 @@
 , lists = [[1, 2], [3, 4], [] : List Natural]
 , nested =
     { floats = [1.1, 2.2]
+    , ints = [-5, +2]
     , moreLists = [[1, 2], [3, 4], [] : List Natural]
     }
 , nested1 =

--- a/dhall-toml/tasty/data/inline-list.toml
+++ b/dhall-toml/tasty/data/inline-list.toml
@@ -4,6 +4,7 @@ lists = [[1, 2], [3, 4], []]
 
 [nested]
 floats = [1.1, 2.2]
+ints = [-5, 2]
 moreLists = [[1, 2], [3, 4], []]
 
 [nested1]


### PR DESCRIPTION
The docs *said* we support integers, but that seems to not actually have been empirically true (actually, most amusingly, fromInteger is partial so it would crash TomlToDhall).

I fixed it.