### PR TITLE
improve Dhall.Map.traverseWithKey performance

### DIFF
--- a/dhall/src/Dhall/Map.hs
+++ b/dhall/src/Dhall/Map.hs
@@ -623,8 +623,8 @@ traverseWithKey
     :: Ord k => Applicative f => (k -> a -> f b) -> Map k a -> f (Map k b)
 traverseWithKey f (Map m Sorted) =
     fmap (\m' -> Map m' Sorted) (Data.Map.traverseWithKey f m)
-traverseWithKey f m =
-    fmap fromList (traverse f' (toList m))
+traverseWithKey f m@(Map _ ks) =
+    flip Map ks . Data.Map.fromList <$> traverse f' (toList m)
   where
     f' (k, a) = fmap ((,) k) (f k a)
 {-# INLINABLE traverseWithKey #-}


### PR DESCRIPTION
`traverseWithKey` currently calls `fromList`, which creates a new list of keys (and calls `nubOrd` on it). this is unnecessary, because a traversal doesn't change the keys.

I haven't done any benchmarking of `traverseWithKey` specifically, but this change reduces my overall parse+typecheck+inject+normalize+extract time by ~20%.