### PR TITLE
Fix: Add threaded option for cabal test

### DIFF
--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -444,7 +444,7 @@ Test-Suite tasty
         Other-Modules:
             Dhall.Test.TH
     Build-Depends:
-        dhall-test-server                               ,
+        dhall-test-server                              ,
         dhall                                          ,
         data-default                                   ,
         foldl                                    < 1.5 ,
@@ -467,6 +467,7 @@ Test-Suite tasty
            build-depends: crypton-connection
     else
            build-depends: connection
+    GHC-Options: -threaded
     Default-Language: Haskell2010
 
 Test-Suite doctest


### PR DESCRIPTION
Running `cabal test` had the tests requiring a local server fail, because the test server required the threaded option. This PR adds it to the cabal file.