### PR TITLE
Add explicit bounds to `base` everywhere

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -44,11 +44,11 @@ Executable dhall-to-bash
     Other-Modules:
         Paths_dhall_bash
     Build-Depends:
-        base                                  ,
-        bytestring                            ,
-        dhall                                 ,
-        dhall-bash                            ,
-        optparse-generic >= 1.1.1    && < 1.6 ,
+        base             >= 4.11.0.0 && < 5  ,
+        bytestring                           ,
+        dhall                                ,
+        dhall-bash                           ,
+        optparse-generic >= 1.1.1    && < 1.6,
         text
     GHC-Options: -Wall
     Default-Language: Haskell2010

--- a/dhall-csv/dhall-csv.cabal
+++ b/dhall-csv/dhall-csv.cabal
@@ -57,17 +57,17 @@ Executable dhall-to-csv
     Hs-Source-Dirs: dhall-to-csv
     Main-Is: Main.hs
     Build-Depends:
-        ansi-terminal                                       ,
-        base                                                ,
-        bytestring                                          ,
-        cassava                                             ,
-        dhall                                               ,
-        dhall-csv                                           ,
-        optparse-applicative                                ,
-        prettyprinter                                       ,
-        prettyprinter-ansi-terminal    >= 1.1.1    && < 1.2 ,
-        unordered-containers                                ,
-        vector                                              ,
+        ansi-terminal                                   ,
+        base                        >= 4.12.0.0 && < 5  ,
+        bytestring                                      ,
+        cassava                                         ,
+        dhall                                           ,
+        dhall-csv                                       ,
+        optparse-applicative                            ,
+        prettyprinter                                   ,
+        prettyprinter-ansi-terminal >= 1.1.1    && < 1.2,
+        unordered-containers                            ,
+        vector                                          ,
         text
     Other-Modules:
         Paths_dhall_csv
@@ -78,17 +78,17 @@ Executable csv-to-dhall
     Hs-Source-Dirs: csv-to-dhall
     Main-Is: Main.hs
     Build-Depends:
-        ansi-terminal                                       ,
-        base                                                ,
-        bytestring                                          ,
-        cassava                                             ,
-        dhall                                               ,
-        dhall-csv                                           ,
-        optparse-applicative                                ,
-        prettyprinter                                       ,
-        prettyprinter-ansi-terminal    >= 1.1.1    && < 1.2 ,
-        unordered-containers                                ,
-        vector                                              ,
+        ansi-terminal                                   ,
+        base                        >= 4.12.0.0 && < 5  ,
+        bytestring                                      ,
+        cassava                                         ,
+        dhall                                           ,
+        dhall-csv                                       ,
+        optparse-applicative                            ,
+        prettyprinter                                   ,
+        prettyprinter-ansi-terminal >= 1.1.1    && < 1.2,
+        unordered-containers                            ,
+        vector                                          ,
         text
     Other-Modules:
         Paths_dhall_csv
@@ -100,17 +100,17 @@ Test-Suite tasty
     Hs-Source-Dirs:   tasty
     Main-Is:          Main.hs
     Build-Depends:
-        base                    ,
-        bytestring              ,
-        cassava                 ,
-        dhall                   ,
-        dhall-csv               ,
-        filepath                ,
-        tasty        <  1.6     ,
-        tasty-silver <  3.4     ,
-        tasty-hunit  >= 0.2     ,
-        unordered-containers    ,
-        text                    ,
+        base         >= 4.12.0.0 && < 5  ,
+        bytestring                       ,
+        cassava                          ,
+        dhall                            ,
+        dhall-csv                        ,
+        filepath                         ,
+        tasty                       < 1.6,
+        tasty-silver                < 3.4,
+        tasty-hunit  >= 0.2              ,
+        unordered-containers             ,
+        text                             ,
         vector
     GHC-Options:      -Wall
     Default-Language: Haskell2010

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -110,8 +110,8 @@ Executable dhall-docs
     Hs-Source-Dirs: dhall-docs
     Main-Is: Main.hs
     Build-Depends:
-        base      ,
-        dhall     ,
+        base       >= 4.11.0.0 && < 5,
+        dhall                        ,
         dhall-docs
     Other-Modules:
         Paths_dhall_docs
@@ -124,10 +124,10 @@ Test-Suite doctest
     Main-Is: Main.hs
     GHC-Options: -Wall
     Build-Depends:
-        base                           ,
-        directory,
-        filepath                 < 1.6 ,
-        doctest    >= 0.7.0
+        base      >= 4.11.0.0 && < 5  ,
+        directory                     ,
+        filepath                 < 1.6,
+        doctest   >= 0.7.0
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010
 
@@ -136,12 +136,12 @@ Test-Suite tasty
     Hs-Source-Dirs: tasty
     Main-Is: Main.hs
     Build-Depends:
