### PR TITLE
Relax restrictive upper bound on lens

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -55,7 +55,7 @@ library
     , lsp                  >= 1.2.0.0  && < 1.5
     , rope-utf16-splay     >= 0.3.1.0  && < 0.5
     , hslogger             >= 1.2.10   && < 1.4
-    , lens                 >= 4.16.1   && < 5.2
+    , lens                 >= 4.16.1   && < 5.3
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     , megaparsec           >= 7.0.2    && < 10
     , mtl                  >= 2.2.2    && < 2.3


### PR DESCRIPTION
Hello!

This is done so that the dhall-lsp-server build is fixed on nixpkgs.  