### PR TITLE
dhall: derive `Eq` instances for `InvalidDecoder` and `ExtractError` (#2481)

### DIFF
--- a/dhall/CHANGELOG.md
+++ b/dhall/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 
 * [Add `Data` instances for `Import` and various other types](https://github.com/dhall-lang/dhall-haskell/pull/2462)
+* [Add `Eq` instances for `InvalidDecoder` and `ExtractError`](https://github.com/dhall-lang/dhall-haskell/pull/2482)
 
 1.41.2
 

--- a/dhall/src/Dhall/Marshal/Decode.hs
+++ b/dhall/src/Dhall/Marshal/Decode.hs
@@ -1554,6 +1554,7 @@ data ExtractError s a =
     TypeMismatch (InvalidDecoder s a)
   | ExpectedTypeError ExpectedTypeError
   | ExtractError Text
+  deriving (Eq)
 
 instance (Pretty s, Pretty a, Typeable s, Typeable a) => Show (ExtractError s a) where
   show (TypeMismatch e)      = show e
@@ -1618,7 +1619,7 @@ data InvalidDecoder s a = InvalidDecoder
   { invalidDecoderExpected   :: Expr s a
   , invalidDecoderExpression :: Expr s a
   }
-  deriving (Typeable)
+  deriving (Eq, Typeable)
 
 instance (Pretty s, Typeable s, Pretty a, Typeable a) => Exception (InvalidDecoder s a)
 


### PR DESCRIPTION
Fixes: https://github.com/dhall-lang/dhall-haskell/issues/2481