### PR TITLE
`to-directory-tree`: Create parents of files when using fixpoint directory tree representation

### DIFF
--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -296,10 +296,16 @@ processFilesystemEntry allowSeparators path (DirectoryEntry entry) =
     processEntryWith path entry $ \path' content -> do
         Directory.createDirectoryIfMissing allowSeparators path'
         processFilesystemEntryList allowSeparators path' content
-processFilesystemEntry _ path (BinaryFileEntry entry) =
-    processEntryWith path entry ByteString.writeFile
-processFilesystemEntry _ path (TextFileEntry entry) =
-    processEntryWith path entry  Text.IO.writeFile
+processFilesystemEntry allowSeparators path (BinaryFileEntry entry) =
+    processEntryWith path entry $ \path' content -> do
+        when allowSeparators $ do
+            Directory.createDirectoryIfMissing True (FilePath.takeDirectory path')
+        ByteString.writeFile path' content
+processFilesystemEntry allowSeparators path (TextFileEntry entry) =
+    processEntryWith path entry $ \path' content -> do
+        when allowSeparators $ do
+            Directory.createDirectoryIfMissing True (FilePath.takeDirectory path')
+        Text.IO.writeFile path' content
 
 -- | A helper function used by 'processFilesystemEntry'.
 processEntryWith

--- a/dhall/tests/Dhall/Test/DirectoryTree.hs
+++ b/dhall/tests/Dhall/Test/DirectoryTree.hs
@@ -13,6 +13,7 @@ import System.FilePath        ((</>))
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import qualified Data.List
 import qualified Data.Text.IO
 import qualified Dhall
 import qualified Dhall.Core
@@ -55,7 +56,7 @@ fixpointedSimple = testCase "simple" $ do
     let outDir = "./tests/to-directory-tree/fixpoint-simple.out"
         path = "./tests/to-directory-tree/fixpoint-simple.dhall"
     entries <- runDirectoryTree False outDir path
-    entries @?=
+    entries @?= Data.List.sort
         [ Directory outDir
         , File $ outDir </> "file"
         , Directory $ outDir </> "directory"
@@ -66,7 +67,7 @@ fixpointedAllowPathSeparators = testCase "allow-path-separators" $ do
     let outDir = "./tests/to-directory-tree/fixpoint-allow-path-separators.out"
         path = "./tests/to-directory-tree/fixpoint-allow-path-separators.dhall"
     entries <- runDirectoryTree True outDir path
-    entries @?=
+    entries @?= Data.List.sort
         [ Directory outDir
         , Directory $ outDir </> "non-existent-1"
         , File $ outDir </> "non-existent-1" </> "file"
@@ -130,12 +131,12 @@ runDirectoryTree allowSeparators outDir path = do
 
     toDirectoryTree allowSeparators outDir $ Dhall.Core.denote expr
 
-    walkFsTree outDir
+    Data.List.sort <$> walkFsTree outDir
 
 data WalkEntry
     = Directory FilePath
     | File FilePath
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
 walkFsTree :: FilePath -> IO [WalkEntry]
 walkFsTree dir = do

--- a/dhall/tests/Dhall/Test/DirectoryTree.hs
+++ b/dhall/tests/Dhall/Test/DirectoryTree.hs
@@ -26,6 +26,7 @@ tests = testGroup "to-directory-tree"
         [ fixpointedType
         , fixpointedEmpty
         , fixpointedSimple
+        , fixpointedAllowPathSeparators
 #ifndef mingw32_HOST_OS
         , fixpointedPermissions
         , fixpointedUserGroup
@@ -58,6 +59,19 @@ fixpointedSimple = testCase "simple" $ do
         [ Directory outDir
         , File $ outDir </> "file"
         , Directory $ outDir </> "directory"
+        ]
+
+fixpointedAllowPathSeparators :: TestTree
+fixpointedAllowPathSeparators = testCase "allow-path-separators" $ do
+    let outDir = "./tests/to-directory-tree/fixpoint-allow-path-separators.out"
+        path = "./tests/to-directory-tree/fixpoint-allow-path-separators.dhall"
+    entries <- runDirectoryTree True outDir path
+    entries @?=
+        [ Directory outDir
+        , Directory $ outDir </> "non-existent-1"
+        , File $ outDir </> "non-existent-1" </> "file"
+        , Directory $ outDir </> "non-existent-2"
+        , Directory $ outDir </> "non-existent-2" </> "directory"
         ]
 
 {-

--- a/dhall/tests/to-directory-tree/fixpoint-allow-path-separators.dhall
+++ b/dhall/tests/to-directory-tree/fixpoint-allow-path-separators.dhall
@@ -1,0 +1,25 @@
+let User = (./fixpoint-helper.dhall).User
+
+let Group = (./fixpoint-helper.dhall).Group
+
+let Mode = (./fixpoint-helper.dhall).Mode
+
+let Make = (./fixpoint-helper.dhall).Make
+
+in  \(r : Type) ->
+    \(make : Make r) ->
+      [ make.file
+          { name = "non-existent-1/file"
+          , content = ""
+          , user = None User
+          , group = None Group
+          , mode = None Mode
+          }
+      , make.directory
+          { name = "non-existent-2/directory"
+          , content = [] : List r
+          , user = None User
+          , group = None Group
+          , mode = None Mode
+          }
+      ]


### PR DESCRIPTION
When one uses `dhall to-directory-tree --allow-path-separators` to create a file using the fixpoint representation of a filesystem tree, then that failed if a path with path separators was passed to the `file` or `binary-file` constructors and the parent directory of the file in question did not exist.

This PR fixes that by ensuring that the parent directory does exist.