### PR TITLE
Bump LSP dependencies of `dhall-lsp-server` package

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -53,7 +53,7 @@ library
     , dhall                >= 1.38.0   && < 1.43
     , dhall-json           >= 1.4      && < 1.8
     , filepath             >= 1.4.2    && < 1.6
-    , lsp                  >= 2.1.0.0  && < 2.2
+    , lsp                  >= 2.1.0.0  && < 2.8
     , lens                 >= 4.16.1   && < 5.4
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     , megaparsec           >= 7.0.2    && < 10
@@ -104,9 +104,9 @@ Test-Suite tests
     GHC-Options: -Wall
     Build-Depends:
         base              >= 4.11     && < 5   ,
-        lsp-types         >= 2.0.1    && < 2.1 ,
+        lsp-types         >= 2.0.2    && < 2.4 ,
         hspec             >= 2.7      && < 2.12,
-        lsp-test          >= 0.15.0.0 && < 0.16,
+        lsp-test          >= 0.15.0.0 && < 0.18,
         tasty             >= 0.11.2   && < 1.6 ,
         tasty-hspec       >= 1.1      && < 1.3 ,
         text              >= 0.11     && < 2.2

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -104,7 +104,7 @@ Test-Suite tests
     GHC-Options: -Wall
     Build-Depends:
         base              >= 4.11     && < 5   ,
-        lsp-types         >= 2.0.2    && < 2.4 ,
+        lsp-types         >= 2.0.1    && < 2.4 ,
         hspec             >= 2.7      && < 2.12,
         lsp-test          >= 0.15.0.0 && < 0.18,
         tasty             >= 0.11.2   && < 1.6 ,

--- a/dhall-lsp-server/src/Dhall/LSP/Server.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Server.hs
@@ -67,7 +67,15 @@ runWith settings = withLogger $ \ioLogger -> do
 
   let defaultConfig = def
 
+#if MIN_VERSION_lsp(2,2,0)
+  let configSection = "dhall"
+
+  let onConfigChange _newConfig = return ()
+
+  let parseConfig _oldConfig json =
+#else
   let onConfigurationChange _oldConfig json =
+#endif
         case fromJSON json of
             Aeson.Success config -> Right config
             Aeson.Error   string -> Left (Text.pack string)


### PR DESCRIPTION
The following additional versions are allowed now:

 - lsp >=2.2 && <2.8
 - lsp-types >=2.1 && <2.4
 - lsp-test >=0.16 && <0.18