### PR TITLE
recalibrate benchmarks to roughly equal time

### DIFF
--- a/dhall/benchmark/evaluation/Main.hs
+++ b/dhall/benchmark/evaluation/Main.hs
@@ -20,6 +20,7 @@ import qualified Lens.Micro
 import           Lens.Micro           ((^.))
 import qualified System.Directory     as Directory
 import qualified System.Environment   as Environment
+import           System.IO            (hClose, openTempFile)
 
 type ParsedExpr = Core.Expr Parser.Src Core.Import
 type ResolvedExpr = Core.Expr Parser.Src Void
@@ -134,7 +135,11 @@ loadK8sExamples =
 withEmptyDhallCacheHome :: IO a -> IO a
 withEmptyDhallCacheHome action = do
     tmp <- Directory.getTemporaryDirectory
-    cacheHome <- Directory.createTempDirectory tmp "dhall-evaluation-bench-cache"
+    (path, handle) <- openTempFile tmp "dhall-evaluation-bench"
+    hClose handle
+    Directory.removeFile path
+    let cacheHome = path <> ".xdg"
+    Directory.createDirectory cacheHome
     Environment.setEnv "XDG_CACHE_HOME" cacheHome
     action
 

--- a/dhall/benchmark/evaluation/Main.hs
+++ b/dhall/benchmark/evaluation/Main.hs
@@ -8,7 +8,7 @@ import System.FilePath   ((</>), takeBaseName, takeDirectory)
 import Test.Tasty.Bench
 
 import qualified Data.ByteString.Lazy as ByteString
-import qualified Data.Text          as Text
+import qualified Data.Text            as Text
 import qualified Data.Text.IO         as Text.IO
 import qualified Dhall
 import qualified Dhall.Binary         as Binary
@@ -17,8 +17,9 @@ import qualified Dhall.Import         as Import
 import qualified Dhall.Parser         as Parser
 import qualified Dhall.TypeCheck      as TypeCheck
 import qualified Lens.Micro
-import           Lens.Micro        ((^.))
+import           Lens.Micro           ((^.))
 import qualified System.Directory     as Directory
+import qualified System.Environment   as Environment
 
 type ParsedExpr = Core.Expr Parser.Src Core.Import
 type ResolvedExpr = Core.Expr Parser.Src Void
@@ -34,10 +35,14 @@ large1Settings =
     Lens.Micro.set Dhall.sourceName large1MainPath
         (Lens.Micro.set Dhall.rootDirectory large1Directory Dhall.defaultInputSettings)
 
