### PR TITLE
Make the warning-reporting controllable

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -34,6 +34,7 @@ module Dhall
     , substitutions
     , normalizer
     , newManager
+    , reportWarning
     , defaultInputSettings
     , InputSettings
     , defaultEvaluateSettings
@@ -84,6 +85,7 @@ import qualified Dhall.Parser
 import qualified Dhall.Pretty.Internal
 import qualified Dhall.Substitution
 import qualified Dhall.TypeCheck
+import qualified Dhall.Util
 import qualified Lens.Micro                       as Lens
 
 import Dhall.Marshal.Decode
@@ -129,6 +131,7 @@ data EvaluateSettings = EvaluateSettings
   , _startingContext :: Dhall.Context.Context (Expr Src Void)
   , _normalizer      :: Maybe (Core.ReifiedNormalizer Void)
   , _newManager      :: IO Dhall.Import.Manager
+  , _reportWarning   :: Text -> IO ()
   }
 
 -- | Default evaluation settings: no extra entries in the initial
@@ -141,6 +144,7 @@ defaultEvaluateSettings = EvaluateSettings
   , _startingContext = Dhall.Context.empty
   , _normalizer      = Nothing
   , _newManager      = Dhall.Import.defaultNewManager
+  , _reportWarning   = Dhall.Util.printWarning
   }
 
 -- | Access the starting context used for evaluation and type-checking.
@@ -182,6 +186,14 @@ newManager
 newManager =
     evaluateSettings
         . lens _newManager (\s x -> s { _newManager = x })
+
+-- | Access the warning reporting action.
+reportWarning
+  :: (HasEvaluateSettings s)
+  => Lens' s (Text -> IO ())
+reportWarning =
+    evaluateSettings
+        . lens _reportWarning (\s x -> s { _reportWarning = x })
 
 -- | @since 1.16
 class HasEvaluateSettings s where
@@ -266,6 +278,7 @@ resolveAndStatusWithSettings settings expression = do
                Lens.set Dhall.Import.substitutions   _substitutions
             .  Lens.set Dhall.Import.normalizer      _normalizer
             .  Lens.set Dhall.Import.startingContext _startingContext
