### PR TITLE
dhall-docs: fix an error and a warning reported by the w3c validator

### DIFF
--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -278,8 +278,7 @@ stylesheet path =
 script :: FilePath -> Html ()
 script relativeResourcesPath =
     script_
-        [ type_ "text/javascript"
-        , src_ $ Data.Text.pack $ relativeResourcesPath <> "index.js"]
+        [ src_ $ Data.Text.pack $ relativeResourcesPath <> "index.js"]
         ("" :: Text)
 
 toUnixPath :: String -> Text

--- a/dhall-docs/src/Dhall/Docs/Html.hs
+++ b/dhall-docs/src/Dhall/Docs/Html.hs
@@ -241,6 +241,7 @@ navBar DocParams{..} = div_ [class_ "nav-bar"] $ do
 
     -- Left side of the nav-bar
     img_ [ class_ "dhall-icon"
+         , alt_ "Dhall logo."
          , src_ $ Data.Text.pack $ relativeResourcesPath <> "dhall-icon.svg"
          ]
     p_ [class_ "package-title"] $ toHtml packageName

--- a/dhall-docs/tasty/data/golden/AsText.dhall.html
+++ b/dhall-docs/tasty/data/golden/AsText.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/AsText.dhall.html
+++ b/dhall-docs/tasty/data/golden/AsText.dhall.html
@@ -4,7 +4,7 @@
 <title>/AsText.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/ImportAsType.dhall.html
+++ b/dhall-docs/tasty/data/golden/ImportAsType.dhall.html
@@ -4,7 +4,7 @@
 <title>/ImportAsType.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/ImportAsType.dhall.html
+++ b/dhall-docs/tasty/data/golden/ImportAsType.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/InvalidBlockComment.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidBlockComment.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/InvalidBlockComment.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidBlockComment.dhall.html
@@ -4,7 +4,7 @@
 <title>/InvalidBlockComment.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/InvalidConsecutiveComments.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidConsecutiveComments.dhall.html
@@ -4,7 +4,7 @@
 <title>/InvalidConsecutiveComments.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/InvalidConsecutiveComments.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidConsecutiveComments.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
@@ -4,7 +4,7 @@
 <title>/InvalidMarkdown.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
+++ b/dhall-docs/tasty/data/golden/InvalidMarkdown.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/InvalidMarkdownFile.md.html
+++ b/dhall-docs/tasty/data/golden/InvalidMarkdownFile.md.html
@@ -4,7 +4,7 @@
 <title>/InvalidMarkdownFile.md</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/InvalidMarkdownFile.md.html
+++ b/dhall-docs/tasty/data/golden/InvalidMarkdownFile.md.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToDefOnUnused.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToDefOnUnused.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToDefOnUnused.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToDefOnUnused.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToDefOnUnused.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToHereImports.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToHereImports.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToHereImports.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToHereImports.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToHereImports.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLamBindingComplex.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingComplex.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLamBindingSimple.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingSimple.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLamBindingWithIndex.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithIndex.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithQuotes.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLamBindingWithQuotes.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLamBindingWithShadowing.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLamBindingWithShadowing.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingSimple.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingSimple.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLetBindingSimple.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingSimple.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingSimple.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithIndex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithIndex.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLetBindingWithIndex.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithIndex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithIndex.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithQuotes.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithQuotes.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLetBindingWithQuotes.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithQuotes.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithQuotes.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithShadowing.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithShadowing.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLetBindingWithShadowing.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLetBindingWithShadowing.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetBindingWithShadowing.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToLetbindingComplex.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToLetbindingComplex.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenFieldDoesNotExist.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenFieldDoesNotExist.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenFieldDoesNotExist.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenFieldDoesNotExist.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenFieldDoesNotExist.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenLetAnnotationPresentShouldIgnoreAnnotation.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsAnnotatedWithRecordType.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordType.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordType.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenVarIsOfRecordType.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordType.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordType.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeComplex.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeDeep.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeFromLamBinding.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeOnPunnedEntry.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeTransitivity.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToRecordFieldWhenVarIsOfRecordTypeWithDotSyntax.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToSelf.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToSelf.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToSelf.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToSelf.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToSelf.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
@@ -4,7 +4,7 @@
 <title>/JumpToUrls.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