--- | Like 'Dhall.resolveWithSettings' but with the semantic disk cache disabled
--- (as with @dhall --no-cache@).
-resolveWithoutSemanticCache :: Dhall.InputSettings -> ParsedExpr -> IO ResolvedExpr
-resolveWithoutSemanticCache settings parsed =
+k8sDirectory :: FilePath
+k8sDirectory = "benchmark/evaluation/k8s"
+
+-- | Resolve imports with the semantic disk cache disabled (as with
+-- @dhall --no-cache@).  Combined with an empty @XDG_CACHE_HOME@ set in 'main',
+-- the semisemantic disk cache is also unused.
+resolveWithoutCache :: Dhall.InputSettings -> ParsedExpr -> IO ResolvedExpr
+resolveWithoutCache settings parsed =
     Import.loadWithStatus
         ( Dhall.emptyStatusWithSettings
             (settings ^. Dhall.evaluateSettings)
@@ -46,8 +51,11 @@ resolveWithoutSemanticCache settings parsed =
         Import.IgnoreSemanticCache
         parsed
 
-k8sDirectory :: FilePath
-k8sDirectory = "benchmark/evaluation/k8s"
+-- | Abort if the expression is ill-typed.  Used at load time so fixtures never
+-- report OK timings when type-checking fails.
+ensureWellTyped :: ResolvedExpr -> IO ()
+ensureWellTyped expression =
+    either throw (\_ -> pure ()) (TypeCheck.typeOf expression)
 
 loadExamples :: IO [(String, ResolvedExpr)]
 loadExamples = do
@@ -68,17 +76,16 @@ loadExample path = do
             Lens.Micro.set Dhall.sourceName path
                 (Lens.Micro.set Dhall.rootDirectory (takeDirectory path) Dhall.defaultInputSettings)
 
-    resolved <- Dhall.resolveWithSettings settings parsed
+    resolved <- resolveWithoutCache settings parsed
 
-    -- Fail fast on ill-typed fixtures so they never report OK timings.
-    _ <- either throw pure (TypeCheck.typeOf resolved)
+    ensureWellTyped resolved
 
     pure (takeBaseName path, resolved)
 
 -- | Load large1 inputs for per-phase benchmarks.
 --
--- Import resolution uses 'resolveWithoutSemanticCache'. A one-time normalize for
--- the CBOR fixture runs here so the timed @typecheck@ / @evaluation@ / @cbor@
+-- Import resolution uses 'resolveWithoutCache'. A one-time normalize for the
+-- CBOR fixture runs here so the timed @typecheck@ / @evaluation@ / @cbor@
 -- benches start from the right artifact. The @resolve@ bench re-runs resolution
 -- on the parsed expression via 'nfAppIO'.
 loadLarge1 :: IO (Text, ParsedExpr, ResolvedExpr, ResolvedExpr)
@@ -88,7 +95,9 @@ loadLarge1 = do
     parsed <-
         either throw pure (Parser.exprFromText large1MainPath text)
 
-    resolved <- resolveWithoutSemanticCache large1Settings parsed
+    resolved <- resolveWithoutCache large1Settings parsed
+
+    ensureWellTyped resolved
 
     let normalized = Core.normalize resolved
 
@@ -107,7 +116,9 @@ loadK8sExample (name, expressionText) = do
     parsed <-
         either throw pure (Parser.exprFromText sourceName (Text.pack expressionText))
 
-    resolved <- resolveWithoutSemanticCache settings parsed
+    resolved <- resolveWithoutCache settings parsed
+
+    ensureWellTyped resolved
 
     pure (name, settings, parsed, resolved)
 
@@ -118,8 +129,17 @@ loadK8sExamples =
         , ( "file4", "(./file4.dhall).mkPod" )
         ]
 
+-- | Point @XDG_CACHE_HOME@ at a fresh empty directory so Dhall's semantic and
+-- semisemantic disk caches cannot serve or pollute the user's real cache.
+withEmptyDhallCacheHome :: IO a -> IO a
+withEmptyDhallCacheHome action = do
+    tmp <- Directory.getTemporaryDirectory
+    cacheHome <- Directory.createTempDirectory tmp "dhall-evaluation-bench-cache"
+    Environment.setEnv "XDG_CACHE_HOME" cacheHome
+    action
+
 main :: IO ()
-main = do
+main = withEmptyDhallCacheHome $ do
     examples <- loadExamples
     (large1Text, large1Parsed, large1Resolved, large1Normalized) <- loadLarge1
     k8sExamples <- loadK8sExamples
@@ -136,7 +156,7 @@ main = do
             ]
         , bgroup "large1"
             [ bench "parse" (nf (parseLarge1 large1MainPath) large1Text)
-            , bench "resolve" (nfAppIO (resolveWithoutSemanticCache large1Settings) large1Parsed)
+            , bench "resolve" (nfAppIO (resolveWithoutCache large1Settings) large1Parsed)
             , bench "typecheck" (nf typecheckResolvedExpr large1Resolved)
             , bench "evaluation" (nf normalizeResolvedExpr large1Resolved)
             , bench "cbor" (nf encodeNormalized large1Normalized)
@@ -145,7 +165,7 @@ main = do
             "k8s"
             [ bgroup
                 name
-                [ bench "resolve" (nfAppIO (resolveWithoutSemanticCache settings) parsed)
+                [ bench "resolve" (nfAppIO (resolveWithoutCache settings) parsed)
                 , bench "typecheck" (nf typecheckResolvedExpr resolved)
                 , bench "evaluation" (nf normalizeResolvedExpr resolved)
                 ]
@@ -153,12 +173,13 @@ main = do
             ]
         ]
  where
-   -- These helpers are needed just to reduce polymorphism in TypeCheck.typeOf and Core.normalize.
-   -- Type-check failures must throw so tasty-bench reports FAIL instead of OK
-   -- (returning @Nothing@ would make the bench succeed).
+   -- These helpers reduce polymorphism in TypeCheck.typeOf and Core.normalize.
+   -- Type-check failures must throw so tasty-bench reports FAIL instead of OK.
    typecheckResolvedExpr :: ResolvedExpr -> Core.Expr Parser.Src Void
    typecheckResolvedExpr = either throw id . TypeCheck.typeOf
 
+   -- Pure NbE; disk caches are irrelevant here. Ill-typed fixtures are rejected
+   -- at load time via 'ensureWellTyped'.
    normalizeResolvedExpr :: ResolvedExpr -> ResolvedExpr
    normalizeResolvedExpr = Core.normalize
 

--- a/dhall/benchmark/evaluation/Main.hs
+++ b/dhall/benchmark/evaluation/Main.hs
@@ -70,6 +70,9 @@ loadExample path = do
 
     resolved <- Dhall.resolveWithSettings settings parsed
 
+    -- Fail fast on ill-typed fixtures so they never report OK timings.
+    _ <- either throw pure (TypeCheck.typeOf resolved)
+
     pure (takeBaseName path, resolved)
 
 -- | Load large1 inputs for per-phase benchmarks.
@@ -151,8 +154,10 @@ main = do
         ]
  where
    -- These helpers are needed just to reduce polymorphism in TypeCheck.typeOf and Core.normalize.
