### PR TITLE
Allow aeson-2.2 in dhall-yaml and dhall-lsp-server

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -42,7 +42,7 @@ library
       src
   default-extensions: RecordWildCards OverloadedStrings
   build-depends:
-      aeson                >= 1.3.1.1  && < 2.2
+      aeson                >= 1.3.1.1  && < 2.3
     , aeson-pretty         >= 0.8.7    && < 0.9
     , base                 >= 4.11     && < 5
     , bytestring           >= 0.10.8.2 && < 0.12

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -34,7 +34,7 @@ Library
         HsYAML                    >= 0.2       && < 0.3 ,
         HsYAML-aeson              >= 0.2       && < 0.3 ,
         base                      >= 4.11.0.0  && < 5   ,
-        aeson                     >= 1.0.0.0   && < 2.2 ,
+        aeson                     >= 1.0.0.0   && < 2.3 ,
         bytestring                                < 0.13,
         dhall                     >= 1.31.0    && < 1.43,
         dhall-json                >= 1.6.0     && < 1.8 ,


### PR DESCRIPTION
Currently `dhall-json` has `aeson < 2.3` but `dhall-yaml` still has `aeson < 2.2`. This PR extends the later upper bound to 2.3 too.