### PR TITLE
Relax upper bounds

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -29,7 +29,7 @@ Library
     Build-Depends:
         base                      >= 4.11.0.0 && < 5   ,
         bytestring                               < 0.13,
-        containers                               < 0.8 ,
+        containers                               < 0.9 ,
         dhall                     >= 1.42.0   && < 1.43,
         neat-interpolation                       < 0.6 ,
         shell-escape                             < 0.3 ,

--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -48,7 +48,7 @@ Executable dhall-to-bash
         bytestring                                 ,
         dhall                                      ,
         dhall-bash                                 ,
-        optparse-applicative >= 0.14.0.0  && < 0.19,
+        optparse-applicative >= 0.14.0.0  && < 0.20,
         text
     GHC-Options: -Wall
     Default-Language: Haskell2010

--- a/dhall-csv/dhall-csv.cabal
+++ b/dhall-csv/dhall-csv.cabal
@@ -79,7 +79,7 @@ Library
         base                 >= 4.12.0.0  && < 5   ,
         bytestring                           < 0.13,
         cassava              >= 0.5.0.0   && < 0.6 ,
-        containers           >= 0.5.9     && < 0.8 ,
+        containers           >= 0.5.9     && < 0.9 ,
         either                                     ,
         exceptions           >= 0.8.3     && < 0.11,
         dhall                >= 1.39.0    && < 1.43,

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -68,7 +68,7 @@ Library
         base                 >= 4.11.0.0  && < 5   ,
         base16-bytestring    >= 1.0.0.0            ,
         bytestring                           < 0.13,
-        containers                                 ,
+        containers           >= 0.5.11.0  && < 0.9 ,
         cryptohash-sha256                          ,
         directory            >= 1.3.0.0   && < 1.4 ,
         dhall                >= 1.38.0    && < 1.43,

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -86,7 +86,7 @@ Library
         text                 >= 0.11.1.0  && < 2.2 ,
         transformers         >= 0.2.0.0   && < 0.7 ,
         mtl                  >= 2.2.1     && < 2.4 ,
-        optparse-applicative >= 0.14.0.0  && < 0.19
+        optparse-applicative >= 0.14.0.0  && < 0.20
     Exposed-Modules:
         Dhall.Docs
         Dhall.Docs.Core

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -47,7 +47,7 @@ Library
         exceptions                >= 0.8.3     && < 0.11,
         filepath                                  < 1.6 ,
         microlens                 >= 0.4.14.0  && < 0.5 ,
-        optparse-applicative      >= 0.14.0.0  && < 0.19,
+        optparse-applicative      >= 0.14.0.0  && < 0.20,
         prettyprinter             >= 1.7.0     && < 1.8 ,
         scientific                >= 0.3.0.0   && < 0.4 ,
         text                      >= 0.11.1.0  && < 2.2 ,

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -42,7 +42,7 @@ Library
         aeson-pretty              >= 0.8.0     && < 0.9 ,
         aeson-yaml                >= 1.1.0     && < 1.2 ,
         bytestring                                < 0.13,
-        containers                >= 0.5.9     && < 0.8 ,
+        containers                >= 0.5.9     && < 0.9 ,
         dhall                     >= 1.42.0    && < 1.43,
         exceptions                >= 0.8.3     && < 0.11,
         filepath                                  < 1.6 ,

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -48,7 +48,7 @@ library
     , bytestring           >= 0.10.8.2 && < 0.13
     , co-log-core          >= 0.3.1.0  && < 0.4
     , containers           >= 0.5.11.0 && < 0.9
-    , data-default         >= 0.7.1.1  && < 0.8
+    , data-default         >= 0.7.1.1  && < 0.9
     , directory            >= 1.2.2.0  && < 1.4
     , dhall                >= 1.38.0   && < 1.43
     , dhall-json           >= 1.4      && < 1.8

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -47,7 +47,7 @@ library
     , base                 >= 4.11     && < 5
     , bytestring           >= 0.10.8.2 && < 0.13
     , co-log-core          >= 0.3.1.0  && < 0.4
-    , containers           >= 0.5.11.0 && < 0.8
+    , containers           >= 0.5.11.0 && < 0.9
     , data-default         >= 0.7.1.1  && < 0.8
     , directory            >= 1.2.2.0  && < 1.4
     , dhall                >= 1.38.0   && < 1.43

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -93,7 +93,7 @@ Test-Suite doctest
         directory  >= 1.3.1.5 && < 1.4,
         filepath                 < 1.6,
         doctest    >= 0.7.0           ,
-        QuickCheck
+        QuickCheck >= 2.14    && < 2.17
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010
 

--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -79,7 +79,7 @@ executable dhall-lsp-server
   build-depends:
       base                 >= 4.11 && < 5
     , dhall-lsp-server
-    , optparse-applicative
+    , optparse-applicative >= 0.14.0.0  && < 0.20
   default-language: Haskell2010
   GHC-Options: -Wall -fwarn-incomplete-uni-patterns
 

