### PR TITLE
feat: Add support for LSP 2

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -53,7 +53,7 @@ library
     , dhall                >= 1.38.0   && < 1.43
     , dhall-json           >= 1.4      && < 1.8
     , filepath             >= 1.4.2    && < 1.5
-    , lsp                  >= 1.5.0.0  && < 2
+    , lsp                  >= 2.1.0.0  && < 2.2
     , lens                 >= 4.16.1   && < 5.3
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     , megaparsec           >= 7.0.2    && < 10
@@ -104,9 +104,9 @@ Test-Suite tests
     GHC-Options: -Wall
     Build-Depends:
         base                                    ,
-        lsp-types         >= 1.2.0.0  && < 1.7  ,
+        lsp-types         >= 2.0.1    && < 2.1  ,
         hspec             >= 2.7      && < 2.11 ,
-        lsp-test          >= 0.13.0.0 && < 0.15 ,
+        lsp-test          >= 0.15.0.0 && < 0.16 ,
         tasty             >= 0.11.2   && < 1.5  ,
         tasty-hspec       >= 1.1      && < 1.3  ,
         text              >= 0.11     && < 2.1

--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
@@ -44,7 +44,7 @@ import qualified Dhall.Import       as Dhall
 import qualified Dhall.Map
 import qualified Dhall.Parser       as Dhall
 import qualified Dhall.TypeCheck    as Dhall
-import qualified Language.LSP.Types as LSP.Types
+import qualified Language.LSP.Protocol.Types as LSP.Types
 import qualified Network.URI        as URI
 
 

