### PR TITLE
Port to GHC-9.8.2 (missing: dhall-{lsp-server,nix,nixpkgs})

### DIFF
--- a/dhall-csv/dhall-csv.cabal
+++ b/dhall-csv/dhall-csv.cabal
@@ -33,7 +33,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                 >= 4.12.0.0  && < 5   ,
-        bytestring                           < 0.12,
+        bytestring                           < 0.13,
         cassava              >= 0.5.0.0   && < 0.6 ,
         containers           >= 0.5.9     && < 0.7 ,
         either                                     ,

--- a/dhall-csv/src/Dhall/CsvToDhall.hs
+++ b/dhall-csv/src/Dhall/CsvToDhall.hs
@@ -159,6 +159,7 @@ import Prettyprinter            (Pretty)
 
 import qualified Data.Csv
 import qualified Data.HashMap.Strict       as HashMap
+import qualified Data.List.NonEmpty        as NonEmpty
 import qualified Data.Sequence             as Sequence
 import qualified Data.Text
 import qualified Dhall.Core                as Core
@@ -273,7 +274,7 @@ dhallFromCsv Conversion{..} typeExpr = listConvert (Core.normalize typeExpr)
     recordConvert (Core.Record record) csvRecord
         | badKeys <- lefts (map decodeUtf8' (HashMap.keys csvRecord))
         , not (null badKeys)
-        = Left $ UnicodeError (head badKeys) -- Only report first key that failed to be decoded
+        = Left $ UnicodeError (NonEmpty.head . NonEmpty.fromList $ badKeys) -- Only report first key that failed to be decoded
         | extraKeys <- (map decodeUtf8 $ HashMap.keys csvRecord) \\ Map.keys record
         , strictRecs && not (null extraKeys)
         = Left $ UnhandledFields extraKeys

--- a/dhall-docs/src/Dhall/Docs/CodeRenderer.hs
+++ b/dhall-docs/src/Dhall/Docs/CodeRenderer.hs
@@ -56,6 +56,7 @@ import Text.Megaparsec.Pos               (SourcePos (..))
 
 import qualified Control.Monad.Trans.Writer.Strict as Writer
 import qualified Data.List
+import qualified Data.List.NonEmpty                as NonEmpty
 import qualified Data.Maybe                        as Maybe
 import qualified Data.Set                          as Set
 import qualified Data.Text                         as Text
@@ -374,7 +375,7 @@ renderCodeWithHyperLinks contents expr = pre_ $ go (1, 1) lines_ imports
 
         -- calls to `head` and `last` here should never fail since `importLines`
         -- have at least one element
-        let (firstImportLine, lastImportLine) = (head importLines, last importLines)
+        let (firstImportLine, lastImportLine) = (NonEmpty.head . NonEmpty.fromList $ importLines, last importLines)
         let prefixCols = Text.take (importStartCol - currCol) firstImportLine
         let suffixCols = Text.drop (importEndCol - currCol) lastImportLine
 

--- a/dhall-docs/src/Dhall/Docs/Comment.hs
+++ b/dhall-docs/src/Dhall/Docs/Comment.hs
@@ -189,7 +189,7 @@ parseDhallDocsText (BlockComment blockComment) =
         Just e -> DhallDocsText e
   where
     joinedText = Data.Text.strip $ Data.Text.unlines reIndentedLines
-    commentLines = tail $ Data.Text.lines blockComment
+    commentLines = NonEmpty.tail $ NonEmpty.fromList $ Data.Text.lines blockComment
 
     leadingSpaces = Data.Text.takeWhile isSpace
         where

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -38,7 +38,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                      >= 4.11.0.0  && < 5   ,
-        aeson                     >= 1.4.6.0   && < 2.2 ,
+        aeson                     >= 1.4.6.0   && < 2.3 ,
         aeson-pretty              >= 0.8.0     && < 0.9 ,
         aeson-yaml                >= 1.1.0     && < 1.2 ,
         bytestring                                < 0.13,

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -42,7 +42,7 @@ library
       src
   default-extensions: RecordWildCards OverloadedStrings
   build-depends:
-      aeson                >= 1.3.1.1  && < 2.2
+      aeson                >= 1.3.1.1  && < 2.3
     , aeson-pretty         >= 0.8.7    && < 0.9
     , base                 >= 4.11     && < 5
     , bytestring           >= 0.10.8.2 && < 0.12

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -77,7 +77,7 @@ Library
   Ghc-Options: -Wall
   Build-Depends:
     base                    >= 4.11.0.0  && < 5    ,
-    aeson                   >= 1.0.0.0   && < 2.2  ,
+    aeson                   >= 1.0.0.0   && < 2.3  ,
     containers              >= 0.5.8.0   && < 0.7  ,
     dhall                   >= 1.38.0    && < 1.43 ,
     prettyprinter           >= 1.7.0     && < 1.8  ,

--- a/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Convert.hs
@@ -22,15 +22,16 @@ import Data.Text              (Text)
 import Dhall.Kubernetes.Types
 import GHC.Generics           (Generic, Rep)
 
-import qualified Data.Char       as Char
-import qualified Data.List       as List
-import qualified Data.Map.Strict as Data.Map
-import qualified Data.Maybe      as Maybe
-import qualified Data.Set        as Set
-import qualified Data.Sort       as Sort
-import qualified Data.Text       as Text
-import qualified Data.Tuple      as Tuple
-import qualified Dhall.Core      as Dhall
+import qualified Data.Char          as Char
+import qualified Data.List          as List
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map.Strict    as Data.Map
+import qualified Data.Maybe         as Maybe
+import qualified Data.Set           as Set
+import qualified Data.Sort          as Sort
+import qualified Data.Text          as Text
+import qualified Data.Tuple         as Tuple
+import qualified Dhall.Core         as Dhall
 import qualified Dhall.Map
 import qualified Dhall.Optics
 import qualified Data.Map as Map
@@ -112,7 +113,7 @@ mkImport :: Data.Map.Map Prefix Dhall.Import -> [Text] -> Text -> Dhall.Import
 mkImport prefixMap components file =
   case Data.Map.toList filteredPrefixMap of
     []    -> localImport
-    xs    -> (snd . head $ Sort.sortOn (Text.length . fst) xs) <> localImport
+    xs    -> (snd . NonEmpty.head . NonEmpty.fromList $ Sort.sortOn (Text.length . fst) xs) <> localImport
   where
     localImport = Dhall.Import{..}
     importMode = Dhall.Code
@@ -206,7 +207,7 @@ toTypes' prefixMap typeSplitter preferNaturalInt natIntExceptions definitions to
           case hierarchy of
             [] -> ""
             [ModelName{..}] -> Text.unpack (last $ Text.splitOn "." unModelName)
-            _ -> getModelName (tail hierarchy)
+            _ -> getModelName (NonEmpty.tail . NonEmpty.fromList $ hierarchy)
 
         convertAndAccumWithKey :: ModelHierarchy -> Data.Map.Map ModelName Definition -> ModelName -> Definition -> (Data.Map.Map ModelName Definition, Expr)
         convertAndAccumWithKey modelHierarchy accDefs k v = (mergeNoConflicts equalsIgnoringDescription accDefs leftOverDefs, expr)

--- a/dhall-openapi/src/Dhall/Kubernetes/Types.hs
+++ b/dhall-openapi/src/Dhall/Kubernetes/Types.hs
@@ -105,10 +105,14 @@ data BaseData = BaseData
   } deriving (Generic, Show, Eq)
 
 instance FromJSON BaseData where
