### PR TITLE
Use normalized filepaths in dhall testsuite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           if [ '${{matrix.os.runner}}' == 'ubuntu-latest' ]; then
             sudo apt-get install -y libsodium-dev
           fi
-          pkg-config --path sodium || true
+          pkg-config --libs --modversion sodium || true
       - name: "Build"
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           stack-version: "latest"
           stack-no-global: true
       - name: "Cache"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ matrix.os.runner }}-${{ runner.arch }}-${{ hashFiles(matrix.stack-yaml) }}-${{ env.cache_generation }}
           restore-keys: |
@@ -157,7 +157,7 @@ jobs:
           package 'dhall-yaml' "bin/dhall-to-yaml-ng${exe}" "bin/yaml-to-dhall${exe}"
       - name: "Upload package"
         if: ${{ matrix.stack-yaml == 'stack.yaml' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'dhall-${{ runner.os }}-${{ runner.arch }}.${{ matrix.os.file-extension }}'
           path: 'dhall-*${{ runner.os }}-${{ runner.arch }}.${{ matrix.os.file-extension }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,12 +53,13 @@ jobs:
             ${{ matrix.os.runner }}-${{ runner.arch }}-
           path: |
             ${{ steps.setup-haskell-cabal.outputs.stack-root }}
-      - name: Install libsodium
+      - name: "Install libsodium"
         shell: bash
         run: |
           if [ '${{matrix.os.runner}}' == 'ubuntu-latest' ]; then
             sudo apt-get install -y libsodium-dev
           fi
+          pkg-config --path sodium || true
       - name: "Build"
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
           if [ '${{matrix.os.runner}}' == 'ubuntu-latest' ]; then
             sudo apt-get install -y libsodium-dev
           fi
+          echo "::debug::'pkg-config libsodium' output:"
           pkg-config --print-errors --libs libsodium || true
       - name: "Build"
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 env:
-  cache_generation: 2021-06-22
+  cache_generation: 2024-06-13
 
 # NOTE: Please keep .mergify.yml in sync when adding or removing any jobs.
 name: main
@@ -60,7 +60,7 @@ jobs:
           if [ '${{matrix.os.runner}}' == 'ubuntu-latest' ]; then
             sudo apt-get install -y libsodium-dev
           fi
-          pkg-config --print-errors --libs --exists libsodium || true
+          pkg-config --print-errors --libs libsodium || true
       - name: "Build"
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,9 +49,9 @@ jobs:
       - name: "Cache"
         uses: actions/cache@v4
         with:
-          key: ${{ matrix.os.runner }}-${{ runner.arch }}-${{ hashFiles(matrix.stack-yaml) }}-${{ env.cache_generation }}
+          key: ${{ matrix.os.runner }}-${{ runner.arch }}-${{ env.cache_generation }}-${{ hashFiles(matrix.stack-yaml) }}
           restore-keys: |
-            ${{ matrix.os.runner }}-${{ runner.arch }}-
+            ${{ matrix.os.runner }}-${{ runner.arch }}-${{ env.cache_generation }}-
           path: |
             ${{ steps.setup-haskell-cabal.outputs.stack-root }}
       - name: "Install libsodium"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           if [ '${{matrix.os.runner}}' == 'ubuntu-latest' ]; then
             sudo apt-get install -y libsodium-dev
           fi
-          pkg-config --libs --modversion sodium || true
+          pkg-config --print-errors --libs --exists libsodium || true
       - name: "Build"
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           enable-stack: true
           stack-version: "latest"
+          stack-no-global: true
       - name: "Cache"
         uses: actions/cache@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cabal.sandbox.config
 cabal.project.local
 cabal.project.local~
 .HTF/
+.envrc
 .ghc.environment.*
 .cache
 .history

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -152,7 +152,7 @@ Test-Suite tasty
         tasty        < 1.5                ,
         tasty-silver < 3.4                ,
         tasty-hunit  >= 0.10     && < 0.11,
-        turtle       < 1.7                ,
+        turtle       >= 1.6      && < 1.7 ,
         text
     GHC-Options: -Wall
     Default-Language: Haskell2010

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -34,7 +34,7 @@ Executable dhall-to-nixpkgs
                      , prettyprinter        >= 1.7.0    && < 1.8
                      , text                 >= 0.11.1.0 && < 2.1
                      , transformers         >= 0.2.0.0  && < 0.6
-                     , turtle                              < 1.6
+                     , turtle               >= 1.6      && < 1.7
                      , network-uri                         < 2.8
   Default-Language:    Haskell2010
   GHC-Options:         -Wall -threaded

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -452,7 +452,7 @@ Test-Suite tasty
         tasty-quickcheck          >= 0.9.2    && < 0.11,
         tasty-silver                             < 3.4 ,
         temporary                 >= 1.2.1    && < 1.4 ,
-        turtle                                   < 1.7 ,
+        turtle                    >= 1.6      && < 1.7 ,
     Default-Language: Haskell2010
 
 Test-Suite doctest

--- a/dhall/src/Dhall/Diff.hs
+++ b/dhall/src/Dhall/Diff.hs
@@ -41,16 +41,16 @@ import Dhall.Syntax
 import Numeric.Natural       (Natural)
 import Prettyprinter         (Doc, Pretty)
 
-import qualified Data.Algorithm.Diff    as Algo.Diff
+import qualified Data.Algorithm.Diff   as Algo.Diff
 import qualified Data.List.NonEmpty
 import qualified Data.Set
 import qualified Data.Text
-import qualified Data.Time              as Time
+import qualified Data.Time             as Time
 import qualified Dhall.Map
-import qualified Dhall.Normalize        as Normalize
-import qualified Dhall.Pretty.Internal  as Internal
-import qualified Dhall.Syntax           as Syntax
-import qualified Prettyprinter          as Pretty
+import qualified Dhall.Normalize       as Normalize
+import qualified Dhall.Pretty.Internal as Internal
+import qualified Dhall.Syntax          as Syntax
+import qualified Prettyprinter         as Pretty
 
 {-| This type is a `Doc` enriched with a `same` flag to efficiently track if
     any difference was detected

--- a/dhall/src/Dhall/Parser/Combinators.hs
+++ b/dhall/src/Dhall/Parser/Combinators.hs
@@ -169,6 +169,10 @@ instance Text.Megaparsec.MonadParsec Void Text Parser where
 
     updateParserState f = Parser (Text.Megaparsec.updateParserState f)
 
+#if MIN_VERSION_megaparsec(9,4,0)
+    mkParsec f = Parser (Text.Megaparsec.mkParsec f)
+#endif
+
 instance Semigroup a => Semigroup (Parser a) where
     (<>) = liftA2 (<>)
 

--- a/dhall/tests/Dhall/Test/Diff.hs
+++ b/dhall/tests/Dhall/Test/Diff.hs
@@ -3,9 +3,7 @@
 module Dhall.Test.Diff where
 
 import Data.Text  (Text)
-import Prelude    hiding (FilePath)
 import Test.Tasty (TestTree)
-import Turtle     (FilePath)
 
 import qualified Data.Text                 as Text
 import qualified Data.Text.IO              as Text.IO

--- a/dhall/tests/Dhall/Test/Format.hs
+++ b/dhall/tests/Dhall/Test/Format.hs
@@ -7,7 +7,6 @@ import Dhall.Parser (Header (..))
 import Dhall.Pretty (CharacterSet (..))
 import Test.Tasty   (TestTree)
 
-import qualified Control.Monad             as Monad
 import qualified Data.Text                 as Text
 import qualified Data.Text.IO              as Text.IO
 import qualified Dhall.Core                as Core
@@ -27,7 +26,7 @@ getTests = do
 
             let skip = [ "./tests/format/asciiA.dhall" ]
 
-            Monad.guard (path `notElem` skip)
+            path `Test.Util.pathNotIn` skip
 
             return path
 

--- a/dhall/tests/Dhall/Test/Freeze.hs
+++ b/dhall/tests/Dhall/Test/Freeze.hs
@@ -4,9 +4,7 @@ module Dhall.Test.Freeze where
 
 import Data.Text    (Text)
 import Dhall.Freeze (Intent (..), Scope (..))
-import Prelude      hiding (FilePath)
 import Test.Tasty   (TestTree)
-import Turtle       (FilePath)
 
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO

--- a/dhall/tests/Dhall/Test/Freeze.hs
+++ b/dhall/tests/Dhall/Test/Freeze.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- FIXME: Re-enable deprecation warnings after removing support for turtle < 1.6.
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
 module Dhall.Test.Freeze where
 
 import Data.Text    (Text)
@@ -53,7 +50,7 @@ freezeTest dir intent prefix =
 
         parsedInput <- Core.throws (Parser.exprFromText mempty inputText)
 
-        actualExpression <- Freeze.freezeExpression (Turtle.encodeString dir) AllImports intent parsedInput
+        actualExpression <- Freeze.freezeExpression dir AllImports intent parsedInput
 
         let actualText = Core.pretty actualExpression <> "\n"
 

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -5,13 +5,12 @@
 module Dhall.Test.Import where
 
 import Control.Exception (SomeException)
-import Data.Text         (Text, isSuffixOf)
+import Data.Text         (Text)
 import Data.Void         (Void)
 import System.FilePath   ((</>))
 import Test.Tasty        (TestTree)
 
 import qualified Control.Exception                as Exception
-import qualified Control.Monad                    as Monad
 import qualified Control.Monad.Trans.State.Strict as State
 import qualified Data.Text                        as Text
 import qualified Data.Text.IO                     as Text.IO
@@ -72,7 +71,7 @@ getTests = do
     successTests <- Test.Util.discover (Turtle.chars <* "A.dhall") successTest (do
         path <- Turtle.lstree (importDirectory </> "success")
 
-        Monad.guard (path `Test.Util.pathNotElem` flakyTests)
+        path `Test.Util.pathNotIn` flakyTests
 
         return path )
 
@@ -96,8 +95,9 @@ getTests = do
 #endif
                 ]
 
-        _ <- Monad.guard (path `Test.Util.pathNotElem` expectedSuccesses)
-        _ <- Monad.guard (not ("ENV.dhall" `isSuffixOf` Text.pack path))
+        path `Test.Util.pathNotIn` expectedSuccesses
+        "ENV.dhall" `Test.Util.pathNotSuffixOf` path
+
         return path )
 
     let testTree =

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -25,8 +25,8 @@ import qualified Test.Tasty.HUnit                 as Tasty.HUnit
 import qualified Turtle
 
 #if defined(WITH_HTTP) && defined(NETWORK_TESTS)
-import qualified Network.HTTP.Client              as HTTP
-import qualified Network.HTTP.Client.TLS          as HTTP
+import qualified Network.HTTP.Client     as HTTP
+import qualified Network.HTTP.Client.TLS as HTTP
 #endif
 
 

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -2,18 +2,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
--- FIXME: Re-enable deprecation warnings after removing support for turtle < 1.6.
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
 module Dhall.Test.Import where
 
 import Control.Exception (SomeException)
-import Data.Foldable     (fold)
 import Data.Text         (Text, isSuffixOf)
 import Data.Void         (Void)
-import Prelude           hiding (FilePath)
+import System.FilePath   ((</>))
 import Test.Tasty        (TestTree)
-import Turtle            (FilePath, toText, (</>))
 
 import qualified Control.Exception                as Exception
 import qualified Control.Monad                    as Monad
@@ -102,7 +97,7 @@ getTests = do
                 ]
 
         _ <- Monad.guard (path `notElem` expectedSuccesses)
