### PR TITLE
optimize Natural/fold in the strict case

### DIFF
--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -527,9 +527,13 @@ eval !env t0 =
                                 -- following issue:
                                 --
                                 -- https://github.com/ghcjs/ghcjs/issues/782
-                                let go !acc 0 = acc
-                                    go  acc m = go (vApp succ acc) (m - 1)
-                                in  go zero (fromIntegral n' :: Integer)
+                                go zero (fromIntegral n' :: Integer) where
+                                  go !acc 0 = acc
+                                  go (VNaturalLit n) m =
+                                    case vApp succ (VNaturalLit n) of
+                                      VNaturalLit n' | n == n' -> VNaturalLit n
+                                      next -> go next (m - 1) 
+                                  go acc m = go (vApp succ acc) (m - 1)
                             _ -> inert
         NaturalBuild ->
             VPrim $ \case

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -122,7 +122,7 @@ instance Semigroup (VChunks a) where
   VChunks xys z <> VChunks [] z' = VChunks xys (z <> z')
   VChunks xys z <> VChunks ((x', y'):xys') z' = VChunks (xys ++ (z <> x', y'):xys') z'
 
-instance Monoid (VChunks b) where
+instance Monoid (VChunks a) where
   mempty = VChunks [] mempty
 
 {-| Some information is lost when `eval` converts a `Lam` or a built-in function

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -529,10 +529,10 @@ eval !env t0 =
                                 -- https://github.com/ghcjs/ghcjs/issues/782
                                 go zero (fromIntegral n' :: Integer) where
                                   go !acc 0 = acc
-                                  go (VNaturalLit n) m =
-                                    case vApp succ (VNaturalLit n) of
-                                      VNaturalLit n' | n == n' -> VNaturalLit n
-                                      next -> go next (m - 1) 
+                                  go (VNaturalLit x) m =
+                                    case vApp succ (VNaturalLit x) of
+                                      VNaturalLit y | x == y -> VNaturalLit x
+                                      notNaturalLit -> go notNaturalLit (m - 1)
                                   go acc m = go (vApp succ acc) (m - 1)
                             _ -> inert
         NaturalBuild ->

--- a/dhall/src/Dhall/Normalize.hs
+++ b/dhall/src/Dhall/Normalize.hs
@@ -212,12 +212,12 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
                         lazy   = loop (  lazyLoop (fromIntegral n0 :: Integer))
 
                         strictLoop !n = strictLoopShortcut n (loop zero)
-			strictLoopShortcut 0 !res = res
-			strictLoopShortcut !n !res = do
-                                                      x <- res
-                                                      next_res = App succ' <$> res >>= loop
-                                                      y <- next_res
-                                                      if judgmentallyEqual x y then res else strictLoopShortcut (n - 1) next_res
+                        strictLoopShortcut 0 !res = res
+                        strictLoopShortcut !n !res = do
+                            x <- res
+                            next_res = App succ' <$> res >>= loop
+                            y <- next_res
+                            if judgmentallyEqual x y then res else strictLoopShortcut (n - 1) next_res
 
                         lazyLoop 0 = zero
                         lazyLoop !n = App succ' (lazyLoop (n - 1))

--- a/dhall/src/Dhall/Normalize.hs
+++ b/dhall/src/Dhall/Normalize.hs
@@ -211,13 +211,16 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
                         strict =       strictLoop (fromIntegral n0 :: Integer)
                         lazy   = loop (  lazyLoop (fromIntegral n0 :: Integer))
 
-                        strictLoop !n = strictLoopShortcut n (loop zero)
-                        strictLoopShortcut 0 !res = res
-                        strictLoopShortcut !n !res = do
-                            x <- res
-                            let next_res = App succ' <$> res >>= loop
-                            y <- next_res
-                            if judgmentallyEqual x y then res else strictLoopShortcut (n - 1) next_res
+                        strictLoop !n = do
+                            z <- loop zero
+                            strictLoopShortcut n z
+
+                        strictLoopShortcut 0 !previous = pure previous
+                        strictLoopShortcut !n !previous = do
+                            current <- loop (App succ' previous)
+                            if judgmentallyEqual previous current
+                                then pure previous
+                                else strictLoopShortcut (n - 1) current
 
                         lazyLoop 0 = zero
                         lazyLoop !n = App succ' (lazyLoop (n - 1))

--- a/dhall/src/Dhall/Normalize.hs
+++ b/dhall/src/Dhall/Normalize.hs
@@ -211,8 +211,13 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
                         strict =       strictLoop (fromIntegral n0 :: Integer)
                         lazy   = loop (  lazyLoop (fromIntegral n0 :: Integer))
 
-                        strictLoop 0 = loop zero
-                        strictLoop !n = App succ' <$> strictLoop (n - 1) >>= loop
+                        strictLoop !n = strictLoopShortcut n (loop zero)
+			strictLoopShortcut 0 !res = res
+			strictLoopShortcut !n !res = do
+                                                      x <- res
+                                                      next_res = App succ' <$> res >>= loop
+                                                      y <- next_res
+                                                      if judgmentallyEqual x y then res else strictLoopShortcut (n - 1) next_res
 
                         lazyLoop 0 = zero
                         lazyLoop !n = App succ' (lazyLoop (n - 1))

--- a/dhall/src/Dhall/Normalize.hs
+++ b/dhall/src/Dhall/Normalize.hs
@@ -215,7 +215,7 @@ normalizeWithM ctx e0 = loop (Syntax.denote e0)
                         strictLoopShortcut 0 !res = res
                         strictLoopShortcut !n !res = do
                             x <- res
-                            next_res = App succ' <$> res >>= loop
+                            let next_res = App succ' <$> res >>= loop
                             y <- next_res
                             if judgmentallyEqual x y then res else strictLoopShortcut (n - 1) next_res
 


### PR DESCRIPTION
The proposed optimization follows the discussion in https://github.com/dhall-lang/dhall-lang/issues/1213#issuecomment-1855878600 

The beta-normalization for `Natural/fold n t succ zero` corresponds to evaluating `succ(succ(succ(...(succ(zero))...)))` where we apply `succ` exactly `n` times.

The current code uses a loop where `succ` is always evaluated `n` times.
However, sometimes the loop can be stopped early because the values stop changing.

For example:

```dhall
let f : Natural → Natural = λ(x : Natural) → if Natural/isZero x then 1 else x
in Natural/fold 10000000 Natural f 5
```

With this definition, we have `f x = x` when x is nonzero. The expression evaluates to 5, but the evaluation takes time linear in the first argument (10000000) because the function `f` will be applied that many times to the value `5` and beta-normalization will be performed each time.

The new code rewrites `strictLoop` via `strictLoopShortcut`, which stops the loop as soon as `f x = x`.

This optimization is only applied in the "strict" case (`Normalization.hs` introduces `strict` and `lazy` cases when evaluating `Natural/fold`.)

There should be no change of behavior after this optimization. 
This is because all Dhall functions are pure; if `f x = x` then the result of evaluating `f (f (f x))` is exactly the same as just `x`.
So, the only effect of the new code is that some `Natural/fold` expressions will be beta-normalized faster than before.

I'd like to add some tests for the new behavior but I don't know how. The new behavior returns exactly the same normal forms as before, but does it faster when the "shortcut" is detected (when `f x = x` is detected). I am not a Haskell programmer, so any suggestions will be welcome here.

Another issue is that I am not familiar with the Haskell build systems, and  both `cabal new-build dhall` as well as `stack build` fail on my machine in this project, with dependency errors that I am unable to fix.