-  parseJSON = withArray "array of values" $ \arr -> withObject "baseData" (\o -> do
-    group   <- o .:? "group" .!= ""
-    kind    <- o .: "kind"
-    version <- o .: "version"
-    let apiVersion = (if Text.null group then "" else group <> "/") <> version
-    pure BaseData{..})
-    (head $ Vector.toList arr)
+  parseJSON = withArray "array of values" $ \arr -> do
+    case Vector.toList arr of
+      [] -> fail "missing baseData object in array"
+      (item:_) ->
+        withObject "baseData" (\o -> do
+          group   <- o .:? "group" .!= ""
+          kind    <- o .: "kind"
+          version <- o .: "version"
+          let apiVersion = (if Text.null group then "" else group <> "/") <> version
+          pure BaseData{..})
+          item

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -34,7 +34,7 @@ Library
         HsYAML                    >= 0.2       && < 0.3 ,
         HsYAML-aeson              >= 0.2       && < 0.3 ,
         base                      >= 4.11.0.0  && < 5   ,
-        aeson                     >= 1.0.0.0   && < 2.2 ,
+        aeson                     >= 1.0.0.0   && < 2.3 ,
         bytestring                                < 0.13,
         dhall                     >= 1.31.0    && < 1.43,
         dhall-json                >= 1.6.0     && < 1.8 ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -223,7 +223,7 @@ Common common
         dotgen                      >= 0.4.2    && < 0.5 ,
         either                      >= 5        && < 5.1,
         exceptions                  >= 0.8.3    && < 0.11,
