### PR TITLE
Allow `microlens-0.5`

### DIFF
--- a/dhall-docs/dhall-docs.cabal
+++ b/dhall-docs/dhall-docs.cabal
@@ -74,7 +74,7 @@ Library
         dhall                >= 1.38.0    && < 1.43,
         file-embed           >= 0.0.10.0           ,
         filepath             >= 1.4       && < 1.6 ,
-        microlens            >= 0.4       && < 0.5 ,
+        microlens            >= 0.4       && < 0.6 ,
         lucid                >= 2.9.12    && < 2.12,
         mmark                >= 0.0.7.0   && < 0.0.9 ,
         -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469

--- a/dhall-json/dhall-json.cabal
+++ b/dhall-json/dhall-json.cabal
@@ -46,7 +46,7 @@ Library
         dhall                     >= 1.42.0    && < 1.43,
         exceptions                >= 0.8.3     && < 0.11,
         filepath                                  < 1.6 ,
-        microlens                 >= 0.4.14.0  && < 0.5 ,
+        microlens                 >= 0.4.14.0  && < 0.6 ,
         optparse-applicative      >= 0.14.0.0  && < 0.20,
         prettyprinter             >= 1.7.0     && < 1.8 ,
         scientific                >= 0.3.0.0   && < 0.4 ,

--- a/dhall-nix/dhall-nix.cabal
+++ b/dhall-nix/dhall-nix.cabal
@@ -31,7 +31,7 @@ Library
         data-fix                                 < 0.4 ,
         dhall                     >= 1.42     && < 1.43,
         hnix                      >= 0.16     && < 0.18,
-        microlens                 >= 0.4      && < 0.5 ,
+        microlens                 >= 0.4      && < 0.6 ,
         neat-interpolation                       < 0.6 ,
         text                      >= 0.8.0.0  && < 2.2
     Exposed-Modules:

--- a/dhall-nixpkgs/dhall-nixpkgs.cabal
+++ b/dhall-nixpkgs/dhall-nixpkgs.cabal
@@ -25,7 +25,7 @@ Executable dhall-to-nixpkgs
                      , dhall                >= 1.42.0   && < 1.43
                      , foldl                               < 1.5
                      , hnix                 >= 0.10.1   && < 0.18
-                     , microlens            >= 0.4      && < 0.5
+                     , microlens            >= 0.4      && < 0.6
                      , microlens-mtl        >= 0.1      && < 0.3
                      -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
                      , megaparsec           >= 7.0.0    && < 10

--- a/dhall-openapi/dhall-openapi.cabal
+++ b/dhall-openapi/dhall-openapi.cabal
@@ -81,7 +81,7 @@ Library
     containers              >= 0.5.8.0   && < 0.9  ,
     dhall                   >= 1.38.0    && < 1.43 ,
     prettyprinter           >= 1.7.0     && < 1.8  ,
-    microlens               >= 0.4       && < 0.5  ,
+    microlens               >= 0.4       && < 0.6  ,
     scientific              >= 0.3.0.0   && < 0.4  ,
     sort                    >= 1.0       && < 1.1  ,
     text                    >= 0.11.1.0  && < 2.2  ,

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -229,7 +229,7 @@ Common common
         haskeline                   >= 0.7.2.1  && < 0.9 ,
         hashable                    >= 1.2      && < 1.6 ,
         indexed-traversable                        < 0.2 ,
-        microlens                   >= 0.4.14.0 && < 0.5 ,
+        microlens                   >= 0.4.14.0 && < 0.6 ,
         microlens-mtl               >= 0.1      && < 0.3 ,
         -- megaparsec follows SemVer: https://github.com/mrkkrp/megaparsec/issues/469#issuecomment-927918469
         megaparsec                  >= 8        && < 10  ,


### PR DESCRIPTION
Tested locally with
```shell
cabal build all --enable-benchmarks --enable-tests --with-compiler ghc-9.6 --constraint 'microlens==0.5.0.0'
cabal test all --enable-benchmarks --enable-tests --with-compiler ghc-9.6 --constraint 'microlens==0.5.0.0'
```

Fixes #2702 