### PR TITLE
`dhall-bash`: Switch from `optparse-generic` to `optparse-applicative`

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -44,11 +44,11 @@ Executable dhall-to-bash
     Other-Modules:
         Paths_dhall_bash
     Build-Depends:
-        base             >= 4.11.0.0 && < 5  ,
-        bytestring                           ,
-        dhall                                ,
-        dhall-bash                           ,
-        optparse-generic >= 1.1.1    && < 1.6,
+        base                 >= 4.11.0.0 && < 5    ,
+        bytestring                                 ,
+        dhall                                      ,
+        dhall-bash                                 ,
+        optparse-applicative >= 0.14.0.0  && < 0.19,
         text
     GHC-Options: -Wall
     Default-Language: Haskell2010


### PR DESCRIPTION
This PR removes the `optparse-generic` dependency in favor of `optparse-applicative` in the `dhall-bash` package.