### PR TITLE
Fix TyVar BndrVis

### DIFF
--- a/dhall/src/Dhall/TH.hs
+++ b/dhall/src/Dhall/TH.hs
@@ -265,7 +265,7 @@ toDeclaration generateOptions@GenerateOptions{..} haskellTypes typ =
         interpretOptions = generateToInterpretOptions generateOptions typ
 
 #if MIN_VERSION_template_haskell(2,21,0)
-        toTypeVar (V n i) = Syntax.PlainTV (Syntax.mkName (Text.unpack n ++ show i)) Syntax.BndrInvis
+        toTypeVar (V n i) = Syntax.PlainTV (Syntax.mkName (Text.unpack n ++ show i)) Syntax.BndrReq
 #elif MIN_VERSION_template_haskell(2,17,0)
         toTypeVar (V n i) = Syntax.PlainTV (Syntax.mkName (Text.unpack n ++ show i)) ()
 #else


### PR DESCRIPTION
<https://github.com/dhall-lang/dhall-haskell/pull/2542> allowed `dhall` to compile with template-haskell-2.21 and GHC-9.8 by adapting to the addition of a binder visibility field on type variables.

Previously all binders were taken to be required, but in GHC-9.8 the possibility of invisible binders was introduced.

The above patch mistakenly set all binders generated by Dhall to be invisible, rather than default value of required. This changes the semantics of the code and broke some examples in the test suite.

This patch fixes this by correctly setting binders to be BndrReq.

Resolves https://github.com/dhall-lang/dhall-haskell/issues/2567