### PR TITLE
dhall-docs: render standalone text files as preformatted text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,5 @@
 *.golden binary
 dhall-csv/tasty/data/* binary
 dhall-docs/tasty/data/golden/**/*.html binary
+dhall-docs/tasty/data/package/StandaloneTextFile.txt binary
 dhall-yaml/tasty/data/* binary

--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -77,7 +77,7 @@ dhallFileToHtml filePath contents expr examples header params@DocParams{..} =
     htmlTitle = breadCrumbsToText breadcrumb
     clipboardText = fold baseImportUrl <> htmlTitle
 
--- | Generates an @`Html` ()@ with all the information about a dhall file
+-- | Generates an @`Html` ()@ with all the information about a non-dhall text file
 textFileToHtml
     :: Path Rel File            -- ^ Source file name, used to extract the title
     -> Text                     -- ^ Contents of the file
@@ -93,7 +93,7 @@ textFileToHtml filePath contents params@DocParams{..} =
                 copyToClipboardButton clipboardText
                 br_ []
                 h3_ "Source"
-                div_ [class_ "source-code"] (toHtml contents)
+                div_ [class_ "source-code"] $ pre_ (toHtml contents)
   where
     breadcrumb = relPathToBreadcrumb filePath
     htmlTitle = breadCrumbsToText breadcrumb

--- a/dhall-docs/tasty/data/golden/StandaloneTextFile.txt.html
+++ b/dhall-docs/tasty/data/golden/StandaloneTextFile.txt.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>/StandaloneTextFile.txt</title>
+<link rel="stylesheet" type="text/css" href="index.css">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
+<script type="text/javascript" src="index.js">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img class="dhall-icon" src="dhall-icon.svg">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span class="title-crumb" href="index.html">StandaloneTextFile.txt</span>
+</h2>
+<a class="copy-to-clipboard" data-path="/StandaloneTextFile.txt">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<h3>Source</h3>
+<div class="source-code">
+<pre>This is a text file that is not referenced by any dhall file.
+
++---------------------------------------------------+
+| It should be displayed as &lt;pre&gt;preformatted&lt;/pre&gt; |
+|   text, with horizontal and vertical whitespace   |
+|          preserved, to keep it readable.          |
++---------------------------------------------------+
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -171,6 +171,9 @@
 </span>
 </li>
 <li>
+<a href="StandaloneTextFile.txt.html">StandaloneTextFile.txt</a>
+</li>
+<li>
 <a href="TwoAnnotations.dhall.html">TwoAnnotations.dhall</a>
 <span class="of-type-token">:</span>
 <span class="dhall-type source-code">

--- a/dhall-docs/tasty/data/package/StandaloneTextFile.txt
+++ b/dhall-docs/tasty/data/package/StandaloneTextFile.txt
@@ -1,0 +1,7 @@
+This is a text file that is not referenced by any dhall file.
+
++---------------------------------------------------+
+| It should be displayed as <pre>preformatted</pre> |
+|   text, with horizontal and vertical whitespace   |
+|          preserved, to keep it readable.          |
++---------------------------------------------------+


### PR DESCRIPTION
I noticed that text files that are not imported by dhall files are not rendered as preformatted text, which often looks awful. See the `README.md` for `dhall-semver`:

![image](https://github.com/dhall-lang/dhall-haskell/assets/53443372/398a4615-d801-4e4b-ad8d-2c08dfbf8b68)

The raw text looks much better: https://raw.githubusercontent.com/Gabriella439/dhall-semver/main/README.md. Moreover, displaying as preformatted text is much closer to the real contents of the file.

I can't be 100% sure, but this looks like an unintentional omission in #2407. The test didn't catch it because the `Plain.txt` file is imported by `AsText.dhall` and thus treated differently (I didn't look for the part of code responsible for this behaviour, I'm guessing based on what I see).

Side note: it's also rather easy to add support for rendering Markdown files as HTML (I have a working proof of concept, but it needs some polish). This could be nice for files like `README.md`, which are common in Dhall packages. On the other hand, Markdown is quite readable on its own. Anyway, that's a story for another PR.