### PR TITLE
implement new Date, Time primitives in the new paradigm

### DIFF
--- a/dhall-nix/src/Dhall/Nix.hs
+++ b/dhall-nix/src/Dhall/Nix.hs
@@ -102,6 +102,7 @@ import qualified  Data.Text as Text
 import Data.Traversable (for)
 import Data.Typeable (Typeable)
 import Data.Void (Void, absurd)
+import Data.String (fromString)
 import Lens.Micro (toListOf, rewriteOf)
 import Numeric (showHex)
 import Data.Char (ord, isDigit, isAsciiLower, isAsciiUpper)
@@ -266,7 +267,7 @@ Right x: y: x + y
 -}
 dhallToNix :: Expr s Void -> Either CompileError NExpr
 dhallToNix e =
-    loop (rewriteShadowed (Dhall.Core.normalize e))
+    loop (rewriteShadowed (renameBuiltinShadowing (Dhall.Core.normalize e)))
   where
     untranslatable = Nix.attrsE []
 
@@ -316,6 +317,18 @@ dhallToNix e =
               where
                 x' = x <> Data.Text.pack (show n)
 
+    renameBuiltin :: (Text, Expr s Void) -> Maybe (Text, Expr s Void)
+    renameBuiltin (x, expression)
+        | isNixBuiltinPrimitiveName x =
+            Just
+              ( x'
+              , Dhall.Core.subst (V x 0) (Var (V x' 0)) (Dhall.Core.shift 1 (V x' 0) expression)
+              )
+        | otherwise =
+            Nothing
+      where
+        x' = x <> "_"
+
     renameShadowed :: Expr s Void -> Maybe (Expr s Void)
     renameShadowed (Lam cs FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = a} b) = do
         (x', b') <- rename (x, b)
@@ -332,11 +345,67 @@ dhallToNix e =
     renameShadowed _ =
         Nothing
 