-        base                              ,
-        bytestring                        ,
-        containers                        ,
-        dhall                             ,
-        dhall-docs                        ,
-        foldl        < 1.5                ,
+        base       >= 4.11.0.0 && < 5   ,
+        bytestring                      ,
+        containers                      ,
+        dhall                           ,
+        dhall-docs                      ,
+        foldl                     < 1.5 ,
 
         -- lucid preserves input attribute order since v2.11.0
         lucid        >= 2.11.0            ,

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -68,13 +68,13 @@ Executable dhall-to-json
     Hs-Source-Dirs: dhall-to-json
     Main-Is: Main.hs
     Build-Depends:
-        base                                   ,
-        aeson                                  ,
-        aeson-pretty         >= 0.8.5 && < 0.9 ,
-        bytestring                             ,
-        dhall                                  ,
-        dhall-json                             ,
-        optparse-applicative                   ,
+        base                 >= 4.11.0.0 && < 5  ,
+        aeson                                    ,
+        aeson-pretty         >= 0.8.5    && < 0.9,
+        bytestring                               ,
+        dhall                                    ,
+        dhall-json                               ,
+        optparse-applicative                     ,
         text
     Other-Modules:
         Paths_dhall_json
@@ -85,7 +85,7 @@ Executable dhall-to-yaml
     Hs-Source-Dirs: dhall-to-yaml
     Main-Is: Main.hs
     Build-Depends:
-        base      ,
+        base       >= 4.11.0.0 && < 5,
         dhall-json
     Other-Modules:
         Paths_dhall_json
@@ -96,7 +96,7 @@ Executable json-to-dhall
     Hs-Source-Dirs: json-to-dhall
     Main-Is: Main.hs
     Build-Depends:
-        base                                             ,
+        base                        >= 4.11.0.0 && < 5   ,
         aeson                                            ,
         ansi-terminal               >= 0.6.3.1  && < 1.2 ,
         bytestring                                       ,
@@ -117,14 +117,14 @@ Test-Suite tasty
     Hs-Source-Dirs: tasty
     Main-Is: Main.hs
     Build-Depends:
-        base               ,
-        aeson              ,
-        bytestring         ,
-        dhall              ,
-        dhall-json         ,
-        tasty        <  1.6,
-        text               ,
-        tasty-hunit  >= 0.2,
+        base         >= 4.11.0.0 && < 5   ,
+        aeson                             ,
+        bytestring                        ,
+        dhall                             ,
+        dhall-json                        ,
+        tasty                       <  1.6,
+        text                              ,
+        tasty-hunit  >= 0.2               ,
         tasty-silver >= 3.0
     GHC-Options: -Wall
     Default-Language: Haskell2010

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -77,7 +77,7 @@ executable dhall-lsp-server
   default-extensions: RecordWildCards OverloadedStrings
   ghc-options: -rtsopts
   build-depends:
-      base
+      base                 >= 4.11 && < 5
     , dhall-lsp-server
     , optparse-applicative
   default-language: Haskell2010
@@ -89,10 +89,10 @@ Test-Suite doctest
     Main-Is: Main.hs
     GHC-Options: -Wall
     Build-Depends:
-        base                           ,
-        directory  >= 1.3.1.5 && < 1.4 ,
-        filepath                 < 1.6 ,
-        doctest    >= 0.7.0            ,
+        base       >= 4.11    && < 5  ,
+        directory  >= 1.3.1.5 && < 1.4,
+        filepath                 < 1.6,
+        doctest    >= 0.7.0           ,
         QuickCheck
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010
@@ -103,12 +103,12 @@ Test-Suite tests
     Main-Is: Main.hs
     GHC-Options: -Wall
     Build-Depends:
-        base                                    ,
-        lsp-types         >= 2.0.1    && < 2.1  ,
-        hspec             >= 2.7      && < 2.12 ,
-        lsp-test          >= 0.15.0.0 && < 0.16 ,
-        tasty             >= 0.11.2   && < 1.6  ,
-        tasty-hspec       >= 1.1      && < 1.3  ,
+        base              >= 4.11     && < 5   ,
+        lsp-types         >= 2.0.1    && < 2.1 ,
+        hspec             >= 2.7      && < 2.12,
+        lsp-test          >= 0.15.0.0 && < 0.16,
+        tasty             >= 0.11.2   && < 1.6 ,
+        tasty-hspec       >= 1.1      && < 1.3 ,
         text              >= 0.11     && < 2.2
     Build-Tool-Depends: dhall-lsp-server:dhall-lsp-server
     Default-Language: Haskell2010

--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -49,7 +49,7 @@ Executable dhall-to-nix
     Other-Modules:
         Paths_dhall_nix
     Build-Depends:
