### PR TITLE
Preliminary support for GHC 9.12.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,3 +13,6 @@ if impl(ghc < 9.8)
   packages:
     ./dhall-nix
     ./dhall-nixpkgs
+
+if impl(ghc >= 9.12)
+  allow-newer: repline:containers

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -245,7 +245,7 @@ Common common
         repline                     >= 0.4.0.0  && < 0.5 ,
         serialise                   >= 0.2.0.0  && < 0.3 ,
         scientific                  >= 0.3.0.0  && < 0.4 ,
-        template-haskell            >= 2.13.0.0 && < 2.23,
+        template-haskell            >= 2.13.0.0 && < 2.24,
         text                        >= 0.11.1.0 && < 2.2 ,
         text-manipulate             >= 0.2.0.1  && < 0.4 ,
         text-short                  >= 0.1      && < 0.2 ,

--- a/dhall/src/Dhall/Syntax/Instances/Lift.hs
+++ b/dhall/src/Dhall/Syntax/Instances/Lift.hs
@@ -21,7 +21,9 @@ import qualified Data.Fixed as Fixed
 #endif
 import qualified Data.Time as Time
 
+#if !MIN_VERSION_time(1,14,0)
 deriving instance Lift Time.Day
+#endif
 deriving instance Lift Time.TimeOfDay
 deriving instance Lift Time.TimeZone
 #if !MIN_VERSION_template_haskell(2,21,0)


### PR DESCRIPTION
This PR adds preliminary support for (most; cf.  #2638 ) packages to be built with GHC 9.12.1.
If merged, this works by adding this repository as a Source Repository Package in your projects `cabal.project` with
```cabal
if impl(ghc >= 9.12)
  allow-newer: repline:containers
```
due to #2643 .