+++ b/dhall-docs/tasty/data/golden/JumpToUrls.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
@@ -4,7 +4,7 @@
 <title>/MarkdownExample.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/MarkdownExample.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/MarkdownFile.md.html
+++ b/dhall-docs/tasty/data/golden/MarkdownFile.md.html
@@ -4,7 +4,7 @@
 <title>/MarkdownFile.md</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/MarkdownFile.md.html
+++ b/dhall-docs/tasty/data/golden/MarkdownFile.md.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/MultilineIndentationExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/MultilineIndentationExample.dhall.html
@@ -4,7 +4,7 @@
 <title>/MultilineIndentationExample.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/MultilineIndentationExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/MultilineIndentationExample.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/NoDoc.dhall.html
+++ b/dhall-docs/tasty/data/golden/NoDoc.dhall.html
@@ -4,7 +4,7 @@
 <title>/NoDoc.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/NoDoc.dhall.html
+++ b/dhall-docs/tasty/data/golden/NoDoc.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/NonDhallDocsCommentAfterValid.dhall.html
+++ b/dhall-docs/tasty/data/golden/NonDhallDocsCommentAfterValid.dhall.html
@@ -4,7 +4,7 @@
 <title>/NonDhallDocsCommentAfterValid.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/NonDhallDocsCommentAfterValid.dhall.html
+++ b/dhall-docs/tasty/data/golden/NonDhallDocsCommentAfterValid.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/OrdinaryAnnotation.dhall.html
+++ b/dhall-docs/tasty/data/golden/OrdinaryAnnotation.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/OrdinaryAnnotation.dhall.html
+++ b/dhall-docs/tasty/data/golden/OrdinaryAnnotation.dhall.html
@@ -4,7 +4,7 @@
 <title>/OrdinaryAnnotation.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/Pair.dhall.html
+++ b/dhall-docs/tasty/data/golden/Pair.dhall.html
@@ -4,7 +4,7 @@
 <title>/Pair.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/Pair.dhall.html
+++ b/dhall-docs/tasty/data/golden/Pair.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/Plain.txt.html
+++ b/dhall-docs/tasty/data/golden/Plain.txt.html
@@ -4,7 +4,7 @@
 <title>/Plain.txt</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/Plain.txt.html
+++ b/dhall-docs/tasty/data/golden/Plain.txt.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/RenderTypeIndexesExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/RenderTypeIndexesExample.dhall.html
@@ -4,7 +4,7 @@
 <title>/RenderTypeIndexesExample.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/RenderTypeIndexesExample.dhall.html
+++ b/dhall-docs/tasty/data/golden/RenderTypeIndexesExample.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/StandaloneTextFile.txt.html
+++ b/dhall-docs/tasty/data/golden/StandaloneTextFile.txt.html
@@ -4,7 +4,7 @@
 <title>/StandaloneTextFile.txt</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/StandaloneTextFile.txt.html
+++ b/dhall-docs/tasty/data/golden/StandaloneTextFile.txt.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/TwoAnnotations.dhall.html
+++ b/dhall-docs/tasty/data/golden/TwoAnnotations.dhall.html
@@ -4,7 +4,7 @@
 <title>/TwoAnnotations.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/TwoAnnotations.dhall.html
+++ b/dhall-docs/tasty/data/golden/TwoAnnotations.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/a/JumpToParent.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/JumpToParent.dhall.html
@@ -4,7 +4,7 @@
 <title>/a/JumpToParent.dhall</title>
 <link rel="stylesheet" type="text/css" href="../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../index.js">
