### PR TITLE
Update legacy wiki URLs to the new website

### DIFF
--- a/dhall/README.md
+++ b/dhall/README.md
@@ -26,7 +26,7 @@ error-prone and difficult to maintain/migrate.
 This post explains in more detail the motivation behind programmable
 configuration files:
 
-* [Programmable configuration files](https://github.com/dhall-lang/dhall-lang/wiki/Programmable-configuration-files)
+* [Programmable configuration files](https://docs.dhall-lang.org/discussions/Programmable-configuration-files.html)
 
 *"Why not configure my program using Haskell code?"*
 

--- a/dhall/src/Dhall/Tutorial.hs
+++ b/dhall/src/Dhall/Tutorial.hs
@@ -1857,7 +1857,7 @@ import Dhall
 -- You can find an up-to-date list of available built-in functions and operators
 -- here:
 --
--- <https://github.com/dhall-lang/dhall-lang/wiki/Built-in-types%2C-functions%2C-and-operators Built-in types, functions, and operators>
+-- <https://docs.dhall-lang.org/references/Built-in-types.html>
 
 -- $caveats
 --
@@ -2316,4 +2316,4 @@ import Dhall
 
 -- $faq
 --
--- <https://github.com/dhall-lang/dhall-lang/wiki/Frequently-Asked-Questions-(FAQ) Frequently Asked Questions (FAQ)>
+-- <https://docs.dhall-lang.org/howtos/FAQ.html>


### PR DESCRIPTION
This is a follow-up for https://github.com/dhall-lang/dhall-lang/pull/827