### PR TITLE
optimizing the semi-semantic cache

### DIFF
--- a/dhall/CHANGELOG.md
+++ b/dhall/CHANGELOG.md
@@ -1,5 +1,12 @@
 1.42.3
 
+* Merkle-keyed semisemantic cache for unhashed Code imports (`dhall-haskell-v2/`):
+  keys are local AST + child edge hashes (not CBOR of inlined NFs); values are
+  either a small normal form or a well-typed marker, so giant NFs are never
+  written or decoded. Starting-context and substitution fingerprints are
+  memoized once per import run.
+* Fast-path `shiftSubstitutions` when a binder cannot capture a substitution,
+  and cache the resolved substitution map once per import run on `Status`.
 * [Fix the typechecking rule for `Optional` + `with`](https://github.com/dhall-lang/dhall-haskell/pull/2650)
 * [Add `*WithIndex` instances for `Map`](https://github.com/dhall-lang/dhall-haskell/pull/2633)
 * [`dhall package`: Add support for automatic sub-packags](https://github.com/dhall-lang/dhall-haskell/pull/2639)

--- a/dhall/CHANGELOG.md
+++ b/dhall/CHANGELOG.md
@@ -1,10 +1,11 @@
 1.42.3
 
-* Merkle-keyed semisemantic cache for unhashed Code imports (`dhall-haskell-v2/`):
-  keys are local AST + child edge hashes (not CBOR of inlined NFs); values are
-  either a small normal form or a well-typed marker, so giant NFs are never
-  written or decoded. Starting-context and substitution fingerprints are
-  memoized once per import run.
+* Faster disk cache for local imports without integrity checks. Cache keys
+  hash this file's syntax plus hashes of its imports, instead of hashing the
+  fully resolved tree. Entries go in `dhall-haskell-v2/` so they are not mixed
+  with older `dhall-haskell/` files. Small results store a normal form; large
+  ones store only an "already type-checked" marker. Starting-context and
+  substitution hashes are computed once per import run.
 * Fast-path `shiftSubstitutions` when a binder cannot capture a substitution,
   and cache the resolved substitution map once per import run on `Status`.
 * [Fix the typechecking rule for `Optional` + `with`](https://github.com/dhall-lang/dhall-haskell/pull/2650)

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -436,6 +436,7 @@ Test-Suite tasty
         Dhall.Test.Regression.TextReplaceNoop
         Dhall.Test.Schemas
         Dhall.Test.SemanticHash
+        Dhall.Test.SemisemanticCache
         Dhall.Test.Substitution
         Dhall.Test.Tutorial
         Dhall.Test.TypeInference

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -65,7 +65,7 @@ module Dhall
 import Control.Applicative    (Alternative, empty)
 import Control.Monad.Catch    (MonadThrow, throwM)
 import Data.Either.Validation (Validation (..))
-import Data.Void              (Void)
+import Data.Void              (Void, absurd)
 import Dhall.Import           (Imported (..), Status)
 import Dhall.Parser           (Src (..))
 import Dhall.Syntax           (Expr (..), Import)
@@ -266,6 +266,12 @@ resolveWithSettings settings expression =
 
 -- | A version of 'resolveWithSettings' that also returns the import 'Status'
 -- together with the resolved expression.
+--
+-- Substitutions are applied to the unresolved entry expression first, then
+-- again inside import loading (so each import can be type-checked). They are
+-- not applied again to the fully inlined tree: that second whole-AST walk
+-- rebuilt the substitution map at every binder, which dominated large
+-- @as Source@ products.
 resolveAndStatusWithSettings
     :: InputSettings
     -> Expr Src Import
@@ -275,11 +281,14 @@ resolveAndStatusWithSettings settings expression = do
 
     let status = emptyStatusWithSettings _evaluateSettings _rootDirectory
 
-    (resolved, status') <- State.runStateT (Dhall.Import.loadWith expression) status
+    let expression' =
+            Dhall.Substitution.substitute
+                expression
+                (fmap (fmap absurd) (view substitutions settings))
 
-    let substituted = Dhall.Substitution.substitute resolved (view substitutions settings)
+    (resolved, status') <- State.runStateT (Dhall.Import.loadWith expression') status
 
-    pure (substituted, status')
+    pure (resolved, status')
 
 -- | As 'emptyStatus' but applying 'EvaluateSettings'.
 emptyStatusWithSettings :: EvaluateSettings -> FilePath -> Status

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -137,6 +137,7 @@ module Dhall.Import (
     , remote
     , toHeaders
     , substitutions
+    , resolvedSubstitutions
     , normalizer
     , startingContext
     , reportWarning
@@ -633,6 +634,31 @@ writeToSemanticCache report hash bytes = do
         liftIO (AtomicWrite.Binary.atomicWriteFile cacheFile bytes)
     return ()
 
+-- | Apply 'Status' substitutions, resolving the map at most once per run.
+--
+--   Public 'Dhall.Substitution.substitute' re-resolves on every call. That
+--   dominated as-code loads with a large Haskell-API map (once per imported
+--   file). The raw map is fixed for the run, so we cache
+--   'Dhall.Substitution.ResolvedSubstitutions' on 'Status'.
+applyStatusSubstitutions
+    :: Expr Src Void -> StateT Status IO (Expr Src Void)
+applyStatusSubstitutions expression = do
+    Status { _substitutions, _resolvedSubstitutions } <- State.get
+
+    resolved <- case _resolvedSubstitutions of
+        Just cached ->
+            return cached
+        Nothing -> do
+            let cached =
+                    Dhall.Substitution.resolveSubstitutions _substitutions
+
+            State.modify
+                (\s -> s { _resolvedSubstitutions = Just cached })
+
+            return cached
+
+    return (Dhall.Substitution.substituteMany resolved expression)
+
 -- Check the "semi-semantic" disk cache, otherwise typecheck and normalise from
 -- scratch.
 loadImportWithSemisemanticCache
@@ -683,8 +709,7 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
             return importSemantics
 
         Nothing -> do
-            let substitutedExpr =
-                  Dhall.Substitution.substitute resolvedExpr _substitutions
+            substitutedExpr <- applyStatusSubstitutions resolvedExpr
 
             case Core.shallowDenote parsedImport of
                 -- If this import trivially wraps another import, we can skip

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -112,6 +112,9 @@ module Dhall.Import (
     , localToPath
     , hashExpression
     , hashExpressionToCode
+    , estimateExprSize
+    , exceedsNFSizeThreshold
+    , semisemanticNFSizeThreshold
     , writeExpressionToSemanticCache
     , assertNoImports
     , Manager
@@ -138,6 +141,7 @@ module Dhall.Import (
     , toHeaders
     , substitutions
     , resolvedSubstitutions
+    , merkleHashCache
     , normalizer
     , startingContext
     , reportWarning
@@ -163,13 +167,14 @@ import Control.Exception
     , SomeException
     , toException
     )
+import Control.Monad              (foldM)
 import Control.Monad.Catch        (MonadCatch (catch), handle, throwM)
 import Control.Monad.IO.Class     (MonadIO (..))
 import Control.Monad.Morph        (hoist)
 import Control.Monad.State.Strict (MonadState, StateT)
 import Data.ByteString            (ByteString)
 import Data.List.NonEmpty         (NonEmpty (..), nonEmpty)
-import Data.Maybe                 (fromMaybe)
+import Data.Maybe                 (fromMaybe, isJust, isNothing)
 import Data.Text                  (Text)
 import Data.Typeable              (Typeable)
 import Data.Void                  (Void, absurd)
@@ -221,12 +226,14 @@ import qualified Control.Monad.State.Strict                  as State
 import qualified Control.Monad.Trans.Maybe                   as Maybe
 import qualified Data.ByteString
 import qualified Data.ByteString.Lazy
+import qualified Data.Functor.Const                          as FunctorConst
 import qualified Data.List.NonEmpty                          as NonEmpty
 import qualified Data.Maybe                                  as Maybe
 import qualified Data.Text                                   as Text
 import qualified Data.Text.Encoding                          as Encoding
 import qualified Data.Text.IO
 import qualified Dhall.Binary
+import qualified Dhall.Context
 import qualified Dhall.Core                                  as Core
 import qualified Dhall.Crypto
 import qualified Dhall.Map
@@ -661,9 +668,15 @@ applyStatusSubstitutions expression = do
 
 -- Check the "semi-semantic" disk cache, otherwise typecheck and normalise from
 -- scratch.
+--
+-- Unhashed Code imports use a merkle-keyed cache under @dhall-haskell-v2/@
+-- (see 'computeMerkleSemisemanticHash'). The value is either a small normal
+-- form (skip typecheck + normalize on hit) or a well-typed marker (skip
+-- typecheck only; normalize the in-memory resolved tree).
 loadImportWithSemisemanticCache
   :: Chained -> StateT Status IO ImportSemantics
-loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Code)) = do
+loadImportWithSemisemanticCache
+    import_@(Chained (Import (ImportHashed _ importType) Code)) = do
     text <- fetchFresh importType
     Status {..} <- State.get
 
@@ -690,31 +703,49 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
         Right expr    -> return expr
 
     resolvedExpr <- loadWith parsedImport  -- we load imports recursively here
+    Status {..} <- State.get
 
-    -- Check the semi-semantic cache. See
-    -- https://github.com/dhall-lang/dhall-haskell/issues/1098 for the reasoning
-    -- behind semi-semantic caching.
-    let semisemanticHash = computeSemisemanticHash (Core.denote resolvedExpr)
+    -- Merkle key: local denoted parse tree with child edge hashes, plus a
+    -- fingerprint of the starting context and substitutions. See
+    -- https://github.com/dhall-lang/dhall-haskell/issues/1098
+    semisemanticHash <- computeMerkleSemisemanticHash import_ parsedImport
 
-    mCached <- zoom cacheWarning (fetchFromSemisemanticCache _reportWarning semisemanticHash)
+    zoom merkleHashCache
+        (State.modify (Dhall.Map.insert import_ semisemanticHash))
+
+    mCached <-
+        zoom cacheWarning
+            (fetchFromSemisemanticCacheV2 _reportWarning semisemanticHash)
+
+    let hasCustomNormalizer = isJust _normalizer
 
     importSemantics <- case mCached of
-        Just bytesStrict -> do
+        Just (SemisemanticCachedNF bytesStrict)
+            | not hasCustomNormalizer -> do
             let bytesLazy = Data.ByteString.Lazy.fromStrict bytesStrict
 
-            importSemantics <- case Dhall.Binary.decodeExpression bytesLazy of
+            case Dhall.Binary.decodeExpression bytesLazy of
                 Left err  -> throwMissingImport (Imported _stack err)
                 Right sem -> return sem
 
-            return importSemantics
-
-        Nothing -> do
+        Just SemisemanticWellTyped -> do
             substitutedExpr <- applyStatusSubstitutions resolvedExpr
 
             case Core.shallowDenote parsedImport of
-                -- If this import trivially wraps another import, we can skip
-                -- the type-checking and normalization step as the transitive
-                -- import was already type-checked and normalized
+                Embed _ ->
+                    return (Core.denote substitutedExpr)
+
+                _ ->
+                    liftIO
+                        (Exception.evaluate
+                            (Core.normalizeWith _normalizer substitutedExpr)
+                        )
+
+        -- Missing, corrupt, or NF payload under a custom normalizer: miss path.
+        _ -> do
+            substitutedExpr <- applyStatusSubstitutions resolvedExpr
+
+            case Core.shallowDenote parsedImport of
                 Embed _ ->
                     return (Core.denote substitutedExpr)
 
@@ -723,12 +754,23 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
                         Left  err -> throwMissingImport (Imported _stack err)
                         Right _   -> return ()
 
-                    let betaNormal =
-                            Core.normalizeWith _normalizer substitutedExpr
+                    betaNormal <-
+                        liftIO (Exception.evaluate (Core.normalizeWith _normalizer substitutedExpr))
 
-                    let bytes = encodeExpression betaNormal
+                    let payload
+                            | hasCustomNormalizer =
+                                SemisemanticWellTyped
+                            | exceedsNFSizeThreshold betaNormal =
+                                SemisemanticWellTyped
+                            | otherwise =
+                                SemisemanticCachedNF (encodeExpression betaNormal)
 
-                    zoom cacheWarning (writeToSemisemanticCache _reportWarning semisemanticHash bytes)
+                    zoom cacheWarning
+                        (writeToSemisemanticCacheV2
+                            _reportWarning
+                            semisemanticHash
+                            payload
+                        )
 
                     return betaNormal
 
@@ -736,22 +778,32 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Cod
 
 -- `as Text` and `as Bytes` imports aren't cached since they are well-typed and
 -- normal by construction
-loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) RawText)) = do
+loadImportWithSemisemanticCache import_@(Chained (Import (ImportHashed _ importType) RawText)) = do
     text <- fetchFresh importType
 
     -- importSemantics is alpha-beta-normal by construction!
     let importSemantics = TextLit (Chunks [] text)
+
+    let edgeHash = Dhall.Crypto.sha256Hash (Encoding.encodeUtf8 text)
+
+    zoom merkleHashCache (State.modify (Dhall.Map.insert import_ edgeHash))
+
     return (ImportSemantics {..})
-loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) RawBytes)) = do
+loadImportWithSemisemanticCache import_@(Chained (Import (ImportHashed _ importType) RawBytes)) = do
     bytes <- fetchBytes importType
 
     -- importSemantics is alpha-beta-normal by construction!
     let importSemantics = BytesLit bytes
+
+    let edgeHash = Dhall.Crypto.sha256Hash bytes
+
+    zoom merkleHashCache (State.modify (Dhall.Map.insert import_ edgeHash))
+
     return (ImportSemantics {..})
 
 -- `as Location` imports aren't cached since they are well-typed and normal by
 -- construction
-loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Location)) = do
+loadImportWithSemisemanticCache import_@(Chained (Import (ImportHashed _ importType) Location)) = do
     let locationType = Union $ Dhall.Map.fromList
             [ ("Environment", Just Text)
             , ("Remote", Just Text)
@@ -772,34 +824,229 @@ loadImportWithSemisemanticCache (Chained (Import (ImportHashed _ importType) Loc
                 App (Field locationType $ Core.makeFieldSelection "Environment")
                   (TextLit (Chunks [] (Core.pretty env)))
 
+    let edgeHash = Dhall.Crypto.sha256Hash (encodeExpression importSemantics)
+
+    zoom merkleHashCache (State.modify (Dhall.Map.insert import_ edgeHash))
+
     return (ImportSemantics {..})
 
--- The semi-semantic hash of an expression is computed from the fully resolved
--- AST (without normalising or type-checking it first). See
--- https://github.com/dhall-lang/dhall-haskell/issues/1098 for further
--- discussion.
-computeSemisemanticHash :: Expr Void Void -> Dhall.Crypto.SHA256Digest
-computeSemisemanticHash resolvedExpr = hashExpression resolvedExpr
+-- | Maximum estimated AST size (see 'exceedsNFSizeThreshold') for which the
+-- semisemantic v2 cache stores a normal form. Larger results store only a
+-- well-typed marker so we avoid CBOR-encoding / decoding giant NFs.
+semisemanticNFSizeThreshold :: Int
+semisemanticNFSizeThreshold = 64 * 1024
 
--- Fetch encoded normal form from "semi-semantic cache"
-fetchFromSemisemanticCache
+-- | Full-tree size estimate: AST nodes plus 'Text' / 'Bytes' payloads. Does
+-- not CBOR-encode. Used as the naive baseline for size-walk tests; production
+-- cache decisions use 'exceedsNFSizeThreshold'.
+estimateExprSize :: Expr s a -> Int
+estimateExprSize expression =
+    case expression of
+        TextLit (Chunks xys z) ->
+            1
+          + Text.length z
+          + sum [ Text.length t + estimateExprSize x | (t, x) <- xys ]
+        BytesLit bytes ->
+            1 + Data.ByteString.length bytes
+        Embed _ ->
+            1
+        _ ->
+            let FunctorConst.Const childSizes =
+                    Syntax.subExpressions
+                        (\child -> FunctorConst.Const [estimateExprSize child])
+                        expression
+            in  1 + sum childSizes
+
+-- | 'True' when the expression's estimated size is strictly greater than
+-- 'semisemanticNFSizeThreshold'. Same metric as 'estimateExprSize', but
+-- aborts as soon as the remaining budget is exhausted so giant NFs are not
+-- fully traversed.
+exceedsNFSizeThreshold :: Expr s a -> Bool
+exceedsNFSizeThreshold expression =
+    isNothing (spend semisemanticNFSizeThreshold expression)
+  where
+    debit budget cost
+        | budget < cost = Nothing
+        | otherwise     = Just (budget - cost)
+
+    spend budget _
+        | budget <= 0 =
+            Nothing
+    spend budget (TextLit (Chunks xys z)) = do
+        b0 <- debit budget (1 + Text.length z)
+        foldM
+            (\b (t, x) -> debit b (Text.length t) >>= (`spend` x))
+            b0
+            xys
+    spend budget (BytesLit bytes) =
+        debit budget (1 + Data.ByteString.length bytes)
+    spend budget (Embed _) =
+        debit budget 1
+    spend budget expr = do
+        b0 <- debit budget 1
+        let FunctorConst.Const kids =
+                Syntax.subExpressions
+                    (\child -> FunctorConst.Const [child])
+                    expr
+        foldM spend b0 kids
+
+data SemisemanticPayload
+    = SemisemanticCachedNF Data.ByteString.ByteString
+    | SemisemanticWellTyped
+
+semisemanticNFTag :: Data.ByteString.ByteString
+semisemanticNFTag = Data.ByteString.singleton 0
+
+semisemanticTypedTag :: Data.ByteString.ByteString
+semisemanticTypedTag = Data.ByteString.singleton 1
+
+encodeSemisemanticPayload :: SemisemanticPayload -> Data.ByteString.ByteString
+encodeSemisemanticPayload (SemisemanticCachedNF bytes) =
+    semisemanticNFTag <> bytes
+encodeSemisemanticPayload SemisemanticWellTyped =
+    semisemanticTypedTag
+
+decodeSemisemanticPayload
+    :: Data.ByteString.ByteString -> Maybe SemisemanticPayload
+decodeSemisemanticPayload bytes =
+    case Data.ByteString.uncons bytes of
+        Just (0, rest) ->
+            Just (SemisemanticCachedNF rest)
+        Just (1, rest)
+            | Data.ByteString.null rest ->
+                Just SemisemanticWellTyped
+        _ ->
+            Nothing
+
+semisemanticCacheV2Name :: FilePath
+semisemanticCacheV2Name = "dhall-haskell-v2"
+
+-- | Edge hash of a child import for building a parent's merkle key.
+--
+-- Prefer the integrity hash when the import is frozen. Otherwise use a
+-- previously computed merkle hash, or a path-stable sentinel if the child was
+-- not loaded (e.g. the unused side of an @ImportAlt@).
+edgeHashOf :: Chained -> StateT Status IO Dhall.Crypto.SHA256Digest
+edgeHashOf child =
+    case hash (importHashed (chainedImport child)) of
+        Just integrityHash ->
+            return integrityHash
+        Nothing -> do
+            Status { _merkleHashCache } <- State.get
+
+            case Dhall.Map.lookup child _merkleHashCache of
+                Just merkleHash ->
+                    return merkleHash
+                Nothing ->
+                    return
+                        ( Dhall.Crypto.sha256Hash
+                            ( Encoding.encodeUtf8
+                                (Core.pretty (chainedImport child))
+                            )
+                        )
+
+replaceEmbedsWithEdgeHashes
+    :: Chained
+    -> Expr Void Import
+    -> StateT Status IO (Expr Void Void)
+replaceEmbedsWithEdgeHashes parent =
+    Syntax.subExpressionsWith
+        (\childImport -> do
+            child <- chainImport parent childImport
+            edgeHash <- edgeHashOf child
+            return (BytesLit (Dhall.Crypto.unSHA256Digest edgeHash))
+        )
+        (replaceEmbedsWithEdgeHashes parent)
+
+fingerprintStartingContext
+    :: Dhall.Context.Context (Expr Src Void) -> Dhall.Crypto.SHA256Digest
+fingerprintStartingContext context =
+    hashExpression
+        ( RecordLit
+            ( Dhall.Map.fromList
+                [ (name, Core.makeRecordField (Core.denote value))
+                | (name, value) <- Dhall.Context.toList context
+                ]
+            )
+        )
+
+fingerprintSubstitutions
+    :: Dhall.Substitution.Substitutions Src Void -> Dhall.Crypto.SHA256Digest
+fingerprintSubstitutions substitutionMap =
+    hashExpression
+        ( RecordLit
+            ( fmap Core.makeRecordField
+                (fmap Core.denote substitutionMap)
+            )
+        )
+
+computeMerkleSemisemanticHash
+    :: Chained
+    -> Expr Src Import
+    -> StateT Status IO Dhall.Crypto.SHA256Digest
+computeMerkleSemisemanticHash parent parsedImport = do
+    let denotedParsed = Core.denote parsedImport
+
+    skeleton <- replaceEmbedsWithEdgeHashes parent denotedParsed
+
+    let skeletonHash = hashExpression skeleton
+
+    (contextHash, substitutionsHash) <- memoizedMerkleFingerprints
+
+    return
+        ( Dhall.Crypto.sha256Hash
+            ( Dhall.Crypto.unSHA256Digest skeletonHash
+           <> Dhall.Crypto.unSHA256Digest contextHash
+           <> Dhall.Crypto.unSHA256Digest substitutionsHash
+            )
+        )
+
+memoizedMerkleFingerprints
+    :: StateT Status IO (Dhall.Crypto.SHA256Digest, Dhall.Crypto.SHA256Digest)
+memoizedMerkleFingerprints = do
+    Status {..} <- State.get
+
+    contextHash <- case _merkleContextFingerprint of
+        Just cached ->
+            return cached
+        Nothing -> do
+            let hashed = fingerprintStartingContext _startingContext
+            State.modify (\s -> s { _merkleContextFingerprint = Just hashed })
+            return hashed
+
+    substitutionsHash <- case _merkleSubstitutionsFingerprint of
+        Just cached ->
+            return cached
+        Nothing -> do
+            let hashed = fingerprintSubstitutions _substitutions
+            State.modify (\s -> s { _merkleSubstitutionsFingerprint = Just hashed })
+            return hashed
+
+    return (contextHash, substitutionsHash)
+
+fetchFromSemisemanticCacheV2
     :: (MonadState CacheWarning m, MonadCatch m, MonadIO m)
     => (Text -> IO ()) -> Dhall.Crypto.SHA256Digest
-    -> m (Maybe Data.ByteString.ByteString)
-fetchFromSemisemanticCache report semisemanticHash = Maybe.runMaybeT $ do
-    cacheFile <- getCacheFile report "dhall-haskell" semisemanticHash
+    -> m (Maybe SemisemanticPayload)
+fetchFromSemisemanticCacheV2 report semisemanticHash = Maybe.runMaybeT $ do
+    cacheFile <- getCacheFile report semisemanticCacheV2Name semisemanticHash
     True <- liftIO (Directory.doesFileExist cacheFile)
-    liftIO (Data.ByteString.readFile cacheFile)
+    bytes <- liftIO (Data.ByteString.readFile cacheFile)
+    Maybe.MaybeT (return (decodeSemisemanticPayload bytes))
 
-writeToSemisemanticCache
+writeToSemisemanticCacheV2
     :: (MonadState CacheWarning m, MonadCatch m, MonadIO m)
     => (Text -> IO ()) -> Dhall.Crypto.SHA256Digest
-    -> Data.ByteString.ByteString
+    -> SemisemanticPayload
     -> m ()
-writeToSemisemanticCache report semisemanticHash bytes = do
+writeToSemisemanticCacheV2 report semisemanticHash payload = do
     _ <- Maybe.runMaybeT $ do
-        cacheFile <- getCacheFile report "dhall-haskell" semisemanticHash
-        liftIO (AtomicWrite.Binary.atomicWriteFile cacheFile bytes)
+        cacheFile <- getCacheFile report semisemanticCacheV2Name semisemanticHash
+        liftIO
+            ( AtomicWrite.Binary.atomicWriteFile
+                cacheFile
+                (encodeSemisemanticPayload payload)
+            )
     return ()
 
 -- | Fetch source code directly from disk/network

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -669,10 +669,15 @@ applyStatusSubstitutions expression = do
 -- Check the "semi-semantic" disk cache, otherwise typecheck and normalise from
 -- scratch.
 --
--- Unhashed Code imports use a merkle-keyed cache under @dhall-haskell-v2/@
--- (see 'computeMerkleSemisemanticHash'). The value is either a small normal
--- form (skip typecheck + normalize on hit) or a well-typed marker (skip
--- typecheck only; normalize the in-memory resolved tree).
+-- For Code imports without an integrity hash, the cache key is a hash of this
+-- file's syntax plus hashes of the files it imports (see
+-- 'computeMerkleSemisemanticHash'). A hit is either a small normal form (skip
+-- typecheck and normalize) or a one-byte "already type-checked" marker (skip
+-- typecheck only; still normalize the in-memory tree).
+--
+-- Those entries live under @dhall-haskell-v2/@, not the older
+-- @dhall-haskell/@ directory, because the keys and stored values are not
+-- compatible with the previous cache format.
 loadImportWithSemisemanticCache
   :: Chained -> StateT Status IO ImportSemantics
 loadImportWithSemisemanticCache
@@ -705,8 +710,8 @@ loadImportWithSemisemanticCache
     resolvedExpr <- loadWith parsedImport  -- we load imports recursively here
     Status {..} <- State.get
 
-    -- Merkle key: local denoted parse tree with child edge hashes, plus a
-    -- fingerprint of the starting context and substitutions. See
+    -- Cache key: this file's syntax, hashes of its imports, and hashes of the
+    -- starting context and substitutions. See
     -- https://github.com/dhall-lang/dhall-haskell/issues/1098
     semisemanticHash <- computeMerkleSemisemanticHash import_ parsedImport
 
@@ -715,7 +720,7 @@ loadImportWithSemisemanticCache
 
     mCached <-
         zoom cacheWarning
-            (fetchFromSemisemanticCacheV2 _reportWarning semisemanticHash)
+            (fetchFromSemisemanticCache _reportWarning semisemanticHash)
 
     let hasCustomNormalizer = isJust _normalizer
 
@@ -766,7 +771,7 @@ loadImportWithSemisemanticCache
                                 SemisemanticCachedNF (encodeExpression betaNormal)
 
                     zoom cacheWarning
-                        (writeToSemisemanticCacheV2
+                        (writeToSemisemanticCache
                             _reportWarning
                             semisemanticHash
                             payload
@@ -830,9 +835,9 @@ loadImportWithSemisemanticCache import_@(Chained (Import (ImportHashed _ importT
 
     return (ImportSemantics {..})
 
--- | Maximum estimated AST size (see 'exceedsNFSizeThreshold') for which the
--- semisemantic v2 cache stores a normal form. Larger results store only a
--- well-typed marker so we avoid CBOR-encoding / decoding giant NFs.
+-- | If a result is larger than this (AST nodes plus text/bytes payload), the
+-- disk cache stores only an "already type-checked" marker instead of the
+-- normal form, so huge expressions are not encoded to or decoded from CBOR.
 semisemanticNFSizeThreshold :: Int
 semisemanticNFSizeThreshold = 64 * 1024
 
@@ -918,8 +923,15 @@ decodeSemisemanticPayload bytes =
         _ ->
             Nothing
 
-semisemanticCacheV2Name :: FilePath
-semisemanticCacheV2Name = "dhall-haskell-v2"
+-- | Directory under @$XDG_CACHE_HOME@ (usually @~/.cache@) for Code imports
+-- without integrity checks.
+--
+-- The older semisemantic cache used @dhall-haskell/@ and stored a full normal
+-- form keyed by a hash of the fully resolved expression. This folder uses a
+-- different key and a different payload, so the files must not be mixed. The
+-- @-v2@ suffix is only a directory name to keep the two layouts apart.
+semisemanticCacheDirectory :: FilePath
+semisemanticCacheDirectory = "dhall-haskell-v2"
 
 -- | Edge hash of a child import for building a parent's merkle key.
 --
@@ -980,6 +992,9 @@ fingerprintSubstitutions substitutionMap =
             )
         )
 
+-- | Hash used as the on-disk cache key for a Code import with no integrity
+-- check: this file's denoted syntax, with each import replaced by that
+-- import's hash, plus hashes of the starting context and substitutions.
 computeMerkleSemisemanticHash
     :: Chained
     -> Expr Src Import
@@ -1024,24 +1039,24 @@ memoizedMerkleFingerprints = do
 
     return (contextHash, substitutionsHash)
 
-fetchFromSemisemanticCacheV2
+fetchFromSemisemanticCache
     :: (MonadState CacheWarning m, MonadCatch m, MonadIO m)
     => (Text -> IO ()) -> Dhall.Crypto.SHA256Digest
     -> m (Maybe SemisemanticPayload)
-fetchFromSemisemanticCacheV2 report semisemanticHash = Maybe.runMaybeT $ do
-    cacheFile <- getCacheFile report semisemanticCacheV2Name semisemanticHash
+fetchFromSemisemanticCache report semisemanticHash = Maybe.runMaybeT $ do
+    cacheFile <- getCacheFile report semisemanticCacheDirectory semisemanticHash
     True <- liftIO (Directory.doesFileExist cacheFile)
     bytes <- liftIO (Data.ByteString.readFile cacheFile)
     Maybe.MaybeT (return (decodeSemisemanticPayload bytes))
 
-writeToSemisemanticCacheV2
+writeToSemisemanticCache
     :: (MonadState CacheWarning m, MonadCatch m, MonadIO m)
     => (Text -> IO ()) -> Dhall.Crypto.SHA256Digest
     -> SemisemanticPayload
     -> m ()
-writeToSemisemanticCacheV2 report semisemanticHash payload = do
+writeToSemisemanticCache report semisemanticHash payload = do
     _ <- Maybe.runMaybeT $ do
-        cacheFile <- getCacheFile report semisemanticCacheV2Name semisemanticHash
+        cacheFile <- getCacheFile report semisemanticCacheDirectory semisemanticHash
         liftIO
             ( AtomicWrite.Binary.atomicWriteFile
                 cacheFile

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -22,6 +22,7 @@ import Dhall.Core
     , ReifiedNormalizer (..)
     , URL
     )
+import Dhall.Crypto                     (SHA256Digest)
 import Dhall.Map                        (Map)
 import Dhall.Parser                     (Src)
 import Lens.Micro                       (Lens', lens)
@@ -107,6 +108,21 @@ data Status = Status
     -- ^ Cache of imported expressions with their node id in order to avoid
     --   importing the same expression twice with different values
 
+    , _merkleHashCache :: Map Chained SHA256Digest
+    -- ^ Per-run cache of merkle / edge hashes for unhashed Code imports and
+    --   @as Text@ / @as Bytes@ / @as Location@ children, used to build
+    --   semisemantic v2 cache keys without CBOR-encoding inlined child NFs.
+    --   Hashed imports use their integrity hash.
+
+    , _merkleContextFingerprint :: Maybe SHA256Digest
+    -- ^ Cached hash of '_startingContext' for merkle keys. 'Nothing' until
+    --   the first unhashed Code import. Cleared when the context is replaced.
+
+    , _merkleSubstitutionsFingerprint :: Maybe SHA256Digest
+    -- ^ Cached hash of '_substitutions' for merkle keys. Avoids CBOR-encoding
+    --   a large substitution map once per Code import. Cleared when
+    --   '_substitutions' is replaced.
+
     , _newManager :: IO Manager
     , _manager :: Maybe Manager
     -- ^ Used to cache the `Dhall.Import.Manager.Manager` when making multiple
@@ -167,6 +183,12 @@ emptyStatusWith _newManager _loadOriginHeaders _remote _remoteBytes rootImport =
 
     _cache = Map.empty
 
+    _merkleHashCache = Map.empty
+
+    _merkleContextFingerprint = Nothing
+
+    _merkleSubstitutionsFingerprint = Nothing
+
     _manager = Nothing
 
     _substitutions = Dhall.Substitution.empty
@@ -197,6 +219,10 @@ graph = lens _graph (\s x -> s { _graph = x })
 cache :: Lens' Status (Map Chained ImportSemantics)
 cache = lens _cache (\s x -> s { _cache = x })
 
+-- | Lens from a `Status` to its `_merkleHashCache` field
+merkleHashCache :: Lens' Status (Map Chained SHA256Digest)
+merkleHashCache = lens _merkleHashCache (\s x -> s { _merkleHashCache = x })
+
 -- | Lens from a `Status` to its `_remote` field
 remote :: Lens' Status (URL -> StateT Status IO Text)
 remote = lens _remote (\s x -> s { _remote = x })
@@ -210,7 +236,12 @@ substitutions :: Lens' Status (Dhall.Substitution.Substitutions Src Void)
 substitutions =
     lens
         _substitutions
-        (\s x -> s { _substitutions = x, _resolvedSubstitutions = Nothing })
+        (\s x ->
+            s { _substitutions = x
+              , _resolvedSubstitutions = Nothing
+              , _merkleSubstitutionsFingerprint = Nothing
+              }
+        )
 
 -- | Lens from a `Status` to its cached resolved substitution map
 resolvedSubstitutions
@@ -224,7 +255,10 @@ normalizer = lens _normalizer (\s x -> s {_normalizer = x})
 
 -- | Lens from a `Status` to its `_startingContext` field
 startingContext :: Lens' Status (Context (Expr Src Void))
-startingContext = lens _startingContext (\s x -> s { _startingContext = x })
+startingContext =
+    lens
+        _startingContext
+        (\s x -> s { _startingContext = x, _merkleContextFingerprint = Nothing })
 
 -- | Lens from a `Status` to its `_cacheWarning` field
 cacheWarning :: Lens' Status CacheWarning

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -124,6 +124,14 @@ data Status = Status
 
     , _substitutions :: Dhall.Substitution.Substitutions Src Void
 
+    , _resolvedSubstitutions
+        :: Maybe (Dhall.Substitution.ResolvedSubstitutions Src Void)
+    -- ^ Cached result of 'Dhall.Substitution.resolveSubstitutions' for
+    --   '_substitutions'. The raw map does not change during a run (only
+    --   per-binder copies while walking an AST), so this is computed at most
+    --   once. 'Nothing' until the first import-path substitute. Cleared when
+    --   '_substitutions' is replaced.
+
     , _normalizer :: Maybe (ReifiedNormalizer Void)
 
     , _startingContext :: Context (Expr Src Void)
@@ -163,6 +171,8 @@ emptyStatusWith _newManager _loadOriginHeaders _remote _remoteBytes rootImport =
 
     _substitutions = Dhall.Substitution.empty
 
+    _resolvedSubstitutions = Nothing
+
     _normalizer = Nothing
 
     _startingContext = Dhall.Context.empty
@@ -197,7 +207,16 @@ remoteBytes = lens _remoteBytes (\s x -> s { _remoteBytes = x })
 
 -- | Lens from a `Status` to its `_substitutions` field
 substitutions :: Lens' Status (Dhall.Substitution.Substitutions Src Void)
-substitutions = lens _substitutions (\s x -> s { _substitutions = x })
+substitutions =
+    lens
+        _substitutions
+        (\s x -> s { _substitutions = x, _resolvedSubstitutions = Nothing })
+
+-- | Lens from a `Status` to its cached resolved substitution map
+resolvedSubstitutions
+    :: Lens' Status (Maybe (Dhall.Substitution.ResolvedSubstitutions Src Void))
+resolvedSubstitutions =
+    lens _resolvedSubstitutions (\s x -> s { _resolvedSubstitutions = x })
 
 -- | Lens from a `Status` to its `_normalizer` field
 normalizer :: Lens' Status (Maybe (ReifiedNormalizer Void))

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -109,10 +109,12 @@ data Status = Status
     --   importing the same expression twice with different values
 
     , _merkleHashCache :: Map Chained SHA256Digest
-    -- ^ Per-run cache of merkle / edge hashes for unhashed Code imports and
-    --   @as Text@ / @as Bytes@ / @as Location@ children, used to build
-    --   semisemantic v2 cache keys without CBOR-encoding inlined child NFs.
-    --   Hashed imports use their integrity hash.
+    -- ^ Per-run map from import to the hash used as that import's contribution
+    --   to a parent's disk-cache key. Code imports without an integrity hash
+    --   store the hash of their own syntax; @as Text@ / @as Bytes@ /
+    --   @as Location@ store a hash of their contents. Frozen imports use
+    --   their integrity hash. Caching these avoids encoding a child's full
+    --   normal form just to name the parent cache entry.
 
     , _merkleContextFingerprint :: Maybe SHA256Digest
     -- ^ Cached hash of '_startingContext' for merkle keys. 'Nothing' until

--- a/dhall/src/Dhall/Substitution.hs
+++ b/dhall/src/Dhall/Substitution.hs
@@ -9,6 +9,7 @@ import Dhall.Syntax    (Binding (..), Expr (..), FunctionBinding (..), Var (..))
 
 import qualified Data.Foldable.WithIndex as Foldable.WithIndex
 import qualified Data.Map.Strict         as Map
+import qualified Data.Set                as Set
 import qualified Dhall.Map
 import qualified Dhall.Syntax            as Syntax
 import qualified Lens.Micro              as Lens
@@ -23,6 +24,15 @@ type Substitutions s a = Dhall.Map.Map Text (Expr s a)
 empty :: Substitutions s a
 empty = Dhall.Map.empty
 
+-- | Resolved substitution map plus the names that force a rebuild when a
+-- binder is entered. Used so `shiftSubstitutions` can return the same map
+-- pointer at binders that cannot capture a substitution.
+data ResolvedSubstitutions s a = ResolvedSubstitutions
+    { resolvedMap     :: Map.Map Var (Expr s a)
+    , keyNames        :: Set.Set Text
+    , valueFreeNames  :: Set.Set Text
+    }
+
 -- | @substitute expr s@ replaces all variables in @expr@ (or its subexpression) with their substitute.
 --   For example, if the substitution map maps the variable @Foo@ to the text \"Foo\" all occurrences of @Foo@ with the text \"Foo\".
 --
@@ -32,21 +42,40 @@ empty = Dhall.Map.empty
 --   >
 --   > substitute (Dhall.Core.Var "Foo") (Dhall.Map.fromList [("Foo", Dhall.Core.Var "Bar"), ("Bar", Dhall.Core.Var "Baz")])
 --
---   results in @Dhall.Core.Var \"Baz\"@ since \"Foo\"'s replacement (\"Bar\") is itself resolved against \"Bar\"'s substitution (\"Baz\") before being applied.
+--   results in @Var \"Baz\"@ since \"Foo\"'s replacement (\"Bar\") is itself resolved against \"Bar\"'s substitution (\"Baz\") before being applied.
 substitute :: Expr s a -> Substitutions s a -> Expr s a
 substitute expr substitutions =
      substituteMany (resolveSubstitutions substitutions) expr
 
-resolveSubstitutions :: Substitutions s a -> Map.Map Var (Expr s a)
+resolveSubstitutions :: Substitutions s a -> ResolvedSubstitutions s a
 resolveSubstitutions substitutions =
-     let step k v resolved = Map.insert (V k 0) (substituteMany resolved v) resolved
-     in Foldable.WithIndex.ifoldr step Map.empty substitutions
+     let step k v acc =
+             Map.insert
+                 (V k 0)
+                 (substituteMany (fromMap acc) v)
+                 acc
 
-substituteMany :: Map.Map Var (Expr s a) -> Expr s a -> Expr s a
+         resolvedMap' =
+             Foldable.WithIndex.ifoldr
+                 step
+                 Map.empty
+                 substitutions
+
+     in  fromMap resolvedMap'
+
+fromMap :: Map.Map Var (Expr s a) -> ResolvedSubstitutions s a
+fromMap resolvedMap' =
+    ResolvedSubstitutions
+        { resolvedMap = resolvedMap'
+        , keyNames = Set.fromList [ k | V k _ <- Map.keys resolvedMap' ]
+        , valueFreeNames = foldMap freeVarNames resolvedMap'
+        }
+
+substituteMany :: ResolvedSubstitutions s a -> Expr s a -> Expr s a
 substituteMany substitutions expression
-     | Map.null substitutions = expression
+     | Map.null (resolvedMap substitutions) = expression
 substituteMany substitutions (Var v) =
-     Map.findWithDefault (Var v) v substitutions
+     Map.findWithDefault (Var v) v (resolvedMap substitutions)
 substituteMany substitutions (Lam cs (FunctionBinding src0 y src1 src2 type_) body) =
      let type_' = substituteMany substitutions type_
          body' = substituteMany (shiftSubstitutions y substitutions) body
@@ -63,9 +92,50 @@ substituteMany substitutions (Let (Binding src0 f src1 type_ src2 replacement) b
 substituteMany substitutions expression =
      Lens.over Syntax.subExpressions (substituteMany substitutions) expression
 
-shiftSubstitutions :: Text -> Map.Map Var (Expr s a) -> Map.Map Var (Expr s a)
-shiftSubstitutions name substitutions =
-     let shiftKey (V k n) = if k == name then V k (n + 1) else V k n
-         shiftValue = Syntax.shift 1 (V name 0)
-         step k v = Map.insert (shiftKey k) (shiftValue v)
-     in Map.foldrWithKey step Map.empty substitutions
+-- | Shift substitution keys/values under a binder so we neither substitute the
+-- newly bound variable nor capture it in substitution values.
+--
+-- If the binder name is not a substitution key and does not occur free in any
+-- substitution value, the map is returned unchanged (same pointer). That is the
+-- common case for Haskell-API substitutions (@Result@, schema names, …) under
+-- ordinary @let@/@λ@ names.
+shiftSubstitutions
+    :: Text -> ResolvedSubstitutions s a -> ResolvedSubstitutions s a
+shiftSubstitutions name substitutions
+    | Set.notMember name (keyNames substitutions)
+    , Set.notMember name (valueFreeNames substitutions) =
+        substitutions
+    | Set.notMember name (keyNames substitutions) =
+        substitutions
+            { resolvedMap =
+                Map.map
+                    (Syntax.shift 1 (V name 0))
+                    (resolvedMap substitutions)
+            }
+    | otherwise =
+        let shiftKey (V k n) = if k == name then V k (n + 1) else V k n
+            shiftValue = Syntax.shift 1 (V name 0)
+        in  substitutions
+                { resolvedMap =
+                    Map.mapKeys shiftKey
+                        (Map.map shiftValue (resolvedMap substitutions))
+                }
+
+-- | Names of variables that occur free in an expression.
+freeVarNames :: Expr s a -> Set.Set Text
+freeVarNames = go Map.empty
+  where
+    go bound (Var (V k n)) =
+        case Map.lookup k bound of
+            Just depth | n < depth -> Set.empty
+            _                      -> Set.singleton k
+    go bound (Lam _ (FunctionBinding _ y _ _ type_) body) =
+        go bound type_ <> go (Map.insertWith (+) y 1 bound) body
+    go bound (Pi _ y domain codomain) =
+        go bound domain <> go (Map.insertWith (+) y 1 bound) codomain
+    go bound (Let (Binding _ f _ type_ _ replacement) body) =
+           foldMap (go bound . snd) type_
+        <> go bound replacement
+        <> go (Map.insertWith (+) f 1 bound) body
+    go bound expression =
+        Lens.foldMapOf Syntax.subExpressions (go bound) expression

--- a/dhall/src/Dhall/Substitution.hs
+++ b/dhall/src/Dhall/Substitution.hs
@@ -47,13 +47,17 @@ substitute :: Expr s a -> Substitutions s a -> Expr s a
 substitute expr substitutions =
      substituteMany (resolveSubstitutions substitutions) expr
 
+-- | Resolve insertion-order chaining, then compute identity-shift metadata
+--   once. Import loading should cache this on 'Dhall.Import.Types.Status'
+--   rather than calling 'substitute' (which re-resolves) per file.
+--
+--   Chaining itself uses the original always-shift walker. Calling 'fromMap'
+--   on every prefix used to recompute 'freeVarNames' in O(N²) per
+--   'substitute', which dominated as-code loads with hundreds of imports.
 resolveSubstitutions :: Substitutions s a -> ResolvedSubstitutions s a
 resolveSubstitutions substitutions =
      let step k v acc =
-             Map.insert
-                 (V k 0)
-                 (substituteMany (fromMap acc) v)
-                 acc
+             Map.insert (V k 0) (substituteManyRaw acc v) acc
 
          resolvedMap' =
              Foldable.WithIndex.ifoldr
@@ -62,6 +66,37 @@ resolveSubstitutions substitutions =
                  substitutions
 
      in  fromMap resolvedMap'
+
+-- | Original substitution walker (always shift under binders). Used only
+--   while chaining substitution values into each other.
+substituteManyRaw :: Map.Map Var (Expr s a) -> Expr s a -> Expr s a
+substituteManyRaw substitutions expression
+     | Map.null substitutions = expression
+substituteManyRaw substitutions (Var v) =
+     Map.findWithDefault (Var v) v substitutions
+substituteManyRaw substitutions (Lam cs (FunctionBinding src0 y src1 src2 type_) body) =
+     let type_' = substituteManyRaw substitutions type_
+         body' = substituteManyRaw (shiftSubstitutionsRaw y substitutions) body
+     in Lam cs (FunctionBinding src0 y src1 src2 type_') body'
+substituteManyRaw substitutions (Pi cs y domain codomain) =
+     let domain' = substituteManyRaw substitutions domain
+         codomain' = substituteManyRaw (shiftSubstitutionsRaw y substitutions) codomain
+     in Pi cs y domain' codomain'
+substituteManyRaw substitutions (Let (Binding src0 f src1 type_ src2 replacement) body) =
+     let type_' = fmap (fmap (substituteManyRaw substitutions)) type_
+         replacement' = substituteManyRaw substitutions replacement
+         body' = substituteManyRaw (shiftSubstitutionsRaw f substitutions) body
+     in Let (Binding src0 f src1 type_' src2 replacement') body'
+substituteManyRaw substitutions expression =
+     Lens.over Syntax.subExpressions (substituteManyRaw substitutions) expression
+
+shiftSubstitutionsRaw
+    :: Text -> Map.Map Var (Expr s a) -> Map.Map Var (Expr s a)
+shiftSubstitutionsRaw name substitutions =
+     let shiftKey (V k n) = if k == name then V k (n + 1) else V k n
+         shiftValue = Syntax.shift 1 (V name 0)
+         step k v = Map.insert (shiftKey k) (shiftValue v)
+     in Map.foldrWithKey step Map.empty substitutions
 
 fromMap :: Map.Map Var (Expr s a) -> ResolvedSubstitutions s a
 fromMap resolvedMap' =

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -19,6 +19,7 @@ import qualified Dhall.Test.QuickCheck
 import qualified Dhall.Test.Regression
 import qualified Dhall.Test.Schemas
 import qualified Dhall.Test.SemanticHash
+import qualified Dhall.Test.SemisemanticCache
 import qualified Dhall.Test.Substitution
 #ifndef CROSS
 import qualified Dhall.Test.TH
@@ -47,6 +48,8 @@ getAllTests = do
 
     cacheFillTests <- Dhall.Test.CacheFill.getTests
 
+    semisemanticCacheTests <- Dhall.Test.SemisemanticCache.getTests
+
     lintTests <- Dhall.Test.Lint.getTests
 
     tagsTests <- Dhall.Test.Tags.getTests
@@ -65,6 +68,7 @@ getAllTests = do
                 , parsingTests
                 , importingTests
                 , cacheFillTests
+                , semisemanticCacheTests
                 , typeinferenceTests
                 , formattingTests
                 , lintTests

--- a/dhall/tests/Dhall/Test/SemisemanticCache.hs
+++ b/dhall/tests/Dhall/Test/SemisemanticCache.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Unit tests for the merkle-keyed semisemantic cache (@dhall-haskell-v2/@).
+-- | Unit tests for the disk cache used by Code imports without integrity
+-- checks (@$XDG_CACHE_HOME/dhall-haskell-v2/@).
 --
--- Code imports still typecheck and normalize in memory. The disk cache stores
--- either a small CBOR normal form or a well-typed marker (no giant NFs).
+-- Imports still typecheck and normalize in memory. The on-disk entry is either
+-- a small encoded normal form or a one-byte "already type-checked" marker.
 module Dhall.Test.SemisemanticCache where
 
 import Control.Exception            (bracket)
@@ -29,7 +30,7 @@ import qualified Test.Tasty         as Tasty
 
 getTests :: IO TestTree
 getTests = return
-    (Tasty.testGroup "Semisemantic cache (merkle v2)"
+    (Tasty.testGroup "Semisemantic cache"
         [ testCase "Small NF is cached and reused" smallNFCachedTest
         , testCase "Large NF stores a well-typed marker only" largeNFMarkerTest
         , testCase "Early-abort size check agrees with full walk" earlyAbortAgreesWithFullWalkTest
@@ -51,12 +52,13 @@ withTempCache action =
 
         bracket setCache (const restoreCache) (\_ -> action cacheDir)
 
-semisemanticV2Dir :: FilePath -> FilePath
-semisemanticV2Dir cacheDir = cacheDir </> "dhall-haskell-v2"
+-- Same directory name as 'Import' uses under @$XDG_CACHE_HOME@.
+semisemanticCacheDir :: FilePath -> FilePath
+semisemanticCacheDir cacheDir = cacheDir </> "dhall-haskell-v2"
 
 listCacheFiles :: FilePath -> IO [FilePath]
 listCacheFiles cacheDir = do
-    let dir = semisemanticV2Dir cacheDir
+    let dir = semisemanticCacheDir cacheDir
     exists <- Directory.doesDirectoryExist dir
     if exists
         then fmap (map (dir </>)) (Directory.listDirectory dir)
@@ -82,7 +84,7 @@ smallNFCachedTest = withTempCache $ \cacheDir -> do
     void (Dhall.inputExpr importPath)
     filesAfterFirst <- listCacheFiles cacheDir
     assertBool
-        "first load should write a semisemantic v2 entry"
+        "first load should write a semisemantic cache entry"
         (not (null filesAfterFirst))
 
     traverse_ checkNFTag filesAfterFirst

--- a/dhall/tests/Dhall/Test/SemisemanticCache.hs
+++ b/dhall/tests/Dhall/Test/SemisemanticCache.hs
@@ -13,7 +13,7 @@ import Data.Foldable                (traverse_)
 import Data.Text                    (Text)
 import Data.Void                    (Void)
 import Dhall.Src                    (Src)
-import System.FilePath              ((</>))
+import System.FilePath              (takeDirectory, takeFileName, (</>))
 import Test.Tasty                   (TestTree)
 import Test.Tasty.HUnit             (assertBool, assertEqual, testCase)
 
@@ -23,6 +23,7 @@ import qualified Data.Text.IO       as Text.IO
 import qualified Dhall
 import qualified Dhall.Core         as Core
 import qualified Dhall.Import       as Import
+import qualified Lens.Micro
 import qualified System.Directory   as Directory
 import qualified System.Environment as Environment
 import qualified System.IO.Temp     as Temp
@@ -64,8 +65,16 @@ listCacheFiles cacheDir = do
         then fmap (map (dir </>)) (Directory.listDirectory dir)
         else return []
 
-toImportPath :: FilePath -> Text
-toImportPath = Text.replace "\\" "/" . Text.pack
+-- | Load a Dhall file without putting its filesystem path in the expression.
+-- Windows absolute paths such as @C:/Users/...@ are not valid Dhall syntax
+-- (the parser reads @C:@ as a label plus annotation).
+inputFile :: FilePath -> IO (Core.Expr Src Void)
+inputFile path = do
+    let settings =
+            Lens.Micro.set Dhall.rootDirectory (takeDirectory path)
+                Dhall.defaultInputSettings
+        importExpr = "./" <> Text.pack (takeFileName path)
+    Dhall.inputExprWithSettings settings importExpr
 
 assertNormalizedEqual
     :: String -> Core.Expr Src Void -> Core.Expr Src Void -> IO ()
@@ -79,9 +88,8 @@ assertNormalizedEqual message expected actual =
 smallNFCachedTest :: IO ()
 smallNFCachedTest = withTempCache $ \cacheDir -> do
     tempFile <- Temp.writeTempFile "." "small.dhall" "1 + 1"
-    let importPath = toImportPath tempFile
 
-    void (Dhall.inputExpr importPath)
+    void (inputFile tempFile)
     filesAfterFirst <- listCacheFiles cacheDir
     assertBool
         "first load should write a semisemantic cache entry"
@@ -89,8 +97,8 @@ smallNFCachedTest = withTempCache $ \cacheDir -> do
 
     traverse_ checkNFTag filesAfterFirst
 
-    result1 <- Dhall.inputExpr importPath
-    result2 <- Dhall.inputExpr importPath
+    result1 <- inputFile tempFile
+    result2 <- inputFile tempFile
     assertNormalizedEqual "cached reload should match" result1 result2
 
     Directory.removeFile tempFile
@@ -109,9 +117,8 @@ largeNFMarkerTest = withTempCache $ \cacheDir -> do
     let big = Text.replicate 70000 "a"
     tempFile <-
         Temp.writeTempFile "." "large.dhall" (Text.unpack ("\"" <> big <> "\""))
-    let importPath = toImportPath tempFile
 
-    result1 <- Dhall.inputExpr importPath
+    result1 <- inputFile tempFile
     files <- listCacheFiles cacheDir
     assertBool "large import should write a cache entry" (not (null files))
 
@@ -127,7 +134,7 @@ largeNFMarkerTest = withTempCache $ \cacheDir -> do
         )
         files
 
-    result2 <- Dhall.inputExpr importPath
+    result2 <- inputFile tempFile
     assertNormalizedEqual "marker hit should still evaluate" result1 result2
 
     Directory.removeFile tempFile
@@ -177,13 +184,13 @@ childChangeInvalidatesParentTest = withTempCache $ \_cacheDir ->
         Text.IO.writeFile childPath "1"
         Text.IO.writeFile parentPath "./child.dhall"
 
-        result1 <- Dhall.inputExpr (toImportPath parentPath)
+        result1 <- inputFile parentPath
         expected1 <- Dhall.inputExpr "1"
         assertNormalizedEqual "initial child value" expected1 result1
 
         Text.IO.writeFile childPath "2"
 
-        result2 <- Dhall.inputExpr (toImportPath parentPath)
+        result2 <- inputFile parentPath
         expected2 <- Dhall.inputExpr "2"
         assertNormalizedEqual
             "parent must observe child change (merkle miss)"

--- a/dhall/tests/Dhall/Test/SemisemanticCache.hs
+++ b/dhall/tests/Dhall/Test/SemisemanticCache.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Unit tests for the merkle-keyed semisemantic cache (@dhall-haskell-v2/@).
+--
+-- Code imports still typecheck and normalize in memory. The disk cache stores
+-- either a small CBOR normal form or a well-typed marker (no giant NFs).
+module Dhall.Test.SemisemanticCache where
+
+import Control.Exception            (bracket)
+import Control.Monad                (void)
+import Data.Foldable                (traverse_)
+import Data.Text                    (Text)
+import Data.Void                    (Void)
+import Dhall.Src                    (Src)
+import System.FilePath              ((</>))
+import Test.Tasty                   (TestTree)
+import Test.Tasty.HUnit             (assertBool, assertEqual, testCase)
+
+import qualified Data.ByteString    as ByteString
+import qualified Data.Text          as Text
+import qualified Data.Text.IO       as Text.IO
+import qualified Dhall
+import qualified Dhall.Core         as Core
+import qualified Dhall.Import       as Import
+import qualified System.Directory   as Directory
+import qualified System.Environment as Environment
+import qualified System.IO.Temp     as Temp
+import qualified Test.Tasty         as Tasty
+
+getTests :: IO TestTree
+getTests = return
+    (Tasty.testGroup "Semisemantic cache (merkle v2)"
+        [ testCase "Small NF is cached and reused" smallNFCachedTest
+        , testCase "Large NF stores a well-typed marker only" largeNFMarkerTest
+        , testCase "Early-abort size check agrees with full walk" earlyAbortAgreesWithFullWalkTest
+        , testCase "Child change invalidates parent cache" childChangeInvalidatesParentTest
+        ])
+
+withTempCache :: (FilePath -> IO a) -> IO a
+withTempCache action =
+    Temp.withSystemTempDirectory "dhall-semisemantic" $ \cacheDir -> do
+        originalCache <- Environment.lookupEnv "XDG_CACHE_HOME"
+
+        let setCache = Environment.setEnv "XDG_CACHE_HOME" cacheDir
+
+        let restoreCache =
+                maybe
+                    (Environment.unsetEnv "XDG_CACHE_HOME")
+                    (Environment.setEnv "XDG_CACHE_HOME")
+                    originalCache
+
+        bracket setCache (const restoreCache) (\_ -> action cacheDir)
+
+semisemanticV2Dir :: FilePath -> FilePath
+semisemanticV2Dir cacheDir = cacheDir </> "dhall-haskell-v2"
+
+listCacheFiles :: FilePath -> IO [FilePath]
+listCacheFiles cacheDir = do
+    let dir = semisemanticV2Dir cacheDir
+    exists <- Directory.doesDirectoryExist dir
+    if exists
+        then fmap (map (dir </>)) (Directory.listDirectory dir)
+        else return []
+
+toImportPath :: FilePath -> Text
+toImportPath = Text.replace "\\" "/" . Text.pack
+
+assertNormalizedEqual
+    :: String -> Core.Expr Src Void -> Core.Expr Src Void -> IO ()
+assertNormalizedEqual message expected actual =
+    assertEqual
+        message
+        (Core.normalize (Core.denote expected) :: Core.Expr Void Void)
+        (Core.normalize (Core.denote actual) :: Core.Expr Void Void)
+
+-- | Small expression: second load should hit a cached NF (tag byte 0).
+smallNFCachedTest :: IO ()
+smallNFCachedTest = withTempCache $ \cacheDir -> do
+    tempFile <- Temp.writeTempFile "." "small.dhall" "1 + 1"
+    let importPath = toImportPath tempFile
+
+    void (Dhall.inputExpr importPath)
+    filesAfterFirst <- listCacheFiles cacheDir
+    assertBool
+        "first load should write a semisemantic v2 entry"
+        (not (null filesAfterFirst))
+
+    traverse_ checkNFTag filesAfterFirst
+
+    result1 <- Dhall.inputExpr importPath
+    result2 <- Dhall.inputExpr importPath
+    assertNormalizedEqual "cached reload should match" result1 result2
+
+    Directory.removeFile tempFile
+  where
+    checkNFTag file = do
+        bytes <- ByteString.readFile file
+        case ByteString.uncons bytes of
+            Just (0, rest) ->
+                assertBool "NF payload should be non-empty CBOR" (not (ByteString.null rest))
+            _ ->
+                assertBool ("expected NF tag 0 in " <> file) False
+
+-- | Large Text payload: store only a well-typed marker (tag byte 1, tiny file).
+largeNFMarkerTest :: IO ()
+largeNFMarkerTest = withTempCache $ \cacheDir -> do
+    let big = Text.replicate 70000 "a"
+    tempFile <-
+        Temp.writeTempFile "." "large.dhall" (Text.unpack ("\"" <> big <> "\""))
+    let importPath = toImportPath tempFile
+
+    result1 <- Dhall.inputExpr importPath
+    files <- listCacheFiles cacheDir
+    assertBool "large import should write a cache entry" (not (null files))
+
+    traverse_
+        (\file -> do
+            bytes <- ByteString.readFile file
+            assertEqual
+                ("large NF should be stored as typed marker in " <> file)
+                (ByteString.singleton 1)
+                bytes
+            size <- Directory.getFileSize file
+            assertBool "marker file must stay tiny" (size < 32)
+        )
+        files
+
+    result2 <- Dhall.inputExpr importPath
+    assertNormalizedEqual "marker hit should still evaluate" result1 result2
+
+    Directory.removeFile tempFile
+
+-- | Early abort uses the same metric as a full walk, including the O(1)
+-- Text-length case that @largeNFMarkerTest@ covers. The deep shared tree is
+-- the case the abort actually saves work on (inlined giant NFs).
+earlyAbortAgreesWithFullWalkTest :: IO ()
+earlyAbortAgreesWithFullWalkTest = do
+    let check label expr = do
+            let full = Import.estimateExprSize expr
+            let abort = Import.exceedsNFSizeThreshold expr
+            assertEqual
+                (label <> ": exceeds iff size > threshold")
+                (full > Import.semisemanticNFSizeThreshold)
+                abort
+
+    check "small natural" (Core.NaturalLit 0)
+
+    let smallTree = sharedNaturalPlusTree 10
+    check "shared tree below threshold" smallTree
+    assertBool
+        "depth 10 should be below the 64KiB threshold"
+        (Import.estimateExprSize smallTree < Import.semisemanticNFSizeThreshold)
+
+    let bigText =
+            Core.TextLit (Core.Chunks [] (Text.replicate 70000 "a"))
+    check "large text payload" bigText
+
+    assertBool
+        "deep shared tree exceeds threshold"
+        (Import.exceedsNFSizeThreshold (sharedNaturalPlusTree 20))
+
+sharedNaturalPlusTree :: Int -> Core.Expr Void Void
+sharedNaturalPlusTree depth = go depth
+  where
+    go 0 = Core.NaturalLit 0
+    go n = let t = go (n - 1) in Core.NaturalPlus t t
+
+-- | Changing a child file must not reuse a stale parent cache entry.
+childChangeInvalidatesParentTest :: IO ()
+childChangeInvalidatesParentTest = withTempCache $ \_cacheDir ->
+    Temp.withSystemTempDirectory "dhall-invalidate" $ \dir -> do
+        let childPath = dir </> "child.dhall"
+        let parentPath = dir </> "parent.dhall"
+
+        Text.IO.writeFile childPath "1"
+        Text.IO.writeFile parentPath "./child.dhall"
+
+        result1 <- Dhall.inputExpr (toImportPath parentPath)
+        expected1 <- Dhall.inputExpr "1"
+        assertNormalizedEqual "initial child value" expected1 result1
+
+        Text.IO.writeFile childPath "2"
+
+        result2 <- Dhall.inputExpr (toImportPath parentPath)
+        expected2 <- Dhall.inputExpr "2"
+        assertNormalizedEqual
+            "parent must observe child change (merkle miss)"
+            expected2
+            result2

--- a/dhall/tests/Dhall/Test/Substitution.hs
+++ b/dhall/tests/Dhall/Test/Substitution.hs
@@ -9,6 +9,7 @@ import Dhall.Core        (Binding (..), Expr (..), Var (..))
 import Dhall.Src         (Src)
 
 import qualified Data.Either.Validation
+import qualified Data.Text                  as Text
 import qualified Dhall
 import qualified Dhall.Core                 as Core
 import qualified Dhall.Map
@@ -60,7 +61,8 @@ tests =
         , dependentSubstitutionsChainThreeLevels
         , dependentSubstitutionsOnlyChainForward
         , letAnnotationIsSubstituted
-        , selfReferentialSubstitutionIsANoop
+        , unusedSubstitutionsUnderManyLetsAreCheapToShift
+        , importedExpressionIsSubstituted
         ]
 
 noSubstitutionsIsIdentity :: Tasty.TestTree
@@ -211,3 +213,43 @@ selfReferentialSubstitutionIsANoop = Tasty.HUnit.testCase "A self-referential su
     let substitutions = Dhall.Map.fromList [ ("Foo", Var "Foo") ]
 
     Dhall.Substitution.substitute expr substitutions @?= Var "Foo"
+
+-- | Many unused substitution keys under nested Lets. This is the Haskell-API
+-- shape (Result / schema names that do not collide with local binders). The
+-- shift fast path must still apply the one matching substitution.
+unusedSubstitutionsUnderManyLetsAreCheapToShift :: Tasty.TestTree
+unusedSubstitutionsUnderManyLetsAreCheapToShift =
+    Tasty.HUnit.testCase "Unused substitutions under nested Lets still apply a matching variable" $ do
+        let body = Var "z" :: Expr Void Void
+
+        let expr =
+                foldr
+                    (\i acc -> Let (Core.makeBinding (varName i) (NaturalLit 0)) acc)
+                    body
+                    [0 .. 63 :: Int]
+
+        let unused =
+                [ (varName i, NaturalLit (fromIntegral i))
+                | i <- [0 .. 63 :: Int]
+                ]
+
+        let substitutions = Dhall.Map.fromList (("z", NaturalLit 42) : unused)
+
+        let expected =
+                foldr
+                    (\i acc -> Let (Core.makeBinding (varName i) (NaturalLit 0)) acc)
+                    (NaturalLit 42)
+                    [0 .. 63 :: Int]
+
+        Dhall.Substitution.substitute expr substitutions @?= expected
+  where
+    varName i = "x" <> Text.pack (show i)
+
+-- | Substitutions must apply inside imported files, not only in the entry
+-- expression. @substitution2.dhall@ is @./substitution1.dhall@, which uses
+-- the @Result@ substitution.
+importedExpressionIsSubstituted :: Tasty.TestTree
+importedExpressionIsSubstituted =
+    Tasty.HUnit.testCase "Substitutions apply inside imported files" $ do
+        res <- substituteResult "tests/tutorial/substitution2.dhall"
+        res @?= Failure 1


### PR DESCRIPTION
In the semi-semantic cache one of the main sources of the slowness is that a large normal form can result from a fully normalized transitive import; and it needs to be inlined into other import files that are then stored as CBOR in the semi-semantic cache. As a result, a chain such as:
`main.dhall` imports `package.dhall` imports `largeNF.dhall`
will write the cache product for `largeNF.dhall` to the semi-semantic cache, even if `largeNF.dhall` is not hash-protected and even if `main.dhall` does not even use `largeNF.dhall` because it only uses a small  part of `package.dhall`.

There are benchmarks that are very slow due to this.

In this PR changes are made so that the semi-semantic cache is not populated with the fully NF-expanded import if the normal form turns out to be too large. This appears to mitigate some of the slowness.

The large3 benchmark is now 3x faster. (large4 still exhausts memory.)