### PR TITLE
Render Markdown files as HTML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,6 @@
 dhall-csv/tasty/data/* binary
 dhall-docs/tasty/data/golden/**/*.html binary
 dhall-docs/tasty/data/package/StandaloneTextFile.txt binary
+dhall-docs/tasty/data/package/MarkdownFile.md binary
+dhall-docs/tasty/data/package/InvalidMarkdownFile.md binary
 dhall-yaml/tasty/data/* binary

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -22,12 +22,14 @@ Category: Compiler
 Extra-Source-Files:
     CHANGELOG.md
     README.md
+    tasty/data/package/*.md
     tasty/data/package/*.txt
     tasty/data/package/*.dhall
     tasty/data/package/a/*.dhall
     tasty/data/package/a/b/*.dhall
     tasty/data/package/a/b/c/*.dhall
     tasty/data/package/deep/nested/folder/*.dhall
+    tasty/data/golden/*.md.html
     tasty/data/golden/*.txt.html
     tasty/data/golden/*.dhall.html
     tasty/data/golden/a/*.dhall.html

--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -13,6 +13,7 @@
 
 module Dhall.Docs.Html
     ( dhallFileToHtml
+    , markdownFileToHtml
     , textFileToHtml
     , indexToHtml
     , DocParams(..)
@@ -47,6 +48,29 @@ data DocParams = DocParams
     , baseImportUrl :: Maybe Text       -- ^ Base import URL
     }
 
+-- | Generates an @`Html` ()@ containing standard elements like title,
+--   navbar, breadcrumbs, and the provided content.
+htmlTemplate
+    :: Path Rel a               -- ^ Source file name or index directory, used to extract the title
+    -> DocParams                -- ^ Parameters for the documentation
+    -> HtmlFileType             -- ^ Are we rendering an index page?
+    -> Html ()                  -- ^ Content to be included
+    -> Html ()
+htmlTemplate filePath params@DocParams{..} isIndex html =
+    doctypehtml_ $ do
+        headContents htmlTitle params
+        body_ $ do
+            navBar params
+            mainContainer $ do
+                setPageTitle params isIndex breadcrumb
+                copyToClipboardButton clipboardText
+                br_ []
+                html
+  where
+    breadcrumb = relPathToBreadcrumb filePath
+    htmlTitle = breadCrumbsToText breadcrumb
+    clipboardText = fold baseImportUrl <> htmlTitle
+
 -- | Generates an @`Html` ()@ with all the information about a dhall file
 dhallFileToHtml
     :: Path Rel File            -- ^ Source file name, used to extract the title
@@ -57,47 +81,42 @@ dhallFileToHtml
     -> DocParams                -- ^ Parameters for the documentation
     -> Html ()
 dhallFileToHtml filePath contents expr examples header params@DocParams{..} =
-    doctypehtml_ $ do
-        headContents htmlTitle params
-        body_ $ do
-            navBar params
-            mainContainer $ do
-                setPageTitle params NotIndex breadcrumb
-                copyToClipboardButton clipboardText
-                br_ []
-                div_ [class_ "doc-contents"] header
-                Control.Monad.unless (null examples) $ do
-                    h3_ "Examples"
-                    div_ [class_ "source-code code-examples"] $
-                        mapM_ (renderCodeSnippet characterSet AssertionExample) examples
-                h3_ "Source"
-                div_ [class_ "source-code"] $ renderCodeWithHyperLinks contents expr
-  where
-    breadcrumb = relPathToBreadcrumb filePath
-    htmlTitle = breadCrumbsToText breadcrumb
-    clipboardText = fold baseImportUrl <> htmlTitle
+    htmlTemplate filePath params NotIndex $ do
+        div_ [class_ "doc-contents"] header
+        Control.Monad.unless (null examples) $ do
+            h3_ "Examples"
+            div_ [class_ "source-code code-examples"] $
+                mapM_ (renderCodeSnippet characterSet AssertionExample) examples
+        h3_ "Source"
+        div_ [class_ "source-code"] $ renderCodeWithHyperLinks contents expr
 
--- | Generates an @`Html` ()@ with all the information about a non-dhall text file
+-- | Generates an @`Html` ()@ with all the information about a Markdown file
+markdownFileToHtml
+    :: Path Rel File            -- ^ Source file name, used to extract the title
+    -> Text                     -- ^ Original text contents of the file
+    -> Html ()                  -- ^ Contents converted to HTML
+    -> DocParams                -- ^ Parameters for the documentation
+    -> Html ()
+markdownFileToHtml filePath contents html params =
+    htmlTemplate filePath params NotIndex $ do
+        details_ [open_ ""] $ do
+            summary_ [class_ "part-summary"] "Rendered content"
+            div_ [class_ "doc-contents"] html
+        details_ $ do
+            summary_ [class_ "part-summary"] "Source"
+            div_ [class_ "source-code"] $ pre_ (toHtml contents)
+
+
+-- | Generates an @`Html` ()@ with all the information about a text file
 textFileToHtml
     :: Path Rel File            -- ^ Source file name, used to extract the title
     -> Text                     -- ^ Contents of the file
     -> DocParams                -- ^ Parameters for the documentation
     -> Html ()
-textFileToHtml filePath contents params@DocParams{..} =
-    doctypehtml_ $ do
-        headContents htmlTitle params
-        body_ $ do
-            navBar params
-            mainContainer $ do
-                setPageTitle params NotIndex breadcrumb
-                copyToClipboardButton clipboardText
-                br_ []
-                h3_ "Source"
-                div_ [class_ "source-code"] $ pre_ (toHtml contents)
-  where
-    breadcrumb = relPathToBreadcrumb filePath
-    htmlTitle = breadCrumbsToText breadcrumb
-    clipboardText = fold baseImportUrl <> htmlTitle
+textFileToHtml filePath contents params =
+    htmlTemplate filePath params NotIndex $ do
+        h3_ "Source"
+        div_ [class_ "source-code"] $ pre_ (toHtml contents)
 
 -- | Generates an index @`Html` ()@ that list all the dhall files in that folder
 indexToHtml
@@ -106,21 +125,15 @@ indexToHtml
     -> [Path Rel Dir]                              -- ^ Generated directories in that directory
     -> DocParams                                   -- ^ Parameters for the documentation
     -> Html ()
-indexToHtml indexDir files dirs params@DocParams{..} = doctypehtml_ $ do
-    headContents htmlTitle params
-    body_ $ do
-        navBar params
-        mainContainer $ do
-            setPageTitle params Index breadcrumbs
-            copyToClipboardButton clipboardText
-            br_ []
-            Control.Monad.unless (null files) $ do
-                h3_ "Exported files: "
-                ul_ $ mconcat $ map listFile files
+indexToHtml indexDir files dirs params@DocParams{..} =
+    htmlTemplate indexDir params Index $ do
+        Control.Monad.unless (null files) $ do
+            h3_ "Exported files: "
+            ul_ $ mconcat $ map listFile files
 
-            Control.Monad.unless (null dirs) $ do
-                h3_ "Exported packages: "
-                ul_ $ mconcat $ map listDir dirs
+        Control.Monad.unless (null dirs) $ do
+            h3_ "Exported packages: "
+            ul_ $ mconcat $ map listDir dirs
 
   where
     listFile :: (Path Rel File, Maybe (Expr Void Import)) -> Html ()
@@ -144,10 +157,6 @@ indexToHtml indexDir files dirs params@DocParams{..} = doctypehtml_ $ do
     tryToTakeExt file = Path.fromRelFile $ case Path.splitExtension file of
         Nothing -> file
         Just (f, _) -> f
-
-    breadcrumbs = relPathToBreadcrumb indexDir
-    htmlTitle = breadCrumbsToText breadcrumbs
-    clipboardText = fold baseImportUrl <> htmlTitle
 
 copyToClipboardButton :: Text -> Html ()
 copyToClipboardButton filePath =

--- a/dhall-docs/src/Dhall/Docs/Markdown.hs
+++ b/dhall-docs/src/Dhall/Docs/Markdown.hs
@@ -2,13 +2,16 @@
 -}
 module Dhall.Docs.Markdown
     ( MarkdownParseError(..)
+    , MMark
+    , parseMarkdown
     , markdownToHtml
+    , MMark.render
     ) where
 
 import Data.Text       (Text)
 import Lucid
 import Path            (File, Path, Rel)
-import Text.MMark      (MMarkErr)
+import Text.MMark      (MMarkErr, MMark)
 import Text.Megaparsec (ParseErrorBundle (..))
 
 import qualified Path
@@ -27,6 +30,16 @@ markdownToHtml
     -> Text          -- ^ Text to parse
     -> Either MarkdownParseError (Html ())
 markdownToHtml relFile contents =
+    MMark.render <$> parseMarkdown relFile contents
+
+{-| Takes a text that could contain markdown and returns either the parsed
+    markdown or, if parsing fails, the error information.
+-}
+parseMarkdown
+    :: Path Rel File -- ^ Used by `Mmark.parse` for error messages
+    -> Text          -- ^ Text to parse
+    -> Either MarkdownParseError MMark
+parseMarkdown relFile contents =
     case MMark.parse (Path.fromRelFile relFile) contents of
         Left err -> Left MarkdownParseError { unwrap = err }
-        Right mmark -> Right $ MMark.render mmark
+        Right mmark -> Right mmark

--- a/dhall-docs/src/Dhall/data/assets/index.css
+++ b/dhall-docs/src/Dhall/data/assets/index.css
@@ -125,6 +125,13 @@ h2.doc-title {
     margin-bottom: 0;
 }
 
+summary.part-summary {
+    cursor: pointer;
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-top: 1rem;
+}
+
 /******** Source code **********/
 
 

