### PR TITLE
[dhall-docs] Bump dependencies for GHC 9.8

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -65,7 +65,7 @@ Library
     Build-Depends:
         base                 >= 4.11.0.0  && < 5   ,
         base16-bytestring    >= 1.0.0.0            ,
-        bytestring                           < 0.12,
+        bytestring                           < 0.13,
         containers                                 ,
         cryptohash-sha256                          ,
         directory            >= 1.3.0.0   && < 1.4 ,
@@ -81,7 +81,7 @@ Library
         -- path-io follows SemVer: https://github.com/mrkkrp/path-io/issues/68
         path-io              >= 1.6.0     && < 2 ,
         prettyprinter        >= 1.7.0     && < 1.8 ,
-        text                 >= 0.11.1.0  && < 2.1 ,
+        text                 >= 0.11.1.0  && < 2.2 ,
         transformers         >= 0.2.0.0   && < 0.7 ,
         mtl                  >= 2.2.1     && < 2.4 ,
         optparse-applicative >= 0.14.0.0  && < 0.19


### PR DESCRIPTION
Builds and tests fine