--- a/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Handlers.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE MultiWayIf     #-}
 {-# LANGUAGE ViewPatterns   #-}
+{-# LANGUAGE TypeOperators  #-}
 
 module Dhall.LSP.Handlers where
 
@@ -67,18 +68,18 @@ import Data.Aeson                       (FromJSON(..), Value(..))
 import Data.Maybe                       (maybeToList)
 import Data.Text                        (Text, isPrefixOf)
 import Language.LSP.Server              (Handlers, LspT)
-import Language.LSP.Types               hiding (Range(..), line)
-import Language.LSP.Types.Lens
+import Language.LSP.Protocol.Types      hiding (Range(..))
+import Language.LSP.Protocol.Message
+import Language.LSP.Protocol.Lens
 import System.FilePath
 import Text.Megaparsec                  (SourcePos (..), unPos)
 
 import qualified Data.Aeson              as Aeson
-import qualified Data.HashMap.Strict     as HashMap
 import qualified Data.Map.Strict         as Map
 import qualified Data.Text.Utf16.Rope    as Rope
 import qualified Data.Text               as Text
 import qualified Language.LSP.Server     as LSP
-import qualified Language.LSP.Types      as LSP.Types
+import qualified Language.LSP.Protocol.Types as LSP.Types
 import qualified Language.LSP.VFS        as LSP
 import qualified Network.URI             as URI
 import qualified Network.URI.Encode      as URI
@@ -132,7 +133,7 @@ rangeToJSON (Range (x1,y1) (x2,y2)) =
 
 hoverHandler :: Handlers HandlerM
 hoverHandler =
-    LSP.requestHandler STextDocumentHover \request respond -> handleErrorWithDefault respond Nothing do
+    LSP.requestHandler SMethod_TextDocumentHover \request respond -> handleErrorWithDefault respond (InR LSP.Types.Null) do
         let uri_ = request^.params.textDocument.uri
 
         let Position{ _line = fromIntegral -> _line, _character = fromIntegral -> _character } = request^.params.position
@@ -150,8 +151,8 @@ hoverHandler =
                     Right (mSrc, typ) -> do
                         let _range = fmap (rangeToJSON . rangeFromDhall) mSrc
 
-                        let _contents = HoverContents (MarkupContent MkPlainText (pretty typ))
-                        respond (Right (Just Hover{ _contents, _range }))
+                        let _contents = InL (mkPlainText (pretty typ))
+                        respond (Right (InL Hover{ _contents, _range }))
             Just err -> do
                 let isHovered (Diagnosis _ (Just (Range left right)) _) =
                         left <= (_line, _character) && (_line, _character) <= right
@@ -162,14 +163,14 @@ hoverHandler =
                         let _range = Just (rangeToJSON (Range left right))
                             encodedDiag = URI.encode (Text.unpack diagnosis)
 
-                            _kind = MkMarkdown
+                            _kind = MarkupKind_Markdown
 
                             _value =
                                     "[Explain error](dhall-explain:?"
                                 <>  Text.pack encodedDiag
                                 <>  " )"
 
-                            _contents = HoverContents MarkupContent{..}
+                            _contents = InL MarkupContent{..}
                         Just Hover{ _contents, _range }
                     hoverFromDiagnosis _ =
                         Nothing
@@ -181,11 +182,11 @@ hoverHandler =
 
                         hoverFromDiagnosis explanation
 
-                respond (Right mHover)
+                respond (Right (maybeToNull mHover))
 
 documentLinkHandler :: Handlers HandlerM
 documentLinkHandler =
-    LSP.requestHandler STextDocumentDocumentLink \request respond -> handleErrorWithDefault respond (List []) do
+    LSP.requestHandler SMethod_TextDocumentDocumentLink \request respond -> handleErrorWithDefault respond (InL []) do
         let uri_ = request^.params.textDocument.uri
 
         path <- case uriToFilePath uri_ of
@@ -211,23 +212,23 @@ documentLinkHandler =
               filePath <- localToPath prefix file
               let filePath' = basePath </> filePath  -- absolute file path
               let _range = rangeToJSON range_
-              let _target = Just (filePathToUri filePath')
+              let _target = Just (getUri (filePathToUri filePath'))
               let _tooltip = Nothing
-              let _xdata = Nothing
+              let _data_ = Nothing
               return [DocumentLink {..}]
 
             go (range_, Import (ImportHashed _ (Remote url)) _) = do
               let _range = rangeToJSON range_
               let url' = url { headers = Nothing }
-              let _target = Just (Uri (pretty url'))
+              let _target = Just (pretty url')
               let _tooltip = Nothing
-              let _xdata = Nothing
+              let _data_ = Nothing
               return [DocumentLink {..}]
 
             go _ = return []
 
         links <- liftIO $ mapM go imports
-        respond (Right (List (concat links)))
+        respond (Right (InL (concat links)))
 
 
 diagnosticsHandler :: Uri -> HandlerM ()
@@ -259,41 +260,44 @@ diagnosticsHandler _uri = do
 
       suggestionToDiagnostic Suggestion { range = range_, .. } =
         let _range = rangeToJSON range_
-            _severity = Just DsHint
+            _severity = Just DiagnosticSeverity_Hint
             _source = Just "Dhall.Lint"
             _code = Nothing
+            _codeDescription = Nothing
             _message = suggestion
             _tags = Nothing
             _relatedInformation = Nothing
+            _data_ = Nothing
         in Diagnostic {..}
 
       diagnosisToDiagnostic Diagnosis { range = range_, .. } =
         let _range = case range_ of
               Just range' -> rangeToJSON range'
               Nothing     -> LSP.Types.Range (Position 0 0) (Position 0 0)
-            _severity = Just DsError
+            _severity = Just DiagnosticSeverity_Error
             _source = Just doctor
             _code = Nothing
+            _codeDescription = Nothing
             _tags = Nothing
             _message = diagnosis
             _relatedInformation = Nothing
+            _data_ = Nothing
         in Diagnostic {..}
 
   modifying errors (Map.alter (const errs) _uri)  -- cache errors
 
   let _version = Nothing
   let _diagnostics =
-          List
               (   concatMap (map diagnosisToDiagnostic . diagnose) (maybeToList errs)
               ++  map suggestionToDiagnostic suggestions
               )
 
 
-  liftLSP (LSP.sendNotification STextDocumentPublishDiagnostics PublishDiagnosticsParams{ _uri, _version, _diagnostics })
+  liftLSP (LSP.sendNotification SMethod_TextDocumentPublishDiagnostics PublishDiagnosticsParams{ _uri, _version, _diagnostics })
 
 documentFormattingHandler :: Handlers HandlerM
 documentFormattingHandler =
-    LSP.requestHandler STextDocumentFormatting \request respond -> handleErrorWithDefault respond (List []) do
+    LSP.requestHandler SMethod_TextDocumentFormatting \request respond -> handleErrorWithDefault respond (InL []) do
         let _uri = request^.params.textDocument.uri
 
         txt <- readUri _uri
@@ -308,12 +312,12 @@ documentFormattingHandler =
         let _newText= formatExprWithHeader chosenCharacterSet expr header
         let _range = LSP.Types.Range (Position 0 0) (Position numLines 0)
 
-        respond (Right (List [TextEdit{..}]))
+        respond (Right (InL [TextEdit{..}]))
 
 
 executeCommandHandler :: Handlers HandlerM
 executeCommandHandler =
-    LSP.requestHandler SWorkspaceExecuteCommand \request respond -> handleErrorWithDefault respond Aeson.Null do
+    LSP.requestHandler SMethod_WorkspaceExecuteCommand \request respond -> handleErrorWithDefault respond (InL Aeson.Null) do
         let command_ = request^.params.command
         if  | command_ == "dhall.server.lint" ->
                 executeLintAndFormat request respond
@@ -330,11 +334,11 @@ executeCommandHandler =
                     )
 
 getCommandArguments
-    :: FromJSON a => RequestMessage 'WorkspaceExecuteCommand -> HandlerM a
+    :: FromJSON a => TRequestMessage 'Method_WorkspaceExecuteCommand -> HandlerM a
 -- (HasParams s a, FromJSON a) => s -> HandlerM a
 getCommandArguments request = do
   json <- case request ^. params . arguments of
-    Just (List (x : _)) -> return x
+    Just (x : _) -> return x
     _ -> throwE (Error, "Failed to execute command; arguments missing.")
   case Aeson.fromJSON json of
     Aeson.Success args ->
@@ -344,8 +348,8 @@ getCommandArguments request = do
 
 -- implements dhall.server.lint
 executeLintAndFormat
-    :: RequestMessage 'WorkspaceExecuteCommand
-    -> (Either a Value -> HandlerM b)
+    :: TRequestMessage 'Method_WorkspaceExecuteCommand
+    -> (Either a (Value |? Null) -> HandlerM b)
     -> HandlerM ()
 executeLintAndFormat request respond = do
   uri_ <- getCommandArguments request
@@ -365,21 +369,21 @@ executeLintAndFormat request respond = do
 
   let _edit =
           WorkspaceEdit
-              { _changes = Just (HashMap.singleton uri_ (List [TextEdit{..}]))
+              { _changes = Just (Map.singleton uri_ [TextEdit{..}])
               , _documentChanges = Nothing
               , _changeAnnotations = Nothing
               }
 
   let _label = Nothing
 
-  _ <- respond (Right Aeson.Null)
+  _ <- respond (Right (InL Aeson.Null))
 
-  _ <- liftLSP (LSP.sendRequest SWorkspaceApplyEdit ApplyWorkspaceEditParams{ _label, _edit } nullHandler)
+  _ <- liftLSP (LSP.sendRequest SMethod_WorkspaceApplyEdit ApplyWorkspaceEditParams{ _label, _edit } nullHandler)
 
   return ()
 
 executeAnnotateLet
-    :: RequestMessage 'WorkspaceExecuteCommand
+    :: TRequestMessage 'Method_WorkspaceExecuteCommand
     -> HandlerM ()
 executeAnnotateLet request = do
   args <- getCommandArguments request :: HandlerM TextDocumentPositionParams
@@ -405,19 +409,19 @@ executeAnnotateLet request = do
   let _newText= formatExpr chosenCharacterSet annotExpr
 
   let _edit = WorkspaceEdit
-          { _changes = Just (HashMap.singleton uri_ (List [TextEdit{..}]))
+          { _changes = Just (Map.singleton uri_ [TextEdit{..}])
           , _documentChanges = Nothing
           , _changeAnnotations = Nothing
           }
 
   let _label = Nothing
 
-  _ <- liftLSP (LSP.sendRequest SWorkspaceApplyEdit ApplyWorkspaceEditParams{ _label, _edit } nullHandler)
+  _ <- liftLSP (LSP.sendRequest SMethod_WorkspaceApplyEdit ApplyWorkspaceEditParams{ _label, _edit } nullHandler)
 
   return ()
 
 executeFreezeAllImports
-    :: RequestMessage 'WorkspaceExecuteCommand
+    :: TRequestMessage 'Method_WorkspaceExecuteCommand
     -> HandlerM ()
 executeFreezeAllImports request = do
   uri_ <- getCommandArguments request
@@ -444,19 +448,19 @@ executeFreezeAllImports request = do
     return TextEdit{..}
 
   let _edit = WorkspaceEdit
-          { _changes = Just (HashMap.singleton uri_ (List edits_))
+          { _changes = Just (Map.singleton uri_ edits_)
           , _documentChanges = Nothing
           , _changeAnnotations = Nothing
           }
 
   let _label = Nothing
 
-  _ <- liftLSP (LSP.sendRequest SWorkspaceApplyEdit ApplyWorkspaceEditParams{ _edit, _label } nullHandler)
+  _ <- liftLSP (LSP.sendRequest SMethod_WorkspaceApplyEdit ApplyWorkspaceEditParams{ _edit, _label } nullHandler)
 
   return ()
 
 executeFreezeImport
-    :: RequestMessage 'WorkspaceExecuteCommand
+    :: TRequestMessage 'Method_WorkspaceExecuteCommand
     -> HandlerM ()
 executeFreezeImport request = do
   args <- getCommandArguments request :: HandlerM TextDocumentPositionParams
@@ -492,20 +496,20 @@ executeFreezeImport request = do
   let _newText = " " <> hash
 
   let _edit = WorkspaceEdit
-          { _changes = Just (HashMap.singleton uri_ (List [TextEdit{..}]))
+          { _changes = Just (Map.singleton uri_ [TextEdit{..}])
           , _documentChanges = Nothing
           , _changeAnnotations = Nothing
           }
 
   let _label = Nothing
 
-  _ <- liftLSP (LSP.sendRequest SWorkspaceApplyEdit ApplyWorkspaceEditParams{ _edit, _label } nullHandler)
+  _ <- liftLSP (LSP.sendRequest SMethod_WorkspaceApplyEdit ApplyWorkspaceEditParams{ _edit, _label } nullHandler)
 
   return ()
 
 completionHandler :: Handlers HandlerM
 completionHandler =
-  LSP.requestHandler STextDocumentCompletion \request respond -> handleErrorWithDefault respond (InR (CompletionList False (List []))) do
+  LSP.requestHandler SMethod_TextDocumentCompletion \request respond -> handleErrorWithDefault respond (InR (InL (CompletionList False Nothing []))) do
     let uri_  = request ^. params . textDocument . uri
         line_ = fromIntegral (request ^. params . position . line)
         col_  = fromIntegral (request ^. params . position . character)
@@ -576,6 +580,7 @@ completionHandler =
     let toCompletionItem (Completion {..}) = CompletionItem {..}
          where
           _label = completeText
+          _labelDetails = Nothing
           _kind = Nothing
           _tags = mempty
           _detail = fmap pretty completeType
@@ -588,29 +593,30 @@ completionHandler =
           _insertTextFormat = Nothing
           _insertTextMode = Nothing
           _textEdit = Nothing
+          _textEditText = Nothing
           _additionalTextEdits = Nothing
           _commitCharacters = Nothing
           _command = Nothing
-          _xdata = Nothing
+          _data_ = Nothing
 
-    let _items = List (map toCompletionItem completions)
-
+    let _items = (map toCompletionItem completions)
+    let _itemDefaults = Nothing
     let _isIncomplete = False
 
-    respond (Right (InR CompletionList{..}))
+    respond (Right (InR (InL CompletionList{..})))
 
 nullHandler :: a -> LspT ServerConfig IO ()
 nullHandler _ = return ()
 
 didOpenTextDocumentNotificationHandler :: Handlers HandlerM
 didOpenTextDocumentNotificationHandler =
-    LSP.notificationHandler STextDocumentDidOpen \notification -> do
+    LSP.notificationHandler SMethod_TextDocumentDidOpen \notification -> do
         let _uri = notification^.params.textDocument.uri
         diagnosticsHandler _uri
 
 didSaveTextDocumentNotificationHandler :: Handlers HandlerM
 didSaveTextDocumentNotificationHandler =
-    LSP.notificationHandler STextDocumentDidSave \notification -> do
+    LSP.notificationHandler SMethod_TextDocumentDidSave \notification -> do
         let _uri = notification^.params.textDocument.uri
         diagnosticsHandler _uri
 
@@ -618,22 +624,22 @@ didSaveTextDocumentNotificationHandler =
 -- this handler is a stab to prevent `lsp:no handler for:` messages.
 initializedHandler :: Handlers HandlerM
 initializedHandler =
-    LSP.notificationHandler SInitialized \_ -> return ()
+    LSP.notificationHandler SMethod_Initialized \_ -> return ()
 
 -- this handler is a stab to prevent `lsp:no handler for:` messages.
 workspaceChangeConfigurationHandler :: Handlers HandlerM
 workspaceChangeConfigurationHandler =
-    LSP.notificationHandler SWorkspaceDidChangeConfiguration \_ -> return ()
+    LSP.notificationHandler SMethod_WorkspaceDidChangeConfiguration \_ -> return ()
 
 -- this handler is a stab to prevent `lsp:no handler for:` messages.
 textDocumentChangeHandler :: Handlers HandlerM
 textDocumentChangeHandler =
-    LSP.notificationHandler STextDocumentDidChange \_ -> return ()
+    LSP.notificationHandler SMethod_TextDocumentDidChange \_ -> return ()
 
 -- this handler is a stab to prevent `lsp:no handler for:` messages.
 cancelationHandler :: Handlers HandlerM
 cancelationHandler =
-    LSP.notificationHandler SCancelRequest \_ -> return ()
+    LSP.notificationHandler SMethod_CancelRequest \_ -> return ()
 
 handleErrorWithDefault :: (Either a1 b -> HandlerM a2)
  -> b
@@ -642,16 +648,16 @@ handleErrorWithDefault :: (Either a1 b -> HandlerM a2)
 handleErrorWithDefault respond _default = flip catchE handler
   where
     handler (Log, _message)  = do
-                    let _xtype = MtLog
-                    liftLSP $ LSP.sendNotification SWindowLogMessage LogMessageParams{..}
+                    let _type_ = MessageType_Log
+                    liftLSP $ LSP.sendNotification SMethod_WindowLogMessage LogMessageParams{..}
                     respond (Right _default)
 
     handler (severity_, _message) = do
-                    let _xtype = case severity_ of
-                          Error   -> MtError
-                          Warning -> MtWarning
-                          Info    -> MtInfo
-                          Log     -> MtLog
+                    let _type_ = case severity_ of
+                          Error   -> MessageType_Error
+                          Warning -> MessageType_Warning
+                          Info    -> MessageType_Info
+                          Log     -> MessageType_Log
 
-                    liftLSP $ LSP.sendNotification SWindowShowMessage ShowMessageParams{..}
+                    liftLSP $ LSP.sendNotification SMethod_WindowShowMessage ShowMessageParams{..}
                     respond (Right _default)

--- a/dhall-lsp-server/src/Dhall/LSP/State.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/State.hs
@@ -21,7 +21,7 @@ import Dhall.LSP.Backend.Dhall          (Cache, DhallError, emptyCache)
 import Dhall.Pretty                     (CharacterSet)
 import Language.LSP.Server              (LspT)
 
-import qualified Language.LSP.Types as J
+import qualified Language.LSP.Protocol.Types as J
 
 -- Inside a handler we have access to the ServerState. The exception layer
 -- allows us to fail gracefully, displaying a message to the user via the

--- a/nix/packages/lsp-types.nix
+++ b/nix/packages/lsp-types.nix
@@ -1,24 +1,31 @@
 { mkDerivation, aeson, base, binary, containers, data-default
-, deepseq, Diff, dlist, exceptions, filepath, hashable, hspec
-, hspec-discover, lens, lib, mod, mtl, network-uri, QuickCheck
-, quickcheck-instances, safe, scientific, some, template-haskell
-, text, tuple, unordered-containers
+, deepseq, Diff, directory, dlist, exceptions, file-embed, filepath
+, hashable, hspec, hspec-discover, lens, lib, mod, mtl, network-uri
+, prettyprinter, QuickCheck, quickcheck-instances, regex, row-types
+, safe, some, template-haskell, text, unordered-containers
 }:
 mkDerivation {
   pname = "lsp-types";
-  version = "1.6.0.1";
-  sha256 = "47d084f3a56195706381b51ad2f5d1b22a958238f3e5519625dbc54a2503f670";
+  version = "2.0.1.0";
+  sha256 = "57406c159d14aa30b3d8e5f48ca713186b340f668c93e940e884387fe561ffe0";
+  isLibrary = true;
+  isExecutable = true;
   libraryHaskellDepends = [
     aeson base binary containers data-default deepseq Diff dlist
-    exceptions filepath hashable lens mod mtl network-uri safe
-    scientific some template-haskell text unordered-containers
+    exceptions file-embed filepath hashable lens mod mtl network-uri
+    row-types safe some template-haskell text unordered-containers
+  ];
+  executableHaskellDepends = [
+    base containers directory filepath mtl prettyprinter regex text
   ];
   testHaskellDepends = [
     aeson base filepath hspec lens network-uri QuickCheck
-    quickcheck-instances text tuple
+    quickcheck-instances row-types text
   ];
   testToolDepends = [ hspec-discover ];
+  doHaddock = false;
   homepage = "https://github.com/haskell/lsp";
   description = "Haskell library for the Microsoft Language Server Protocol, data types";
   license = lib.licenses.mit;
+  mainProgram = "generator";
 }

--- a/nix/packages/lsp.nix
+++ b/nix/packages/lsp.nix
@@ -1,24 +1,24 @@
 { mkDerivation, aeson, async, attoparsec, base, bytestring
 , co-log-core, containers, data-default, directory, exceptions
 , filepath, hashable, hspec, hspec-discover, lens, lib, lsp-types
-, mtl, prettyprinter, random, sorted-list, stm, temporary, text
-, text-rope, transformers, unliftio-core, unordered-containers
-, uuid
+, mtl, prettyprinter, random, row-types, sorted-list, stm
+, temporary, text, text-rope, transformers, unliftio-core
+, unordered-containers, uuid
 }:
 mkDerivation {
   pname = "lsp";
-  version = "1.6.0.0";
-  sha256 = "896803766e8ceabeacc72743f4b92cf7766b2a1f09be270b29d0a39692b00470";
+  version = "2.1.0.0";
+  sha256 = "c8a7a2b82d074641c77894639bdd5aacae5046610ee8d6b8a74b0cf71c4af30d";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     aeson async attoparsec base bytestring co-log-core containers
     data-default directory exceptions filepath hashable lens lsp-types
-    mtl prettyprinter random sorted-list stm temporary text text-rope
-    transformers unliftio-core unordered-containers uuid
+    mtl prettyprinter random row-types sorted-list stm temporary text
+    text-rope transformers unliftio-core unordered-containers uuid
   ];
   testHaskellDepends = [
-    base containers hspec sorted-list text text-rope
+    base containers hspec row-types sorted-list text text-rope
     unordered-containers
   ];
   testToolDepends = [ hspec-discover ];

--- a/stack.ghc-8.10.yaml
+++ b/stack.ghc-8.10.yaml
@@ -12,14 +12,16 @@ packages:
   - dhall-yaml
 extra-deps:
   - co-log-core-0.3.2.0
+  - hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
   - hnix-0.16.0
   - hnix-store-core-0.5.0.0
   - hnix-store-remote-0.5.0.0
-  - lsp-1.5.0.0
-  - lsp-types-1.5.0.0
-  - lsp-test-0.14.1.0
+  - lsp-2.1.0.0
+  - lsp-types-2.0.1.0
+  - lsp-test-0.15.0.1
   - lucid-2.11.0
   - relude-1.0.0.1@sha256:35bcdaf14018e79f11e712b0e2314c1aac79976f28f4adc179985457493557d5,11569
+  - row-types-1.0.1.2@sha256:4d4c7cb95d06a32b28ba977852d52a26b4c1f695ef083a6fd874ab6d79933b64,3071
   - semialign-1.2@sha256:9afb6eb7e50db7ca34d7c4108aec0f643dae2caaaa80394b44ffdd643315685c,2721
   - text-rope-0.2
   - typerep-map-0.5.0.0

--- a/stack.ghc-9.2.yaml
+++ b/stack.ghc-9.2.yaml
@@ -18,8 +18,11 @@ extra-deps:
   - hnix-store-core-0.6.1.0
   - hnix-store-remote-0.6.0.0
   - logict-0.7.0.3
-  - lsp-test-0.14.1.0
+  - lsp-2.1.0.0
+  - lsp-types-2.0.1.0
+  - lsp-test-0.15.0.1
   - optparse-applicative-0.16.1.0
+  - row-types-1.0.1.2@sha256:4d4c7cb95d06a32b28ba977852d52a26b4c1f695ef083a6fd874ab6d79933b64,3071
   - saltine-0.2.1.0
   - tomland-1.3.3.2
   - typerep-map-0.5.0.0


### PR DESCRIPTION
@mmhat 
Building upon #2531, this further adds support for
- `lsp 2.1`
- `lsp-types 2.0` 
- `lsp-test 0.16`

This is a minimum refactoring by essentially following the compile errors and fixing them one by one without major structural changes. Most changes are just renaming.

No thoughts were given to backwards compatibility within LSP - the above versions are also the minimum requirement for `dhall-lsp-server`.
This is consistent with GHC 9.6.

#### Note
I had this diff lying around for a few days and it has been verified in my build for updating Arch packages to GHC 9.6.

Supersedes #2428 