### PR TITLE
dhall,dhall-docs: Allow transformers-0.6 and mtl-2.3

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -82,8 +82,8 @@ Library
         path-io              >= 1.6.0     && < 2 ,
         prettyprinter        >= 1.7.0     && < 1.8 ,
         text                 >= 0.11.1.0  && < 2.1 ,
-        transformers         >= 0.2.0.0  && < 0.6 ,
-        mtl                  >= 2.2.1     && < 2.3 ,
+        transformers         >= 0.2.0.0   && < 0.7 ,
+        mtl                  >= 2.2.1     && < 2.4 ,
         optparse-applicative >= 0.14.0.0  && < 0.18
     Exposed-Modules:
         Dhall.Docs

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -231,7 +231,7 @@ Common common
         -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
         megaparsec                  >= 8        && < 10  ,
         mmorph                                     < 1.3 ,
-        mtl                         >= 2.2.1    && < 2.3 ,
+        mtl                         >= 2.2.1    && < 2.4 ,
         network-uri                 >= 2.6      && < 2.7 ,
         optparse-applicative        >= 0.14.0.0 && < 0.18,
         parsers                     >= 0.12.4   && < 0.13,
@@ -249,7 +249,7 @@ Common common
         text-short                  >= 0.1      && < 0.2 ,
         th-lift-instances           >= 0.1.13   && < 0.2 ,
         time                        >= 1.1.4    && < 1.13,
-        transformers                >= 0.5.2.0  && < 0.6 ,
+        transformers                >= 0.5.2.0  && < 0.7 ,
         unix-compat                 >= 0.4.2    && < 0.7 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
         uri-encode                                 < 1.6 ,


### PR DESCRIPTION
This patch contains a subset of the changes in https://github.com/dhall-lang/dhall-haskell/pull/2248. `dhall-lsp-server` and `dhall-nixpkgs` also require bounds bumps but are currently blocked on upstream issues or compatibility issues.