### PR TITLE
Fix `missing <hash> ? ./path.dhall` not filling semantic cache

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -419,6 +419,7 @@ Test-Suite tasty
     Hs-Source-Dirs: tests
     Main-Is: Dhall/Test/Main.hs
     Other-Modules:
+        Dhall.Test.CacheFill
         Dhall.Test.Dhall
         Dhall.Test.Diff
         Dhall.Test.DirectoryTree

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1246,7 +1246,25 @@ loadWith expr₀ = case expr₀ of
           | any isNotResolutionError es₀ =
               throwM exception₀
           | otherwise = do
-              loadWith b `catch` handler₁
+              result <- loadWith b `catch` handler₁
+
+              -- If the left side was a frozen missing import
+              -- and the right side succeeded
+              -- populate the semantic cache.
+              case Core.shallowDenote a of
+                Embed (Import (ImportHashed (Just h) _) _) -> do
+                    Status { _reportWarning } <- State.get
+
+                    let bytes = encodeExpression (Core.alphaNormalize (Core.denote result))
+
+                    let actualHash = Dhall.Crypto.sha256Hash bytes
+
+                    if actualHash == h
+                        then zoom cacheWarning (writeToSemanticCache _reportWarning h bytes)
+                        else return ()
+                _ -> return ()
+
+              return result
         where
           handler₁ exception₁@(SourcedException (Src _ end text₁) (MissingImports es₁))
               | any isNotResolutionError es₁ =

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1249,21 +1249,26 @@ loadWith expr₀ = case expr₀ of
               -- If the left side was a frozen missing import
               -- and the right side succeeded
               -- populate the semantic cache.
-              case Core.shallowDenote a of
-                Embed (Import (ImportHashed (Just h) Missing) _) -> do
+              case findMissingImportHash a of
+                Just hash -> do
                     Status { _reportWarning } <- State.get
 
                     let bytes = encodeExpression (Core.alphaNormalize (Core.denote result))
 
                     let actualHash = Dhall.Crypto.sha256Hash bytes
 
-                    if actualHash == h
-                        then zoom cacheWarning (writeToSemanticCache _reportWarning h bytes)
+                    if actualHash == hash
+                        then zoom cacheWarning (writeToSemanticCache _reportWarning hash bytes)
                         else return ()
-                _ -> return ()
+                Nothing -> return ()
 
               return result
         where
+          findMissingImportHash expr = case Core.shallowDenote expr of
+            Embed (Import (ImportHashed (Just hash) Missing) _) -> Just hash
+            ImportAlt left _ -> findMissingImportHash left
+            _ -> Nothing
+
           handler₁ exception₁@(SourcedException (Src _ end text₁) (MissingImports es₁))
               | any isNotResolutionError es₁ =
                   throwM exception₁

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1252,7 +1252,7 @@ loadWith expr₀ = case expr₀ of
               -- and the right side succeeded
               -- populate the semantic cache.
               case Core.shallowDenote a of
-                Embed (Import (ImportHashed (Just h) _) _) -> do
+                Embed (Import (ImportHashed (Just h) Missing) _) -> do
                     Status { _reportWarning } <- State.get
 
                     let bytes = encodeExpression (Core.alphaNormalize (Core.denote result))

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1213,8 +1213,6 @@ loadWith expr₀ = case expr₀ of
         then return ()
         else throwMissingImport (Imported _stack (ReferentiallyOpaque import₀))
 
-    let _stack' = NonEmpty.cons child _stack
-
     if child `elem` _stack
         then throwMissingImport (Imported _stack (Cycle import₀))
         else return ()

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1246,10 +1246,10 @@ loadWith expr₀ = case expr₀ of
           | otherwise = do
               result <- loadWith b `catch` handler₁
 
-              -- If the left side was a frozen missing import
+              -- If the left side was a frozen import
               -- and the right side succeeded
               -- populate the semantic cache.
-              case findMissingImportHash a of
+              case findImportHash a of
                 Just hash -> do
                     Status { _reportWarning } <- State.get
 
@@ -1264,9 +1264,9 @@ loadWith expr₀ = case expr₀ of
 
               return result
         where
-          findMissingImportHash expr = case Core.shallowDenote expr of
-            Embed (Import (ImportHashed (Just hash) Missing) _) -> Just hash
-            ImportAlt left _ -> findMissingImportHash left
+          findImportHash expr = case Core.shallowDenote expr of
+            Embed (Import (ImportHashed (Just hash) _) _) -> Just hash
+            ImportAlt left right -> findImportHash left <|> findImportHash right
             _ -> Nothing
 
           handler₁ exception₁@(SourcedException (Src _ end text₁) (MissingImports es₁))

--- a/dhall/tests/Dhall/Test/CacheFill.hs
+++ b/dhall/tests/Dhall/Test/CacheFill.hs
@@ -13,6 +13,7 @@ import qualified Dhall.Core             as Core
 import qualified Dhall.Import           as Import
 import qualified System.Directory       as Directory
 import qualified System.Environment     as Environment
+import qualified System.FilePath.Posix  as FilePath.Posix
 import qualified System.IO.Temp         as Temp
 import qualified Data.Text              as Text
 
@@ -32,7 +33,9 @@ cacheFillTest = Temp.withSystemTempDirectory "dhall-cache" $ \cacheDir -> do
 
     tempFile <- Temp.writeTempFile "." "tmp.dhall" (Text.unpack simpleValue)
 
