### PR TITLE
treewide: Raise upperbound on optparse-applicative

### DIFF
--- a/dhall-bash/dhall-bash.cabal
+++ b/dhall-bash/dhall-bash.cabal
@@ -48,7 +48,7 @@ Executable dhall-to-bash
         bytestring                                 ,
         dhall                                      ,
         dhall-bash                                 ,
-        optparse-applicative >= 0.14.0.0  && < 0.19,
+        optparse-applicative >= 0.14.0.0  && < 0.20,
         text
     GHC-Options: -Wall
     Default-Language: Haskell2010

--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -86,7 +86,7 @@ Library
         text                 >= 0.11.1.0  && < 2.2 ,
         transformers         >= 0.2.0.0   && < 0.7 ,
         mtl                  >= 2.2.1     && < 2.4 ,
-        optparse-applicative >= 0.14.0.0  && < 0.19
+        optparse-applicative >= 0.14.0.0  && < 0.20
     Exposed-Modules:
         Dhall.Docs
         Dhall.Docs.Core

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -47,7 +47,7 @@ Library
         exceptions                >= 0.8.3     && < 0.11,
         filepath                                  < 1.6 ,
         microlens                 >= 0.4.14.0  && < 0.5 ,
-        optparse-applicative      >= 0.14.0.0  && < 0.19,
+        optparse-applicative      >= 0.14.0.0  && < 0.20,
         prettyprinter             >= 1.7.0     && < 1.8 ,
         scientific                >= 0.3.0.0   && < 0.4 ,
         text                      >= 0.11.1.0  && < 2.2 ,

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -31,7 +31,7 @@ Executable dhall-to-nixpkgs
                      , megaparsec           >= 7.0.0    && < 10
                      , mmorph                              < 1.3
                      , neat-interpolation                  < 0.6
-                     , optparse-applicative >= 0.14.0.0 && < 0.19
+                     , optparse-applicative >= 0.14.0.0 && < 0.20
                      , prettyprinter        >= 1.7.0    && < 1.8
                      , text                 >= 0.11.1.0 && < 2.2
                      , transformers         >= 0.2.0.0  && < 0.7

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -45,7 +45,7 @@ Executable openapi-to-dhall
     filepath                >= 1.4       && < 1.6 ,
     -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
     megaparsec              >= 7.0       && < 10  ,
-    optparse-applicative    >= 0.14.3.0  && < 0.19,
+    optparse-applicative    >= 0.14.3.0  && < 0.20,
     parser-combinators                            ,
     prettyprinter                                 ,
     sort                                          ,

--- a/dhall-toml/dhall-toml.cabal
+++ b/dhall-toml/dhall-toml.cabal
@@ -42,7 +42,7 @@ Library
         containers           >= 0.5.9    && < 0.8  ,
         unordered-containers >= 0.2      && < 0.3  ,
         prettyprinter        >= 1.7.0    && < 1.8  ,
-        optparse-applicative >= 0.14     && < 0.19
+        optparse-applicative >= 0.14     && < 0.20
     Exposed-Modules:
         Dhall.DhallToToml
         Dhall.TomlToDhall

--- a/dhall-yaml/dhall-yaml.cabal
+++ b/dhall-yaml/dhall-yaml.cabal
@@ -38,7 +38,7 @@ Library
         bytestring                                < 0.13,
         dhall                     >= 1.31.0    && < 1.43,
         dhall-json                >= 1.6.0     && < 1.8 ,
-        optparse-applicative      >= 0.14.0.0  && < 0.19,
+        optparse-applicative      >= 0.14.0.0  && < 0.20,
         text                      >= 0.11.1.0  && < 2.2 ,
         vector
     Exposed-Modules:

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -236,7 +236,7 @@ Common common
         mmorph                                     < 1.3 ,
         mtl                         >= 2.2.1    && < 2.4 ,
         network-uri                 >= 2.6      && < 2.7 ,
-        optparse-applicative        >= 0.14.0.0 && < 0.19,
+        optparse-applicative        >= 0.14.0.0 && < 0.20,
         parsers                     >= 0.12.4   && < 0.13,
         parser-combinators                               ,
         prettyprinter               >= 1.7.0    && < 1.8 ,


### PR DESCRIPTION
`cabal build all --constraint 'optparse-applicative ^>=0.19.0.0' && cabal test all --constraint 'optparse-applicative ^>=0.19.0.0'` passes everything except doctests which I'm not set up for.

Can we please have a metadata revision or new releases soon?