### PR TITLE
Don't URL encode path components

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -253,7 +253,6 @@ Common common
         transformers                >= 0.5.2.0  && < 0.7 ,
         unix-compat                 >= 0.4.2    && < 0.7 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
-        uri-encode                                 < 1.6 ,
         vector                      >= 0.11.0.0 && < 0.14
 
     if flag(with-http)

--- a/dhall/src/Dhall/URL.hs
+++ b/dhall/src/Dhall/URL.hs
@@ -7,10 +7,8 @@ import Data.Text (Text)
 
 import Dhall.Syntax (Directory (..), File (..), Scheme (..), URL (..))
 
-import qualified Network.URI.Encode as URI.Encode
-
 renderComponent :: Text -> Text
-renderComponent component = "/" <> URI.Encode.encodeText component
+renderComponent component = "/" <> component
 
 renderQuery :: Text -> Text
 renderQuery query = "?" <> query


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2467

After https://github.com/dhall-lang/dhall-lang/issues/581 the standard requires implementations to not do anything special with respect to URL encoding.  In other words, a conforming implementation:

- Should not URL-encode path components when parsing imports from Dhall source code

- Should not URL-encode path components when resolving those same imports

The user can still specify an import that uses URL encoded path components, but the implementation does not give them any special treatment.  It just blindly forwards those path components undisturbed.

Before this change, the Haskell implementation of Dhall was correctly handling the first part (not url encoding path components at parse time) but was still incorrectly handling the second part (because it would URL encode path components at import resolution time).  This change fixes that.