-    let importPath = "./" <> Text.pack tempFile
+    -- normalise will ensure that the path uses slashes,
+    -- but will strip the leading ./ so we have to add it
+    let importPath = "./" <> Text.pack (FilePath.Posix.normalise tempFile)
 
     let alwaysFailing = "missing"
 

--- a/dhall/tests/Dhall/Test/CacheFill.hs
+++ b/dhall/tests/Dhall/Test/CacheFill.hs
@@ -13,7 +13,6 @@ import qualified Dhall.Core             as Core
 import qualified Dhall.Import           as Import
 import qualified System.Directory       as Directory
 import qualified System.Environment     as Environment
-import qualified System.FilePath.Posix  as FilePath.Posix
 import qualified System.IO.Temp         as Temp
 import qualified Data.Text              as Text
 
@@ -33,9 +32,7 @@ cacheFillTest = Temp.withSystemTempDirectory "dhall-cache" $ \cacheDir -> do
 
     tempFile <- Temp.writeTempFile "." "tmp.dhall" (Text.unpack simpleValue)
 
-    -- normalise will ensure that the path uses slashes,
-    -- but will strip the leading ./ so we have to add it
-    let importPath = "./" <> Text.pack (FilePath.Posix.normalise tempFile)
+    let importPath = Text.replace "\\" "/" (Text.pack tempFile)
 
     let alwaysFailing = "missing"
 

--- a/dhall/tests/Dhall/Test/CacheFill.hs
+++ b/dhall/tests/Dhall/Test/CacheFill.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Dhall.Test.CacheFill where
+
+import Data.Foldable                    (traverse_)
+import Control.Monad                    (void, when)
+import System.FilePath                  ((</>))
+import Test.Tasty                       (TestTree)
+import Test.Tasty.HUnit                 (assertBool, testCase)
+
+import qualified Dhall
+import qualified Dhall.Core             as Core
+import qualified Dhall.Import           as Import
+import qualified System.Directory       as Directory
+import qualified System.Environment     as Environment
+import qualified System.IO.Temp         as Temp
+import qualified Data.Text              as Text
+
+cacheFillTest :: IO ()
+cacheFillTest = Temp.withSystemTempDirectory "dhall-cache" $ \cacheDir -> do
+    Environment.setEnv "XDG_CACHE_HOME" cacheDir
+
+    let simpleValue = "True"
+
+    expr <- Dhall.inputExpr simpleValue
+
+    let expectedHash = Import.hashExpression (Core.denote expr)
+
+    let semanticCacheDir = cacheDir </> "dhall"
+
+    let cacheFile = semanticCacheDir </> "1220" <> show expectedHash
+
+    tempFile <- Temp.writeTempFile "." "tmp.dhall" (Text.unpack simpleValue)
+
+    let importPath = "./" <> Text.pack tempFile
+
+    let alwaysFailing = "missing"
+
+    let missingWithHash = "missing " <> Import.hashExpressionToCode (Core.denote expr)
+
+    let cases =
+            [ "(" <> missingWithHash <> " ? " <> alwaysFailing <> ") ? " <> importPath
+            , missingWithHash <> " ? (" <> alwaysFailing <> " ? " <> importPath <> ")"
+            , "(" <> alwaysFailing <> " ? " <> missingWithHash <> ") ? " <> importPath
+            , alwaysFailing <> " ? (" <> missingWithHash <> " ? " <> importPath <> ")"
+            ]
+
+    traverse_ (\exprText -> do
+        clearCache semanticCacheDir
+
+        void (Dhall.inputExpr exprText)
+
+        cached <- Directory.doesFileExist cacheFile
+
+        assertBool ("The semantic cache entry for " <> Text.unpack exprText <> " was not written") cached)
+            cases
+
+    Directory.removeFile tempFile
+
+clearCache :: FilePath -> IO ()
+clearCache cacheDir = do
+    exists <- Directory.doesDirectoryExist cacheDir
+    when exists (Directory.removeDirectoryRecursive cacheDir)
+
+getTests :: IO TestTree
+getTests = return (testCase "Cache write for fallbacks" cacheFillTest)

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -4,6 +4,7 @@ module Main where
 import System.FilePath ((</>))
 import Test.Tasty      (TestTree)
 
+import qualified Dhall.Test.CacheFill
 import qualified Dhall.Test.Dhall
 import qualified Dhall.Test.Diff
 import qualified Dhall.Test.DirectoryTree
@@ -43,6 +44,8 @@ getAllTests = do
 
     importingTests <- Dhall.Test.Import.getTests
 
+    cacheFillTests <- Dhall.Test.CacheFill.getTests
+
     lintTests <- Dhall.Test.Lint.getTests
 
     tagsTests <- Dhall.Test.Tags.getTests
@@ -60,6 +63,7 @@ getAllTests = do
                 [ normalizationTests
                 , parsingTests
                 , importingTests
+                , cacheFillTests
                 , typeinferenceTests
                 , formattingTests
                 , lintTests


### PR DESCRIPTION
Addresses #2780

I realized that when running a simple file like the following on a cold cache:
```
let Prelude = ../../dhall/dhall-lang/Prelude/package.dhall
in Prelude.List.map Natural Text (\(x : Natural) -> Natural/show x) [1, 2, 3]
```
that the semantic cache ( ~/.cache/dhall ) was empty.
This meant that re-running the file was barely being sped up.

The old behavior can be simulated by cleaning ~/.cache/dhall after warming the cache.