### PR TITLE
Added support for binary files to `to-directory-tree`

### DIFF
--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -27,6 +27,7 @@ module Dhall.DirectoryTree.Types
     , isMetadataSupported
     ) where
 
+import Data.ByteString          (ByteString)
 import Data.Functor.Identity    (Identity (..))
 import Data.Sequence            (Seq)
 import Data.Text                (Text)
@@ -72,6 +73,8 @@ type FileEntry = Entry Text
 data FilesystemEntry
     = DirectoryEntry (Entry (Seq FilesystemEntry))
     | FileEntry (Entry Text)
+    | BinaryFileEntry (Entry ByteString)
+    | TextFileEntry (Entry Text)
     deriving (Eq, Generic, Ord, Show)
 
 instance FromDhall FilesystemEntry where
@@ -82,6 +85,10 @@ instance FromDhall FilesystemEntry where
                 DirectoryEntry <$> extract (autoWith normalizer) entry
             Make "file" entry ->
                 FileEntry <$> extract (autoWith normalizer) entry
+            Make "binary-file" entry ->
+                BinaryFileEntry <$> extract (autoWith normalizer) entry
+            Make "text-file" entry ->
+                TextFileEntry <$> extract (autoWith normalizer) entry
             expr -> Decode.typeError (expected (Decode.autoWith normalizer :: Decoder FilesystemEntry)) expr
         }
 

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -172,6 +172,7 @@ import Data.Text                  (Text)
 import Data.Typeable              (Typeable)
 import Data.Void                  (Void, absurd)
 import Dhall.TypeCheck            (TypeError)
+import Dhall.Util                 (printWarning)
 
 import Dhall.Syntax
     ( Chunks (..)
@@ -1279,15 +1280,6 @@ loadWithManager newManager =
     loadWithStatus
         (makeEmptyStatus newManager defaultOriginHeaders ".")
         UseSemanticCache
-
-printWarning :: (MonadIO m) => String -> m ()
-printWarning message = do
-    let warning =
-                "\n"
-            <> "\ESC[1;33mWarning\ESC[0m: "
-            <> message
-
-    liftIO $ System.IO.hPutStrLn System.IO.stderr warning
 
 -- | Resolve all imports within an expression, importing relative to the given
 -- directory.

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -9,6 +9,8 @@ module Dhall.Util
     , snipDoc
     , insert
     , _ERROR
+    , _WARNING
+    , printWarning
     , Censor(..)
     , Input(..)
     , Transitivity(..)
@@ -110,6 +112,21 @@ insert expression =
 -- | Prefix used for error messages
 _ERROR :: IsString string => string
 _ERROR = "\ESC[1;31mError\ESC[0m"
+
+-- | Prefix used for error messages
+_WARNING :: IsString string => string
+_WARNING = "\ESC[1;33mWarning\ESC[0m"
+
+-- | Output a warning message on stderr.
+printWarning :: (MonadIO m) => String -> m ()
+printWarning message = do
+    let warning =
+                "\n"
+            <> _WARNING
+            <> ": "
+            <> message
+
+    liftIO $ IO.hPutStrLn IO.stderr warning
 
 get
     :: (String -> Text -> Either ParseError a)


### PR DESCRIPTION
Since `Byte` is part of the Dhall language we can produce binary files with the `to-directory-tree` command as well.
This PR implements that feature.

It also deprecates the `file` constructor used to construct files containing `Text` in favor of `text-file` and `binary-file` -- The former is what `file` used to be while the latter is for files containing `Byte`s.