### PR TITLE
Fix cross-compilation (exclude TH)

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -268,6 +268,8 @@ Common common
       if flag(network-tests)
         CPP-Options:
           -DNETWORK_TESTS
+    if flag(cross)
+      CPP-Options: -DCROSS
 
     GHC-Options: -Wall -Wcompat -Wincomplete-uni-patterns -optP-Wno-unicode-homoglyph
 
@@ -432,10 +434,12 @@ Test-Suite tasty
         Dhall.Test.Schemas
         Dhall.Test.SemanticHash
         Dhall.Test.Substitution
-        Dhall.Test.TH
         Dhall.Test.Tutorial
         Dhall.Test.TypeInference
         Dhall.Test.Util
+    if !flag(cross)
+        Other-Modules:
+            Dhall.Test.TH
     Build-Depends:
         dhall                                          ,
         foldl                                    < 1.5 ,

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Main where
 
 import System.FilePath ((</>))
@@ -17,7 +18,9 @@ import qualified Dhall.Test.QuickCheck
 import qualified Dhall.Test.Regression
 import qualified Dhall.Test.Schemas
 import qualified Dhall.Test.SemanticHash
+#ifndef CROSS
 import qualified Dhall.Test.TH
+#endif
 import qualified Dhall.Test.Tags
 import qualified Dhall.Test.Tutorial
 import qualified Dhall.Test.TypeInference
@@ -69,7 +72,9 @@ getAllTests = do
                 , Dhall.Test.Tutorial.tests
                 , Dhall.Test.QuickCheck.tests
                 , Dhall.Test.Dhall.tests
+#ifndef CROSS
                 , Dhall.Test.TH.tests
+#endif
                 , Dhall.Test.Package.tests
                 ]
 


### PR DESCRIPTION
Tested by removing all projects except `dhall` from the project file and running

```
cabal build -w ghc-9.8.4 --enable-tests --allow-newer=special-values:bytestring -f cross -f network-tests tasty
```

special-values issues posted as

* https://github.com/minad/special-values/issues/5