--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -27,7 +27,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                      >= 4.11.0.0 && < 5   ,
-        containers                               < 0.8 ,
+        containers                               < 0.9 ,
         data-fix                                 < 0.4 ,
         dhall                     >= 1.42     && < 1.43,
         hnix                      >= 0.16     && < 0.18,

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -31,7 +31,7 @@ Executable dhall-to-nixpkgs
                      , megaparsec           >= 7.0.0    && < 10
                      , mmorph                              < 1.3
                      , neat-interpolation                  < 0.6
-                     , optparse-applicative >= 0.14.0.0 && < 0.19
+                     , optparse-applicative >= 0.14.0.0 && < 0.20
                      , prettyprinter        >= 1.7.0    && < 1.8
                      , text                 >= 0.11.1.0 && < 2.2
                      , transformers         >= 0.2.0.0  && < 0.7

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -78,7 +78,7 @@ Library
   Build-Depends:
     base                    >= 4.11.0.0  && < 5    ,
     aeson                   >= 1.0.0.0   && < 2.3  ,
-    containers              >= 0.5.8.0   && < 0.8  ,
+    containers              >= 0.5.8.0   && < 0.9  ,
     dhall                   >= 1.38.0    && < 1.43 ,
     prettyprinter           >= 1.7.0     && < 1.8  ,
     microlens               >= 0.4       && < 0.5  ,

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -45,7 +45,7 @@ Executable openapi-to-dhall
     filepath                >= 1.4       && < 1.6 ,
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     megaparsec              >= 7.0       && < 10  ,
-    optparse-applicative    >= 0.14.3.0  && < 0.19,
+    optparse-applicative    >= 0.14.3.0  && < 0.20,
     parser-combinators                            ,
     prettyprinter                                 ,
     sort                                          ,

--- a/dhall-toml/dhall-toml.cabal
+++ b/dhall-toml/dhall-toml.cabal
@@ -39,7 +39,7 @@ Library
         filepath                            < 1.6  ,
         tomland              >= 1.3.2.0  && < 1.4  ,
         text                 >= 0.11.1.0 && < 2.2  ,
-        containers           >= 0.5.9    && < 0.8  ,
+        containers           >= 0.5.9    && < 0.9  ,
         unordered-containers >= 0.2      && < 0.3  ,
         prettyprinter        >= 1.7.0    && < 1.8  ,
         optparse-applicative >= 0.14     && < 0.20

--- a/dhall-toml/dhall-toml.cabal
+++ b/dhall-toml/dhall-toml.cabal
@@ -42,7 +42,7 @@ Library
         containers           >= 0.5.9    && < 0.8  ,
         unordered-containers >= 0.2      && < 0.3  ,
         prettyprinter        >= 1.7.0    && < 1.8  ,
-        optparse-applicative >= 0.14     && < 0.19
+        optparse-applicative >= 0.14     && < 0.20
     Exposed-Modules:
         Dhall.DhallToToml
         Dhall.TomlToDhall

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -38,7 +38,7 @@ Library
         bytestring                                < 0.13,
         dhall                     >= 1.31.0    && < 1.43,
         dhall-json                >= 1.6.0     && < 1.8 ,
-        optparse-applicative      >= 0.14.0.0  && < 0.19,
+        optparse-applicative      >= 0.14.0.0  && < 0.20,
         text                      >= 0.11.1.0  && < 2.2 ,
         vector
     Exposed-Modules:

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -447,7 +447,7 @@ Test-Suite tasty
         generic-random            >= 1.3.0.0  && < 1.6 ,
         http-client                                    ,
         http-client-tls                                ,
-        QuickCheck                >= 2.14     && < 2.16,
+        QuickCheck                >= 2.14     && < 2.17,
         quickcheck-instances      >= 0.3.12   && < 0.4 ,
         special-values                           < 0.2 ,
         spoon                                    < 0.4 ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -236,7 +236,7 @@ Common common
         mmorph                                     < 1.3 ,
         mtl                         >= 2.2.1    && < 2.4 ,
         network-uri                 >= 2.6      && < 2.7 ,
-        optparse-applicative        >= 0.14.0.0 && < 0.19,
+        optparse-applicative        >= 0.14.0.0 && < 0.20,
         parsers                     >= 0.12.4   && < 0.13,
         parser-combinators                               ,
         prettyprinter               >= 1.7.0    && < 1.8 ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -215,7 +215,7 @@ Common common
         case-insensitive                           < 1.3 ,
         cborg                       >= 0.2.0.0  && < 0.3 ,
         cborg-json                  >= 0.2.2.0  && < 0.3 ,
-        containers                  >= 0.5.8.0  && < 0.8 ,
+        containers                  >= 0.5.8.0  && < 0.9 ,
         contravariant                              < 1.6 ,
         data-fix                                   < 0.4 ,
         deepseq                                    < 1.6 ,


### PR DESCRIPTION
Relaxes upper bounds for `containters`, `data-default`, `optparse-applicative`, and `QuickCheck`. Requires no code changes, so can be done with hackage revisions.

Thanks!