### PR TITLE
Avoid forcing unused function arguments while type-checking

### DIFF
--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -62,6 +62,7 @@ import Data.Void          (Void)
 import Dhall.Map          (Map)
 import Dhall.Set          (Set)
 import GHC.Natural        (Natural)
+import Lens.Micro         (anyOf)
 import Prelude            hiding (succ)
 
 import Dhall.Syntax
@@ -155,6 +156,31 @@ toVHPi (VHPi x a b             ) = Just (x, a, b)
 toVHPi  _                        = Nothing
 {-# INLINABLE toVHPi #-}
 
+-- | Whether @V x i@ occurs free in an expression (avoids importing
+-- `Dhall.Normalize.freeIn`, which would create an import cycle).
+--
+-- Used when evaluating @Pi@ to choose @VHPi@ for non-dependent function types
+-- so type-checking need not evaluate unused arguments.
+boundVarOccurs :: Eq a => Text -> Int -> Expr Void a -> Bool
+boundVarOccurs x i = go i
+  where
+    go !j = \case
+        Var (V x' j') ->
+            x == x' && j == j'
+        Lam _ FunctionBinding{ functionBindingVariable = y
+                             , functionBindingAnnotation = a } b ->
+            go j a || go (if x == y then j + 1 else j) b
+        Pi _ y a b ->
+            go j a || go (if x == y then j + 1 else j) b
+        Let (Binding _ y _ mA _ a) b ->
+               maybe False (\(_, t) -> go j t) mA
+            || go j a
+            || go (if x == y then j + 1 else j) b
+        Note _ e ->
+            go j e
+        expression ->
+            anyOf Syntax.subExpressions (go j) expression
+    
 data Val a
     = VConst !Const
     | VVar !Text !Int
@@ -265,6 +291,10 @@ countEnvironment x = go (0 :: Int)
     go  acc (Skip env x'    ) = go (if x == x' then acc + 1 else acc) env
     go  acc (Extend env x' _) = go (if x == x' then acc + 1 else acc) env
 
+-- | Instantiate a closure.  Kept strict in the argument for NbE performance.
+-- Non-dependent @Pi@ types are evaluated to lazy @VHPi@ instead, so
+-- type-checking does not rely on a free-variable check here.
+-- And `instantiate` does not check for free variables in the closure (this would be slow).
 instantiate :: Eq a => Closure a -> Val a -> Val a
 instantiate (Closure x env t) !u = eval (Extend env x u) t
 {-# INLINE instantiate #-}
@@ -473,7 +503,13 @@ eval !env t0 =
         Lam _ (FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = a }) t ->
             VLam (eval env a) (Closure x env t)
         Pi _ x a b ->
-            VPi (eval env a) (Closure x env b)
+            -- Classify once: non-dependent Pis become lazy VHPi so applying
+            -- the type during type-checking does not force an unused argument
+            -- (e.g. @List a → List b@).  Dependent Pis stay as VPi closures.
+            let !a' = eval env a
+            in  if boundVarOccurs x 0 b
+                then VPi a' (Closure x env b)
+                else VHPi x a' (\_ -> eval (Skip env x) b)
         App t u ->
             vApp (eval env t) (eval env u)
         Let (Binding _ x _ _mA _ a) b ->

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -277,6 +277,10 @@ infer typer = loop
 
                     if Eval.conv values _A₀' _A₁'
                         then do
+                            -- For non-dependent Pis, `eval` produces a lazy
+                            -- `VHPi` that ignores this argument, so a large
+                            -- unused arg is not forced.  Dependent `VPi`s still
+                            -- instantiate strictly via `toVHPi`.
                             let a' = eval values a
 
                             return (_B' a')


### PR DESCRIPTION
When typechecking a function applied to an argument, `instantiate` is used, which is strict in the argument. This means the argument needs to be calculated even though it's just for typechecking. The argument's type might depend on some values, so in `App f a` the output type of `f` might depend on the _value_ of `a`, and the evaluation of `a` is needed for typechecking this expression.

However, often the output type does not depend on the argument value. In that case it's a waste of time to evaluate the argument. However, existing code always evaluates `a` in that case. If `a` is a big expression but it does not occur in the output type of `f` then it is a waste.

This PR skips evaluation in those cases, without putting the occurrence check into the `instantiate` itself (as `instantiate` is a hot path, called for every function application). The occurrence check is put only on the type-checking helper `resultTypeOfApp`, not on `instantiate`.

Evaluation benchmark: typechecking `ListBench` and `ListBenchAlt` has become instantaneous with this change. The old code would require evaluating a slow function during typechecking, just in case the type depends on the output value of that function; the new code detects that the type does not depend on that value.

Baseline (main branch):

```
  normalize
    ChurchEval
      typecheck:  OK
        23.7 μs ± 1.7 μs
      evaluation: OK
        800  ms ±  45 ms
    FunCompose
      typecheck:  OK
        10.1 μs ± 896 ns
      evaluation: OK
        542  μs ±  35 μs
    ListBench
      typecheck:  OK
        1.968 s ±  95 ms
      evaluation: OK
        981  ms ±  34 ms
    ListBenchAlt
      typecheck:  OK
        2.67 ms ± 116 μs
      evaluation: OK
        2.48 ms ± 119 μs
    NaturalFoldShortcut
      typecheck:  OK
        497  ns ±  35 ns
      evaluation: OK
        8.36 μs ± 454 ns
  large1
    parse:        OK
      181  ms ±  14 ms
    resolve:      OK
      88.6 ms ± 6.2 ms
    typecheck:    OK
      58.8 ms ± 1.8 ms
    evaluation:   OK
      106  ms ± 9.8 ms
    cbor:         OK
      107  ms ± 3.4 ms
  k8s
    file3
      resolve:    OK
        2.450 s ± 110 ms
      typecheck:  OK
        2.52 ms ± 228 μs
      evaluation: OK
        250  μs ±  19 μs
    file4
      resolve:    OK
        2.168 s ±  60 ms
      typecheck:  OK
        2.50 ms ± 217 μs
      evaluation: OK
        257  μs ±  15 μs

All 21 tests passed (72.78s)
```

This branch:

```
Benchmark evaluation: RUNNING...
All
  normalize
    ChurchEval
      typecheck:  OK
        22.1 μs ± 1.9 μs
      evaluation: OK
        786  ms ±  50 ms
    FunCompose
      typecheck:  OK
        10.8 μs ± 871 ns
      evaluation: OK
        547  μs ±  54 μs
    ListBench
      typecheck:  OK
        24.5 μs ± 1.7 μs
      evaluation: OK
        986  ms ±  38 ms
    ListBenchAlt
      typecheck:  OK
        22.8 μs ± 1.7 μs
      evaluation: OK
        2.50 ms ± 106 μs
    NaturalFoldShortcut
      typecheck:  OK
        493  ns ±  27 ns
      evaluation: OK
        8.38 μs ± 426 ns
  large1
    parse:        OK
      185  ms ±  14 ms
    resolve:      OK
      87.5 ms ± 5.8 ms
    typecheck:    OK
      59.1 ms ± 3.9 ms
    evaluation:   OK
      106  ms ±  10 ms
    cbor:         OK
      108  ms ± 4.6 ms
  k8s
    file3
      resolve:    OK
        2.461 s ±  97 ms
      typecheck:  OK
        2.51 ms ± 210 μs
      evaluation: OK
        247  μs ±  15 μs
    file4
      resolve:    OK
        2.166 s ± 191 ms
      typecheck:  OK
        2.51 ms ± 219 μs
      evaluation: OK
        248  μs ±  17 μs

All 21 tests passed (54.16s)
```