-        filepath                    >= 1.4      && < 1.5 ,
+        filepath                    >= 1.4      && < 1.6 ,
         half                        >= 0.2.2.3  && < 0.4 ,
         haskeline                   >= 0.7.2.1  && < 0.9 ,
         hashable                    >= 1.2      && < 1.5 ,

--- a/dhall/src/Dhall/Import/Headers.hs
+++ b/dhall/src/Dhall/Import/Headers.hs
@@ -10,7 +10,7 @@ module Dhall.Import.Headers
     , toOriginHeaders
     ) where
 
-#if (MIN_VERSION_base(4,10,0))
+#if (MIN_VERSION_base(4,19,0))
 import Control.Applicative (Alternative (..))
 #else
 import Control.Applicative (Alternative (..), liftA2)

--- a/dhall/src/Dhall/Import/Headers.hs
+++ b/dhall/src/Dhall/Import/Headers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns        #-}
@@ -9,7 +10,11 @@ module Dhall.Import.Headers
     , toOriginHeaders
     ) where
 
+#if (MIN_VERSION_base(4,10,0))
+import Control.Applicative (Alternative (..))
+#else
 import Control.Applicative (Alternative (..), liftA2)
+#endif
 import Control.Exception   (SomeException)
 import Control.Monad.Catch (handle, throwM)
 import Data.Text           (Text)

--- a/dhall/src/Dhall/Marshal/Decode.hs
+++ b/dhall/src/Dhall/Marshal/Decode.hs
@@ -136,7 +136,7 @@ module Dhall.Marshal.Decode
     ) where
 
 
-#if (MIN_VERSION_base(4,10,0))
+#if (MIN_VERSION_base(4,19,0))
 import Control.Applicative              (empty)
 #else
 import Control.Applicative              (empty, liftA2)

--- a/dhall/src/Dhall/Parser/Combinators.hs
+++ b/dhall/src/Dhall/Parser/Combinators.hs
@@ -23,7 +23,11 @@ module Dhall.Parser.Combinators
     ) where
 
 
+#if (MIN_VERSION_base(4,10,0))
+import Control.Applicative     (Alternative (..))
+#else
 import Control.Applicative     (Alternative (..), liftA2)
+#endif
 import Control.Exception       (Exception)
 import Control.Monad           (MonadPlus (..))
 import Data.String             (IsString (..))
