### PR TITLE
Fix formatting of `T.Some`

### DIFF
--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Completion.hs
@@ -7,6 +7,7 @@ import Dhall.Context                 (Context, empty, insert, toList)
 import Dhall.LSP.Backend.Diagnostics (Position, positionToOffset)
 import Dhall.LSP.Backend.Parsing     (holeExpr)
 import Dhall.Parser                  (Src, exprFromText)
+import Dhall.Pretty                  (UnescapedLabel(..))
 import Dhall.TypeCheck               (typeOf, typeWithA)
 import System.Directory              (doesDirectoryExist, listDirectory)
 import System.Environment            (getEnvironment)
@@ -186,9 +187,9 @@ completeProjections (CompletionContext context values) expr =
   -- complete a union constructor by inspecting the union value
   completeUnion _A (Union m) =
     let constructor (k, Nothing) =
-            Completion (Dhall.Pretty.escapeLabel True k) (Just _A)
+            Completion (Dhall.Pretty.escapeLabel AnyLabelOrSome k) (Just _A)
         constructor (k, Just v) =
-            Completion (Dhall.Pretty.escapeLabel True k) (Just (Pi mempty k v _A))
+            Completion (Dhall.Pretty.escapeLabel AnyLabelOrSome k) (Just (Pi mempty k v _A))
      in map constructor (Dhall.Map.toList m)
   completeUnion _ _ = []
 
@@ -197,5 +198,5 @@ completeProjections (CompletionContext context values) expr =
   completeRecord (Record m) = map toCompletion (Dhall.Map.toList $ recordFieldValue <$> m)
     where
       toCompletion (name, typ) =
-          Completion (Dhall.Pretty.escapeLabel True name) (Just typ)
+          Completion (Dhall.Pretty.escapeLabel AnyLabel name) (Just typ)
   completeRecord _ = []

--- a/dhall/src/Dhall/Pretty.hs
+++ b/dhall/src/Dhall/Pretty.hs
@@ -15,6 +15,7 @@ module Dhall.Pretty
     , Dhall.Pretty.Internal.layoutOpts
 
     , escapeEnvironmentVariable
+    , UnescapedLabel(..)
     , escapeLabel
 
     , temporalToText

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -47,7 +47,7 @@ import Dhall.Eval
     , Val (..)
     , (~>)
     )
-import Dhall.Pretty                      (Ann)
+import Dhall.Pretty                      (Ann, UnescapedLabel(..))
 import Dhall.Src                         (Src)
 import Lens.Family                       (over)
 import Prettyprinter                     (Doc, Pretty (..), vsep)
@@ -2915,7 +2915,7 @@ prettyTypeMessage (InvalidDuplicateField k expr0 expr1) =
         \                                                                                \n\
         \... which is not a record type                                                  \n"
       where
-        txt0 = insert (Dhall.Pretty.Internal.escapeLabel True k)
+        txt0 = insert (Dhall.Pretty.Internal.escapeLabel AnyLabelOrSome k)
         txt1 = insert expr0
         txt2 = insert expr1
 
@@ -3073,7 +3073,7 @@ prettyTypeMessage (DuplicateFieldCannotBeMerged ks) = ErrorMessages {..}
         \                                                                                \n\
         \" <> txt1 <> "\n"
       where
-        txt0 = insert (Dhall.Pretty.Internal.escapeLabel True (NonEmpty.head ks))
+        txt0 = insert (Dhall.Pretty.Internal.escapeLabel AnyLabelOrSome (NonEmpty.head ks))
 
         txt1 = insert (toPath ks)
 
@@ -5055,7 +5055,7 @@ checkContext context =
 toPath :: (Functor list, Foldable list) => list Text -> Text
 toPath ks =
     Text.intercalate "."
-        (Foldable.toList (fmap (Dhall.Pretty.Internal.escapeLabel True) ks))
+        (Foldable.toList (fmap (Dhall.Pretty.Internal.escapeLabel AnyLabelOrSome) ks))
 
 duplicateElement :: Ord a => [a] -> Maybe a
 duplicateElement = go Data.Set.empty

--- a/dhall/tests/format/issue2601A.dhall
+++ b/dhall/tests/format/issue2601A.dhall
@@ -1,0 +1,11 @@
+let T = < Some | Type >
+
+let t
+    : T
+    = T.`Some`
+
+let x
+    : T
+    = T.Type
+
+in  True

--- a/dhall/tests/format/issue2601B.dhall
+++ b/dhall/tests/format/issue2601B.dhall
@@ -1,0 +1,11 @@
+let T = < Some | Type >
+
+let t
+    : T
+    = T.`Some`
+
+let x
+    : T
+    = T.Type
+
+in  True

--- a/nix/packages/lsp-test.nix
+++ b/nix/packages/lsp-test.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, aeson, aeson-pretty, ansi-terminal, async, base
+, bytestring, co-log-core, conduit, conduit-parse, containers
+, data-default, Diff, directory, exceptions, extra, filepath, Glob
+, hspec, lens, lib, lsp, lsp-types, mtl, parser-combinators
+, process, row-types, some, text, time, transformers, unix
+, unliftio
+}:
+mkDerivation {
+  pname = "lsp-test";
+  version = "0.15.0.1";
+  sha256 = "ad5be9baa344337b87958dfeb765e3edceca47c4ada57fb1ffeccf4056c57ad8";
+  libraryHaskellDepends = [
+    aeson aeson-pretty ansi-terminal async base bytestring co-log-core
+    conduit conduit-parse containers data-default Diff directory
+    exceptions filepath Glob lens lsp lsp-types mtl parser-combinators
+    process row-types some text time transformers unix
+  ];
+  testHaskellDepends = [
+    aeson base co-log-core containers data-default directory filepath
+    hspec lens lsp mtl parser-combinators process text unliftio
+  ];
+  testToolDepends = [ lsp ];
+  benchmarkHaskellDepends = [ base extra lsp process ];
+  homepage = "https://github.com/haskell/lsp/blob/master/lsp-test/README.md";
+  description = "Functional test framework for LSP servers";
+  license = lib.licenses.bsd3;
+}


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/2601

According to the standard the `Some` needs to be escaped when used as a field accessor because the `any-label` grammar rule kicks in, which specifically does not permit `Some`.