-   typecheckResolvedExpr :: ResolvedExpr -> Maybe (Core.Expr Parser.Src Void)
-   typecheckResolvedExpr = either (const Nothing) Just . TypeCheck.typeOf
+   -- Type-check failures must throw so tasty-bench reports FAIL instead of OK
+   -- (returning @Nothing@ would make the bench succeed).
+   typecheckResolvedExpr :: ResolvedExpr -> Core.Expr Parser.Src Void
+   typecheckResolvedExpr = either throw id . TypeCheck.typeOf
 
    normalizeResolvedExpr :: ResolvedExpr -> ResolvedExpr
    normalizeResolvedExpr = Core.normalize

--- a/dhall/benchmark/evaluation/normalize/ChurchEval.dhall
+++ b/dhall/benchmark/evaluation/normalize/ChurchEval.dhall
@@ -43,4 +43,4 @@ let n50M = mul n10M n5
 
 let n100M = mul n10M n10
 
-in  n10M Natural (λ(x : Natural) → x + 1) 0
+in  n5M Natural (λ(x : Natural) → x + 1) 0

--- a/dhall/benchmark/evaluation/normalize/FunCompose.dhall
+++ b/dhall/benchmark/evaluation/normalize/FunCompose.dhall
@@ -1,4 +1,4 @@
-let limit = 5000
+let limit = 1000000
 
 let compose
     : ∀(a : Type) → ∀(b : Type) → ∀(c : Type) → (a → b) → (b → c) → a → c

--- a/dhall/benchmark/evaluation/normalize/Iterate.dhall
+++ b/dhall/benchmark/evaluation/normalize/Iterate.dhall
@@ -1,0 +1,27 @@
+let limit = 300000
+
+let iterate =
+      λ(n : Natural) →
+      λ(a : Type) →
+      λ(f : a → a) →
+      λ(x : a) →
+        List/build
+          a
+          ( λ(list : Type) →
+            λ(cons : a → list → list) →
+            λ(nil : list) →
+              let state =
+                    Natural/fold
+                      n
+                      { next : a, rest : list → list }
+                      ( λ(p : { next : a, rest : list → list }) →
+                          { next = f p.next
+                          , rest = λ(tail : list) → p.rest (cons p.next tail)
+                          }
+                      )
+                      { next = x, rest = λ(tail : list) → tail }
+
+              in  state.rest nil
+          )
+
+in  List/length Natural (iterate limit Natural (λ(x : Natural) → x + 1) 0)

--- a/dhall/benchmark/evaluation/normalize/Iterate.dhall
+++ b/dhall/benchmark/evaluation/normalize/Iterate.dhall
@@ -1,27 +1,12 @@
 let limit = 300000
 