+            .  Lens.set Dhall.Import.reportWarning   _reportWarning
 
     let status = transform (Dhall.Import.emptyStatusWithManager _newManager _rootDirectory)
 

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -139,6 +139,7 @@ module Dhall.Import (
     , substitutions
     , normalizer
     , startingContext
+    , reportWarning
     , chainImport
     , dependencyToFile
     , ImportSemantics
@@ -172,7 +173,6 @@ import Data.Text                  (Text)
 import Data.Typeable              (Typeable)
 import Data.Void                  (Void, absurd)
 import Dhall.TypeCheck            (TypeError)
-import Dhall.Util                 (printWarning)
 
 import Dhall.Syntax
     ( Chunks (..)
@@ -191,6 +191,7 @@ import Dhall.Syntax
     )
 
 import System.FilePath ((</>))
+import System.IO (stderr)
 import Text.Megaparsec (SourcePos (SourcePos), mkPos)
 
 #ifdef WITH_HTTP
@@ -238,7 +239,6 @@ import qualified System.Directory                            as Directory
 import qualified System.Environment
 import qualified System.FilePath                             as FilePath
 import qualified System.Info
-import qualified System.IO
 import qualified Text.Megaparsec
 import qualified Text.Parser.Combinators
 import qualified Text.Parser.Token
@@ -546,7 +546,7 @@ loadImportWithSemanticCache
     mCached <-
         case _semanticCacheMode of
             UseSemanticCache ->
-                zoom cacheWarning (fetchFromSemanticCache semanticHash)
+                zoom cacheWarning (fetchFromSemanticCache _reportWarning semanticHash)
             IgnoreSemanticCache ->
                 pure Nothing
 
@@ -564,7 +564,7 @@ loadImportWithSemanticCache
 
                     return (ImportSemantics {..})
                 else do
-                    printWarning $
+                    liftIO $ _reportWarning $ Text.pack $
                         makeHashMismatchMessage semanticHash actualHash
                         <> "\n"
                         <> "The interpreter will attempt to fix the cached import\n"
@@ -574,6 +574,8 @@ loadImportWithSemanticCache
         Nothing -> fetch
     where
         fetch = do
+            Status{ _reportWarning } <- State.get
+
             ImportSemantics{ importSemantics } <- loadImportWithSemisemanticCache import_
 
             let bytes = encodeExpression (Core.alphaNormalize importSemantics)
@@ -584,7 +586,7 @@ loadImportWithSemanticCache
 
             if actualHash == expectedHash
                 then do
-                    zoom cacheWarning (writeToSemanticCache semanticHash bytes)
+                    zoom cacheWarning (writeToSemanticCache _reportWarning semanticHash bytes)
 
                 else do
                     Status{ _stack } <- State.get
@@ -598,10 +600,10 @@ loadImportWithSemanticCache
 -- Fetch encoded normal form from "semantic cache"
 fetchFromSemanticCache
     :: (MonadState CacheWarning m, MonadCatch m, MonadIO m)
-    => Dhall.Crypto.SHA256Digest
+    => (Text -> IO ()) -> Dhall.Crypto.SHA256Digest
     -> m (Maybe Data.ByteString.ByteString)
-fetchFromSemanticCache expectedHash = Maybe.runMaybeT $ do
-    cacheFile <- getCacheFile "dhall" expectedHash
+fetchFromSemanticCache report expectedHash = Maybe.runMaybeT $ do
+    cacheFile <- getCacheFile report "dhall" expectedHash
     True <- liftIO (Directory.doesFileExist cacheFile)
     liftIO (Data.ByteString.readFile cacheFile)
 
@@ -611,7 +613,7 @@ writeExpressionToSemanticCache :: Expr Void Void -> IO ()
 writeExpressionToSemanticCache expression =
     -- Defaulting to not displaying the warning is for backwards compatibility
     -- with the old behavior
-    State.evalStateT (writeToSemanticCache hash bytes) CacheWarned
+    State.evalStateT (writeToSemanticCache (\message -> Data.Text.IO.hPutStrLn stderr message) hash bytes) CacheWarned
   where
     bytes = encodeExpression expression
 
@@ -619,12 +621,12 @@ writeExpressionToSemanticCache expression =
 
 writeToSemanticCache
     :: (MonadState CacheWarning m, MonadCatch m, MonadIO m)
-    => Dhall.Crypto.SHA256Digest
+    => (Text -> IO ()) -> Dhall.Crypto.SHA256Digest
     -> Data.ByteString.ByteString
     -> m ()
-writeToSemanticCache hash bytes = do
+writeToSemanticCache report hash bytes = do
     _ <- Maybe.runMaybeT $ do
-        cacheFile <- getCacheFile "dhall" hash
+        cacheFile <- getCacheFile report "dhall" hash
         liftIO (AtomicWrite.Binary.atomicWriteFile cacheFile bytes)
     return ()
 
@@ -665,7 +667,7 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
     -- behind semi-semantic caching.
     let semisemanticHash = computeSemisemanticHash (Core.denote resolvedExpr)
 
-    mCached <- zoom cacheWarning (fetchFromSemisemanticCache semisemanticHash)
+    mCached <- zoom cacheWarning (fetchFromSemisemanticCache _reportWarning semisemanticHash)
 
     importSemantics <- case mCached of
         Just bytesStrict -> do
@@ -698,7 +700,7 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
 
                     let bytes = encodeExpression betaNormal
 
-                    zoom cacheWarning (writeToSemisemanticCache semisemanticHash bytes)
+                    zoom cacheWarning (writeToSemisemanticCache _reportWarning semisemanticHash bytes)
 
                     return betaNormal
 
@@ -754,21 +756,21 @@ computeSemisemanticHash resolvedExpr = hashExpression resolvedExpr
 -- Fetch encoded normal form from "semi-semantic cache"
 fetchFromSemisemanticCache
     :: (MonadState CacheWarning m, MonadCatch m, MonadIO m)
-    => Dhall.Crypto.SHA256Digest
+    => (Text -> IO ()) -> Dhall.Crypto.SHA256Digest
     -> m (Maybe Data.ByteString.ByteString)
-fetchFromSemisemanticCache semisemanticHash = Maybe.runMaybeT $ do
-    cacheFile <- getCacheFile "dhall-haskell" semisemanticHash
+fetchFromSemisemanticCache report semisemanticHash = Maybe.runMaybeT $ do
+    cacheFile <- getCacheFile report "dhall-haskell" semisemanticHash
     True <- liftIO (Directory.doesFileExist cacheFile)
     liftIO (Data.ByteString.readFile cacheFile)
 
 writeToSemisemanticCache
     :: (MonadState CacheWarning m, MonadCatch m, MonadIO m)
-    => Dhall.Crypto.SHA256Digest
+    => (Text -> IO ()) -> Dhall.Crypto.SHA256Digest
     -> Data.ByteString.ByteString
     -> m ()
-writeToSemisemanticCache semisemanticHash bytes = do
+writeToSemisemanticCache report semisemanticHash bytes = do
     _ <- Maybe.runMaybeT $ do
-        cacheFile <- getCacheFile "dhall-haskell" semisemanticHash
+        cacheFile <- getCacheFile report "dhall-haskell" semisemanticHash
         liftIO (AtomicWrite.Binary.atomicWriteFile cacheFile bytes)
     return ()
 
@@ -861,9 +863,9 @@ fetchRemoteBytes url = do
 
 getCacheFile
     :: (MonadCatch m, Alternative m, MonadState CacheWarning m, MonadIO m)
-    => FilePath -> Dhall.Crypto.SHA256Digest -> m FilePath
-getCacheFile cacheName hash = do
-    cacheDirectory <- getOrCreateCacheDirectory cacheName
+    => (Text -> IO ()) -> FilePath -> Dhall.Crypto.SHA256Digest -> m FilePath
+getCacheFile report cacheName hash = do
+    cacheDirectory <- getOrCreateCacheDirectory report cacheName
 
     let cacheFile = cacheDirectory </> ("1220" <> show hash)
 
@@ -871,13 +873,13 @@ getCacheFile cacheName hash = do
 
 getOrCreateCacheDirectory
     :: (MonadCatch m, Alternative m, MonadState CacheWarning m, MonadIO m)
-    => FilePath -> m FilePath
-getOrCreateCacheDirectory cacheName = do
+    => (Text -> IO ()) -> FilePath -> m FilePath
+getOrCreateCacheDirectory report cacheName = do
     let warn message = do
             cacheWarningStatus <- State.get
 
             case cacheWarningStatus of
-                CacheWarned    -> printWarning message
+                CacheWarned    -> liftIO (report (Text.pack message))
                 CacheNotWarned -> return ()
 
             State.put CacheWarned
@@ -978,7 +980,7 @@ getOrCreateCacheDirectory cacheName = do
 
                             setPermissions dir
 
-    cacheBaseDirectory <- getCacheBaseDirectory
+    cacheBaseDirectory <- getCacheBaseDirectory report
 
     let directory = cacheBaseDirectory </> cacheName
 
@@ -997,8 +999,8 @@ getOrCreateCacheDirectory cacheName = do
     return directory
 
 getCacheBaseDirectory
-    :: (MonadState CacheWarning m, Alternative m, MonadIO m) => m FilePath
-getCacheBaseDirectory = alternative₀ <|> alternative₁ <|> alternative₂
+    :: (MonadState CacheWarning m, Alternative m, MonadIO m) => (Text -> IO ()) -> m FilePath
+getCacheBaseDirectory report = alternative₀ <|> alternative₁ <|> alternative₂
   where
     alternative₀ = do
         maybeXDGCacheHome <-
@@ -1031,16 +1033,14 @@ getCacheBaseDirectory = alternative₀ <|> alternative₁ <|> alternative₂
         cacheWarningStatus <- State.get
 
         let message =
-                "\n"
-             <> "\ESC[1;33mWarning\ESC[0m: "
-             <> "Could not locate a cache base directory from the environment.\n"
+                "Could not locate a cache base directory from the environment.\n"
              <> "\n"
              <> "You can provide a cache base directory by pointing the $XDG_CACHE_HOME\n"
              <> "environment variable to a directory with read and write permissions.\n"
 
         case cacheWarningStatus of
             CacheNotWarned ->
-                liftIO (System.IO.hPutStrLn System.IO.stderr message)
+                liftIO (report message)
             CacheWarned ->
                 return ()
 

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -13,6 +13,7 @@ import Data.CaseInsensitive             (CI)
 import Data.Dynamic
 import Data.HashMap.Strict              (HashMap)
 import Data.List.NonEmpty               (NonEmpty)
+import Data.Text                        (Text)
 import Data.Void                        (Void)
 import Dhall.Context                    (Context)
 import Dhall.Core
@@ -30,10 +31,11 @@ import Prettyprinter                    (Pretty (..))
 import qualified Dhall.Import.Manager
 #endif
 
-import qualified Data.Text
+import qualified Data.Text.IO
 import qualified Dhall.Context
 import qualified Dhall.Map          as Map
 import qualified Dhall.Substitution
+import qualified Dhall.Util
 
 -- | A fully \"chained\" import, i.e. if it contains a relative path that path
 --   is relative to the current directory. If it is a remote import with headers
@@ -84,7 +86,7 @@ defaultNewManager =
 type HTTPHeader = (CI ByteString, ByteString)
 
 -- | A map of site origin -> HTTP headers
-type OriginHeaders = HashMap Data.Text.Text [HTTPHeader]
+type OriginHeaders = HashMap Text [HTTPHeader]
 
 {-| Used internally to track whether or not we've already warned the user about
     caching issues
@@ -114,7 +116,7 @@ data Status = Status
     -- ^ Load the origin headers from environment or configuration file.
     --   After loading once, further evaluations return the cached version.
 
-    , _remote :: URL -> StateT Status IO Data.Text.Text
+    , _remote :: URL -> StateT Status IO Text
     -- ^ The remote resolver, fetches the content at the given URL.
 
     , _remoteBytes :: URL -> StateT Status IO Data.ByteString.ByteString
@@ -131,6 +133,9 @@ data Status = Status
     , _cacheWarning :: CacheWarning
     -- ^ Records whether or not we already warned the user about issues with
     --   cache directory
+
+    , _reportWarning :: Text -> IO ()
+    -- ^ Action to report warnings with (defaults to writing to stderr)
     }
 
 -- | Initial `Status`, parameterised over the HTTP 'Manager',
@@ -139,7 +144,7 @@ data Status = Status
 emptyStatusWith
     :: IO Manager
     -> StateT Status IO OriginHeaders
-    -> (URL -> StateT Status IO Data.Text.Text)
+    -> (URL -> StateT Status IO Text)
     -> (URL -> StateT Status IO Data.ByteString.ByteString)
     -> Import
     -> Status
@@ -163,6 +168,8 @@ emptyStatusWith _newManager _loadOriginHeaders _remote _remoteBytes rootImport =
 
     _cacheWarning = CacheNotWarned
 
+    _reportWarning = Dhall.Util.printWarning
+
 -- | Lens from a `Status` to its `_stack` field
 stack :: Lens' Status (NonEmpty Chained)
 stack = lens _stack (\s x -> s { _stack = x })
@@ -176,7 +183,7 @@ cache :: Lens' Status (Map Chained ImportSemantics)
 cache = lens _cache (\s x -> s { _cache = x })
 
 -- | Lens from a `Status` to its `_remote` field
-remote :: Lens' Status (URL -> StateT Status IO Data.Text.Text)
+remote :: Lens' Status (URL -> StateT Status IO Text)
 remote = lens _remote (\s x -> s { _remote = x })
 
 -- | Lens from a `Status` to its `_remote` field
@@ -198,6 +205,10 @@ startingContext = lens _startingContext (\s x -> s { _startingContext = x })
 -- | Lens from a `Status` to its `_cacheWarning` field
 cacheWarning :: Lens' Status CacheWarning
 cacheWarning = lens _cacheWarning (\s x -> s { _cacheWarning = x })
+
+-- | Lens from a `Status` to its `_reportWarning` field
+reportWarning :: Lens' Status (Text -> IO ())
+reportWarning = lens _reportWarning (\s x -> s { _reportWarning = x })
 
 {-| This exception indicates that there was an internal error in Dhall's
     import-related logic

--- a/dhall/src/Dhall/Util.hs
+++ b/dhall/src/Dhall/Util.hs
@@ -118,7 +118,7 @@ _WARNING :: IsString string => string
 _WARNING = "\ESC[1;33mWarning\ESC[0m"
 
 -- | Output a warning message on stderr.
-printWarning :: (MonadIO m) => String -> m ()
+printWarning :: (MonadIO m) => Text -> m ()
 printWarning message = do
     let warning =
                 "\n"
@@ -126,7 +126,7 @@ printWarning message = do
             <> ": "
             <> message
 
-    liftIO $ IO.hPutStrLn IO.stderr warning
+    liftIO $ Data.Text.IO.hPutStrLn IO.stderr warning
 
 get
     :: (String -> Text -> Either ParseError a)

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -156,10 +156,13 @@ successTest prefix = do
         let status = Import.emptyStatus directoryString
 #endif
 
+        let status' =
+                status { Import._reportWarning = \_ -> return () }
+
         let load =
                 State.evalStateT
                     (Test.Util.loadWith actualExpr)
-                    status
+                    status'
 
         let usesCache = [ "hashFromCache"
                         , "unit/asLocation/Hash"


### PR DESCRIPTION
In my app that executes a Dhall code while also printing to `stderr` I've noticed garbled output like the following:

```
Warni
ng[1[;03m3:m WCaorunlidn gno[t0 mg:e tC oourl dc rneoatt eg etth eo rd ecfraeualtte  ctahceh ed edfiaruelctt ocrayc:h
e
 ↳d i/rUescetrosr/yr:u
n
n↳e r//U.scearcsh/er/udnhnaelrl/
.
cYaocuh ec/adnh aelnla
b
lYeo uc accahni negn abbyl ec rceaacthiinngg  ibty  icfr enaeteidnegd  iatn di fs enteteidnegd  raenadd ,s
ewtrtiitneg  arneda ds,e
awrrciht ep earnmdi ssseiaorncsh  opne rimti sosri opnrso voind iintg  oarn optrhoevri dciancgh ea nboatshee
rd icraecchteo rbya sbey
 dsiertetcitnogr yt hbey  $sXeDtGt_iCnAgC HtEh_eH O$MXED Ge_nCvAiCrHoEn_mHeOnMtE  veanrviiarbolnem.e
n
t
 variable.
```

My analysis led me to discovery that Dhall prints warnings directly to `stderr`, which results in competing writes to the same output stream leading to such garbling.

This PR replaces writes to `stderr` with a configurable action, which by default behaves the old way.