### PR TITLE
make import tests complete by setting HOME env variable

### DIFF
--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -468,14 +468,17 @@ makeHashMismatchMessage expectedHash actualHash =
 -- | Construct the file path corresponding to a local import. If the import is
 --   _relative_ then the resulting path is also relative.
 localToPath :: MonadIO io => FilePrefix -> File -> io FilePath
-localToPath prefix file_ = liftIO $ do
+localToPath = localToPathWith Directory.getHomeDirectory
+
+localToPathWith :: MonadIO io => IO FilePath -> FilePrefix -> File -> io FilePath
+localToPathWith getHomeDirectory prefix file_ = liftIO $ do
     let File {..} = file_
 
     let Directory {..} = directory
 
     prefixPath <- case prefix of
         Home ->
-            Directory.getHomeDirectory
+            getHomeDirectory
 
         Absolute ->
             return "/"
@@ -640,7 +643,7 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
 
     path <- case importType of
         Local prefix file -> liftIO $ do
-            path <- localToPath prefix file
+            path <- localToPathWith _getHomeDirectory prefix file
             absolutePath <- Directory.makeAbsolute path
             return absolutePath
         Remote url -> do
@@ -777,8 +780,8 @@ writeToSemisemanticCache report semisemanticHash bytes = do
 -- | Fetch source code directly from disk/network
 fetchFresh :: ImportType -> StateT Status IO Text
 fetchFresh (Local prefix file) = do
-    Status { _stack } <- State.get
-    path <- liftIO $ localToPath prefix file
+    Status { _stack, _getHomeDirectory } <- State.get
+    path <- liftIO $ localToPathWith _getHomeDirectory prefix file
     exists <- liftIO $ Directory.doesFileExist path
     if exists
         then liftIO $ Data.Text.IO.readFile path
@@ -802,8 +805,8 @@ fetchFresh Missing = throwM (MissingImports [])
 -- | Like `fetchFresh`, except for `Dhall.Syntax.Expr.Bytes`
 fetchBytes :: ImportType -> StateT Status IO ByteString
 fetchBytes (Local prefix file) = do
-    Status { _stack } <- State.get
-    path <- liftIO $ localToPath prefix file
+    Status { _stack, _getHomeDirectory } <- State.get
+    path <- liftIO $ localToPathWith _getHomeDirectory prefix file
     exists <- liftIO $ Directory.doesFileExist path
     if exists
         then liftIO $ Data.ByteString.readFile path
@@ -1376,8 +1379,10 @@ dependencyToFile status import_ = flip State.evalStateT status $ do
         Code ->
             case importType (importHashed child) of
                 Local filePrefix file -> do
+                    let Status{ _getHomeDirectory } = status
+
                     let descend = liftIO $ do
-                            path <- localToPath filePrefix file
+                            path <- localToPathWith _getHomeDirectory filePrefix file
 
                             return (Just path)
 

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -35,6 +35,7 @@ import qualified Dhall.Context
 import qualified Dhall.Map          as Map
 import qualified Dhall.Substitution
 import qualified Dhall.Util
+import qualified System.Directory   as Directory
 
 -- | A fully \"chained\" import, i.e. if it contains a relative path that path
 --   is relative to the current directory. If it is a remote import with headers
@@ -135,6 +136,9 @@ data Status = Status
 
     , _reportWarning :: Text -> IO ()
     -- ^ Action to report warnings with (defaults to writing to stderr)
+
+    , _getHomeDirectory :: IO FilePath
+    -- ^ Action to get the home directory for resolving @~@ imports (special case for Windows tests)
     }
 
 -- | Initial `Status`, parameterised over the HTTP 'Manager',
@@ -168,6 +172,8 @@ emptyStatusWith _newManager _loadOriginHeaders _remote _remoteBytes rootImport =
     _cacheWarning = CacheNotWarned
 
     _reportWarning = Dhall.Util.printWarning
+
+    _getHomeDirectory = Directory.getHomeDirectory
 
 -- | Lens from a `Status` to its `_stack` field
 stack :: Lens' Status (NonEmpty Chained)

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -21,6 +21,7 @@ import qualified Dhall.Core                       as Core
 import qualified Dhall.Import                     as Import
 import qualified Dhall.Parser                     as Parser
 import qualified Dhall.Test.Util                  as Test.Util
+import qualified System.Directory                 as Directory
 import qualified System.FilePath                  as FilePath
 import qualified System.IO.Temp                   as Temp
 import qualified Test.Tasty                       as Tasty
@@ -42,7 +43,7 @@ importDirectory = "./dhall-lang/tests/import"
 
 getTests :: IO TestTree
 getTests = do
