### PR TITLE
dhall-json: Expose UnionConv(..)

### DIFF
--- a/dhall-json/src/Dhall/JSONToDhall.hs
+++ b/dhall-json/src/Dhall/JSONToDhall.hs
@@ -344,6 +344,7 @@ module Dhall.JSONToDhall (
       parseConversion
     , Conversion(..)
     , defaultConversion
+    , UnionConv(..)
     , resolveSchemaExpr
     , typeCheckSchemaExpr
     , dhallFromJSON


### PR DESCRIPTION
This makes it easier to reuse `dhallFromJSON` externally. At the moment we are stuck with `defaultOptions` which sets `unions = UFirst`.