### PR TITLE
remove imports that cause warnings

### DIFF
--- a/dhall/src/Dhall/Import/Headers.hs
+++ b/dhall/src/Dhall/Import/Headers.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns        #-}
 
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
 module Dhall.Import.Headers
     ( normalizeHeaders
     , originHeadersTypeExpr

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -31,7 +31,6 @@ import Prettyprinter                    (Pretty (..))
 import qualified Dhall.Import.Manager
 #endif
 
-import qualified Data.Text.IO
 import qualified Dhall.Context
 import qualified Dhall.Map          as Map
 import qualified Dhall.Substitution

--- a/dhall/src/Dhall/Marshal/Decode.hs
+++ b/dhall/src/Dhall/Marshal/Decode.hs
@@ -20,6 +20,7 @@
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE ViewPatterns               #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 {-| Please read the "Dhall.Tutorial" module, which contains a tutorial explaining
     how to use the language, the compiler, and this library

--- a/dhall/src/Dhall/Parser/Combinators.hs
+++ b/dhall/src/Dhall/Parser/Combinators.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 {-| This module contains Dhall's parser combinators
 -}

--- a/dhall/src/Dhall/Parser/Expression.hs
+++ b/dhall/src/Dhall/Parser/Expression.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 -- | Parsing Dhall expressions.
 module Dhall.Parser.Expression where


### PR DESCRIPTION
- Remove some unneeded imports that cause warnings
- Set `{-# OPTIONS_GHC -Wno-unused-imports #-}` for some files where warnings are due to change in `liftA2`