### PR TITLE
Bump upper bounds of some dependencies

### DIFF
--- a/dhall-lsp-server/dhall-lsp-server.cabal
+++ b/dhall-lsp-server/dhall-lsp-server.cabal
@@ -93,7 +93,7 @@ Test-Suite doctest
         directory  >= 1.3.1.5 && < 1.4,
         filepath                 < 1.6,
         doctest    >= 0.7.0           ,
-        QuickCheck >= 2.14    && < 2.18
+        QuickCheck >= 2.14    && < 2.19
     Other-Extensions: OverloadedStrings RecordWildCards
     Default-Language: Haskell2010
 

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -292,7 +292,7 @@ Library
           http-client                 >= 0.5.0    && < 0.8
         if flag(use-http-client-tls)
           Build-Depends:
-            http-client-tls           >= 0.2.0    && < 0.4
+            http-client-tls           >= 0.2.0    && < 0.5
 
     Other-Extensions:
         BangPatterns
@@ -447,7 +447,7 @@ Test-Suite tasty
         generic-random            >= 1.3.0.0  && < 1.6 ,
         http-client                                    ,
         http-client-tls                                ,
-        QuickCheck                >= 2.14     && < 2.18,
+        QuickCheck                >= 2.14     && < 2.19,
         quickcheck-instances      >= 0.3.12   && < 0.5 ,
         special-values                           < 0.2 ,
         spoon                                    < 0.4 ,


### PR DESCRIPTION
  * Allow QuickCheck ^>=2.18
  * Allow https-client-tls ^>=0.4
 
Tested locally with
```
cabal build all --enable-benchmarks --enable-tests --with-compiler ghc-9.12 --constraint 'QuickCheck==2.18.0.0' --allow-newer aeson --constraint 'path +os-string'
cabal test all --enable-benchmarks --enable-tests --with-compiler ghc-9.12 --constraint 'QuickCheck==2.18.0.0' --allow-newer --constraint 'path +os-string'
```
and
```
cabal build all --enable-benchmarks --enable-tests --with-compiler ghc-9.12 --constraint 'http-client-tls==0.4.0'
cabal test all --enable-benchmarks --enable-tests --with-compiler ghc-9.12 --constraint 'http-client-tls==0.4.0'
```