--- a/dhall-docs/tasty/data/golden/InvalidMarkdownFile.md.html
+++ b/dhall-docs/tasty/data/golden/InvalidMarkdownFile.md.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>/InvalidMarkdownFile.md</title>
+<link rel="stylesheet" type="text/css" href="index.css">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
+<script type="text/javascript" src="index.js">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img class="dhall-icon" src="dhall-icon.svg">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span class="title-crumb" href="index.html">InvalidMarkdownFile.md</span>
+</h2>
+<a class="copy-to-clipboard" data-path="/InvalidMarkdownFile.md">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<h3>Source</h3>
+<div class="source-code">
+<pre>This file is not valid [Markdown](aaa
+</pre>
+</div>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/MarkdownFile.md.html
+++ b/dhall-docs/tasty/data/golden/MarkdownFile.md.html
@@ -1,0 +1,77 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>/MarkdownFile.md</title>
+<link rel="stylesheet" type="text/css" href="index.css">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
+<script type="text/javascript" src="index.js">
+</script>
+<meta charset="UTF-8">
+</head>
+<body>
+<div class="nav-bar">
+<img class="dhall-icon" src="dhall-icon.svg">
+<p class="package-title">test-package</p>
+<div class="nav-bar-content-divider">
+</div>
+<a id="switch-light-dark-mode" class="nav-option">Switch Light/Dark Mode</a>
+</div>
+<div class="main-container">
+<h2 class="doc-title">
+<span class="crumb-divider">/</span>
+<a href="index.html">test-package</a>
+<span class="crumb-divider">/</span>
+<span class="title-crumb" href="index.html">MarkdownFile.md</span>
+</h2>
+<a class="copy-to-clipboard" data-path="/MarkdownFile.md">
+<i>
+<small>Copy path to clipboard</small>
+</i>
+</a>
+<br>
+<details open>
+<summary class="part-summary">Rendered content</summary>
+<div class="doc-contents">
+<h1 id="title">Title</h1>
+<p>This is a <em>Markdown</em> file.</p>
+<table>
+<thead>
+<tr>
+<th>A very</th>
+<th>nice</th>
+<th>table</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>2</td>
+<td>3</td>
+</tr>
+<tr>
+<td>4</td>
+<td>5</td>
+<td>6</td>
+</tr>
+</tbody>
+</table>
+</div>
+</details>
+<details>
+<summary class="part-summary">Source</summary>
+<div class="source-code">
+<pre># Title
+
+This is a *Markdown* file.
+
+|A very | nice | table|
+|---|---|---|
+|1|2|3|
+|4|5|6|
+
+</pre>
+</div>
+</details>
+</div>
+</body>
+</html>

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -55,6 +55,9 @@
 <a href="InvalidMarkdown.dhall.html">InvalidMarkdown.dhall</a>
 </li>
 <li>
+<a href="InvalidMarkdownFile.md.html">InvalidMarkdownFile.md</a>
+</li>
+<li>
 <a href="JumpToDefOnUnused.dhall.html">JumpToDefOnUnused.dhall</a>
 </li>
 <li>
@@ -128,6 +131,9 @@
 </li>
 <li>
 <a href="MarkdownExample.dhall.html">MarkdownExample.dhall</a>
+</li>
+<li>
+<a href="MarkdownFile.md.html">MarkdownFile.md</a>
 </li>
 <li>
 <a href="MultilineIndentationExample.dhall.html">MultilineIndentationExample.dhall</a>

--- a/dhall-docs/tasty/data/package/InvalidMarkdownFile.md
+++ b/dhall-docs/tasty/data/package/InvalidMarkdownFile.md
@@ -1,0 +1,1 @@
+This file is not valid [Markdown](aaa

--- a/dhall-docs/tasty/data/package/MarkdownFile.md
+++ b/dhall-docs/tasty/data/package/MarkdownFile.md
@@ -1,0 +1,9 @@
+# Title
+
+This is a *Markdown* file.
+
+|A very | nice | table|
+|---|---|---|
+|1|2|3|
+|4|5|6|
+


### PR DESCRIPTION
This PR introduces HTML rendering of Markdown files, as announced in #2565. The main usecase is rendering `README.md` files accompanying a package.

If a file has the `.md` extension and can be parsed by the MMark parser, we display both the HTML output generated by MMark, and the Markdown sources, which are hidden by default using a `<details>` tag. If a problem occurs in the parsing phase, we treat the file as plain text and display a warning.

One issue that I am aware of is handling of local (non-external) links. For example in the Prelude's `README.md` we have a link pointing to `./Natural/fold`. In the generated documentation this will stil point to `./Natural/fold`, but there is no such file in the docs: we are missing the `.html` extension. (And for links to folders we should add a trailing `/index.html`.) A "full" solution of this could be rather tricky, as it should involve handling of symlinks etc., and would probably need IO and some restructuring of the code. I think a simple solution that works in most real-life scenarios can be implemented using a [MMark extension](https://hackage.haskell.org/package/mmark-0.0.7.6/docs/Text-MMark-Extension.html), a helper function similar to `shake`'s [`NormaliseEx`](https://hackage.haskell.org/package/shake-0.19.8/docs/Development-Shake-FilePath.html#v:normaliseEx) and the list of rendered files. However, this would still require some work, and I believe the present changes already improve the `dhall-docs` tool a little bit, so I'd rather take care of this in a separate PR. (Moreover, rendering of comments in `.dhall` files has the same issue, so it could be fixed in both places at once.)