-    successTests <- Test.Util.discover (Turtle.chars <* "A.dhall") successTest (do
+    successTests <- Test.Util.discover (Turtle.chars <* "A.dhall") successTest $ (do
         path <- Turtle.lstree (importDirectory </> "success")
 
         return path )
@@ -79,18 +80,7 @@ successTest prefix = do
 
     let directoryString = FilePath.takeDirectory inputPath
 
-    let expectedFailures =
-            [
-              -- Importing relative to the home directory works, but I'm too
-              -- lazy to mock the home directory for testing purposes
-              importDirectory </> "success/unit/ImportRelativeToHome"
-#if !(defined(WITH_HTTP) && defined(NETWORK_TESTS))
-            , importDirectory </> "success/originHeadersImportFromEnv"
-            , importDirectory </> "success/originHeadersImport"
-            , importDirectory </> "success/originHeadersOverride"
-            , importDirectory </> "success/unit/asLocation/RemoteChainEnv"
-#endif
-            ]
+    let expectedFailures = []
 
     Test.Util.testCase prefix expectedFailures (do
 
@@ -102,11 +92,14 @@ successTest prefix = do
 
         expectedExpr <- Core.throws (Parser.exprFromText mempty expectedText)
 
+        homeDirectory <- Directory.makeAbsolute (importDirectory </> "home")
+
         let originalCache = "dhall-lang/tests/import/cache"
 
 #if defined(WITH_HTTP) && defined(NETWORK_TESTS)
         let testTlsSettings =
 #if __GLASGOW_HASKELL__ >= 906
+-- note: MIN_VERSION_crypton_connection is defined only if we are building with GHC 9.6 and later
 #if MIN_VERSION_crypton_connection(0,4,0)
                 let defaultSupported :: Supported
                     defaultSupported = def
@@ -146,7 +139,10 @@ successTest prefix = do
 #endif
 
         let status' =
-                status { Import._reportWarning = \_ -> return () }
+                status
+                    { Import._reportWarning = \_ -> return ()
+                    , Import._getHomeDirectory = pure homeDirectory
+                    }
 
         let load =
                 State.evalStateT
@@ -218,10 +214,16 @@ failureTest prefix = do
         actualExpr <- do
           Core.throws (Parser.exprFromText mempty (Test.Util.toDhallPath path))
 
+        homeDirectory <- Directory.makeAbsolute (importDirectory </> "home")
+
+        let status =
+                (Import.emptyStatus ".")
+                    { Import._getHomeDirectory = pure homeDirectory }
+
         let setup = Test.Util.managedTestEnvironment prefix
 
         let run = Exception.catch @SomeException
-              (Test.Util.load actualExpr >> return True)
+              (State.evalStateT (Test.Util.loadWith actualExpr) status >> return True)
               (\_ -> return False)
 
         succeeded <- Turtle.with setup (const run)

--- a/dhall/tests/Dhall/Test/Import.hs
+++ b/dhall/tests/Dhall/Test/Import.hs
@@ -43,7 +43,7 @@ importDirectory = "./dhall-lang/tests/import"
 
 getTests :: IO TestTree
 getTests = do
-    successTests <- Test.Util.discover (Turtle.chars <* "A.dhall") successTest $ (do
+    successTests <- Test.Util.discover (Turtle.chars <* "A.dhall") successTest (do
         path <- Turtle.lstree (importDirectory </> "success")
 
         return path )

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -28,7 +28,6 @@ import qualified Dhall.Test.Server
 import qualified GHC.IO.Encoding
 import qualified System.Directory
 import qualified System.Environment
-import qualified System.Info
 import qualified System.IO
 import qualified Test.Tasty
 
@@ -88,38 +87,13 @@ main = do
 
     pwd <- System.Directory.getCurrentDirectory
 
-    let isWindows = System.Info.os == "mingw32"
-
-    if isWindows
-        then do
-            maybeLocalAppData <- System.Environment.lookupEnv "LOCALAPPDATA"
-            case maybeLocalAppData of
-                Just localAppData -> System.Environment.setEnv "XDG_CACHE_HOME" localAppData
-                Nothing           -> return ()
-        else
-            System.Environment.setEnv "XDG_CACHE_HOME" (pwd </> ".cache")
+    System.Environment.setEnv "XDG_CACHE_HOME" (pwd </> ".cache")
 
     System.Environment.setEnv "DHALL_TEST_VAR" "6 * 7"
 
     -- Make test failures easier to find by eliding the successes.
     -- https://github.com/feuerbach/tasty/issues/273#issuecomment-657054281
     System.Environment.setEnv "TASTY_HIDE_SUCCESSES" "true"
-
-    let certDirCandidates =
-            [ pwd </> ".." </> "dhall-test-server" </> "cert"
-            , pwd </> "dhall-test-server" </> "cert"
-            ]
-
-    certDirs <- traverse System.Directory.doesDirectoryExist certDirCandidates
-
-    let certDir =
-            case [ path | (path, True) <- zip certDirCandidates certDirs ] of
-                path : _ -> path
-                _        -> head certDirCandidates
-
-    -- The Haskell x509 unix backend reads this path to locate trusted roots
-    -- for TLS verification in tests.
-    System.Environment.setEnv "SYSTEM_CERTIFICATE_PATH" certDir
 
     Dhall.Test.Server.withServers $ do
         allTests <- getAllTests

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -28,6 +28,7 @@ import qualified Dhall.Test.Server
 import qualified GHC.IO.Encoding
 import qualified System.Directory
 import qualified System.Environment
+import qualified System.Info
 import qualified System.IO
 import qualified Test.Tasty
 
@@ -87,7 +88,16 @@ main = do
 
     pwd <- System.Directory.getCurrentDirectory
 
-    System.Environment.setEnv "XDG_CACHE_HOME" (pwd </> ".cache")
+    let isWindows = System.Info.os == "mingw32"
+
+    if isWindows
+        then do
+            maybeLocalAppData <- System.Environment.lookupEnv "LOCALAPPDATA"
+            case maybeLocalAppData of
+                Just localAppData -> System.Environment.setEnv "XDG_CACHE_HOME" localAppData
+                Nothing           -> return ()
+        else
+            System.Environment.setEnv "XDG_CACHE_HOME" (pwd </> ".cache")
 
     System.Environment.setEnv "DHALL_TEST_VAR" "6 * 7"
 


### PR DESCRIPTION
This PR completes the import tests for the Haskell implementation by mocking the home directory as required by the Dhall standard tests. (Previously those tests were skipped.)