### PR TITLE
Fix O(N²) parsing of large decimal Natural literals

### DIFF
--- a/dhall/benchmark/parser/Main.hs
+++ b/dhall/benchmark/parser/Main.hs
@@ -75,6 +75,10 @@ main = do
         , benchExprFromText "Large number of function arguments" (Text.replicate 10000 "x ")
         , benchExprFromText "Long double-quoted strings" ("\"" <> Text.replicate 1000000 "x" <> "\"")
         , benchExprFromText "Long single-quoted strings" ("''" <> Text.replicate 1000000 "x" <> "''")
+        -- A very large decimal literal triggers the big-integer path in naturalLiteral.
+        -- Before the divide-and-conquer fix this was O(N²); it should now be
+        -- O(N^1.585·log N) via GMP Karatsuba multiplication.
+        , benchExprFromText "Large natural number literal (1M digits)" (Text.replicate 1000000 "1")
         , benchExprFromText "Whitespace" (Text.replicate 1000000 " " <> "x")
         , benchExprFromText "Line comment" ("x -- " <> Text.replicate 1000000 " ")
         , benchExprFromText "Block comment" ("x {- " <> Text.replicate 1000000 " " <> "-}")

--- a/dhall/src/Dhall/Parser/Token.hs
+++ b/dhall/src/Dhall/Parser/Token.hs
@@ -141,7 +141,6 @@ import Text.Parser.Combinators (choice, try, (<?>))
 
 import qualified Control.Monad              as Monad
 import qualified Data.Char                  as Char
-import qualified Data.Foldable
 import qualified Data.HashSet
 import qualified Data.List                  as List
 import qualified Data.List.NonEmpty
@@ -308,23 +307,33 @@ naturalLiteral = (do
     binary = try (char '0' >> char 'b' >> Text.Megaparsec.Char.Lexer.binary)
     hexadecimal = try (char '0' >> char 'x' >> Text.Megaparsec.Char.Lexer.hexadecimal)
     decimal = do
-        n <- headDigit
-        ns <- many tailDigit
-        return (mkNum (n:ns))
+        -- Consume the first (non-zero) digit then any remaining decimal digits
+        h <- Text.Parser.Char.satisfy (\c -> '1' <= c && c <= '9') <?> "non-zero digit"
+        t <- Text.Megaparsec.takeWhileP Nothing (\c -> '0' <= c && c <= '9')
+        -- Use divide-and-conquer conversion to avoid O(N²) big-integer arithmetic.
+        -- A naïve left-fold `foldl' (\acc c -> acc * 10 + digit c) 0` costs O(k)
+        -- per step (big-integer multiply) at step k, totalling O(N²) for N digits.
+        -- The divide-and-conquer approach splits the digit string in two halves,
+        -- converts each recursively, then combines: hi * 10^lo_len + lo. This
+        -- uses fast exponentiation and reduces multiplications to O(log N) calls
+        -- on numbers of size O(N/2), O(N/4), …, giving O(M(N)·log N) total where
+        -- M(N) is the cost of one N-digit multiply (O(N^1.585) via Karatsuba in GMP).
+        return (fromDecimalText (Data.Text.cons h t))
       where
-        headDigit = decimalDigit nonZeroDigit <?> "non-zero digit"
-          where
-            nonZeroDigit c = '1' <= c && c <= '9'
+        fromDecimalText t = go (Data.Text.length t) t
 
-        tailDigit = decimalDigit digit <?> "digit"
-
-        decimalDigit predicate = do
-            c <- Text.Parser.Char.satisfy predicate
-            return (fromIntegral (Char.ord c - Char.ord '0'))
-
-        mkNum = Data.Foldable.foldl' step 0
-          where
-            step acc x = acc * 10 + x
+        go len t
+            | len <= 18 =
+                -- Short enough to fit in a 64-bit word; plain left-fold is fine.
+                Data.Text.foldl'
+                    (\acc c -> acc * 10 + fromIntegral (Char.ord c - Char.ord '0'))
+                    0
+                    t
+            | otherwise =
+                let lo_len = len `div` 2
+                    hi_len = len - lo_len
+                    (hi_t, lo_t) = Data.Text.splitAt hi_len t
+                in  go hi_len hi_t * (10 ^ lo_len) + go lo_len lo_t
 
 {-| Parse a 4-digit year
 

--- a/dhall/tests/Dhall/Test/Regression.hs
+++ b/dhall/tests/Dhall/Test/Regression.hs
@@ -15,6 +15,7 @@ import Test.Tasty             (TestTree)
 import Test.Tasty.HUnit       ((@?=))
 
 import qualified Control.Exception
+import qualified Data.Text
 import qualified Data.Text.IO
 import qualified Data.Text.Lazy.IO
 import qualified Dhall
@@ -57,6 +58,7 @@ tests =
         , typeChecking2
         , unnamedFields
         , trailingSpaceAfterStringLiterals
+        , largeNaturalLiteralParsing
         ]
 
 data Foo = Foo Integer Bool | Bar Bool Bool Bool | Baz Integer Integer
@@ -325,3 +327,17 @@ trailingSpaceAfterStringLiterals =
         -- (Yes, I did get this wrong at some point)
         _ <- Util.code "(''\nABC'' ++ \"DEF\" )"
         return () )
