### PR TITLE
implement shortcut for more data types in Natural/fold

### DIFF
--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -252,26 +252,6 @@ data Val a
 -- | For use with "Text.Show.Functions".
 deriving instance (Show a, Show (Val a -> Val a)) => Show (Val a)
 
-valEq :: Val a -> Val a -> Bool
-valEq (VConst x1) (VConst x2) = x1 == x2
-valEq (VVar t1 i1) (VVar t2 i2) = t1 == t2 && i1 == i2
-valEq VPrimVar VPrimVar = True
-valEq (VApp f1 x1) (VApp f2 x2) = valEq f1 f2 && valEq x1 x2
-valEq VBool VBool = True
-valEq (VBoolLit x1) (VBoolLit x2) = x1 == x2
-valEq (VBytesLit x1) (VBytesLit x2) = x1 == x2
-valEq (VNaturalLit x1) (VNaturalLit x2) = x1 == x2
-valEq (VNaturalFold t1 x1 y1 z1) (VNaturalFold t2 x2 y2 z2) = valEq t1 t2 && valEq x1 x2 && valEq y1 y2 && valEq z1 z2
-valEq (VNaturalIsZero x1) (VNaturalIsZero x2) = valEq x1 x2
-valEq (VIntegerLit x1) (VIntegerLit x2) = x1 == x2
-valEq (VDoubleLit x1) (VDoubleLit x2) = x1 == x2
-valEq (VList _) (VList _) = True
-valEq (VListLit _ x1) (VListLit _ x2) = all (uncurry valEq) (zip (toList x1) (toList x2))
-valEq (VSome x1) (VSome x2) = valEq x1 x2
-valEq (VNone _) (VNone _) = True
-valEq (VRecordLit x1) (VRecordLit x2) = (length x1 == length x2) && (all (uncurry valEq) (zip (Map.elems x1) (Map.elems x2)))
-valEq _ _ = False
-
 (~>) :: Val a -> Val a -> Val a
 (~>) a b = VHPi "_" a (\_ -> b)
 {-# INLINE (~>) #-}
@@ -551,7 +531,7 @@ eval !env t0 =
                                   go !acc 0 = acc
                                   go acc m =
                                     let next = vApp succ acc in
-                                    if valEq next acc then acc else go next (m - 1)
+                                    if conv env next acc then acc else go next (m - 1)
                             _ -> inert
         NaturalBuild ->
             VPrim $ \case

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -530,8 +530,9 @@ eval !env t0 =
                                 go zero (fromIntegral n' :: Integer) where
                                   go !acc 0 = acc
                                   go acc m =
-                                    let next = vApp succ acc in
-                                    if conv env next acc then acc else go next (m - 1)
+                                  -- Detect a shortcut: if succ acc == acc then return acc immediately.
+                                    let next = vApp succ acc
+                                    in  if conv env next acc then acc else go next (m - 1)
                             _ -> inert
         NaturalBuild ->
             VPrim $ \case


### PR DESCRIPTION
This is a continuation of https://github.com/dhall-lang/dhall-haskell/pull/2585

This PR implements a shortcut for Natural/fold for more data types. When the accumulator stops changing, `Natural/fold` should return immediately.

First test: (This involves an accumulator of type `Natural`, which is already supported after the previous PR.)

```dhall
let f : Natural → Natural = λ(x : Natural) → if Natural/isZero x then 1 else x
  in assert : 1 === Natural/fold 10000000000 Natural f 0
```

Second test shows a plausible use case: an integer division algorithm. Division proceeds by repeated subtraction, but we cannot know the required number of subtractions precisely. We know that to divide `x / y` we need no more than `x` subtractions.

 The accumulator has a more complicated type than just `Natural`. The implementation now requires us to be able to compare `Val a` values of more complicated type.
```dhall
-- unsafeDiv x y means x / y but it will return wrong results when y = 0.
let unsafeDiv : Natural → Natural → Natural =
  let Natural/lessThan = https://prelude.dhall-lang.org/Natural/lessThan
  let Accum = { result : Natural, sub : Natural, done : Bool }  -- Accumulator has this type.
  in λ(x : Natural) → λ(y : Natural) →
         let init : Accum = {result = 0, sub = x, done = False}
         let update : Accum → Accum = λ(acc : Accum) →
             if acc.done then acc
             else if Natural/lessThan acc.sub y then acc // {done = True}
             else acc // {result = acc.result + 1, sub = Natural/subtract y acc.sub}
         let r : Accum = Natural/fold x Accum update init
         in r.result
let x = 10000000000000000000
in  assert : unsafeDiv (3 * x) x === 3
```

Please let me know how I can improve this Haskell code. I am new to Haskell.

What I did:

- implement `valEq` to compare two `Val a` values in case we can easily compare them (natural literals, record literals, `Some()`, etc.)
- do a shortcut for `Natural/fold`: return immediately when the accumulator stops changing

What I would like to do in addition to that:

- figure out how to make this code more elegant by deriving some typeclass instances
- figure out how to compare more subtypes of `Val`