### PR TITLE
dhall-docs: Fix white flashes on page load in dark mode

### DIFF
--- a/dhall-docs/src/Dhall/data/assets/index.css
+++ b/dhall-docs/src/Dhall/data/assets/index.css
@@ -187,7 +187,7 @@ span.of-type-token {
     color: #EBEBEB;
 }
 
-body.dark-mode {
+.dark-mode body {
     background-color: #484848;
 }
 
@@ -214,7 +214,6 @@ body.dark-mode {
 .dark-mode .source-code span {
     color: #D4D4D4;
 }
-
 
 .dark-mode a.copy-to-clipboard {
     color: #bdbdbd !important;

--- a/dhall-docs/src/Dhall/data/assets/index.js
+++ b/dhall-docs/src/Dhall/data/assets/index.js
@@ -2,16 +2,15 @@ const DARK_MODE_OPT = 'dark-mode'
 const DARK_MODE_ACTIVE = 'dark-mode-active'
 const DARK_MODE_INACTIVE = 'dark-mode-inactive'
 
+if (localStorage.getItem(DARK_MODE_OPT) == DARK_MODE_ACTIVE) {
+  document.documentElement.classList.add('dark-mode')
+}
+
 function onReady() {
-  if (localStorage.getItem(DARK_MODE_OPT) == DARK_MODE_ACTIVE) {
-    document.body.classList.add('dark-mode')
-  } else {
-    document.body.classList.remove('dark-mode')
-  }
   document.getElementById('switch-light-dark-mode')
     .addEventListener('click', () => {
-      document.body.classList.toggle('dark-mode')
-      if (document.body.classList.contains('dark-mode')) {
+      document.documentElement.classList.toggle('dark-mode')
+      if (document.documentElement.classList.contains('dark-mode')) {
         localStorage.setItem(DARK_MODE_OPT, DARK_MODE_ACTIVE)
       } else {
         localStorage.setItem(DARK_MODE_OPT, DARK_MODE_INACTIVE)


### PR DESCRIPTION
Loading a page with dark mode enabled currently results in a short white flash. This happens because the page is first rendered in light mode, and only after it is loaded the class indicating that dark mode is enabled is toggled. The effect is even more visible because of the 0.5s transition effect set in CSS.

![test](https://github.com/dhall-lang/dhall-haskell/assets/53443372/5cf771a1-5938-4f89-865c-e0a594b5d73d)

This PR solves the problem by toggling the class indicating that dark mode is enabled before the page is rendered (the script is called inside `<head>`). The class is now set on the `<html>` element instead of `<body>` because `document.body` is not ready yet when the script is executed.