+
+largeNaturalLiteralParsing :: TestTree
+largeNaturalLiteralParsing =
+    Test.Tasty.HUnit.testCase "Large natural number literal parsing is not O(N²)" (do
+        -- A 100,000-digit decimal literal.  Before the divide-and-conquer fix
+        -- in naturalLiteral (Token.hs) this was O(N²) in big-integer arithmetic
+        -- and would have taken many seconds here.  We allow 10 seconds which is
+        -- generous even on slow machines; the fixed version runs in < 0.3 s.
+        let bigNum = Data.Text.replicate 100000 "1"
+        Just result <- System.Timeout.timeout 10000000
+            (Control.Exception.evaluate $! Dhall.Parser.exprFromText mempty bigNum)
+        case result of
+            Left err -> Test.Tasty.HUnit.assertFailure (show err)
+            Right _  -> return () )


### PR DESCRIPTION
I've encountered this issue upon attempts to load large resolved files, which led to Dhall getting stuck on the loading phase. I then fed the reproduction of the problem to an LLM. Following is what it has come up with. I have confirmed on my use case that the fix works.

---

The previous 'decimal' parser in 'naturalLiteral' (Token.hs) read digits one by one via 'many (satisfy digit)' and then converted with:

    foldl' (\acc x -> acc * 10 + x) 0 digits

For an N-digit number this performs N big-integer multiplications, where the k-th multiplication costs O(k) (Karatsuba grows with operand size), so the total is O(1+2+…+N) = O(N²).  For a 1.26 M-digit literal this caused 0.79 s of parse time per number; with 8+ such literals in a single file parsing alone took ~13 s out of the observed ~39 s total.

Fix
---
Replace the naive left-fold with a divide-and-conquer conversion:

1. Capture all digits in one shot using 'takeWhileP' (single O(N) scan).
2. Recursively split the digit string in half: convert the high half and the low half independently, then combine as hi_value * 10^lo_len + lo_value For strings ≤ 18 digits the plain left-fold is used (fits in 64-bit).

This reduces the work to O(M(N)·log N) where M(N) is the cost of one N-digit multiplication (O(N^1.585) via GMP Karatsuba), which is far better than O(N²).

Measurements (aarch64-osx, GHC 9.12.2):
  Single 1.26 M-digit literal:  0.79 s → 0.17 s   (4.6×)
  All 120 large literals:       13.2 s →  2.0 s   (6.6×)
  Full resolved.dhall (type):   ~39  s →  7.4 s   (5.3×)

Regression test and benchmark
------------------------------
* Added 'largeNaturalLiteralParsing' to Dhall.Test.Regression: parses a 100,000-digit literal and asserts completion within 10 seconds.
* Added 'Large natural number literal (1M digits)' to the parser benchmark so future regressions are visible in benchmark runs.