### PR TITLE
fix: bump dependencies for GHC 9.8

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -65,7 +65,7 @@ Library
     Build-Depends:
         base                 >= 4.11.0.0  && < 5   ,
         base16-bytestring    >= 1.0.0.0            ,
-        bytestring                           < 0.12,
+        bytestring                           < 0.13,
         containers                                 ,
         cryptohash-sha256                          ,
         directory            >= 1.3.0.0   && < 1.4 ,
@@ -81,7 +81,7 @@ Library
         -- path-io follows SemVer: https://github.com/mrkkrp/path-io/issues/68
         path-io              >= 1.6.0     && < 2 ,
         prettyprinter        >= 1.7.0     && < 1.8 ,
-        text                 >= 0.11.1.0  && < 2.1 ,
+        text                 >= 0.11.1.0  && < 2.2 ,
         transformers         >= 0.2.0.0   && < 0.7 ,
         mtl                  >= 2.2.1     && < 2.4 ,
         optparse-applicative >= 0.14.0.0  && < 0.19

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -41,7 +41,7 @@ Library
         aeson                     >= 1.4.6.0   && < 2.2 ,
         aeson-pretty              >= 0.8.0     && < 0.9 ,
         aeson-yaml                >= 1.1.0     && < 1.2 ,
-        bytestring                                < 0.12,
+        bytestring                                < 0.13,
         containers                >= 0.5.9     && < 0.7 ,
         dhall                     >= 1.42.0    && < 1.43,
         exceptions                >= 0.8.3     && < 0.11,
@@ -50,7 +50,7 @@ Library
         optparse-applicative      >= 0.14.0.0  && < 0.19,
         prettyprinter             >= 1.7.0     && < 1.8 ,
         scientific                >= 0.3.0.0   && < 0.4 ,
-        text                      >= 0.11.1.0  && < 2.1 ,
+        text                      >= 0.11.1.0  && < 2.2 ,
         unordered-containers                      < 0.3 ,
         vector
     Exposed-Modules:

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -35,11 +35,11 @@ Library
         HsYAML-aeson              >= 0.2       && < 0.3 ,
         base                      >= 4.11.0.0  && < 5   ,
         aeson                     >= 1.0.0.0   && < 2.2 ,
-        bytestring                                < 0.12,
+        bytestring                                < 0.13,
         dhall                     >= 1.31.0    && < 1.43,
         dhall-json                >= 1.6.0     && < 1.8 ,
         optparse-applicative      >= 0.14.0.0  && < 0.19,
-        text                      >= 0.11.1.0  && < 2.1 ,
+        text                      >= 0.11.1.0  && < 2.2 ,
         vector
     Exposed-Modules:
         Dhall.Yaml


### PR DESCRIPTION
Builds and tests fine

Includes #2568