### PR TITLE
Fix `-Wunicode-homoglyph` build failure

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -269,7 +269,7 @@ Common common
         CPP-Options:
           -DNETWORK_TESTS
 
-    GHC-Options: -Wall -Wcompat -Wincomplete-uni-patterns
+    GHC-Options: -Wall -Wcompat -Wincomplete-uni-patterns -optP-Wno-unicode-homoglyph
 
 Library
     Import: common


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/646

This fixes a build failure that tends to happen when building Dhall using Nix on macOS.  The failure is related to the `-Wunicode-homoglyph` `cpp` warning, which this change disables.