### PR TITLE
Relax upper bounds of `Diff` dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -219,7 +219,7 @@ Common common
         contravariant                              < 1.6 ,
         data-fix                                   < 0.4 ,
         deepseq                                    < 1.6 ,
-        Diff                        >= 0.2      && < 0.6 ,
+        Diff                        >= 0.2      && < 1.1 ,
         directory                   >= 1.3.0.0  && < 1.4 ,
         dotgen                      >= 0.4.2    && < 0.5 ,
         either                      >= 5        && < 5.1,


### PR DESCRIPTION
Fixes #2623 

This PR also adds a Dependabot configuration that keeps our GitHub Actions up to date.