### PR TITLE
Fix a space leak by forcing the decoded expression to normal form

### DIFF
--- a/dhall/src/Dhall/Binary.hs
+++ b/dhall/src/Dhall/Binary.hs
@@ -25,6 +25,7 @@ import Codec.CBOR.Decoding  (Decoder, TokenType (..))
 import Codec.CBOR.Encoding  (Encoding)
 import Codec.Serialise      (Serialise (decode, encode))
 import Control.Applicative  (empty, (<|>))
+import Control.DeepSeq      (NFData, force)
 import Control.Exception    (Exception)
 import Data.ByteString.Lazy (ByteString)
 import Dhall.Syntax
@@ -1355,10 +1356,10 @@ encodeExpression = Serialise.serialise
 
 -- | Decode a Dhall expression from a CBOR `Codec.CBOR.Term.Term`
 decodeExpression
-    :: Serialise (Expr s a) => ByteString -> Either DecodingFailure (Expr s a)
+    :: (NFData s, NFData a, Serialise (Expr s a)) => ByteString -> Either DecodingFailure (Expr s a)
 decodeExpression bytes =
     case decodeWithoutVersion <|> decodeWithVersion of
-        Just expression -> Right expression
+        Just expression -> Right (force expression)
         Nothing         -> Left (CBORIsNotDhall bytes)
   where
     adapt (Right ("", x)) = Just x


### PR DESCRIPTION
# The bug

This fixes https://github.com/dhall-lang/dhall-lang/issues/1420. Details follow.

# Root Cause

The leak is in decodeExpression (Dhall.Binary.decodeExpression), specifically in how it returns the decoded expression.

decodeExpression uses decodeExpressionInternal, which recursively builds the Expr tree inside cborg's CPS Decoder monad. The Decoder monad sequences operations strictly, but the result values are constructed lazily. This means decodeExpressionInternal does not return a fully-evaluated expression tree; it returns a massive tree of thunks — unevaluated closures representing the decoded AST.

When loadWith later traverses this tree (via bindingExprs on Let bindings, or unsafeSubExpressions on other constructors), it forces these thunks one by one. Because the tree is lazy, the following happens:

The unevaluated thunk tree and the forced result coexist in memory during traversal. Each thunk retains references to the decoder's continuation closures and intermediate CBOR decoding state. For a large expression this laziness causes memory usage to balloon far beyond the size of the expression itself. The profiling showed decodeExpression as the hotspot because that's where the lazy thunk tree originates. The stack trace decodeExpression ← bindingExprs ← loadWith confirms that loadWith is the code path that forces the thunks, exposing the leak.

# The Fix

The fix is to force the decoded expression to normal form immediately, before returning it from decodeExpression. This evaluates all the thunks up front, so loadWith traverses a compact, fully-evaluated data structure instead of a lazy thunk tree.