### PR TITLE
Require `time >= 1.9` for `DayOfWeek`

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -248,7 +248,7 @@ Common common
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
         text-short                  >= 0.1      && < 0.2 ,
         th-lift-instances           >= 0.1.13   && < 0.2 ,
-        time                        >= 1.1.4    && < 1.13,
+        time                        >= 1.9      && < 1.13,
         transformers                >= 0.5.2.0  && < 0.7 ,
         unix-compat                 >= 0.4.2    && < 0.7 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,


### PR DESCRIPTION
`DayOfWeek`, which is being used since #2413, has been added in `time-1.9`, but e.g. GHC 8.6.5 has `time-1.8.0.2` as its boot version.

https://hackage.haskell.org/package/time-1.12.2/changelog