### PR TITLE
Preliminary support for GHC 9.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,9 @@ jobs:
             dhall-yaml
           )
           for package in "${packages[@]}"; do
+            if [ '${{matrix.stack-yaml}}' == 'stack.ghc-9.8.yaml' ] && [ "${package}" == 'dhall-nix' ]; then
+              continue
+            fi
             if [ '${{matrix.os.runner}}' == 'windows-latest' ] && [ "${package}" == 'dhall-nix' ]; then
               continue
             fi
@@ -112,6 +115,9 @@ jobs:
             dhall-yaml
           )
           for package in "${packages[@]}"; do
+            if [ '${{matrix.stack-yaml}}' == 'stack.ghc-9.8.yaml' ] && [ "${package}" == 'dhall-nix' ]; then
+              continue
+            fi
             if [ '${{matrix.os.runner}}' == 'windows-latest' ] && [ "${package}" == 'dhall-nix' ]; then
               continue
             fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
           - os:
               runner: "ubuntu-latest"
             stack-yaml: "stack.ghc-9.4.yaml"
+          - os:
+              runner: "ubuntu-latest"
+            stack-yaml: "stack.ghc-9.8.yaml"
       fail-fast: false
     name: ${{ matrix.os.runner }} - ${{ matrix.stack-yaml }}
     runs-on: ${{ matrix.os.runner }}

--- a/cabal.project
+++ b/cabal.project
@@ -5,8 +5,11 @@ packages:
   ./dhall-docs
   ./dhall-json
   ./dhall-lsp-server
-  ./dhall-nix
-  ./dhall-nixpkgs
   ./dhall-openapi
   ./dhall-toml
   ./dhall-yaml
+
+if impl(ghc < 9.8)
+  packages:
+    ./dhall-nix
+    ./dhall-nixpkgs

--- a/stack.ghc-9.2.yaml
+++ b/stack.ghc-9.2.yaml
@@ -18,9 +18,10 @@ extra-deps:
   - hnix-store-core-0.6.1.0@sha256:0171c3a571ab263c3e3aa3e6daca15602f2030a6862cb032038017e6d0265898,3882
   - hnix-store-remote-0.6.0.0@sha256:a8ea18bb355164bfd357fac12b0c5d32c95ffd455260f8b6c7fcaeddebf5918c,3270
   - logict-0.7.0.3
-  - lsp-2.1.0.0
-  - lsp-types-2.0.1.0
-  - lsp-test-0.15.0.1
+  - lsp-2.7.0.1@sha256:239f926026b6181ca5b35874f5458415baba46164444df434e0df6c4a586361c,3868
+  - lsp-test-0.17.1.1@sha256:0eb5df735429ec88579c11ca1a8d8c20734ff049dc839ceeb697e53c845f701f,4422
+  - lsp-types-2.3.0.1@sha256:a5497aa4ae7b27d956df8dab701495d3062b88eee52e3a6c65fc13fa28b7b191,34230
+  - mod-0.2.0.1@sha256:eeb316fef3a8c12f4e83bbeeea748e74d75fca54d4498d574ace92e464adb05a,2409
   - optparse-applicative-0.18.1.0@sha256:b4cf8d9018e5e67cb1f14edb5130b6d05ad8bc1b5f6bd4efaa6ec0b7f28f559d,5132
   - optparse-generic-1.5.2
   - row-types-1.0.1.2@sha256:4d4c7cb95d06a32b28ba977852d52a26b4c1f695ef083a6fd874ab6d79933b64,3071

--- a/stack.ghc-9.6.yaml
+++ b/stack.ghc-9.6.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.23
+resolver: lts-22.43
 packages:
   - dhall
   - dhall-bash
@@ -11,15 +11,12 @@ packages:
   - dhall-toml
   - dhall-yaml
 extra-deps:
-  - lsp-test-0.15.0.1
   - algebraic-graphs-0.6.1@sha256:b0b0a916a74f9cba3e678cde25e27f045d7b026a8d0f1a55a05e86f2877fdfd2,8807
   - free-5.1.10@sha256:58496bb68e5704be250ddc823622d50b5a3b8bdf0dc4f6539ecfde25bc4ef6e2,5169
   - hnix-0.17.0@sha256:57e172f915d70be2dd88c6377caebe8bd63337123ffef42df49b05dc0b1f168b,19224
   - hnix-store-core-0.6.1.0@sha256:0171c3a571ab263c3e3aa3e6daca15602f2030a6862cb032038017e6d0265898,3882
   - hnix-store-remote-0.6.0.0@sha256:a8ea18bb355164bfd357fac12b0c5d32c95ffd455260f8b6c7fcaeddebf5918c,3270
   - lens-family-th-0.5.3.1@sha256:725700a89f26f790ee7d6630a4fa394ac0305ae8d2cff06c037ee47cb3499654,1700
-  - lsp-2.1.0.0@sha256:ef6fc28eac6dc27672cd8471c9f83f14de646a9c1fcaf993a451d2ae4de274e8,3533
-  - lsp-types-2.0.2.0@sha256:a9a51c3cea0726d91fe63fa0670935ee720f7b31bc3f3b33b2483fc538152677,29421
   - tomland-1.3.3.2@sha256:8dd15cd2e8178a9bc3c3db4ef53e706e36ee093417a98b1d26131524629c3c07,9483
   - validation-selective-0.2.0.0@sha256:cc847f1a110e3b1bd437a5356f115881b61cafcb11781b570b180efd88bf0907,3917
 nix:

--- a/stack.ghc-9.8.yaml
+++ b/stack.ghc-9.8.yaml
@@ -1,0 +1,22 @@
+resolver: lts-23.6
+packages:
+  - dhall
+  - dhall-bash
+  - dhall-csv
+  - dhall-docs
+  - dhall-json
+  - dhall-lsp-server
+  # - dhall-nix
+  - dhall-openapi
+  - dhall-toml
+  - dhall-yaml
+extra-deps:
+  - special-values-0.1.0.0@sha256:ea855ec644acac84d3a4c9aadae9ba70a11d1d48d00940805dbb81cc95672bbd,1416
+nix:
+  packages:
+    - ncurses
+    - zlib
+flags:
+  # https://github.com/RyanGlScott/mintty/issues/4
+  mintty:
+    Win32-2-13-1: false


### PR DESCRIPTION
The Stack configuration added by this PR is not (yet) the "default" configuration -- That means the `stack.yaml` symlink still points to `stack.ghc-9.6.yaml`. The reason for this it that `dhall-nix` and `dhall-nixpkgs` are not supported due to the dependency on `hnix`.
I also added a conditional to the `cabal.project` file to exclude those packages for `ghc >=9.8`.

This is only meant as a temporary solution until `hnix` caught up with the ecosystem.