### PR TITLE
Require prettyprinter-ansi-terminal >= 1.1.2

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -237,7 +237,7 @@ Common common
         parsers                     >= 0.12.4   && < 0.13,
         parser-combinators                               ,
         prettyprinter               >= 1.7.0    && < 1.8 ,
-        prettyprinter-ansi-terminal >= 1.1.1    && < 1.2 ,
+        prettyprinter-ansi-terminal >= 1.1.2    && < 1.2 ,
         pretty-simple                              < 4.2 ,
         profunctors                 >= 3.1.2    && < 5.7 ,
         repline                     >= 0.4.0.0  && < 0.5 ,


### PR DESCRIPTION
`Prettyprinter.Render.Terminal` is not available before `prettyprinter-ansi-terminal-1.1.2`.