-let iterate =
-      λ(n : Natural) →
-      λ(a : Type) →
-      λ(f : a → a) →
-      λ(x : a) →
-        List/build
-          a
-          ( λ(list : Type) →
-            λ(cons : a → list → list) →
-            λ(nil : list) →
-              let state =
-                    Natural/fold
-                      n
-                      { next : a, rest : list → list }
-                      ( λ(p : { next : a, rest : list → list }) →
-                          { next = f p.next
-                          , rest = λ(tail : list) → p.rest (cons p.next tail)
-                          }
-                      )
-                      { next = x, rest = λ(tail : list) → tail }
+let iterate = ../../../dhall-lang/Prelude/List/iterate.dhall
 
-              in  state.rest nil
-          )
+let a =
+      List/length
+        (List Natural)
+        (iterate limit (List Natural) (λ(x : List Natural) → x # [ 1 ]) [ 1 ])
 
-in  List/length Natural (iterate limit Natural (λ(x : Natural) → x + 1) 0)
+let b = List/length Natural (iterate limit Natural (λ(x : Natural) → x + 1) 1)
+
+in  b

--- a/dhall/benchmark/evaluation/normalize/Iterate.dhall
+++ b/dhall/benchmark/evaluation/normalize/Iterate.dhall
@@ -9,4 +9,4 @@ let a =
 
 let b = List/length Natural (iterate limit Natural (λ(x : Natural) → x + 1) 1)
 
-in  b
+in  a

--- a/dhall/benchmark/evaluation/normalize/IterateAlt.dhall
+++ b/dhall/benchmark/evaluation/normalize/IterateAlt.dhall
@@ -1,3 +1,5 @@
+-- Optimized version of iterate.dhall using a Natural/fold with an accumulator of type { next : a, rest : list → list }.
+
 let limit = 300000
 
 let iterate =
@@ -31,4 +33,4 @@ let a =
 
 let b = List/length Natural (iterate limit Natural (λ(x : Natural) → x + 1) 1)
 
-in  b
+in  a

--- a/dhall/benchmark/evaluation/normalize/IterateAlt.dhall
+++ b/dhall/benchmark/evaluation/normalize/IterateAlt.dhall
@@ -1,0 +1,34 @@
+let limit = 300000
+
+let iterate =
+      λ(n : Natural) →
+      λ(a : Type) →
+      λ(f : a → a) →
+      λ(x : a) →
+        List/build
+          a
+          ( λ(list : Type) →
+            λ(cons : a → list → list) →
+            λ(nil : list) →
+              let state =
+                    Natural/fold
+                      n
+                      { next : a, rest : list → list }
+                      ( λ(p : { next : a, rest : list → list }) →
+                          { next = f p.next
+                          , rest = λ(tail : list) → p.rest (cons p.next tail)
+                          }
+                      )
+                      { next = x, rest = λ(tail : list) → tail }
+
+              in  state.rest nil
+          )
+
+let a =
+      List/length
+        (List Natural)
+        (iterate limit (List Natural) (λ(x : List Natural) → x # [ 1 ]) [ 1 ])
+
+let b = List/length Natural (iterate limit Natural (λ(x : Natural) → x + 1) 1)
+
+in  b

--- a/dhall/benchmark/evaluation/normalize/IterateAlt2.dhall
+++ b/dhall/benchmark/evaluation/normalize/IterateAlt2.dhall
@@ -29,4 +29,4 @@ let a =
 
 let b = List/length Natural (iterate limit Natural (λ(x : Natural) → x + 1) 1)
 
-in  b
+in  a

--- a/dhall/benchmark/evaluation/normalize/IterateAlt2.dhall
+++ b/dhall/benchmark/evaluation/normalize/IterateAlt2.dhall
@@ -1,0 +1,32 @@
+let limit = 300000
+
+let iterate =
+      λ(n : Natural) →
+      λ(a : Type) →
+      λ(f : a → a) →
+      λ(x : a) →
+        List/reverse a (List/build
+          a
+          ( λ(list : Type) →
+            λ(cons : a → list → list) →
+            λ(nil : list) →
+              let state =
+                    Natural/fold
+                      n
+                      { next : a, rest : list }
+                      ( λ(p : { next : a, rest : list }) →
+                          { next = f p.next, rest = cons p.next p.rest }
+                      )
+                      { next = x, rest = nil }
+
+              in  state.rest
+          ))
+
+let a =
+      List/length
+        (List Natural)
+        (iterate limit (List Natural) (λ(x : List Natural) → x # [ 1 ]) [ 1 ])
+
+let b = List/length Natural (iterate limit Natural (λ(x : Natural) → x + 1) 1)
+
+in  b

--- a/dhall/benchmark/evaluation/normalize/ListBench.dhall
+++ b/dhall/benchmark/evaluation/normalize/ListBench.dhall
@@ -1,30 +1,30 @@
-let limit = 6000
+let limit = 100000
 
 let iterate =
       λ(n : Natural) →
       λ(a : Type) →
       λ(f : a → a) →
       λ(x : a) →
+        -- Natural/fold builds [x, f x, …, fⁿ⁻¹ x] using the
+        -- cons / nil constructors.
         List/build
           a
           ( λ(list : Type) →
             λ(cons : a → list → list) →
-              List/fold
-                { index : Natural, value : {} }
-                ( List/indexed
-                    {}
-                    ( List/build
-                        {}
-                        ( λ(list : Type) →
-                          λ(cons : {} → list → list) →
-                            Natural/fold n list (cons {=})
-                        )
-                    )
-                )
-                list
-                ( λ(y : { index : Natural, value : {} }) →
-                    cons (Natural/fold y.index a f x)
-                )
+            λ(nil : list) →
+              let state =
+                    Natural/fold
+                      n
+                      { next : a, rest : list → list }
+                      ( λ(p : { next : a, rest : list → list }) →
+                          { next = f p.next
+                          , rest =
+                              λ(tail : list) → p.rest (cons p.next tail)
+                          }
+                      )
+                      { next = x, rest = λ(tail : list) → tail }
+
+              in  state.rest nil
           )
 
 let countTo = λ(x : Natural) → iterate x Natural (λ(x : Natural) → x + 1) 0

--- a/dhall/benchmark/evaluation/normalize/ListBenchAlt.dhall
+++ b/dhall/benchmark/evaluation/normalize/ListBenchAlt.dhall
@@ -1,4 +1,4 @@
-let limit = 3000
+let limit = 100000
 
 let iterate =
       λ(n : Natural) →


### PR DESCRIPTION
Some benchmarks are too slow, others too fast, after last optimizations. Recalibrate them to roughly equal time.

New baseline: run `stack bench dhall:bench:evaluation`

```
  normalize
    ChurchEval
      typecheck:  OK
        23.0 μs ± 1.7 μs
      evaluation: OK
        325  ms ±  29 ms
    FunCompose
      typecheck:  OK
        11.2 μs ± 865 ns
      evaluation: OK
        278  ms ± 8.5 ms
    Iterate
      typecheck:  OK
        7.41 μs ± 450 ns
      evaluation: OK
        299  ms ±  27 ms
    IterateAlt
      typecheck:  OK
        9.73 μs ± 472 ns
      evaluation: OK
        294  ms ± 9.6 ms
    IterateAlt2
      typecheck:  OK
        8.55 μs ± 413 ns
      evaluation: OK
        305  ms ±  21 ms
    ListBench
      typecheck:  OK
        25.8 μs ± 988 ns
      evaluation: OK
        107  ms ± 8.5 ms
    ListBenchAlt
      typecheck:  OK
        23.6 μs ± 1.7 μs
      evaluation: OK
        207  ms ±  14 ms
    NaturalFoldShortcut
      typecheck:  OK
        508  ns ±  27 ns
      evaluation: OK
        8.48 μs ± 837 ns
  large1
    parse:        OK
      200  ms ±  14 ms
    resolve:      OK
      96.0 ms ± 7.0 ms
    typecheck:    OK
      63.4 ms ± 5.2 ms
    evaluation:   OK
      111  ms ± 8.4 ms
    cbor:         OK
      115  ms ±  11 ms
  k8s
    file3
      resolve:    OK
        2.827 s ±  89 ms
      typecheck:  OK
        2.97 ms ± 183 μs
      evaluation: OK
        256  μs ±  13 μs
    file4
      resolve:    OK
        2.629 s ±  55 ms
      typecheck:  OK
        2.97 ms ± 212 μs
      evaluation: OK
        255  μs ±  15 μs
```