### PR TITLE
lsp-server: Compatibility with lsp ==2.3.0.0

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -57,12 +57,12 @@ library
     , lens                 >= 4.16.1   && < 5.3
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     , megaparsec           >= 7.0.2    && < 10
-    , mtl                  >= 2.2.2    && < 2.3
+    , mtl                  >= 2.2.2    && < 2.4
     , network-uri          >= 2.6.1.0  && < 2.7
     , prettyprinter        >= 1.7.0    && < 1.8
     , text                 >= 1.2.3.0  && < 2.1
     , text-rope            >= 0.2      && < 0.3
-    , transformers         >= 0.5.5.0  && < 0.6
+    , transformers         >= 0.5.5.0  && < 0.7
     , unordered-containers >= 0.2.9.0  && < 0.3
     , uri-encode           >= 1.5.0.5  && < 1.6
   default-language: Haskell2010

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -53,7 +53,8 @@ library
     , dhall                >= 1.38.0   && < 1.43
     , dhall-json           >= 1.4      && < 1.8
     , filepath             >= 1.4.2    && < 1.5
-    , lsp                  >= 2.1.0.0  && < 2.2
+    , lsp                  >= 2.3.0.0  && < 2.4
+    , lsp-types            >= 2.1      && < 2.2
     , lens                 >= 4.16.1   && < 5.3
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     , megaparsec           >= 7.0.2    && < 10
@@ -104,9 +105,9 @@ Test-Suite tests
     GHC-Options: -Wall
     Build-Depends:
         base                                    ,
-        lsp-types         >= 2.0.1    && < 2.1  ,
+        lsp-types         >= 2.1      && < 2.2  ,
         hspec             >= 2.7      && < 2.11 ,
-        lsp-test          >= 0.15.0.0 && < 0.16 ,
+        lsp-test          >= 0.16.0.0 && < 0.17 ,
         tasty             >= 0.11.2   && < 1.5  ,
         tasty-hspec       >= 1.1      && < 1.3  ,
         text              >= 0.11     && < 2.1

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -52,10 +52,14 @@ run = withLogger $ \ioLogger -> do
 
   let defaultConfig = def
 
-  let onConfigurationChange _oldConfig json =
+  let configSection = "dhall"
+
+  let parseConfig _oldConfig json =
         case fromJSON json of
             Aeson.Success config -> Right config
             Aeson.Error   string -> Left (Text.pack string)
+
+  let onConfigChange _config = return ()
 
   let doInitialize environment _request = do
           return (Right environment)


### PR DESCRIPTION
This change lets dhall-lsp-server build and pass unit tests with [lsp-2.3.0.0](https://hackage.haskell.org/package/lsp-2.3.0.0/changelog).

The PR is in draft until I've done some actual testing with eglot.