### PR TITLE
Fixing the typechecking rule for Optional + with ?

### DIFF
--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -1314,25 +1314,6 @@ infer typer = loop
 
                   VOptional _O' -> do
                     case ks of
-                        -- The old rule was:
-                        -- 
-                        -- Γ ⊢ e : Optional T
-                        -- Γ ⊢ v : T'
-                        -- T === T'
-                        -- ──────────────────────────────────
-                        -- Γ ⊢ e with ?.ks… = v : Optional T
-                        --
-                        -- Here T is _O' and T' = tV'.
-                        -- 
-                        -- The new rule is:
-                        --
-                        -- Γ ⊢ e : Optional T
-                        -- Γ, x : T ⊢ x with ks… = v : T₁
-                        -- T ≡ T₁
-                        -- ────────────────────────────────── x ∉ FV(v)
-                        -- Γ ⊢ e with ?.ks… = v : Optional T
-                        --
-                        -- Here T is _O' and T₁ is tV'.
 
                         -- (Some x) with ? = v is valid iff the type of x is the same as the type of v.
                       WithQuestion :| [] -> do

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -1314,36 +1314,14 @@ infer typer = loop
 
                   VOptional _O' -> do
                     case ks of
-                        -- The old rule was:
-                        -- 
-                        -- Γ ⊢ e : Optional T
-                        -- Γ ⊢ v : T'
-                        -- T === T'
-                        -- ──────────────────────────────────
-                        -- Γ ⊢ e with ?.ks… = v : Optional T
-                        --
-                        -- Here T is _O' and T' = tV'.
-                        -- 
-                        -- The new rule is:
-                        --
-                        -- Γ ⊢ e : Optional T
-                        -- Γ, x : T ⊢ x with ks… = v : T₁
-                        -- T ≡ T₁
-                        -- ────────────────────────────────── x ∉ FV(v)
-                        -- Γ ⊢ e with ?.ks… = v : Optional T
-                        --
-                        -- Here T is _O' and T₁ is tV'.
 
                         -- (Some x) with ? = v is valid iff the type of x is the same as the type of v.
-                      WithQuestion :| [] -> do
-                        tV' <- loop ctx v
-                        if Eval.conv values _O' tV'
-                          then return (VOptional _O')
-                          else die OptionalWithTypeMismatch
-
                         -- (Some x) with ?.a.b = v is valid iff the type of x.a.b is the same as the type of v.
-                      WithQuestion :| k₁ : ks' -> do
-                        tV' <- with _O' (k₁ :| ks') v
+                      WithQuestion :| ks' -> do
+                        let typecheckLhs = case ks' of
+                            [] -> loop ctx v
+                            k₁ : ks' -> with _O' (k₁ :| ks') v
+                        tV' <- typecheckLhs
                         if Eval.conv values _O' tV'
                           then return (VOptional _O')
                           else die OptionalWithTypeMismatch

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -1314,8 +1314,36 @@ infer typer = loop
 
                   VOptional _O' -> do
                     case ks of
-                      WithQuestion  :| _ -> do
+                        -- The old rule was:
+                        -- 
+                        -- Γ ⊢ e : Optional T
+                        -- Γ ⊢ v : T'
+                        -- T === T'
+                        -- ──────────────────────────────────
+                        -- Γ ⊢ e with ?.ks… = v : Optional T
+                        --
+                        -- Here T is _O' and T' = tV'.
+                        -- 
+                        -- The new rule is:
+                        --
+                        -- Γ ⊢ e : Optional T
+                        -- Γ, x : T ⊢ x with ks… = v : T₁
+                        -- T ≡ T₁
+                        -- ────────────────────────────────── x ∉ FV(v)
+                        -- Γ ⊢ e with ?.ks… = v : Optional T
+                        --
+                        -- Here T is _O' and T₁ is tV'.
+
+                        -- (Some x) with ? = v is valid iff the type of x is the same as the type of v.
+                      WithQuestion :| [] -> do
                         tV' <- loop ctx v
+                        if Eval.conv values _O' tV'
+                          then return (VOptional _O')
+                          else die OptionalWithTypeMismatch
+
+                        -- (Some x) with ?.a.b = v is valid iff the type of x.a.b is the same as the type of v.
+                      WithQuestion :| k₁ : ks' -> do
+                        tV' <- with _O' (k₁ :| ks') v
                         if Eval.conv values _O' tV'
                           then return (VOptional _O')
                           else die OptionalWithTypeMismatch


### PR DESCRIPTION
The corrected typechecking rules should be as follows:

```
Γ ⊢ e : Optional T₀
Γ ⊢ v : T₁
T₀ ≡ T₁
──────────────────────────────────
Γ ⊢ e with ? = v : Optional T₀


Γ ⊢ e : Optional T₀
Γ, x : T₀ ⊢ x with k.ks… = v : T₁
T₀ ≡ T₁
────────────────────────────────── x ∉ FV(v)
Γ ⊢ e with ?.k.ks… = v : Optional T₀
```

Two rules are necessary because we need to process `e with ? = v` and `e with ?.x = v` in different ways.

The types are now checked correctly:

```dhall
⊢ (Some { a = 1 }) with ? = { a = 2 }

Some { a = 2 }

⊢ (Some { a = 1 }) with ?.a = { a = 2 }

Error: ❰with❱ cannot change the type of an ❰Optional❱ value

1│ (Some { a = 1 }) with ?.a = { a = 2 }

(input):1:1
⊢ (Some { a = 1 }) with ?.a = 2

Some { a = 2 }

⊢ (Some { a = 1 }) with ?.x.y = { a = 2 }

Error: ❰with❱ cannot change the type of an ❰Optional❱ value

1│ (Some { a = 1 }) with ?.x.y = { a = 2 }

(input):1:1
⊢ (Some { x = { y = 1 } }) with ?.x.y = 2

Some { x.y = 2 }

⊢ (Some { x = { y = 1 } }) with ?.x.y = "b"

Error: ❰with❱ cannot change the type of an ❰Optional❱ value

```

Could someone please help me with adding unit tests and with adding standard regression tests to dhall-lang/dhall-lang as well?