-        _ <- Monad.guard (not ("ENV.dhall" `isSuffixOf` (fold (toText path))))
+        _ <- Monad.guard (not ("ENV.dhall" `isSuffixOf` Text.pack path))
         return path )
 
     let testTree =
@@ -176,7 +171,7 @@ successTest prefix = do
                 not (null (Turtle.match (Turtle.ends path') (Test.Util.toDhallPath prefix)))
 
         let buildNewCache = do
-                tempdir <- fmap Turtle.decodeString (Turtle.managed (Temp.withSystemTempDirectory "dhall-cache"))
+                tempdir <- Turtle.managed (Temp.withSystemTempDirectory "dhall-cache")
                 Turtle.liftIO (Turtle.cptree originalCache tempdir)
                 return tempdir
 

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -72,7 +72,7 @@ getTests = do
     successTests <- Test.Util.discover (Turtle.chars <* "A.dhall") successTest (do
         path <- Turtle.lstree (importDirectory </> "success")
 
-        Monad.guard (path `notElem` flakyTests)
+        Monad.guard (path `Test.Util.pathNotElem` flakyTests)
 
         return path )
 
@@ -96,7 +96,7 @@ getTests = do
 #endif
                 ]
 
-        _ <- Monad.guard (path `notElem` expectedSuccesses)
+        _ <- Monad.guard (path `Test.Util.pathNotElem` expectedSuccesses)
         _ <- Monad.guard (not ("ENV.dhall" `isSuffixOf` Text.pack path))
         return path )
 

--- a/dhall/tests/Dhall/Test/Lint.hs
+++ b/dhall/tests/Dhall/Test/Lint.hs
@@ -4,9 +4,7 @@ module Dhall.Test.Lint where
 
 import Data.Text    (Text)
 import Dhall.Parser (Header (..))
-import Prelude      hiding (FilePath)
 import Test.Tasty   (TestTree)
-import Turtle       (FilePath)
 
 import qualified Data.Text                 as Text
 import qualified Data.Text.IO              as Text.IO

--- a/dhall/tests/Dhall/Test/Normalization.hs
+++ b/dhall/tests/Dhall/Test/Normalization.hs
@@ -46,9 +46,9 @@ getTests = do
 
     let testTree =
             Tasty.testGroup "normalization"
-                [ betaNormalizationTests
-                , unitTests
-                , alphaNormalizationTests
+                [ Tasty.testGroup "beta-normalization" [ betaNormalizationTests ]
+                , Tasty.testGroup "unit tests" [ unitTests ]
+                , Tasty.testGroup "alpha-normalization" [ alphaNormalizationTests ]
                 , customization
                 ]
 
@@ -127,7 +127,7 @@ alphaNormalizationTest prefix = do
         let expectedNormalized = Core.denote expectedResolved :: Expr Void Void
 
         let message =
-                "The normalized expression did not match the expected output"
+                "The alpha-normalized expression did not match the expected output"
 
         Tasty.HUnit.assertEqual message expectedNormalized actualNormalized
 
@@ -199,6 +199,6 @@ betaNormalizationTest prefix = do
                 Core.alphaNormalize (Core.denote expectedResolved)
 
         let message =
-                "The normalized expression did not match the expected output"
+                "The beta-normalized expression did not match the expected output"
 
         Tasty.HUnit.assertEqual message expectedNormalized actualNormalized

--- a/dhall/tests/Dhall/Test/Normalization.hs
+++ b/dhall/tests/Dhall/Test/Normalization.hs
@@ -8,8 +8,6 @@ import Dhall.Core (Expr (..), Var (..), throws)
 import System.FilePath ((</>))
 import Test.Tasty (TestTree)
 
-import qualified Control.Monad    as Monad
-import qualified Data.List        as List
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO
 import qualified Dhall.Context    as Context
@@ -36,7 +34,7 @@ getTests = do
     let normalizationFiles = do
             path <- FilePath.normalise <$> Turtle.lstree normalizationDirectory
 
-            Monad.guard (not (FilePath.normalise unitDirectory `List.isPrefixOf` path))
+            unitDirectory `Test.Util.pathNotPrefixOf` path
 
             return path
 

--- a/dhall/tests/Dhall/Test/Normalization.hs
+++ b/dhall/tests/Dhall/Test/Normalization.hs
@@ -2,11 +2,11 @@
 
 module Dhall.Test.Normalization where
 
-import Data.Text  (Text)
-import Data.Void  (Void)
-import Dhall.Core (Expr (..), Var (..), throws)
+import Data.Text       (Text)
+import Data.Void       (Void)
+import Dhall.Core      (Expr (..), Var (..), throws)
 import System.FilePath ((</>))
-import Test.Tasty (TestTree)
+import Test.Tasty      (TestTree)
 
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO

--- a/dhall/tests/Dhall/Test/Normalization.hs
+++ b/dhall/tests/Dhall/Test/Normalization.hs
@@ -5,9 +5,8 @@ module Dhall.Test.Normalization where
 import Data.Text  (Text)
 import Data.Void  (Void)
 import Dhall.Core (Expr (..), Var (..), throws)
-import Prelude    hiding (FilePath)
+import System.FilePath ((</>))
 import Test.Tasty (TestTree)
-import Turtle     (FilePath, (</>))
 
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO

--- a/dhall/tests/Dhall/Test/Parser.hs
+++ b/dhall/tests/Dhall/Test/Parser.hs
@@ -2,11 +2,11 @@
 
 module Dhall.Test.Parser where
 
-import Data.Text  (Text)
-import Data.Void  (Void)
-import Dhall.Core (Binding (..), Expr (..), Import, Var (..))
+import Data.Text       (Text)
+import Data.Void       (Void)
+import Dhall.Core      (Binding (..), Expr (..), Import, Var (..))
 import System.FilePath ((</>))
-import Test.Tasty (TestTree)
+import Test.Tasty      (TestTree)
 
 import qualified Control.Monad        as Monad
 import qualified Data.Bifunctor       as Bifunctor

--- a/dhall/tests/Dhall/Test/Parser.hs
+++ b/dhall/tests/Dhall/Test/Parser.hs
@@ -5,9 +5,8 @@ module Dhall.Test.Parser where
 import Data.Text  (Text)
 import Data.Void  (Void)
 import Dhall.Core (Binding (..), Expr (..), Import, Var (..))
-import Prelude    hiding (FilePath)
+import System.FilePath ((</>))
 import Test.Tasty (TestTree)
-import Turtle     (FilePath, (</>))
 
 import qualified Control.Monad        as Monad
 import qualified Data.Bifunctor       as Bifunctor

--- a/dhall/tests/Dhall/Test/Schemas.hs
+++ b/dhall/tests/Dhall/Test/Schemas.hs
@@ -4,9 +4,7 @@ module Dhall.Test.Schemas where
 
 import Data.Text    (Text)
 import Dhall.Parser (Header (..))
-import Prelude      hiding (FilePath)
 import Test.Tasty   (TestTree)
-import Turtle       (FilePath)
 
 import qualified Data.Text                 as Text
 import qualified Data.Text.IO              as Text.IO

--- a/dhall/tests/Dhall/Test/SemanticHash.hs
+++ b/dhall/tests/Dhall/Test/SemanticHash.hs
@@ -3,9 +3,7 @@
 module Dhall.Test.SemanticHash where
 
 import Data.Text  (Text)
-import Prelude    hiding (FilePath)
 import Test.Tasty (TestTree)
-import Turtle     (FilePath)
 
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO

--- a/dhall/tests/Dhall/Test/Tags.hs
+++ b/dhall/tests/Dhall/Test/Tags.hs
@@ -29,6 +29,8 @@ getTests = do
 tagsTest :: Text -> TestTree
 tagsTest prefix =
     Tasty.HUnit.testCase (Text.unpack prefix) $ do
+        -- The use of toDhallPah is a hack to ensure we always get the same file
+        -- paths, i.e. ones with a '.' prefixed and UNIX path separators.
         let inputFile  = Text.unpack (Test.Util.toDhallPath prefix <> ".dhall")
         let outputFile = Text.unpack (prefix <> ".tags")
 

--- a/dhall/tests/Dhall/Test/Tags.hs
+++ b/dhall/tests/Dhall/Test/Tags.hs
@@ -4,9 +4,8 @@ module Dhall.Test.Tags where
 
 import Data.Text  (Text)
 import Dhall.Util (Input (..))
-import Prelude    hiding (FilePath)
+import System.FilePath ((</>))
 import Test.Tasty (TestTree)
-import Turtle     (FilePath)
 
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO
@@ -30,7 +29,7 @@ getTests = do
 tagsTest :: Text -> TestTree
 tagsTest prefix =
     Tasty.HUnit.testCase (Text.unpack prefix) $ do
-        let inputFile  = Text.unpack (prefix <> ".dhall")
+        let inputFile  = Text.unpack (Test.Util.toDhallPath prefix <> ".dhall")
         let outputFile = Text.unpack (prefix <> ".tags")
 
         actualTags <- fixPathSeparators <$> Tags.generate (InputFile inputFile) Nothing False
@@ -44,7 +43,7 @@ tagsTest prefix =
 tagsDirTest :: TestTree
 tagsDirTest =
     Tasty.HUnit.testCase "all" $ do
-        let outputFile = Text.unpack . Turtle.format Turtle.fp $ tagsDirectory Turtle.</> "all.tags"
+        let outputFile = Text.unpack . Turtle.format Turtle.fp $ tagsDirectory </> "all.tags"
 
         actualTags <- fmap fixPathSeparators
                       (Tags.generate

--- a/dhall/tests/Dhall/Test/Tags.hs
+++ b/dhall/tests/Dhall/Test/Tags.hs
@@ -2,10 +2,10 @@
 
 module Dhall.Test.Tags where
 
-import Data.Text  (Text)
-import Dhall.Util (Input (..))
+import Data.Text       (Text)
+import Dhall.Util      (Input (..))
 import System.FilePath ((</>))
-import Test.Tasty (TestTree)
+import Test.Tasty      (TestTree)
 
 import qualified Data.Text        as Text
 import qualified Data.Text.IO     as Text.IO

--- a/dhall/tests/Dhall/Test/TypeInference.hs
+++ b/dhall/tests/Dhall/Test/TypeInference.hs
@@ -5,9 +5,8 @@ module Dhall.Test.TypeInference where
 
 import Control.Exception (SomeException (..))
 import Data.Text         (Text)
-import Prelude           hiding (FilePath)
+import System.FilePath   ((</>))
 import Test.Tasty        (TestTree)
-import Turtle            (FilePath, (</>))
 
 import qualified Control.Exception as Exception
 import qualified Control.Monad     as Monad

--- a/dhall/tests/Dhall/Test/TypeInference.hs
+++ b/dhall/tests/Dhall/Test/TypeInference.hs
@@ -9,7 +9,6 @@ import System.FilePath   ((</>))
 import Test.Tasty        (TestTree)
 
 import qualified Control.Exception as Exception
-import qualified Control.Monad     as Monad
 import qualified Data.Text         as Text
 import qualified Data.Text.IO      as Text.IO
 import qualified Dhall.Core        as Core
@@ -37,7 +36,7 @@ getTests = do
                     , typeInferenceDirectory </> "success/CacheImportsCanonicalizeA.dhall"
                     ]
 
-            Monad.guard (path `notElem` skip)
+            path `Test.Util.pathNotIn` skip
 
             return path
 

--- a/dhall/tests/Dhall/Test/Util.hs
+++ b/dhall/tests/Dhall/Test/Util.hs
@@ -72,7 +72,7 @@ import qualified Turtle
 import qualified Data.Foldable
 #else
 import Control.Monad.IO.Class   (MonadIO (..))
-import Dhall.Core               (URL (..), File (..), Directory (..))
+import Dhall.Core               (Directory (..), File (..), URL (..))
 import Lens.Family.State.Strict (zoom)
 
 import qualified Data.Foldable

--- a/dhall/tests/Dhall/Test/Util.hs
+++ b/dhall/tests/Dhall/Test/Util.hs
@@ -318,10 +318,12 @@ pathNotIn :: Alternative f => FilePath -> [FilePath] -> f ()
 pathNotIn this = guard . not . any (FilePath.equalFilePath this)
 
 pathNotPrefixOf :: Alternative f => FilePath -> FilePath -> f ()
-pathNotPrefixOf this = guard . not . List.isPrefixOf this
+pathNotPrefixOf this =
+    guard . not . List.isPrefixOf (FilePath.normalise this) . FilePath.normalise
 
 pathNotSuffixOf :: Alternative f => FilePath -> FilePath -> f ()
-pathNotSuffixOf this = guard . not . List.isSuffixOf this
+pathNotSuffixOf this =
+    guard . not . List.isSuffixOf (FilePath.normalise this) . FilePath.normalise
 
 {-| Path names on Windows are not valid Dhall paths due to using backslashes
     instead of forwardslashes to separate path components.  This utility fixes

--- a/dhall/tests/Dhall/Test/Util.hs
+++ b/dhall/tests/Dhall/Test/Util.hs
@@ -54,6 +54,7 @@ import qualified Control.Exception
 import qualified Control.Foldl                    as Foldl
 import qualified Control.Monad.Trans.State.Strict as State
 import qualified Data.Functor
+import qualified Data.List                        as List
 import qualified Data.Text                        as Text
 import qualified Data.Text.IO                     as Text.IO
 import qualified Dhall.Context
@@ -69,7 +70,6 @@ import qualified Turtle
 
 #if defined(WITH_HTTP) && defined(NETWORK_TESTS)
 import qualified Data.Foldable
-import qualified Data.List as List
 #else
 import Control.Monad.IO.Class   (MonadIO (..))
 import Dhall.Core               (URL (..), File (..), Directory (..))

--- a/nix/packages/turtle.nix
+++ b/nix/packages/turtle.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, ansi-wl-pprint, async, base, bytestring, clock
+, containers, directory, doctest, exceptions, filepath, foldl
+, hostname, lib, managed, optional-args, optparse-applicative
+, process, stm, streaming-commons, tasty, tasty-bench, tasty-hunit
+, temporary, text, time, transformers, unix, unix-compat
+}:
+mkDerivation {
+  pname = "turtle";
+  version = "1.6.2";
+  sha256 = "1a0166b11566e956bcec6f37cfcfc4d0647d4540479545d4858d2ff8c43a5b2d";
+  revision = "3";
+  editedCabalFile = "19i3n3hd2a0rkdz1ikwdgwhg4ds5pcfah25vgk0jnmwf71h0qwbm";
+  libraryHaskellDepends = [
+    ansi-wl-pprint async base bytestring clock containers directory
+    exceptions filepath foldl hostname managed optional-args
+    optparse-applicative process stm streaming-commons temporary text
+    time transformers unix unix-compat
+  ];
+  testHaskellDepends = [
+    base doctest filepath tasty tasty-hunit temporary
+  ];
+  benchmarkHaskellDepends = [ base tasty-bench text ];
+  description = "Shell programming, Haskell-style";
+  license = lib.licenses.bsd3;
+}

--- a/stack.ghc-8.10.yaml
+++ b/stack.ghc-8.10.yaml
@@ -11,6 +11,7 @@ packages:
   - dhall-toml
   - dhall-yaml
 extra-deps:
+  - ansi-wl-pprint-1.0.2@sha256:b817853b5310b8e7847469847608b664c3e75b4b30c332f2cb8c0d00751ef9c1,1915
   - co-log-core-0.3.2.0
   - hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
   - hnix-0.17.0@sha256:57e172f915d70be2dd88c6377caebe8bd63337123ffef42df49b05dc0b1f168b,19224
@@ -20,10 +21,13 @@ extra-deps:
   - lsp-types-2.0.1.0
   - lsp-test-0.15.0.1
   - lucid-2.11.0
+  - optparse-applicative-0.18.1.0@sha256:b4cf8d9018e5e67cb1f14edb5130b6d05ad8bc1b5f6bd4efaa6ec0b7f28f559d,5132
+  - optparse-generic-1.5.2
   - relude-1.0.0.1@sha256:35bcdaf14018e79f11e712b0e2314c1aac79976f28f4adc179985457493557d5,11569
   - row-types-1.0.1.2@sha256:4d4c7cb95d06a32b28ba977852d52a26b4c1f695ef083a6fd874ab6d79933b64,3071
   - semialign-1.2@sha256:9afb6eb7e50db7ca34d7c4108aec0f643dae2caaaa80394b44ffdd643315685c,2721
   - text-rope-0.2
+  - turtle-1.6.2@sha256:75710c60388e572bc17cbb08a81cbb4537f2207f8dcf187e9b1928d1e0b023a6,5767
   - typerep-map-0.5.0.0
 nix:
   packages:

--- a/stack.ghc-8.10.yaml
+++ b/stack.ghc-8.10.yaml
@@ -13,9 +13,9 @@ packages:
 extra-deps:
   - co-log-core-0.3.2.0
   - hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
-  - hnix-0.16.0
-  - hnix-store-core-0.5.0.0
-  - hnix-store-remote-0.5.0.0
+  - hnix-0.17.0@sha256:57e172f915d70be2dd88c6377caebe8bd63337123ffef42df49b05dc0b1f168b,19224
+  - hnix-store-core-0.6.1.0@sha256:0171c3a571ab263c3e3aa3e6daca15602f2030a6862cb032038017e6d0265898,3882
+  - hnix-store-remote-0.6.0.0@sha256:a8ea18bb355164bfd357fac12b0c5d32c95ffd455260f8b6c7fcaeddebf5918c,3270
   - lsp-2.1.0.0
   - lsp-types-2.0.1.0
   - lsp-test-0.15.0.1

--- a/stack.ghc-9.2.yaml
+++ b/stack.ghc-9.2.yaml
@@ -11,12 +11,11 @@ packages:
   - dhall-toml
   - dhall-yaml
 extra-deps:
-  - github: haskell-nix/hnix
-    commit: 2adbc502e62e755ca0372c913e6278ebe564d7d2
   - chronos-1.1.5
   - hashing-0.1.1.0
-  - hnix-store-core-0.6.1.0
-  - hnix-store-remote-0.6.0.0
+  - hnix-0.17.0@sha256:57e172f915d70be2dd88c6377caebe8bd63337123ffef42df49b05dc0b1f168b,19224
+  - hnix-store-core-0.6.1.0@sha256:0171c3a571ab263c3e3aa3e6daca15602f2030a6862cb032038017e6d0265898,3882
+  - hnix-store-remote-0.6.0.0@sha256:a8ea18bb355164bfd357fac12b0c5d32c95ffd455260f8b6c7fcaeddebf5918c,3270
   - logict-0.7.0.3
   - lsp-2.1.0.0
   - lsp-types-2.0.1.0

--- a/stack.ghc-9.2.yaml
+++ b/stack.ghc-9.2.yaml
@@ -11,6 +11,7 @@ packages:
   - dhall-toml
   - dhall-yaml
 extra-deps:
+  - ansi-wl-pprint-1.0.2@sha256:b817853b5310b8e7847469847608b664c3e75b4b30c332f2cb8c0d00751ef9c1,1915
   - chronos-1.1.5
   - hashing-0.1.1.0
   - hnix-0.17.0@sha256:57e172f915d70be2dd88c6377caebe8bd63337123ffef42df49b05dc0b1f168b,19224
@@ -20,10 +21,12 @@ extra-deps:
   - lsp-2.1.0.0
   - lsp-types-2.0.1.0
   - lsp-test-0.15.0.1
-  - optparse-applicative-0.16.1.0
+  - optparse-applicative-0.18.1.0@sha256:b4cf8d9018e5e67cb1f14edb5130b6d05ad8bc1b5f6bd4efaa6ec0b7f28f559d,5132
+  - optparse-generic-1.5.2
   - row-types-1.0.1.2@sha256:4d4c7cb95d06a32b28ba977852d52a26b4c1f695ef083a6fd874ab6d79933b64,3071
   - saltine-0.2.1.0
   - tomland-1.3.3.2
+  - turtle-1.6.2@sha256:75710c60388e572bc17cbb08a81cbb4537f2207f8dcf187e9b1928d1e0b023a6,5767
   - typerep-map-0.5.0.0
   - validation-selective-0.1.0.2
 nix:


### PR DESCRIPTION
Missing filepath normalization caused some failures in #2591 ; See https://github.com/dhall-lang/dhall-haskell/actions/runs/9338722607/job/25702207276?pr=2591 for an example.

Other changes:
- Require `turtle >=1.6` in all packages.
- Use `hnix-0.17` in Stack configurations.
- Also add `mkParsec` method to `MonadParsec` instance for `megaparsec >=9.4`.