### PR TITLE
Fix `dhall freeze --cache --all` to be idempotent

### DIFF
--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -223,6 +223,17 @@ freezeRemoteImportWithSettings settings directory import_ =
         Remote {} -> freezeImportWithSettings settings directory import_
         _         -> return import_
 
+-- | See 'freezeRemoteImport'.
+freezeNonMissingImportWithSettings
+    :: EvaluateSettings
+    -> FilePath
+    -> Import
+    -> IO Import
+freezeNonMissingImportWithSettings settings directory import_ =
+    case importType (importHashed import_) of
+        Missing -> return import_
+        _ -> freezeImportWithSettings settings directory import_
+
 -- | See 'freeze'.
 freezeWithSettings
     :: EvaluateSettings
@@ -322,7 +333,7 @@ freezeExpressionWithSettings
 freezeExpressionWithSettings settings directory scope intent expression = do
     let freezeScope =
             case scope of
-                AllImports        -> freezeImportWithSettings
+                AllImports        -> freezeNonMissingImportWithSettings
                 OnlyRemoteImports -> freezeRemoteImportWithSettings
 
     let freezeFunction = freezeScope settings directory

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -513,7 +513,7 @@ parseMode =
     parseAllFlag =
         Options.Applicative.switch
         (   Options.Applicative.long "all"
-        <>  Options.Applicative.help "Add integrity checks to all imports (not just remote imports)"
+        <>  Options.Applicative.help "Add integrity checks to all imports (not just remote imports) except for missing imports"
         )
 
     parseCacheFlag =

--- a/dhall/tests/freeze/cached/idempotentA.dhall
+++ b/dhall/tests/freeze/cached/idempotentA.dhall
@@ -1,0 +1,5 @@
+-- The purpose of this test is to verify that `dhall freeze --cached` is
+-- idempotent and doesn't attempt to resolve the `missing` import
+  missing
+    sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
+? ./True.dhall

--- a/dhall/tests/freeze/cached/idempotentB.dhall
+++ b/dhall/tests/freeze/cached/idempotentB.dhall
@@ -1,0 +1,3 @@
+  missing
+    sha256:27abdeddfe8503496adeb623466caa47da5f63abd2bc6fa19f6cfcb73ecfed70
+? ./True.dhall


### PR DESCRIPTION
The fix in https://github.com/dhall-lang/dhall-haskell/pull/2350 introduced a new problem: now `dhall freeze --cache --all` is not idempotent and will fail if you run it a second time on the same due to trying to resolve the `missing` import.  This change fixes that.