### PR TITLE
Relax upper bound to accommodate dependency on `ansi-terminal-1.0`

### DIFF
--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -98,7 +98,7 @@ Executable json-to-dhall
     Build-Depends:
         base                                             ,
         aeson                                            ,
-        ansi-terminal               >= 0.6.3.1  && < 0.12,
+        ansi-terminal               >= 0.6.3.1  && < 1.1 ,
         bytestring                                       ,
         dhall                                            ,
         dhall-json                                       ,

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -65,7 +65,7 @@ Executable yaml-to-dhall
     Build-Depends:
         base                                             ,
         aeson                                            ,
-        ansi-terminal               >= 0.6.3.1  && < 0.12,
+        ansi-terminal               >= 0.6.3.1  && < 1.1 ,
         bytestring                                       ,
         dhall                                            ,
         dhall-json                                       ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -207,7 +207,7 @@ Common common
         base                        >= 4.11.0.0 && < 5   ,
         aeson                       >= 1.0.0.0  && < 2.2 ,
         aeson-pretty                               < 0.9 ,
-        ansi-terminal               >= 0.6.3.1  && < 0.12,
+        ansi-terminal               >= 0.6.3.1  && < 1.1 ,
         atomic-write                >= 0.2.0.7  && < 0.3 ,
         base16-bytestring           >= 1.0.0.0           ,
         bytestring                                 < 0.12,


### PR DESCRIPTION
`ansi-terminal-1.0` is released on Hackage.

See also https://github.com/commercialhaskell/stackage/issues/6976.

Tested by building with Stack >= 2.9.3 using the existing `stack.yaml` with these additions:
~~~yaml
extra-deps:
  - ansi-terminal-1.0
  - ansi-terminal-types-0.11.5

allow-newer: true
allow-newer-deps:
- ansi-wl-pprint
~~~