### PR TITLE
Support GHC 9.4

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -244,7 +244,7 @@ Common common
         repline                     >= 0.4.0.0  && < 0.5 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
-        template-haskell            >= 2.13.0.0 && < 2.17,
+        template-haskell            >= 2.13.0.0 && < 2.20,
         text                        >= 0.11.1.0 && < 2.1 ,
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
         text-short                  >= 0.1      && < 0.2 ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -1,6 +1,6 @@
 Cabal-Version: 2.4
 Name: dhall
-Version: 1.42.0
+Version: 1.42.1
 Build-Type: Simple
 License: BSD-3-Clause
 License-File: LICENSE

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -244,7 +244,7 @@ Common common
         repline                     >= 0.4.0.0  && < 0.5 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
-        template-haskell            >= 2.13.0.0 && < 2.20,
+        template-haskell            >= 2.13.0.0 && < 2.17,
         text                        >= 0.11.1.0 && < 2.1 ,
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
         text-short                  >= 0.1      && < 0.2 ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -251,9 +251,13 @@ Common common
         th-lift-instances           >= 0.1.13   && < 0.2 ,
         time                        >= 1.9      && < 1.13,
         transformers                >= 0.5.2.0  && < 0.7 ,
-        unix-compat                 >= 0.4.2    && < 0.7 ,
+        unix-compat                 >= 0.4.2    && < 0.8 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
         vector                      >= 0.11.0.0 && < 0.14
+
+    if !os(windows)
+      Build-Depends:
+        unix                        >= 2.7      && < 2.9 ,
 
     if flag(with-http)
       CPP-Options:

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -409,57 +410,57 @@ instance Show FilesystemError where
         Pretty.renderString (Dhall.Pretty.layout message)
       where
         message =
