### PR TITLE
Fix freeze not applying fields from settings

### DIFF
--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -52,6 +52,7 @@ module Dhall
     , parseWithSettings
     , resolveWithSettings
     , resolveAndStatusWithSettings
+    , emptyStatusWithSettings
     , typecheckWithSettings
     , checkWithSettings
     , expectWithSettings
@@ -272,21 +273,24 @@ resolveAndStatusWithSettings
 resolveAndStatusWithSettings settings expression = do
     let InputSettings{..} = settings
 
-    let EvaluateSettings{..} = _evaluateSettings
-
-    let transform =
-               Lens.set Dhall.Import.substitutions   _substitutions
-            .  Lens.set Dhall.Import.normalizer      _normalizer
-            .  Lens.set Dhall.Import.startingContext _startingContext
-            .  Lens.set Dhall.Import.reportWarning   _reportWarning
-
-    let status = transform (Dhall.Import.emptyStatusWithManager _newManager _rootDirectory)
+    let status = emptyStatusWithSettings _evaluateSettings _rootDirectory
 
     (resolved, status') <- State.runStateT (Dhall.Import.loadWith expression) status
 
     let substituted = Dhall.Substitution.substitute resolved (view substitutions settings)
 
     pure (substituted, status')
+
+-- | As 'emptyStatus' but applying 'EvaluateSettings'.
+emptyStatusWithSettings :: EvaluateSettings -> FilePath -> Status
+emptyStatusWithSettings EvaluateSettings{..} rootDir =
+        transform (Dhall.Import.emptyStatusWithManager _newManager rootDir)
+    where
+        transform =
+               Lens.set Dhall.Import.substitutions   _substitutions
+            .  Lens.set Dhall.Import.normalizer      _normalizer
+            .  Lens.set Dhall.Import.startingContext _startingContext
+            .  Lens.set Dhall.Import.reportWarning   _reportWarning
 
 -- | Normalize an expression, using the supplied `InputSettings`
 normalizeWithSettings :: InputSettings -> Expr Src Void -> Expr Src Void

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -191,7 +191,7 @@ freezeImportWithSettings settings directory import_ = do
                         }
                 }
 
-    let status = Dhall.Import.emptyStatusWithManager (view Dhall.newManager settings) directory
+    let status = Dhall.emptyStatusWithSettings settings directory
 
     expression <- State.evalStateT (Dhall.Import.loadWith (Embed unprotectedImport)) status
 
@@ -255,7 +255,7 @@ freezeWithSettings settings outputMode transitivity0 inputs scope intent chosenC
                 InputFile file ->
                     System.FilePath.takeDirectory file
 
-        let status = Dhall.Import.emptyStatusWithManager (view Dhall.newManager settings) directory
+        let status = Dhall.emptyStatusWithSettings settings directory
 
         (inputName, originalText, transitivity) <- case input of
             InputFile file -> do


### PR DESCRIPTION
Fixes #2768 

Side note: `emptyStatusWithSettings` cannot be moved to Dhall.Import because it would introduce a cyclic dependency. I am open for suggestions if this should be moved into a different module.