### PR TITLE
add code for better benchmark preparation and logging

### DIFF
--- a/dhall/benchmark/evaluation/Main.hs
+++ b/dhall/benchmark/evaluation/Main.hs
@@ -1,10 +1,16 @@
 module Main where
 
 import Control.Exception (throw)
-import Data.List         (isSuffixOf, sort)
+import Data.Char         (toLower)
+import Data.List         (isInfixOf, isPrefixOf, isSuffixOf, sort)
+import Data.Maybe        (listToMaybe, mapMaybe)
 import Data.Text         (Text)
+import Data.Time.Clock   (diffUTCTime, getCurrentTime)
 import Data.Void         (Void)
+import System.Environment (getArgs)
 import System.FilePath   ((</>), takeBaseName, takeDirectory)
+import System.IO         (hFlush, stdout)
+import Text.Printf       (printf)
 import Test.Tasty.Bench
 
 import qualified Data.ByteString.Lazy as ByteString
@@ -19,8 +25,6 @@ import qualified Dhall.TypeCheck      as TypeCheck
 import qualified Lens.Micro
 import           Lens.Micro           ((^.))
 import qualified System.Directory     as Directory
-import qualified System.Environment   as Environment
-import           System.IO            (hClose, openTempFile)
 
 type ParsedExpr = Core.Expr Parser.Src Core.Import
 type ResolvedExpr = Core.Expr Parser.Src Void
@@ -39,9 +43,41 @@ large1Settings =
 k8sDirectory :: FilePath
 k8sDirectory = "benchmark/evaluation/k8s"
 
+say :: String -> IO ()
+say msg = putStrLn msg >> hFlush stdout
+
+formatDuration :: Double -> String
+formatDuration seconds
+    | seconds < 0.001 = printf "%.0f μs" (seconds * 1e6)
+    | seconds < 1     = printf "%.1f ms" (seconds * 1e3)
+    | otherwise       = printf "%.2f s" seconds
+
+-- | Informational wall-clock timing for preparation steps (not a Criterion bench).
+timed :: String -> IO a -> IO a
+timed label action = do
+    say $ "  " <> label <> "…"
+    start <- getCurrentTime
+    result <- action
+    end <- getCurrentTime
+    let seconds = realToFrac (diffUTCTime end start) :: Double
+    say $ "  " <> label <> ": " <> formatDuration seconds
+    pure result
+
+-- | Resolve imports using the normal semantic / semisemantic disk caches.
+-- Used only for fixture preparation so large imports (e.g. large1) are not
+-- paid cold on every bench run.
+resolveWithCache :: Dhall.InputSettings -> ParsedExpr -> IO ResolvedExpr
+resolveWithCache settings parsed =
+    Import.loadWithStatus
+        ( Dhall.emptyStatusWithSettings
+            (settings ^. Dhall.evaluateSettings)
+            (settings ^. Dhall.rootDirectory)
+        )
+        Import.UseSemanticCache
+        parsed
+
 -- | Resolve imports with the semantic disk cache disabled (as with
--- @dhall --no-cache@).  Combined with an empty @XDG_CACHE_HOME@ set in 'main',
--- the semisemantic disk cache is also unused.
+-- @dhall --no-cache@).  Used for the timed @resolve@ benches.
 resolveWithoutCache :: Dhall.InputSettings -> ParsedExpr -> IO ResolvedExpr
 resolveWithoutCache settings parsed =
     Import.loadWithStatus
@@ -58,49 +94,122 @@ ensureWellTyped :: ResolvedExpr -> IO ()
 ensureWellTyped expression =
     either throw (\_ -> pure ()) (TypeCheck.typeOf expression)
 