-          Util._ERROR <> ": Not a valid directory tree expression                             \n\
-          \                                                                                   \n\
-          \Explanation: Only a subset of Dhall expressions can be converted to a directory    \n\
-          \tree.  Specifically, record literals or maps can be converted to directories,      \n\
-          \❰Text❱ literals can be converted to files, and ❰Optional❱ values are included if   \n\
-          \❰Some❱ and omitted if ❰None❱.  Values of union types can also be converted if      \n\
-          \they are an alternative which has a non-nullary constructor whose argument is of   \n\
-          \an otherwise convertible type.  Furthermore, there is a more advanced approach to  \n\
-          \constructing a directory tree utilizing a fixpoint encoding. Consult the upstream  \n\
-          \documentation of the `toDirectoryTree` function in the Dhall.Directory module for  \n\
-          \further information on that.                                                       \n\
-          \No other type of value can be translated to a directory tree.                      \n\
-          \                                                                                   \n\
-          \For example, this is a valid expression that can be translated to a directory      \n\
-          \tree:                                                                              \n\
-          \                                                                                   \n\
-          \                                                                                   \n\
-          \    ┌──────────────────────────────────┐                                           \n\
-          \    │ { `example.json` = \"[1, true]\" } │                                         \n\
-          \    └──────────────────────────────────┘                                           \n\
-          \                                                                                   \n\
-          \                                                                                   \n\
-          \In contrast, the following expression is not allowed due to containing a           \n\
-          \❰Natural❱ field, which cannot be translated in this way:                           \n\
-          \                                                                                   \n\
-          \                                                                                   \n\
-          \    ┌───────────────────────┐                                                      \n\
-          \    │ { `example.txt` = 1 } │                                                      \n\
-          \    └───────────────────────┘                                                      \n\
-          \                                                                                   \n\
-          \                                                                                   \n\
-          \Note that key names cannot contain path separators:                                \n\
-          \                                                                                   \n\
-          \                                                                                   \n\
-          \    ┌─────────────────────────────────────┐                                        \n\
-          \    │ { `directory/example.txt` = \"ABC\" } │ Invalid: Key contains a forward slash\n\
-          \    └─────────────────────────────────────┘                                        \n\
-          \                                                                                   \n\
-          \                                                                                   \n\
-          \Instead, you need to refactor the expression to use nested records instead:        \n\
-          \                                                                                   \n\
-          \                                                                                   \n\
-          \    ┌───────────────────────────────────────────┐                                  \n\
-          \    │ { directory = { `example.txt` = \"ABC\" } } │                                \n\
-          \    └───────────────────────────────────────────┘                                  \n\
-          \                                                                                   \n\
-          \                                                                                   \n\
-          \You tried to translate the following expression to a directory tree:               \n\
-          \                                                                                   \n\
-          \" <> Util.insert unexpectedExpression <> "\n\
-          \                                                                                   \n\
+          Util._ERROR <> ": Not a valid directory tree expression                             \n\\
+          \                                                                                   \n\\
+          \Explanation: Only a subset of Dhall expressions can be converted to a directory    \n\\
+          \tree.  Specifically, record literals or maps can be converted to directories,      \n\\
+          \❰Text❱ literals can be converted to files, and ❰Optional❱ values are included if   \n\\
+          \❰Some❱ and omitted if ❰None❱.  Values of union types can also be converted if      \n\\
+          \they are an alternative which has a non-nullary constructor whose argument is of   \n\\
+          \an otherwise convertible type.  Furthermore, there is a more advanced approach to  \n\\
+          \constructing a directory tree utilizing a fixpoint encoding. Consult the upstream  \n\\
+          \documentation of the `toDirectoryTree` function in the Dhall.Directory module for  \n\\
+          \further information on that.                                                       \n\\
+          \No other type of value can be translated to a directory tree.                      \n\\
+          \                                                                                   \n\\
+          \For example, this is a valid expression that can be translated to a directory      \n\\
+          \tree:                                                                              \n\\
+          \                                                                                   \n\\
+          \                                                                                   \n\\
+          \    ┌──────────────────────────────────┐                                           \n\\
+          \    │ { `example.json` = \"[1, true]\" } │                                         \n\\
+          \    └──────────────────────────────────┘                                           \n\\
+          \                                                                                   \n\\
+          \                                                                                   \n\\
+          \In contrast, the following expression is not allowed due to containing a           \n\\
+          \❰Natural❱ field, which cannot be translated in this way:                           \n\\
+          \                                                                                   \n\\
+          \                                                                                   \n\\
+          \    ┌───────────────────────┐                                                      \n\\
+          \    │ { `example.txt` = 1 } │                                                      \n\\
+          \    └───────────────────────┘                                                      \n\\
+          \                                                                                   \n\\
+          \                                                                                   \n\\
+          \Note that key names cannot contain path separators:                                \n\\
+          \                                                                                   \n\\
+          \                                                                                   \n\\
+          \    ┌─────────────────────────────────────┐                                        \n\\
+          \    │ { `directory/example.txt` = \"ABC\" } │ Invalid: Key contains a forward slash\n\\
+          \    └─────────────────────────────────────┘                                        \n\\
+          \                                                                                   \n\\
+          \                                                                                   \n\\
+          \Instead, you need to refactor the expression to use nested records instead:        \n\\
+          \                                                                                   \n\\
+          \                                                                                   \n\\
+          \    ┌───────────────────────────────────────────┐                                  \n\\
+          \    │ { directory = { `example.txt` = \"ABC\" } } │                                \n\\
+          \    └───────────────────────────────────────────┘                                  \n\\
+          \                                                                                   \n\\
+          \                                                                                   \n\\
+          \You tried to translate the following expression to a directory tree:               \n\\
+          \                                                                                   \n\\
+          \" <> Util.insert unexpectedExpression <> "\n\\
+          \                                                                                   \n\\
           \... which is not an expression that can be translated to a directory tree.         \n"
 
 {- | This error indicates that you want to set some metadata for a file or
@@ -475,11 +476,11 @@ instance Show MetadataUnsupportedError where
         Pretty.renderString (Dhall.Pretty.layout message)
       where
         message =
-          Util._ERROR <> ": Setting metadata is not supported on this platform.               \n\
-          \                                                                                   \n\
-          \Explanation: Your Dhall expression indicates that you intend to set some metadata  \n\
-          \like ownership or permissions for the following file or directory:                 \n\
-          \                                                                                   \n\
-          \" <> Pretty.pretty metadataForPath <> "\n\
-          \                                                                                   \n\
+          Util._ERROR <> ": Setting metadata is not supported on this platform.               \n\\
+          \                                                                                   \n\\
+          \Explanation: Your Dhall expression indicates that you intend to set some metadata  \n\\
+          \like ownership or permissions for the following file or directory:                 \n\\
+          \                                                                                   \n\\
+          \" <> Pretty.pretty metadataForPath <> "\n\\
+          \                                                                                   \n\\
           \... which is not supported on your platform.                                       \n"

--- a/dhall/src/Dhall/TH.hs
+++ b/dhall/src/Dhall/TH.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -263,7 +264,11 @@ toDeclaration generateOptions@GenerateOptions{..} haskellTypes typ =
 
         interpretOptions = generateToInterpretOptions generateOptions typ
 
-        toTypeVar (V n i) = Syntax.PlainTV $ Syntax.mkName (Text.unpack n ++ show i)
+#if MIN_VERSION_template_haskell(2,17,0)
+        toTypeVar (V n i) = Syntax.PlainTV (Syntax.mkName (Text.unpack n ++ show i)) ()
+#else
+        toTypeVar (V n i) = Syntax.PlainTV (Syntax.mkName (Text.unpack n ++ show i))
+#endif
 
         toDataD typeName typeParams constructors = do
             let name = Syntax.mkName (Text.unpack typeName)


### PR DESCRIPTION
A more conservative approach than https://github.com/dhall-lang/dhall-haskell/pull/2496. Older versions of libraries should still work, and the behaviour on windows should not have changed at all (except for the error string).

I was able to build `dhall` with GHC 8.10 and 9.4; I don't have time to update the other packages.