@@ -168,6 +172,10 @@ instance Text.Megaparsec.MonadParsec Void Text Parser where
     {-# INLINE getParserState #-}
 
     updateParserState f = Parser (Text.Megaparsec.updateParserState f)
+
+#if (MIN_VERSION_megaparsec(9,4,0))
+    mkParsec f = Parser (Text.Megaparsec.mkParsec f)
+#endif
 
 instance Semigroup a => Semigroup (Parser a) where
     (<>) = liftA2 (<>)

--- a/dhall/src/Dhall/Parser/Combinators.hs
+++ b/dhall/src/Dhall/Parser/Combinators.hs
@@ -23,7 +23,7 @@ module Dhall.Parser.Combinators
     ) where
 
 
-#if (MIN_VERSION_base(4,10,0))
+#if (MIN_VERSION_base(4,19,0))
 import Control.Applicative     (Alternative (..))
 #else
 import Control.Applicative     (Alternative (..), liftA2)

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedLists     #-}
 {-# LANGUAGE OverloadedStrings   #-}
@@ -7,7 +8,11 @@
 -- | Parsing Dhall expressions.
 module Dhall.Parser.Expression where
 
+#if (MIN_VERSION_base(4,10,0))
+import Control.Applicative     (Alternative (..), optional)
+#else
 import Control.Applicative     (Alternative (..), liftA2, optional)
+#endif
 import Data.Foldable           (foldl')
 import Data.List.NonEmpty      (NonEmpty (..))
 import Data.Text               (Text)

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -8,7 +8,7 @@
 -- | Parsing Dhall expressions.
 module Dhall.Parser.Expression where
 
-#if (MIN_VERSION_base(4,10,0))
+#if (MIN_VERSION_base(4,19,0))
 import Control.Applicative     (Alternative (..), optional)
 #else
 import Control.Applicative     (Alternative (..), liftA2, optional)

--- a/dhall/src/Dhall/Tags.hs
+++ b/dhall/src/Dhall/Tags.hs
@@ -8,7 +8,7 @@ module Dhall.Tags
     ) where
 
 import Control.Exception  (SomeException (..), handle)
-import Data.List          (foldl', isSuffixOf)
+import Data.List          (foldl', isPrefixOf, isSuffixOf)
 import Data.Maybe         (fromMaybe)
 import Data.Text          (Text)
 import Data.Text.Encoding (encodeUtf8)
@@ -261,9 +261,10 @@ inputToFiles followSyms suffixes (InputFile path) = go path
                             then return []
                             else do
                                    -- filter . .. and hidden files .*
-                                   contents <- fmap (filter ((/=) '.' . head))
+                                   contents <- fmap (filter (not . isHiddenOrSpecialDirectoryLinkName))
                                                     (SD.getDirectoryContents p)
                                    concat <$> mapM (go . (</>) p) contents
                      else return [p | matchingSuffix || p == path]
                where matchingSuffix = maybe True (any (`isSuffixOf` p)) suffixes
                      isSymLink = SD.pathIsSymbolicLink p
+                     isHiddenOrSpecialDirectoryLinkName filename = "." `isPrefixOf` filename


### PR DESCRIPTION
Starting something to upgrade to 9.8.2, taking baby-steps absent #2583 .

My goal is to compile with `-Werror` with 9.8.2 (I run cabal 3.10.3.0 but that shouldn't matter much) then pass tests (without -Werror then with).

- [x] I've mainly replaced safe `head` calls to `NonEmpty.head . NonEmpty.fromList` except in `dhall/src/Dhall/Tags.hs` (a more human-friendly symbol is welcomed) and `dhall-openapi/src/Dhall/Kubernetes/Types.hs` (we may expect the parser to occur at a boundary where human-readable errors are paramount)
- [x] upgrade some package bounds here and there
- [x] CPP-guard `liftA2` imports 
- [ ] pass tests
- [ ] same for `dhall-{lspt-server,nix,nixpkgs})` (tbc: blocked on `hnix`)

 I'm struggling to find cycles to feel free to take over the pull-request.