### PR TITLE
Use unnamed Pi type argument.

### DIFF
--- a/dhall/src/Dhall/Marshal/Decode.hs
+++ b/dhall/src/Dhall/Marshal/Decode.hs
@@ -507,7 +507,7 @@ instance (Functor f, FromDhall (f (Result f))) => FromDhall (Fix f) where
                 | a /= b    = Core.subst (V a 0) (Var (V b 0)) (Core.shift 1 (V b 0) expr)
                 | otherwise = expr
 
-        expected = (\x -> Pi mempty "result" (Const Core.Type) (Pi mempty "Make" (Pi mempty "_" x "result") "result"))
+        expected = (\x -> Pi mempty "result" (Const Core.Type) (Pi mempty "_" (Pi mempty "_" x "result") "result"))
             <$> Dhall.Marshal.Decode.expected (autoWith inputNormalizer :: Decoder (f (Result f)))
 
 resultToFix :: Functor f => Result f -> Fix f


### PR DESCRIPTION
I noticed that the `FromDhall` and `ToDhall` instance of `Fix` don't use the exact same definition of the type. Sure they are judgementally equal, but why not make them syntactically equal aswell?

In particular the use of the named argument in the pi type `"Make"` is not the same. I personally think the best solution is to remove the name of this function, because `Make` is not used in the return type of the pi type anyways. This is what I'm doing in this commit.

---

Alternatively you could also change the `"_"` to `"Make"` here: https://github.com/dhall-lang/dhall-haskell/blob/f48fda94822f507217fa6357ae2b07b2e46a09db/dhall/src/Dhall/Marshal/Encode.hs#L537
That way both types would include the name `Make`.