+    renameBuiltinShadowing :: Expr s Void -> Expr s Void
+    renameBuiltinShadowing =
+        rewriteOf Dhall.Core.subExpressions renameBuiltinShadowed
+
+    renameBuiltinShadowed :: Expr s Void -> Maybe (Expr s Void)
+    renameBuiltinShadowed (Lam cs FunctionBinding { functionBindingVariable = x, functionBindingAnnotation = a} b) = do
+        (x', b') <- renameBuiltin (x, b)
+
+        return (Lam cs (Dhall.Core.makeFunctionBinding x' a) b')
+    renameBuiltinShadowed (Pi cs x a b) = do
+        (x', b') <- renameBuiltin (x, b)
+
+        return (Pi cs x' a b')
+    renameBuiltinShadowed (Let Binding{ variable = x, .. } a) = do
+        (x' , a') <- renameBuiltin (x, a)
+
+        return (Let Binding{ variable = x', .. } a')
+    renameBuiltinShadowed _ =
+        Nothing
+
     -- Even higher-level utility that renames all shadowed references
     rewriteShadowed =
         rewriteOf Dhall.Core.subExpressions renameShadowed
 
+    regexSubstrToInt :: String -> Text -> NExpr
+    regexSubstrToInt argName regex =
+        fromString argName
+            ==> (   "builtins.fromJSON"
+                @@  (   "builtins.head"
+                    @@  (   "builtins.match"
+                        @@  Nix.mkStr regex
+                        @@  fromString argName
+                        )
+                    )
+                )
+
+    nixBuiltinPrimitive :: Text -> Maybe NExpr
+    nixBuiltinPrimitive "Date/year" =
+        Just (regexSubstrToInt "date" "0*([0-9]+)-[0-9]{2}-[0-9]{2}")
+    nixBuiltinPrimitive "Date/month" =
+        Just (regexSubstrToInt "date" "[0-9]{4}-0?([0-9]+)-[0-9]{2}")
+    nixBuiltinPrimitive "Date/day" =
+        Just (regexSubstrToInt "date" "[0-9]{4}-[0-9]{2}-0?([0-9]+)")
+    nixBuiltinPrimitive "Time/hour" =
+        Just (regexSubstrToInt "time" "0?([0-9]+):[0-9]{2}:[0-9]{2}.*")
+    nixBuiltinPrimitive "Time/minute" =
+        Just (regexSubstrToInt "time" "[0-9]{2}:0?([0-9]+):[0-9]{2}.*")
+    nixBuiltinPrimitive "Time/second" =
+        Just (regexSubstrToInt "time" "[0-9]{2}:[0-9]{2}:0?([0-9]+).*")
+    nixBuiltinPrimitive _ =
+        Nothing
+
+    isNixBuiltinPrimitiveName :: Text -> Bool
+    isNixBuiltinPrimitiveName name =
+        case nixBuiltinPrimitive name of
+            Just _  -> True
+            Nothing -> False
+
     loop (Const _) = return untranslatable
+    loop (Var (V a 0))
+        | Just builtin <- nixBuiltinPrimitive a = return builtin
     loop (Var (V a 0)) = return (Nix.mkSym (zEncodeSymbol a))
     loop (Var  a     ) = Left (CannotReferenceShadowedVariable a)
     loop (Lam _ FunctionBinding { functionBindingVariable = a } c) = do

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -433,6 +433,7 @@ Test-Suite tasty
         Dhall.Test.Parser
         Dhall.Test.QuickCheck
         Dhall.Test.Regression
+        Dhall.Test.Regression.Primitives
         Dhall.Test.Regression.TextReplaceNoop
         Dhall.Test.Schemas
         Dhall.Test.SemanticHash

--- a/dhall/src/Dhall/Eval.hs
+++ b/dhall/src/Dhall/Eval.hs
@@ -45,6 +45,7 @@ module Dhall.Eval (
   , Environment(..)
   , Val(..)
   , (~>)
+  , unboundBuiltinTypes
   , textShow
   , dateShow
   , timeShow
@@ -79,14 +80,15 @@ import Dhall.Syntax
     )
 
 import qualified Data.Char
-import qualified Data.Sequence as Sequence
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Sequence       as Sequence
 import qualified Data.Set
-import qualified Data.Text     as Text
-import qualified Data.Time     as Time
-import qualified Dhall.Map     as Map
+import qualified Data.Text           as Text
+import qualified Data.Time           as Time
+import qualified Dhall.Map           as Map
 import qualified Dhall.Set
-import qualified Dhall.Syntax  as Syntax
-import qualified Text.Printf   as Printf
+import qualified Dhall.Syntax        as Syntax
+import qualified Text.Printf         as Printf
 
 data Environment a
     = Empty
@@ -313,8 +315,107 @@ vVar env0 (V x i0) = go env0 i0
             if i == 0 then VVar x (countEnvironment x env) else go env (i - 1)
         | otherwise =
             go env i
+    go Empty 0
+        | Just builtin <- HashMap.lookup x unboundBuiltinValues =
+            builtin
     go Empty i =
         VVar x (negate i - 1)
+
+data BuiltinPrim a = BuiltinPrim
+    { primName :: Text
+    , primType :: Val a
+    , primVal  :: Val a
+    }
+
+-- New-style primitives implemented as ordinary variables with specially recognized names.
+-- Parsing, pretty-printing, and CBOR still treat these primitives as plain variables.
+unboundPrimitives :: [BuiltinPrim a]
+unboundPrimitives =
+    [ BuiltinPrim { primName = "Date/year"  , primType = dateYearType  , primVal = dateYearPrimVal   }
+    , BuiltinPrim { primName = "Date/month" , primType = dateMonthType , primVal = dateMonthPrimVal  }
+    , BuiltinPrim { primName = "Date/day"   , primType = dateDayType   , primVal = dateDayPrimVal    }
+    , BuiltinPrim { primName = "Time/hour"  , primType = timeHourType  , primVal = timeHourPrimVal   }
+    , BuiltinPrim { primName = "Time/minute", primType = timeMinuteType, primVal = timeMinutePrimVal }
+    , BuiltinPrim { primName = "Time/second", primType = timeSecondType, primVal = timeSecondPrimVal }
+    ]
+  where
+    dateYearType = VDate ~> VNatural
+    dateYearPrimVal = dateComponent "Date/year" getYear
+
+    dateMonthType = VDate ~> VNatural
+    dateMonthPrimVal = dateComponent "Date/month" getMonth
+
+    dateDayType = VDate ~> VNatural
+    dateDayPrimVal = dateComponent "Date/day" getDay
+
+    timeHourType = VTime ~> VNatural
+    timeHourPrimVal = timeComponent "Time/hour" getHour
+
+    timeMinuteType = VTime ~> VNatural
+    timeMinutePrimVal = timeComponent "Time/minute" getMinute
+
+    timeSecondType = VTime ~> VNatural
+    timeSecondPrimVal = timeComponent "Time/second" getSecond
+
+-- Type registration table for primitives implemented as ordinary variable
+-- names.
+unboundBuiltinTypes :: HashMap.HashMap Text (Val a)
+unboundBuiltinTypes =
+    HashMap.fromList
+        [ (primName prim, primType prim)
+        | prim <- unboundPrimitives
+        ]
+
+-- Evaluation registration table for primitives implemented as ordinary
+-- variable names.
+unboundBuiltinValues :: HashMap.HashMap Text (Val a)
+unboundBuiltinValues =
+    HashMap.fromList
+        [ (primName prim, primVal prim)
+        | prim <- unboundPrimitives
+        ]
+
+dateComponent :: Text -> (Day -> Natural) -> Val a
+dateComponent name extract =
+    VPrim $ \case
+        VPrimVar ->
+            neutral
+        VDateLiteral d ->
+            VNaturalLit (extract d)
+        t ->
+            VApp neutral t
+  where
+    neutral = VVar name (-1)
+
+timeComponent :: Text -> (TimeOfDay -> Natural) -> Val a
+timeComponent name extract =
+    VPrim $ \case
+        VPrimVar ->
+            neutral
+        VTimeLiteral time _ ->
+            VNaturalLit (extract time)
+        t ->
+            VApp neutral t
+  where
+    neutral = VVar name (-1)
+
+getYear :: Day -> Natural
+getYear = fromIntegral . (\(year, _, _) -> year) . Time.toGregorian
+
+getMonth :: Day -> Natural
+getMonth = fromIntegral . (\(_, month, _) -> month) . Time.toGregorian
+
+getDay :: Day -> Natural
+getDay = fromIntegral . (\(_, _, day) -> day) . Time.toGregorian
+
+getHour :: TimeOfDay -> Natural
+getHour (TimeOfDay hour _ _) = fromIntegral hour
+
+getMinute :: TimeOfDay -> Natural
+getMinute (TimeOfDay _ minute _) = fromIntegral minute
+
+getSecond :: TimeOfDay -> Natural
+getSecond (TimeOfDay _ _ seconds) = floor seconds
 
 vApp :: Eq a => Val a -> Val a -> Val a
 vApp !t !u =

--- a/dhall/src/Dhall/TypeCheck.hs
+++ b/dhall/src/Dhall/TypeCheck.hs
@@ -66,6 +66,7 @@ import Dhall.Syntax
 
 import qualified Data.Foldable               as Foldable
 import qualified Data.Foldable.WithIndex     as Foldable.WithIndex
+import qualified Data.HashMap.Strict         as HashMap
 import qualified Data.List.NonEmpty          as NonEmpty
 import qualified Data.Map
 import qualified Data.Sequence
@@ -108,6 +109,11 @@ rule Sort Kind = Sort
 rule Type Sort = Sort
 rule Kind Sort = Sort
 rule Sort Sort = Sort
+
+-- Type registration table for primitives implemented as ordinary variable
+-- names.  The entries are defined in `Dhall.Eval.unboundPrimitives`.
+unboundBuiltinTypes :: HashMap.HashMap Text (Val a)
+unboundBuiltinTypes = Eval.unboundBuiltinTypes
 
 {-| Type-check an expression and return the expression's type if type-checking
     succeeds or an error if type-checking fails
@@ -218,7 +224,11 @@ infer typer = loop
             fmap VConst (axiom c)
 
         Var (V x0 n0) -> do
-            let go TypesEmpty _ =
+            let go TypesEmpty 0 =
+                    case HashMap.lookup x0 unboundBuiltinTypes of
+                        Just t  -> return t
+                        Nothing -> die (UnboundVariable x0)
+                go TypesEmpty _ =
                     die (UnboundVariable x0)
                 go (TypesBind ts x t) n
                     | x == x0   = if n == 0 then return t else go ts (n - 1)

--- a/dhall/tests/Dhall/Test/Regression.hs
+++ b/dhall/tests/Dhall/Test/Regression.hs
@@ -24,6 +24,7 @@ import qualified Dhall.Core
 import qualified Dhall.Map
 import qualified Dhall.Parser
 import qualified Dhall.Pretty
+import qualified Dhall.Test.Regression.Primitives
 import qualified Dhall.Test.Util           as Util
 import qualified Dhall.Test.Regression.TextReplaceNoop
 import qualified Dhall.TypeCheck
@@ -59,6 +60,7 @@ tests =
         , typeChecking2
         , unnamedFields
         , trailingSpaceAfterStringLiterals
+        , Dhall.Test.Regression.Primitives.tests
         , Dhall.Test.Regression.TextReplaceNoop.tests
         , largeNaturalLiteralParsing
         , largeNaturalHexadecimalParsing

--- a/dhall/tests/Dhall/Test/Regression/Primitives.hs
+++ b/dhall/tests/Dhall/Test/Regression/Primitives.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Dhall.Test.Regression.Primitives (tests) where
+
+import Data.Void        (Void)
+import Numeric.Natural  (Natural)
+import Test.Tasty       (TestTree)
+import Test.Tasty.HUnit ((@?=))
+
+import qualified Dhall
+import qualified Dhall.Binary
+import qualified Dhall.Core
+import qualified Dhall.Test.Util      as Util
+import qualified Test.Tasty
+import qualified Test.Tasty.HUnit
+
+-- These tests cover built-ins implemented as ordinary variable names.  A name
+-- behaves like a built-in only when lookup reaches the empty context/environment.
+tests :: TestTree
+tests =
+    Test.Tasty.testGroup "Primitives"
+        [ Test.Tasty.HUnit.testCase "extracts fields from date literals" $ do
+            year :: Natural <- Dhall.input Dhall.auto "Date/year 2024-08-13"
+            month :: Natural <- Dhall.input Dhall.auto "Date/month 2024-08-13"
+            day :: Natural <- Dhall.input Dhall.auto "Date/day 2024-08-13"
+
+            year @?= 2024
+            month @?= 8
+            day @?= 13
+
+        , Test.Tasty.HUnit.testCase "extracts fields from time literals" $ do
+            hour :: Natural <- Dhall.input Dhall.auto "Time/hour 09:08:07.123"
+            minute :: Natural <- Dhall.input Dhall.auto "Time/minute 09:08:07.123"
+            second :: Natural <- Dhall.input Dhall.auto "Time/second 09:08:07.123"
+
+            hour @?= 9
+            minute @?= 8
+            second @?= 7
+
+        , Test.Tasty.HUnit.testCase "normalizes field extraction" $ do
+            dateExpression <- Util.code "Date/day 2024-08-13"
+            timeExpression <- Util.code "Time/second 09:08:07.987"
+
+            Util.normalize' dateExpression @?= "13"
+            Util.normalize' timeExpression @?= "7"
+
+        , Test.Tasty.HUnit.testCase "allows let-bound names to override primitives" $ do
+            dateResult :: Natural <-
+                Dhall.input Dhall.auto "let Date/year : Natural = 42 in Date/year"
+            timeResult :: Natural <-
+                Dhall.input Dhall.auto "let Time/hour : Natural = 42 in Time/hour"
+
+            dateResult @?= 42
+            timeResult @?= 42
+
+        , Test.Tasty.HUnit.testCase "allows lambda-bound names to override primitives" $ do
+            dateResult :: Natural <-
+                Dhall.input Dhall.auto "(\\(Date/day : Natural) -> Date/day) 99"
+            timeResult :: Natural <-
+                Dhall.input Dhall.auto "(\\(Time/second : Natural) -> Time/second) 99"
+
+            dateResult @?= 99
+            timeResult @?= 99
+
+        , Test.Tasty.HUnit.testCase "allows explicit outer index to reach shadowed primitive" $ do
+            dateResult :: Natural <-
+                Dhall.input Dhall.auto "let Date/year : Natural = 42 in Date/year@1 2024-08-13"
+            timeResult :: Natural <-
+                Dhall.input Dhall.auto "let Time/hour : Natural = 42 in Time/hour@1 09:08:07"
+
+            dateResult @?= 2024
+            timeResult @?= 9
+
+        , Test.Tasty.HUnit.testCase "rejects out-of-range builtin indices" $ do
+            Util.assertDoesntTypeCheck "Date/year@1 2024-08-13"
+            Util.assertDoesntTypeCheck "Time/hour@1 09:08:07"
+
+        , Test.Tasty.HUnit.testCase "encodes as ordinary variables" $ do
+            let dateExpression =
+                    Dhall.Core.Var (Dhall.Core.V "Date/year" 0) :: Dhall.Core.Expr Void Void
+            let timeExpression =
+                    Dhall.Core.Var (Dhall.Core.V "Time/hour" 0) :: Dhall.Core.Expr Void Void
+
+            Dhall.Binary.decodeExpression (Dhall.Binary.encodeExpression dateExpression)
+                @?= Right dateExpression
+            Dhall.Binary.decodeExpression (Dhall.Binary.encodeExpression timeExpression)
+                @?= Right timeExpression
+        ]


### PR DESCRIPTION
In https://github.com/dhall-lang/dhall-lang/issues/1439 I described a new way of implementing Dhall primitives: as overloadable names rather than as new syntax elements.

To try out this new idea, here is a re-implementation of the `Date` and `Time` primitives from https://github.com/dhall-lang/dhall-haskell/pull/2655 where the new primitives are just identifiers with special names, not new elements of syntax. @kukimik 

Compared with https://github.com/dhall-lang/dhall-haskell/pull/2655 this PR has very localized changes. No changes in `Bash.hs`, `Json.hs`, no changes in the parser or CBOR code. The Nix translation needs to be updated similarly to the old PR.