### PR TITLE
Map-based substitution

### DIFF
--- a/dhall/src/Dhall/Substitution.hs
+++ b/dhall/src/Dhall/Substitution.hs
@@ -4,12 +4,14 @@
 
 module Dhall.Substitution where
 
-import Data.List       (foldl')
 import Data.Text       (Text)
-import Dhall.Normalize (subst)
-import Dhall.Syntax    (Expr, Var (..))
+import Dhall.Syntax    (Binding (..), Expr (..), FunctionBinding (..), Var (..))
 
+import qualified Data.Foldable.WithIndex as Foldable.WithIndex
+import qualified Data.Map.Strict         as Map
 import qualified Dhall.Map
+import qualified Dhall.Syntax            as Syntax
+import qualified Lens.Micro              as Lens
 
 {- | Substitutions map variables to arbitrary Dhall expressions.
      Note that we use "Dhall.Map.Map" as an underlying structure. Hence we respect insertion order.
@@ -30,6 +32,40 @@ empty = Dhall.Map.empty
 --   >
 --   > substitute (Dhall.Core.Var "Foo") (Dhall.Map.fromList [("Foo", Dhall.Core.Var "Bar"), ("Bar", Dhall.Core.Var "Baz")])
 --
---   results in @Dhall.Core.Var \"Baz\"@ since we first substitute \"Foo\" with \"Bar\" and then the resulting \"Bar\" with the final \"Baz\".
+--   results in @Dhall.Core.Var \"Baz\"@ since \"Foo\"'s replacement (\"Bar\") is itself resolved against \"Bar\"'s substitution (\"Baz\") before being applied.
 substitute :: Expr s a -> Substitutions s a -> Expr s a
-substitute expr = foldl' (\memo (k, v) -> subst (V k 0) v memo) expr . Dhall.Map.toList
+substitute expr substitutions =
+     substituteMany (resolveSubstitutions substitutions) expr
+
+resolveSubstitutions :: Substitutions s a -> Map.Map Var (Expr s a)
+resolveSubstitutions substitutions =
+     let step k v resolved = Map.insert (V k 0) (substituteMany resolved v) resolved
+     in Foldable.WithIndex.ifoldr step Map.empty substitutions
+
+substituteMany :: Map.Map Var (Expr s a) -> Expr s a -> Expr s a
+substituteMany substitutions expression
+     | Map.null substitutions = expression
+substituteMany substitutions (Var v) =
+     Map.findWithDefault (Var v) v substitutions
+substituteMany substitutions (Lam cs (FunctionBinding src0 y src1 src2 type_) body) =
+     let type_' = substituteMany substitutions type_
+         body' = substituteMany (shiftSubstitutions y substitutions) body
+     in Lam cs (FunctionBinding src0 y src1 src2 type_') body'
+substituteMany substitutions (Pi cs y domain codomain) =
+     let domain' = substituteMany substitutions domain
+         codomain' = substituteMany (shiftSubstitutions y substitutions) codomain
+     in Pi cs y domain' codomain'
+substituteMany substitutions (Let (Binding src0 f src1 type_ src2 replacement) body) =
+     let type_' = fmap (fmap (substituteMany substitutions)) type_
+         replacement' = substituteMany substitutions replacement
+         body' = substituteMany (shiftSubstitutions f substitutions) body
+     in Let (Binding src0 f src1 type_' src2 replacement') body'
+substituteMany substitutions expression =
+     Lens.over Syntax.subExpressions (substituteMany substitutions) expression
+
+shiftSubstitutions :: Text -> Map.Map Var (Expr s a) -> Map.Map Var (Expr s a)
+shiftSubstitutions name substitutions =
+     let shiftKey (V k n) = if k == name then V k (n + 1) else V k n
+         shiftValue = Syntax.shift 1 (V name 0)
+         step k v = Map.insert (shiftKey k) (shiftValue v)
+     in Map.foldrWithKey step Map.empty substitutions

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -19,6 +19,7 @@ import qualified Dhall.Test.QuickCheck
 import qualified Dhall.Test.Regression
 import qualified Dhall.Test.Schemas
 import qualified Dhall.Test.SemanticHash
+import qualified Dhall.Test.Substitution
 #ifndef CROSS
 import qualified Dhall.Test.TH
 #endif
@@ -74,6 +75,7 @@ getAllTests = do
                 , schemaTests
                 , Dhall.Test.DirectoryTree.tests
                 , Dhall.Test.Regression.tests
+                , Dhall.Test.Substitution.tests
                 , Dhall.Test.Tutorial.tests
                 , Dhall.Test.QuickCheck.tests
                 , Dhall.Test.Dhall.tests

--- a/dhall/tests/Dhall/Test/Substitution.hs
+++ b/dhall/tests/Dhall/Test/Substitution.hs
@@ -5,13 +5,19 @@ module Dhall.Test.Substitution where
 
 import Control.Exception (throwIO)
 import Data.Void         (Void)
-import Dhall.Core        (Expr (BoolLit, Var))
+import Dhall.Core        (Binding (..), Expr (..), Var (..))
 import Dhall.Src         (Src)
 
 import qualified Data.Either.Validation
 import qualified Dhall
+import qualified Dhall.Core                 as Core
 import qualified Dhall.Map
-import qualified Lens.Micro             as Lens
+import qualified Dhall.Substitution
+import qualified Lens.Micro                 as Lens
+import qualified Test.Tasty                 as Tasty
+import qualified Test.Tasty.HUnit           as Tasty.HUnit
+
+import Test.Tasty.HUnit ((@?=))
 
 data Result = Failure Integer | Success String
     deriving (Eq, Dhall.Generic, Show)
@@ -36,3 +42,172 @@ substituteFoo :: FilePath -> IO Bool
 substituteFoo fp = let
     evaluateSettings = Lens.set Dhall.substitutions (Dhall.Map.fromList [("Foo", Var "Bar"), ("Bar", BoolLit True)]) Dhall.defaultEvaluateSettings
     in Dhall.inputFileWithSettings evaluateSettings Dhall.auto fp
+
+tests :: Tasty.TestTree
+tests =
+    Tasty.testGroup "Substitution"
+        [ noSubstitutionsIsIdentity
+        , freeVariableIsSubstituted
+        , unrelatedVariableIsUntouched
+        , shadowedVariableInLamIsUntouched
+        , shadowedVariableInPiIsUntouched
+        , shadowedVariableInLetIsUntouched
+        , variableReferringPastLamShadowIsSubstituted
+        , letBindingValueIsSubstituted
+        , substitutionAvoidsCapture
+        , multipleIndependentSubstitutionsAreApplied
+        , dependentSubstitutionsChain
+        , dependentSubstitutionsChainThreeLevels
+        , dependentSubstitutionsOnlyChainForward
+        , letAnnotationIsSubstituted
+        , selfReferentialSubstitutionIsANoop
+        ]
+
+noSubstitutionsIsIdentity :: Tasty.TestTree
+noSubstitutionsIsIdentity = Tasty.HUnit.testCase "No substitutions is the identity" $ do
+    let expr = Var "x" :: Expr Void Void
+
+    Dhall.Substitution.substitute expr Dhall.Substitution.empty @?= expr
+
+freeVariableIsSubstituted :: Tasty.TestTree
+freeVariableIsSubstituted = Tasty.HUnit.testCase "A free variable is substituted" $ do
+    let expr = Var "x" :: Expr Void Void
+
+    let substitutions = Dhall.Map.fromList [ ("x", NaturalLit 1) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= NaturalLit 1
+
+unrelatedVariableIsUntouched :: Tasty.TestTree
+unrelatedVariableIsUntouched = Tasty.HUnit.testCase "An unrelated variable is untouched" $ do
+    let expr = Var "y" :: Expr Void Void
+
+    let substitutions = Dhall.Map.fromList [ ("x", NaturalLit 1) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= expr
+
+shadowedVariableInLamIsUntouched :: Tasty.TestTree
+shadowedVariableInLamIsUntouched = Tasty.HUnit.testCase "A variable shadowed by a Lam is untouched" $ do
+    --  \(x : Natural) -> x
+    let expr = Lam mempty (Core.makeFunctionBinding "x" Natural) (Var "x") :: Expr Void Void
+
+    let substitutions = Dhall.Map.fromList [ ("x", NaturalLit 1) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= expr
+
+shadowedVariableInPiIsUntouched :: Tasty.TestTree
+shadowedVariableInPiIsUntouched = Tasty.HUnit.testCase "A variable shadowed by a Pi is untouched" $ do
+    --  forall (x : Type) -> x
+    let expr = Pi mempty "x" (Const Core.Type) (Var "x") :: Expr Void Void
+
+    let substitutions = Dhall.Map.fromList [ ("x", Bool) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= expr
+
+shadowedVariableInLetIsUntouched :: Tasty.TestTree
+shadowedVariableInLetIsUntouched = Tasty.HUnit.testCase "A variable shadowed by a Let is untouched" $ do
+    --  let x = 5 in x
+    let expr = Let (Core.makeBinding "x" (NaturalLit 5)) (Var "x") :: Expr Void Void
+
+    let substitutions = Dhall.Map.fromList [ ("x", NaturalLit 999) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= expr
+
+variableReferringPastLamShadowIsSubstituted :: Tasty.TestTree
+variableReferringPastLamShadowIsSubstituted = Tasty.HUnit.testCase "A variable referring past a Lam shadow is substituted" $ do
+    --  \(x : Natural) -> x@1
+    let expr = Lam mempty (Core.makeFunctionBinding "x" Natural) (Var (V "x" 1)) :: Expr Void Void
+
+    --  \(x : Natural) -> 1
+    let expected = Lam mempty (Core.makeFunctionBinding "x" Natural) (NaturalLit 1)
+
+    let substitutions = Dhall.Map.fromList [ ("x", NaturalLit 1) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= expected
+
+letBindingValueIsSubstituted :: Tasty.TestTree
+letBindingValueIsSubstituted = Tasty.HUnit.testCase "A Let's bound value is substituted" $ do
+    --  let y = x in y
+    let expr = Let (Core.makeBinding "y" (Var "x")) (Var "y") :: Expr Void Void
+
+    --  let y = 5 in y
+    let expected = Let (Core.makeBinding "y" (NaturalLit 5)) (Var "y")
+
+    let substitutions = Dhall.Map.fromList [ ("x", NaturalLit 5) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= expected
+
+substitutionAvoidsCapture :: Tasty.TestTree
+substitutionAvoidsCapture = Tasty.HUnit.testCase "Substitution avoids variable capture" $ do
+    --  \(y : Natural) -> x
+    let expr = Lam mempty (Core.makeFunctionBinding "y" Natural) (Var "x") :: Expr Void Void
+
+    --  \(y : Natural) -> y@1
+    let expected = Lam mempty (Core.makeFunctionBinding "y" Natural) (Var (V "y" 1))
+
+    let substitutions = Dhall.Map.fromList [ ("x", Var "y") ]
+
+    Dhall.Substitution.substitute expr substitutions @?= expected
+
+multipleIndependentSubstitutionsAreApplied :: Tasty.TestTree
+multipleIndependentSubstitutionsAreApplied = Tasty.HUnit.testCase "Multiple independent substitutions are all applied" $ do
+    --  \(a : Natural) -> \(b : Natural) -> x + y
+    let expr =
+            Lam mempty (Core.makeFunctionBinding "a" Natural)
+                (Lam mempty (Core.makeFunctionBinding "b" Natural)
+                    (NaturalPlus (Var "x") (Var "y"))
+                ) :: Expr Void Void
+
+    --  \(a : Natural) -> \(b : Natural) -> 2 + 3
+    let expected =
+            Lam mempty (Core.makeFunctionBinding "a" Natural)
+                (Lam mempty (Core.makeFunctionBinding "b" Natural)
+                    (NaturalPlus (NaturalLit 2) (NaturalLit 3))
+                )
+
+    let substitutions = Dhall.Map.fromList [ ("x", NaturalLit 2), ("y", NaturalLit 3) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= expected
+
+dependentSubstitutionsChain :: Tasty.TestTree
+dependentSubstitutionsChain = Tasty.HUnit.testCase "Dependent substitutions chain" $ do
+    let expr = Var "Foo" :: Expr Void Void
+
+    let substitutions = Dhall.Map.fromList [ ("Foo", Var "Bar"), ("Bar", BoolLit True) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= BoolLit True
+
+dependentSubstitutionsChainThreeLevels :: Tasty.TestTree
+dependentSubstitutionsChainThreeLevels = Tasty.HUnit.testCase "Dependent substitutions chain through multiple levels" $ do
+    let expr = Var "A" :: Expr Void Void
+
+    let substitutions = Dhall.Map.fromList [ ("A", Var "B"), ("B", Var "C"), ("C", BoolLit True) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= BoolLit True
+
+dependentSubstitutionsOnlyChainForward :: Tasty.TestTree
+dependentSubstitutionsOnlyChainForward = Tasty.HUnit.testCase "Dependent substitutions only chain forward" $ do
+    let expr = Var "A" :: Expr Void Void
+
+    let substitutions = Dhall.Map.fromList [ ("C", BoolLit True), ("B", Var "C"), ("A", Var "B") ]
+
+    Dhall.Substitution.substitute expr substitutions @?= Var "B"
+
+letAnnotationIsSubstituted :: Tasty.TestTree
+letAnnotationIsSubstituted = Tasty.HUnit.testCase "A Let's type annotation is substituted" $ do
+    --  let y : x = 5 in y
+    let expr = Let (Binding Nothing "y" Nothing (Just (Nothing, Var "x")) Nothing (NaturalLit 5)) (Var "y") :: Expr Void Void
+
+    --  let y : Natural = 5 in y
+    let expected = Let (Binding Nothing "y" Nothing (Just (Nothing, Natural)) Nothing (NaturalLit 5)) (Var "y")
+
+    let substitutions = Dhall.Map.fromList [ ("x", Natural) ]
+
+    Dhall.Substitution.substitute expr substitutions @?= expected
+
+selfReferentialSubstitutionIsANoop :: Tasty.TestTree
+selfReferentialSubstitutionIsANoop = Tasty.HUnit.testCase "A self-referential substitution terminates as a no-op" $ do
+    let expr = Var "Foo" :: Expr Void Void
+
+    let substitutions = Dhall.Map.fromList [ ("Foo", Var "Foo") ]
+
+    Dhall.Substitution.substitute expr substitutions @?= Var "Foo"


### PR DESCRIPTION
We have a big prelude and evaluating it for the first time took around 10 minutes.
We profiled and found substitution was the bottleneck.
For us the substitutions work as some form of type aliases where we substitute vars with their corresponding types, so that we do not have to write out e.g. big records.
As we have many types in the map, this became quite expensive, because expressions had to be traversed for each entry.
Using a map-based approach the expression has to be traversed only once and evaluation time was reduced to around 2 minutes, so this was a noticeable speed up.
As a side note: we handle interdependecies by applying the map to itself.

The tests are a little bit ad-hoc and thrown together.
You can decide which tests are essential and I can throw some out if they are unnecessary.
The substitute code should be fairly readable, but I am also open for suggestions.