### PR TITLE
to-directory-tree: Do not support setting file metadata on Windows

### DIFF
--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -23,6 +23,8 @@ module Dhall.DirectoryTree.Types
 
     , setFileMode
     , prettyFileMode
+
+    , isMetadataSupported
     ) where
 
 import Data.Functor.Identity    (Identity (..))
@@ -239,3 +241,11 @@ prettyFileMode mode = userPP <> groupPP <> otherPP
         isBitSet c mask = if mask `Posix.intersectFileModes` mode /= Posix.nullFileMode
             then [c]
             else "-"
+
+-- | Is setting metadata supported on this platform or not.
+isMetadataSupported :: Bool
+#ifdef mingw32_HOST_OS
+isMetadataSupported = False
+#else
+isMetadataSupported = True
+#endif

--- a/dhall/tests/Dhall/Test/DirectoryTree.hs
+++ b/dhall/tests/Dhall/Test/DirectoryTree.hs
@@ -28,8 +28,8 @@ tests = testGroup "to-directory-tree"
         , fixpointedSimple
 #ifndef mingw32_HOST_OS
         , fixpointedPermissions
-#endif
         , fixpointedUserGroup
+#endif
         ]
     ]
 


### PR DESCRIPTION
... as it was never supported properly on that platform.