-loadExamples :: IO [(String, ResolvedExpr)]
-loadExamples = do
+-- | Best-effort extract of @-p@ / @--pattern@ from the benchmark argv, so we can
+-- skip loading fixtures that tasty-bench would filter out anyway.
+patternFromArgs :: [String] -> Maybe String
+patternFromArgs args =
+    listToMaybe $ mapMaybe match (zip args (drop 1 args)) ++ naked
+  where
+    match ("-p", value)        = Just value
+    match ("--pattern", value) = Just value
+    match _                    = Nothing
+
+    naked =
+        [ drop (length prefix) arg
+        | arg <- args
+        , prefix <- ["--pattern=", "-p="]
+        , prefix `isPrefixOf` arg
+        ]
+
+-- | Whether a tasty-style label path could match the user pattern (infix, like
+-- tasty's default).  @Nothing@ means no pattern → load everything.
+couldMatch :: Maybe String -> String -> Bool
+couldMatch Nothing _ = True
+couldMatch (Just pat) label =
+    map toLower pat `isInfixOf` map toLower label
+
+normalizeLabels :: String -> [String]
+normalizeLabels name =
+    [ "normalize." <> name
+    , "normalize." <> name <> ".typecheck"
+    , "normalize." <> name <> ".evaluation"
+    ]
+
+large1Labels :: [String]
+large1Labels =
+    [ "large1"
+    , "large1.parse"
+    , "large1.resolve"
+    , "large1.typecheck"
+    , "large1.evaluation"
+    , "large1.cbor"
+    ]
+
+k8sLabels :: String -> [String]
+k8sLabels name =
+    [ "k8s." <> name
+    , "k8s." <> name <> ".resolve"
+    , "k8s." <> name <> ".typecheck"
+    , "k8s." <> name <> ".evaluation"
+    ]
+
+loadExamples :: Maybe String -> IO [(String, ResolvedExpr)]
+loadExamples mPattern = do
     files <- sort <$> Directory.listDirectory normalizeDirectory
-    traverse loadExample
-        [ normalizeDirectory </> file | file <- files, ".dhall" `isSuffixOf` file ]
+    let paths =
+            [ normalizeDirectory </> file
+            | file <- files
+            , ".dhall" `isSuffixOf` file
+            , let name = takeBaseName file
+            , any (couldMatch mPattern) (normalizeLabels name)
+            ]
+    if null paths
+        then do
+            say "Skipping normalize fixtures (do not match pattern)"
+            pure []
+        else do
+            say $ "Loading normalize fixtures (" <> show (length paths) <> " file(s))…"
+            traverse loadExample paths
   where
     normalizeDirectory = "benchmark/evaluation/normalize"
 
 loadExample :: FilePath -> IO (String, ResolvedExpr)
 loadExample path = do
-    text <- Text.IO.readFile path
+    let name = takeBaseName path
+    let prefix = "normalize/" <> name
 
-    parsed <-
+    text <- timed (prefix <> ": read") (Text.IO.readFile path)
+
+    parsed <- timed (prefix <> ": parse") $
         either throw pure (Parser.exprFromText path text)
 
     let settings =
             Lens.Micro.set Dhall.sourceName path
                 (Lens.Micro.set Dhall.rootDirectory (takeDirectory path) Dhall.defaultInputSettings)
 
-    resolved <- resolveWithoutCache settings parsed
+    resolved <- timed (prefix <> ": resolve (cache on)") $
+        resolveWithCache settings parsed
 
-    ensureWellTyped resolved
+    timed (prefix <> ": typecheck") (ensureWellTyped resolved)
+    say $ "  " <> prefix <> ": ready"
 
-    pure (takeBaseName path, resolved)
+    pure (name, resolved)
 
 -- | Load large1 inputs for per-phase benchmarks.
 --
--- Import resolution uses 'resolveWithoutCache'. A one-time normalize for the
--- CBOR fixture runs here so the timed @typecheck@ / @evaluation@ / @cbor@
--- benches start from the right artifact. The @resolve@ bench re-runs resolution
--- on the parsed expression via 'nfAppIO'.
+-- Import resolution for prep uses 'resolveWithCache'. A one-time normalize for
+-- the CBOR fixture runs here so the timed @typecheck@ / @evaluation@ / @cbor@
+-- benches start from the right artifact. The timed @resolve@ bench re-runs
+-- resolution with 'resolveWithoutCache' via 'nfAppIO'.
 loadLarge1 :: IO (Text, ParsedExpr, ResolvedExpr, ResolvedExpr)
 loadLarge1 = do
-    text <- Text.IO.readFile large1MainPath
+    say "Loading large1…"
 
-    parsed <-
+    text <- timed "large1: read" (Text.IO.readFile large1MainPath)
+
+    parsed <- timed "large1: parse" $
         either throw pure (Parser.exprFromText large1MainPath text)
 
-    resolved <- resolveWithoutCache large1Settings parsed
+    resolved <- timed "large1: resolve (cache on)" $
+        resolveWithCache large1Settings parsed
 
-    ensureWellTyped resolved
+    timed "large1: typecheck" (ensureWellTyped resolved)
 
-    let normalized = Core.normalize resolved
+    -- Lazy: prep time may under-report if work is deferred until the cbor bench.
+    normalized <- timed "large1: normalize (for cbor fixture)" $
+        pure (Core.normalize resolved)
+
+    say "  large1: ready"
 
     pure (text, parsed, resolved, normalized)
 
@@ -113,69 +222,94 @@ loadK8sExample :: (String, String) -> IO (String, Dhall.InputSettings, ParsedExp
 loadK8sExample (name, expressionText) = do
     let sourceName = k8sDirectory </> name <> ".dhall"
     let settings = k8sSettings sourceName
+    let prefix = "k8s/" <> name
 
-    parsed <-
+    parsed <- timed (prefix <> ": parse") $
         either throw pure (Parser.exprFromText sourceName (Text.pack expressionText))
 
-    resolved <- resolveWithoutCache settings parsed
+    resolved <- timed (prefix <> ": resolve (cache on)") $
+        resolveWithCache settings parsed
 
-    ensureWellTyped resolved
+    timed (prefix <> ": typecheck") (ensureWellTyped resolved)
+    say $ "  " <> prefix <> ": ready"
 
     pure (name, settings, parsed, resolved)
 
-loadK8sExamples :: IO [(String, Dhall.InputSettings, ParsedExpr, ResolvedExpr)]
-loadK8sExamples =
-    traverse loadK8sExample
-        [ ( "file3", "(./file3.dhall).mkPod" )
-        , ( "file4", "(./file4.dhall).mkPod" )
-        ]
+loadK8sExamples :: Maybe String -> IO [(String, Dhall.InputSettings, ParsedExpr, ResolvedExpr)]
+loadK8sExamples mPattern = do
+    let candidates =
+            [ ( "file3", "(./file3.dhall).mkPod" )
+            , ( "file4", "(./file4.dhall).mkPod" )
+            ]
+        selected =
+            [ entry
+            | entry@(name, _) <- candidates
+            , any (couldMatch mPattern) (k8sLabels name)
+            ]
+    if null selected
+        then do
+            say "Skipping k8s fixtures (do not match pattern)"
+            pure []
+        else do
+            say $ "Loading k8s fixtures (" <> show (length selected) <> " file(s))…"
+            traverse loadK8sExample selected
 
--- | Point @XDG_CACHE_HOME@ at a fresh empty directory so Dhall's semantic and
--- semisemantic disk caches cannot serve or pollute the user's real cache.
-withEmptyDhallCacheHome :: IO a -> IO a
-withEmptyDhallCacheHome action = do
-    tmp <- Directory.getTemporaryDirectory
-    (path, handle) <- openTempFile tmp "dhall-evaluation-bench"
-    hClose handle
-    Directory.removeFile path
-    let cacheHome = path <> ".xdg"
-    Directory.createDirectory cacheHome
-    Environment.setEnv "XDG_CACHE_HOME" cacheHome
-    action
-
+-- Prep uses the normal disk caches; timed @resolve@ benches still use
+-- 'resolveWithoutCache'.
 main :: IO ()
-main = withEmptyDhallCacheHome $ do
-    examples <- loadExamples
-    (large1Text, large1Parsed, large1Resolved, large1Normalized) <- loadLarge1
-    k8sExamples <- loadK8sExamples
+main = do
+    args <- getArgs
+    let mPattern = patternFromArgs args
+    case mPattern of
+        Nothing  -> say "Preparing benchmarks (loading fixtures; prep cache on)…"
+        Just pat -> say $ "Preparing benchmarks matching " <> show pat <> " (prep cache on)…"
 
-    defaultMain
-        [ bgroup
-            "normalize"
-            [ bgroup
-                name
-                [ bench "typecheck" (nf typecheckResolvedExpr expression)
-                , bench "evaluation" (nf normalizeResolvedExpr expression)
-                ]
-            | (name, expression) <- examples
-            ]
-        , bgroup "large1"
-            [ bench "parse" (nf (parseLarge1 large1MainPath) large1Text)
-            , bench "resolve" (nfAppIO (resolveWithoutCache large1Settings) large1Parsed)
-            , bench "typecheck" (nf typecheckResolvedExpr large1Resolved)
-            , bench "evaluation" (nf normalizeResolvedExpr large1Resolved)
-            , bench "cbor" (nf encodeNormalized large1Normalized)
-            ]
-        , bgroup
-            "k8s"
-            [ bgroup
-                name
-                [ bench "resolve" (nfAppIO (resolveWithoutCache settings) parsed)
-                , bench "typecheck" (nf typecheckResolvedExpr resolved)
-                , bench "evaluation" (nf normalizeResolvedExpr resolved)
-                ]
-            | (name, settings, parsed, resolved) <- k8sExamples
-            ]
+    examples <- loadExamples mPattern
+
+    let wantLarge1 = any (couldMatch mPattern) large1Labels
+    large1 <-
+        if wantLarge1
+            then Just <$> loadLarge1
+            else do
+                say "Skipping large1 (does not match pattern)"
+                pure Nothing
+
+    k8sExamples <- loadK8sExamples mPattern
+
+    say "Starting tasty-bench…"
+
+    defaultMain $ concat
+        [ [ bgroup
+              "normalize"
+              [ bgroup
+                  name
+                  [ bench "typecheck" (nf typecheckResolvedExpr expression)
+                  , bench "evaluation" (nf normalizeResolvedExpr expression)
+                  ]
+              | (name, expression) <- examples
+              ]
+          ]
+        , [ bgroup "large1"
+              [ bench "parse" (nf (parseLarge1 large1MainPath) large1Text)
+              , bench "resolve" (nfAppIO (resolveWithoutCache large1Settings) large1Parsed)
+              , bench "typecheck" (nf typecheckResolvedExpr large1Resolved)
+              , bench "evaluation" (nf normalizeResolvedExpr large1Resolved)
+              , bench "cbor" (nf encodeNormalized large1Normalized)
+              ]
+          | Just (large1Text, large1Parsed, large1Resolved, large1Normalized) <- [large1]
+          ]
+        , [ bgroup
+              "k8s"
+              [ bgroup
+                  name
+                  [ bench "resolve" (nfAppIO (resolveWithoutCache settings) parsed)
+                  , bench "typecheck" (nf typecheckResolvedExpr resolved)
+                  , bench "evaluation" (nf normalizeResolvedExpr resolved)
+                  ]
+              | (name, settings, parsed, resolved) <- k8sExamples
+              ]
+          | not (null k8sExamples)
+          ]
         ]
  where
    -- These helpers reduce polymorphism in TypeCheck.typeOf and Core.normalize.

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -514,4 +514,5 @@ Benchmark evaluation
     Build-Depends:
         dhall                                         ,
         tasty-bench               >= 0.4      && < 0.6,
+        time                                          ,
     Default-Language: Haskell2010


### PR DESCRIPTION
While benchmarks are being prepared, do more logging - helps when something takes too long due to code changes.

```
$ stack bench dhall:bench:evaluation

Running 1 benchmarks...
Benchmark evaluation: RUNNING...
Preparing benchmarks (loading fixtures; prep cache on)…
Loading normalize fixtures (8 file(s))…
  normalize/ChurchEval: read…
  normalize/ChurchEval: read: 63 μs
  normalize/ChurchEval: parse…
  normalize/ChurchEval: parse: 3.2 ms
  normalize/ChurchEval: resolve (cache on)…
  normalize/ChurchEval: resolve (cache on): 13 μs
  normalize/ChurchEval: typecheck…
  normalize/ChurchEval: typecheck: 52 μs
  normalize/ChurchEval: ready
  normalize/FunCompose: read…
  normalize/FunCompose: read: 69 μs
  normalize/FunCompose: parse…
  normalize/FunCompose: parse: 1.1 ms
  normalize/FunCompose: resolve (cache on)…
  normalize/FunCompose: resolve (cache on): 9 μs
  normalize/FunCompose: typecheck…
  normalize/FunCompose: typecheck: 31 μs
  normalize/FunCompose: ready
  normalize/Iterate: read…
  normalize/Iterate: read: 42 μs
  normalize/Iterate: parse…
  normalize/Iterate: parse: 521 μs
  normalize/Iterate: resolve (cache on)…
  normalize/Iterate: resolve (cache on): 1.9 ms
  normalize/Iterate: typecheck…
  normalize/Iterate: typecheck: 47 μs
  normalize/Iterate: ready
  normalize/IterateAlt: read…
  normalize/IterateAlt: read: 29 μs
  normalize/IterateAlt: parse…
  normalize/IterateAlt: parse: 1.3 ms
  normalize/IterateAlt: resolve (cache on)…
  normalize/IterateAlt: resolve (cache on): 13 μs
  normalize/IterateAlt: typecheck…
  normalize/IterateAlt: typecheck: 33 μs
  normalize/IterateAlt: ready
  normalize/IterateAlt2: read…
  normalize/IterateAlt2: read: 46 μs
  normalize/IterateAlt2: parse…
  normalize/IterateAlt2: parse: 1.2 ms
  normalize/IterateAlt2: resolve (cache on)…
  normalize/IterateAlt2: resolve (cache on): 10 μs
  normalize/IterateAlt2: typecheck…
  normalize/IterateAlt2: typecheck: 22 μs
  normalize/IterateAlt2: ready
  normalize/ListBench: read…
  normalize/ListBench: read: 76 μs
  normalize/ListBench: parse…
  normalize/ListBench: parse: 2.8 ms
  normalize/ListBench: resolve (cache on)…
  normalize/ListBench: resolve (cache on): 20 μs
  normalize/ListBench: typecheck…
  normalize/ListBench: typecheck: 86 μs
  normalize/ListBench: ready
  normalize/ListBenchAlt: read…
  normalize/ListBenchAlt: read: 57 μs
  normalize/ListBenchAlt: parse…
  normalize/ListBenchAlt: parse: 2.5 ms
  normalize/ListBenchAlt: resolve (cache on)…
  normalize/ListBenchAlt: resolve (cache on): 20 μs
  normalize/ListBenchAlt: typecheck…
  normalize/ListBenchAlt: typecheck: 51 μs
  normalize/ListBenchAlt: ready
  normalize/NaturalFoldShortcut: read…
  normalize/NaturalFoldShortcut: read: 35 μs
  normalize/NaturalFoldShortcut: parse…
  normalize/NaturalFoldShortcut: parse: 109 μs
  normalize/NaturalFoldShortcut: resolve (cache on)…
  normalize/NaturalFoldShortcut: resolve (cache on): 2 μs
  normalize/NaturalFoldShortcut: typecheck…
  normalize/NaturalFoldShortcut: typecheck: 2 μs
  normalize/NaturalFoldShortcut: ready
Loading large1…
  large1: read…
  large1: read: 770 μs
  large1: parse…
  large1: parse: 182.2 ms
  large1: resolve (cache on)…
  large1: resolve (cache on): 64.1 ms
  large1: typecheck…
  large1: typecheck: 69.6 ms
  large1: normalize (for cbor fixture)…
  large1: normalize (for cbor fixture): 0 μs
  large1: ready
Loading k8s fixtures (2 file(s))…
  k8s/file3: parse…
  k8s/file3: parse: 107 μs
  k8s/file3: resolve (cache on)…
  k8s/file3: resolve (cache on): 1.03 s
  k8s/file3: typecheck…
  k8s/file3: typecheck: 2.7 ms
  k8s/file3: ready
  k8s/file4: parse…
  k8s/file4: parse: 108 μs
  k8s/file4: resolve (cache on)…
  k8s/file4: resolve (cache on): 633.5 ms
  k8s/file4: typecheck…
  k8s/file4: typecheck: 2.8 ms
  k8s/file4: ready
Starting tasty-bench…
All
  normalize
    ChurchEval
      typecheck:  OK
        22.3 μs ± 1.8 μs
      evaluation: OK
        320  ms ±  28 ms
    FunCompose
      typecheck:  OK
        10.8 μs ± 845 ns
      evaluation: OK
        277  ms ±  27 ms
    Iterate
      typecheck:  OK
        7.23 μs ± 431 ns
      evaluation: OK
        283  ms ±  23 ms
    IterateAlt
      typecheck:  OK
        9.22 μs ± 441 ns
      evaluation: OK
        278  ms ±  21 ms
    IterateAlt2
      typecheck:  OK
        8.13 μs ± 430 ns
      evaluation: OK
        279  ms ± 7.5 ms
    ListBench
      typecheck:  OK
        24.7 μs ± 2.0 μs
      evaluation: OK
        102  ms ± 8.6 ms
    ListBenchAlt
      typecheck:  OK
        23.0 μs ± 1.1 μs
      evaluation: OK
        201  ms ±  13 ms
    NaturalFoldShortcut
      typecheck:  OK
        498  ns ±  29 ns
      evaluation: OK
        8.33 μs ± 415 ns
  large1
    parse:        OK
      184  ms ±  16 ms
    resolve:      OK
      88.2 ms ± 8.0 ms
    typecheck:    OK
      60.1 ms ± 5.3 ms
    evaluation:   OK
      106  ms ± 7.7 ms
    cbor:         OK
      110  ms ± 8.0 ms
  k8s
    file3
      resolve:    OK
        2.476 s ± 178 ms
      typecheck:  OK
        2.90 ms ± 243 μs
      evaluation: OK
        248  μs ±  16 μs
    file4
      resolve:    OK
        2.163 s ±  53 ms
      typecheck:  OK
        2.86 ms ± 199 μs
      evaluation: OK
        246  μs ±  17 μs

All 27 tests passed (87.33s)
```