### PR TITLE
treewide: Raise bounds on optparse-applicative

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -84,7 +84,7 @@ Library
         text                 >= 0.11.1.0  && < 2.1 ,
         transformers         >= 0.2.0.0   && < 0.7 ,
         mtl                  >= 2.2.1     && < 2.4 ,
-        optparse-applicative >= 0.14.0.0  && < 0.18
+        optparse-applicative >= 0.14.0.0  && < 0.19
     Exposed-Modules:
         Dhall.Docs
         Dhall.Docs.Core

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -47,7 +47,7 @@ Library
         exceptions                >= 0.8.3     && < 0.11,
         filepath                                  < 1.5 ,
         lens-family-core          >= 1.0.0     && < 2.2 ,
-        optparse-applicative      >= 0.14.0.0  && < 0.18,
+        optparse-applicative      >= 0.14.0.0  && < 0.19,
         prettyprinter             >= 1.7.0     && < 1.8 ,
         scientific                >= 0.3.0.0   && < 0.4 ,
         text                      >= 0.11.1.0  && < 2.1 ,

--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -40,7 +40,7 @@ Library
     Default-Language: Haskell2010
     if os(windows)
         Buildable: False
-        
+
 Executable dhall-to-nix
     if os(windows)
         Buildable: False
@@ -53,7 +53,7 @@ Executable dhall-to-nix
         dhall                               ,
         dhall-nix                           ,
         hnix                                ,
-        optparse-generic >= 1.1.1   && < 1.5,
+        optparse-generic >= 1.1.1   && < 1.6,
         text
     GHC-Options: -Wall
     Default-Language: Haskell2010

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -30,7 +30,7 @@ Executable dhall-to-nixpkgs
                      , megaparsec           >= 7.0.0    && < 10
                      , mmorph                              < 1.3
                      , neat-interpolation                  < 0.6
-                     , optparse-applicative >= 0.14.0.0 && < 0.18
+                     , optparse-applicative >= 0.14.0.0 && < 0.19
                      , prettyprinter        >= 1.7.0    && < 1.8
                      , text                 >= 0.11.1.0 && < 2.1
                      , transformers         >= 0.2.0.0  && < 0.6

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -45,8 +45,8 @@ Executable openapi-to-dhall
     filepath                >= 1.4       && < 1.5  ,
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     megaparsec              >= 7.0       && < 10   ,
-    optparse-applicative    >= 0.14.3.0  && < 0.18 ,
-    parser-combinators                             , 
+    optparse-applicative    >= 0.14.3.0  && < 0.19 ,
+    parser-combinators                             ,
     prettyprinter                                  ,
     sort                                           ,
     text                                           ,

--- a/dhall-toml/dhall-toml.cabal
+++ b/dhall-toml/dhall-toml.cabal
@@ -41,7 +41,7 @@ Library
         containers           >= 0.5.9    && < 0.7  ,
         unordered-containers >= 0.2      && < 0.3  ,
         prettyprinter        >= 1.7.0    && < 1.8  ,
-        optparse-applicative >= 0.14     && < 0.18
+        optparse-applicative >= 0.14     && < 0.19
     Exposed-Modules:
         Dhall.DhallToToml
         Dhall.TomlToDhall

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -38,7 +38,7 @@ Library
         bytestring                                < 0.12,
         dhall                     >= 1.31.0    && < 1.43,
         dhall-json                >= 1.6.0     && < 1.8 ,
-        optparse-applicative      >= 0.14.0.0  && < 0.18,
+        optparse-applicative      >= 0.14.0.0  && < 0.19,
         text                      >= 0.11.1.0  && < 2.1 ,
         vector
     Exposed-Modules:

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -234,7 +234,7 @@ Common common
         mmorph                                     < 1.3 ,
         mtl                         >= 2.2.1    && < 2.4 ,
         network-uri                 >= 2.6      && < 2.7 ,
-        optparse-applicative        >= 0.14.0.0 && < 0.18,
+        optparse-applicative        >= 0.14.0.0 && < 0.19,
         parsers                     >= 0.12.4   && < 0.13,
         parser-combinators                               ,
         prettyprinter               >= 1.7.0    && < 1.8 ,


### PR DESCRIPTION
optparse-applicative-0.18.0.0 is a deprecated release which used layoutSmart from package prettyprinter, which causes the runtime to blow up in certain cases.

See: https://github.com/pcapriotti/optparse-applicative/issues/475#issuecomment-1563698884

Tested with GHC 8.10.7 using `cabal test all --constraint 'optparse-applicative == 0.18.1.0' --allow-newer=hnix:optparse-applicative --allow-newer=dhall-nixpkgs:turtle --keep-going`. Doctests are failing, I'm not sure why. They also fail for me on `main`.