-        base                                ,
+        base             >= 4.11.0.0 && < 5 ,
         dhall                               ,
         dhall-nix                           ,
         hnix                                ,

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -36,20 +36,20 @@ Executable openapi-to-dhall
     TupleSections
   Ghc-Options: -Wall
   Build-Depends:
-    base                                           ,
-    aeson                                          ,
-    containers                                     ,
-    directory               >= 1.3.0.0   && < 1.4  ,
-    dhall                                          ,
-    dhall-openapi                                  ,
-    filepath                >= 1.4       && < 1.6  ,
+    base                    >= 4.11.0.0  && < 5   ,
+    aeson                                         ,
+    containers                                    ,
+    directory               >= 1.3.0.0   && < 1.4 ,
+    dhall                                         ,
+    dhall-openapi                                 ,
+    filepath                >= 1.4       && < 1.6 ,
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
-    megaparsec              >= 7.0       && < 10   ,
-    optparse-applicative    >= 0.14.3.0  && < 0.19 ,
-    parser-combinators                             ,
-    prettyprinter                                  ,
-    sort                                           ,
-    text                                           ,
+    megaparsec              >= 7.0       && < 10  ,
+    optparse-applicative    >= 0.14.3.0  && < 0.19,
+    parser-combinators                            ,
+    prettyprinter                                 ,
+    sort                                          ,
+    text                                          ,
     vector
   Default-Language: Haskell2010
 

--- a/dhall-toml/dhall-toml.cabal
+++ b/dhall-toml/dhall-toml.cabal
@@ -56,7 +56,7 @@ Executable dhall-to-toml
     Hs-Source-Dirs:   dhall-to-toml
     Main-Is:          Main.hs
     Build-Depends:
-        base       ,
+        base       >= 4.12 && < 5,
         dhall-toml
     GHC-Options:      -Wall
     Default-Language: Haskell2010
@@ -65,7 +65,7 @@ Executable toml-to-dhall
     Hs-Source-Dirs:   toml-to-dhall
     Main-Is:          Main.hs
     Build-Depends:
-        base       ,
+        base       >= 4.12 && < 5,
         dhall-toml
     GHC-Options:      -Wall
     Default-Language: Haskell2010
@@ -75,12 +75,12 @@ Test-Suite dhall-toml-test
     Hs-Source-Dirs:   tasty
     Main-Is:          Main.hs
     Build-Depends:
-        base               ,
-        dhall              ,
-        dhall-toml         ,
-        tasty       <  1.6 ,
-        tasty-hunit >= 0.2 ,
-        text               ,
+        base        >= 4.12 && < 5  ,
+        dhall                       ,
+        dhall-toml                  ,
+        tasty                  < 1.6,
+        tasty-hunit >= 0.2          ,
+        text                        ,
         tomland
     GHC-Options:      -Wall
     Default-Language: Haskell2010
@@ -90,9 +90,9 @@ Test-Suite doctest
     Hs-Source-Dirs:   doctest
     Main-Is:          Main.hs
     Build-Depends:
-        base      ,
-        directory ,
-        filepath  ,
+        base      >= 4.12 && < 5,
+        directory               ,
+        filepath                ,
         doctest
     GHC-Options:      -Wall
     Default-Language: Haskell2010

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -51,8 +51,8 @@ Executable dhall-to-yaml-ng
     Hs-Source-Dirs: dhall-to-yaml-ng
     Main-Is: Main.hs
     Build-Depends:
-        base      ,
-        dhall-json,
+        base       >= 4.11.0.0 && < 5,
+        dhall-json                   ,
         dhall-yaml
     Other-Modules:
         Paths_dhall_yaml
@@ -63,7 +63,7 @@ Executable yaml-to-dhall
     Hs-Source-Dirs: yaml-to-dhall
     Main-Is: Main.hs
     Build-Depends:
-        base                                             ,
+        base                        >= 4.11.0.0 && < 5   ,
         aeson                                            ,
         ansi-terminal               >= 0.6.3.1  && < 1.2 ,
         bytestring                                       ,
@@ -85,14 +85,14 @@ Test-Suite tasty
     Hs-Source-Dirs: tasty
     Main-Is: Main.hs
     Build-Depends:
-        base                         ,
-        bytestring                   ,
-        dhall                        ,
-        dhall-json                   ,
-        dhall-yaml                   ,
-        tasty                  <  1.6,
-        tasty-expected-failure < 0.13,
-        text                                    ,
+        base                   >= 4.11.0.0 && < 5   ,
+        bytestring                                  ,
+        dhall                                       ,
+        dhall-json                                  ,
+        dhall-yaml                                  ,
+        tasty                                 < 1.6 ,
+        tasty-expected-failure                < 0.13,
+        text                                        ,
         tasty-hunit            >= 0.2
 
     GHC-Options: -Wall


### PR DESCRIPTION
Hackage requires this, even if the bounds could be inferred from other targets