### PR TITLE
Dhall.TH: Call `addDependentFile` for each local import

### DIFF
--- a/dhall/src/Dhall/TH.hs
+++ b/dhall/src/Dhall/TH.hs
@@ -56,7 +56,7 @@ import qualified Dhall.Map
 import qualified Dhall.Pretty
 import qualified Dhall.Util
 import qualified GHC.IO.Encoding
-import qualified Language.Haskell.TH.Syntax  as Syntax
+import qualified Language.Haskell.TH.Syntax  as TH
 import qualified Numeric.Natural
 import qualified Prettyprinter.Render.String as Pretty
 import qualified System.IO
@@ -88,15 +88,15 @@ import qualified System.IO
 -}
 staticDhallExpression :: Text -> Q Exp
 staticDhallExpression text = do
-    Syntax.runIO (GHC.IO.Encoding.setLocaleEncoding System.IO.utf8)
+    TH.runIO (GHC.IO.Encoding.setLocaleEncoding System.IO.utf8)
 
-    expression <- Syntax.runIO (Dhall.inputExpr text)
+    expression <- TH.runIO (Dhall.inputExpr text)
 
     dataToExpQ (fmap liftText . Typeable.cast) expression
   where
     -- A workaround for a problem in TemplateHaskell (see
     -- https://stackoverflow.com/questions/38143464/cant-find-inerface-file-declaration-for-variable)
-    liftText = fmap (AppE (VarE 'Text.pack)) . Syntax.lift . Text.unpack
+    liftText = fmap (AppE (VarE 'Text.pack)) . TH.lift . Text.unpack
 
 {-| A quasi-quoter for Dhall expressions.
 
@@ -207,14 +207,14 @@ toNestedHaskellType typeParams haskellTypes = loop
 
         Var v
             | Just (V param index) <- List.find (v ==) typeParams -> do
-                let name = Syntax.mkName $ (Text.unpack param) ++ (show index)
+                let name = TH.mkName $ (Text.unpack param) ++ (show index)
 
                 return (VarT name)
 
             | otherwise -> fail $ message v
 
         _   | Just haskellType <- List.find (predicate dhallType) haskellTypes -> do
-                let name = Syntax.mkName (Text.unpack (typeName haskellType))
+                let name = TH.mkName (Text.unpack (typeName haskellType))
 
                 return (ConT name)
             | otherwise -> fail $ message dhallType
@@ -225,7 +225,7 @@ derivingGenericClause = DerivClause (Just StockStrategy) [ ConT ''Generic ]
 
 -- | Generates a `FromDhall` instances.
 fromDhallInstance
-    :: Syntax.Name -- ^ The name of the type the instances is for
+    :: TH.Name -- ^ The name of the type the instances is for
     -> Q Exp       -- ^ A TH splice generating some `Dhall.InterpretOptions`
     -> Q [Dec]
 fromDhallInstance n interpretOptions = [d|
@@ -235,7 +235,7 @@ fromDhallInstance n interpretOptions = [d|
 
 -- | Generates a `ToDhall` instances.
 toDhallInstance
-    :: Syntax.Name -- ^ The name of the type the instances is for
+    :: TH.Name -- ^ The name of the type the instances is for
     -> Q Exp       -- ^ A TH splice generating some `Dhall.InterpretOptions`
     -> Q [Dec]
 toDhallInstance n interpretOptions = [d|
@@ -265,15 +265,15 @@ toDeclaration generateOptions@GenerateOptions{..} haskellTypes typ =
         interpretOptions = generateToInterpretOptions generateOptions typ
 
 #if MIN_VERSION_template_haskell(2,21,0)
-        toTypeVar (V n i) = Syntax.PlainTV (Syntax.mkName (Text.unpack n ++ show i)) Syntax.BndrInvis
+        toTypeVar (V n i) = TH.PlainTV (TH.mkName (Text.unpack n ++ show i)) TH.BndrInvis
 #elif MIN_VERSION_template_haskell(2,17,0)
-        toTypeVar (V n i) = Syntax.PlainTV (Syntax.mkName (Text.unpack n ++ show i)) ()
+        toTypeVar (V n i) = TH.PlainTV (TH.mkName (Text.unpack n ++ show i)) ()
 #else
-        toTypeVar (V n i) = Syntax.PlainTV (Syntax.mkName (Text.unpack n ++ show i))
+        toTypeVar (V n i) = TH.PlainTV (TH.mkName (Text.unpack n ++ show i))
 #endif
 
         toDataD typeName typeParams constructors = do
-            let name = Syntax.mkName (Text.unpack typeName)
+            let name = TH.mkName (Text.unpack typeName)
 
             let params = fmap toTypeVar typeParams
 
@@ -355,7 +355,7 @@ toConstructor
     -- ^ @(constructorName, fieldType)@
     -> Q Con
 toConstructor typeParams GenerateOptions{..} haskellTypes outerTypeName (constructorName, maybeAlternativeType) = do
-    let name = Syntax.mkName (Text.unpack $ constructorModifier constructorName)
+    let name = TH.mkName (Text.unpack $ constructorModifier constructorName)
 
     let strictness = if makeStrict then SourceStrict else NoSourceStrictness
 
@@ -368,7 +368,7 @@ toConstructor typeParams GenerateOptions{..} haskellTypes outerTypeName (constru
                     && typeName haskellType /= outerTypeName
             , Just haskellType <- List.find predicate haskellTypes -> do
                 let innerName =
-                        Syntax.mkName (Text.unpack (typeName haskellType))
+                        TH.mkName (Text.unpack (typeName haskellType))
 
                 return (NormalC name [ (bang, ConT innerName) ])
 
@@ -376,7 +376,7 @@ toConstructor typeParams GenerateOptions{..} haskellTypes outerTypeName (constru
             let process (key, dhallFieldType) = do
                     haskellFieldType <- toNestedHaskellType typeParams haskellTypes dhallFieldType
 
-                    return (Syntax.mkName (Text.unpack $ fieldModifier key), bang, haskellFieldType)
+                    return (TH.mkName (Text.unpack $ fieldModifier key), bang, haskellFieldType)
 
             varBangTypes <- traverse process (Dhall.Map.toList $ Core.recordFieldValue <$> kts)
 
@@ -508,16 +508,16 @@ generateToInterpretOptions GenerateOptions{..} haskellType = [| Dhall.InterpretO
                 mkMatch n = Match (textToPat $ f n) (NormalB $ textToExp n) []
 
         nameE :: Exp
-        nameE = Syntax.VarE $ Syntax.mkName "n"
+        nameE = TH.VarE $ TH.mkName "n"
 
         nameP :: Pat
-        nameP = Syntax.VarP $ Syntax.mkName "n"
+        nameP = TH.VarP $ TH.mkName "n"
 
         textToExp :: Text -> Exp
-        textToExp = Syntax.LitE . Syntax.StringL . Text.unpack
+        textToExp = TH.LitE . TH.StringL . Text.unpack
 
         textToPat :: Text -> Pat
-        textToPat = Syntax.LitP . Syntax.StringL . Text.unpack
+        textToPat = TH.LitP . TH.StringL . Text.unpack
 
 -- | Generate a Haskell datatype declaration with one constructor from a Dhall
 -- type.
@@ -605,8 +605,8 @@ makeHaskellTypes = makeHaskellTypesWith defaultGenerateOptions
 -- > makeHaskellTypes = makeHaskellTypesWith defaultGenerateOptions
 makeHaskellTypesWith :: GenerateOptions -> [HaskellType Text] -> Q [Dec]
 makeHaskellTypesWith generateOptions haskellTypes = do
-    Syntax.runIO (GHC.IO.Encoding.setLocaleEncoding System.IO.utf8)
+    TH.runIO (GHC.IO.Encoding.setLocaleEncoding System.IO.utf8)
 
-    haskellTypes' <- traverse (traverse (Syntax.runIO . Dhall.inputExpr)) haskellTypes
+    haskellTypes' <- traverse (traverse (TH.runIO . Dhall.inputExpr)) haskellTypes
 
     concat <$> traverse (toDeclaration generateOptions haskellTypes') haskellTypes'


### PR DESCRIPTION
This PR improves recompilation checking for modules that use the `Dhall.TH.staticDhallExpression` function and the `Dhall.TH.dhall` Quasi Quoter. Specifically, we call `Language.Haskell.TH.addDependentFile` for each local import appearing in a Dhall expression: By doing that GHC will rebuild the module splicing in that expression if one of its local imports changes.

In order to collect the imports that where processed in the import resolution phase a new function `resolveAndStatusWithSettings` was added to the `Dhall` module. This function also returns the final import status (`Dhall.Import.Status`) together with the resolved expression.

Fixes #2518 