### PR TITLE
Narrow mmark constraint

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -76,7 +76,7 @@ Library
         filepath             >= 1.4       && < 1.6 ,
         microlens            >= 0.4       && < 0.5 ,
         lucid                >= 2.9.12    && < 2.12,
-        mmark                >= 0.0.7.0   && < 0.8 ,
+        mmark                >= 0.0.7.0   && < 0.0.9 ,
         -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
         megaparsec           >= 7         && < 10  ,
         path                 >= 0.7.0     && < 0.10,


### PR DESCRIPTION
< 0.8 was probably a typo to exclude 0.0.8. By now, 0.0.8 has been released and works fine, so update to 0.0.9.