+<script src="../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/a/JumpToParent.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/JumpToParent.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/a/b.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/a/b.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b.dhall.html
@@ -4,7 +4,7 @@
 <title>/a/b.dhall</title>
 <link rel="stylesheet" type="text/css" href="../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../index.js">
+<script src="../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/a/b/JumpToGrandfather.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/JumpToGrandfather.dhall.html
@@ -4,7 +4,7 @@
 <title>/a/b/JumpToGrandfather.dhall</title>
 <link rel="stylesheet" type="text/css" href="../../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../../index.js">
+<script src="../../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/a/b/JumpToGrandfather.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/JumpToGrandfather.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/a/b/c.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c.dhall.html
@@ -4,7 +4,7 @@
 <title>/a/b/c.dhall</title>
 <link rel="stylesheet" type="text/css" href="../../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../../index.js">
+<script src="../../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/a/b/c.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../../../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../../../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/a.dhall.html
@@ -4,7 +4,7 @@
 <title>/a/b/c/a.dhall</title>
 <link rel="stylesheet" type="text/css" href="../../../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../../../index.js">
+<script src="../../../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/a/b/c/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../../../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../../../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/a/b/c/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/c/index.html
@@ -4,7 +4,7 @@
 <title>/a/b/c</title>
 <link rel="stylesheet" type="text/css" href="../../../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../../../index.js">
+<script src="../../../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/a/b/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/a/b/index.html
+++ b/dhall-docs/tasty/data/golden/a/b/index.html
@@ -4,7 +4,7 @@
 <title>/a/b</title>
 <link rel="stylesheet" type="text/css" href="../../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../../index.js">
+<script src="../../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/a/index.html
+++ b/dhall-docs/tasty/data/golden/a/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/a/index.html
+++ b/dhall-docs/tasty/data/golden/a/index.html
@@ -4,7 +4,7 @@
 <title>/a</title>
 <link rel="stylesheet" type="text/css" href="../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../index.js">
+<script src="../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../../../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../../../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/index.html
@@ -4,7 +4,7 @@
 <title>/deep/nested/folder</title>
 <link rel="stylesheet" type="text/css" href="../../../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../../../index.js">
+<script src="../../../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../../../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../../../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/folder/my-even.dhall.html
@@ -4,7 +4,7 @@
 <title>/deep/nested/folder/my-even.dhall</title>
 <link rel="stylesheet" type="text/css" href="../../../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../../../index.js">
+<script src="../../../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/deep/nested/index.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/index.html
@@ -4,7 +4,7 @@
 <title>/deep/nested</title>
 <link rel="stylesheet" type="text/css" href="../../index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="../../index.js">
+<script src="../../index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/deep/nested/index.html
+++ b/dhall-docs/tasty/data/golden/deep/nested/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="../../dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="../../dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -4,7 +4,7 @@
 <title>/</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/index.html
+++ b/dhall-docs/tasty/data/golden/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>

--- a/dhall-docs/tasty/data/golden/package.dhall.html
+++ b/dhall-docs/tasty/data/golden/package.dhall.html
@@ -4,7 +4,7 @@
 <title>/package.dhall</title>
 <link rel="stylesheet" type="text/css" href="index.css">
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&amp;family=Lato:ital,wght@0,400;0,700;1,400&amp;display=swap">
-<script type="text/javascript" src="index.js">
+<script src="index.js">
 </script>
 <meta charset="UTF-8">
 </head>

--- a/dhall-docs/tasty/data/golden/package.dhall.html
+++ b/dhall-docs/tasty/data/golden/package.dhall.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div class="nav-bar">
-<img class="dhall-icon" src="dhall-icon.svg">
+<img class="dhall-icon" alt="Dhall logo." src="dhall-icon.svg">
 <p class="package-title">test-package</p>
 <div class="nav-bar-content-divider">
 </div>


### PR DESCRIPTION
Except some special cases `<img>` elements should have an `alt` attribute; otherwise it's an accessibility issue. The [w3c validator](https://validator.w3.org/) reports this as an error.

The validator also suggested (in the form of warning) to remove the `type` attribute of the `<script>` tag, because it is unnecessary.