### PR TITLE
Delay beta-normalization of unhashed Code imports

### DIFF
--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1632,11 +1632,18 @@ In any expression `p ? q` the opportunistic caching rule says:
                     let actualHash = Dhall.Crypto.sha256Hash bytes
 
                     if actualHash == hash
-                        then zoom cacheWarning (writeToSemanticCache _reportWarning hash bytes)
-                        else return ()
-                Nothing -> return ()
+                        then do
+                            zoom cacheWarning
+                                (writeToSemanticCache _reportWarning hash bytes)
 
-              return result
+                            -- A matching fill is the same product a semantic
+                            -- cache hit would return: the alpha-beta-normal
+                            -- form, not the delayed TypecheckedOnly fallback.
+                            return (Core.renote normalized)
+                        else
+                            return result
+                Nothing ->
+                    return result
         where
           findImportHash expr = case Core.shallowDenote expr of
             Embed (Import (ImportHashed (Just hash) _) _) -> Just hash

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -524,9 +524,11 @@ chainImport (Chained parent) child@(Import importHashed@(ImportHashed _ (Remote 
 chainImport (Chained parent) child =
     return (Chained (canonicalize (parent <> child)))
 
--- | Load an import, resulting in a fully resolved, type-checked and normalised
---   expression. @loadImport@ handles the \"hot\" cache in @Status@ and defers
---   to @loadImportWithSemanticCache@ for imports that aren't in the @Status@
+-- | Load an import, resulting in a fully resolved, type-checked expression.
+--   Unhashed Code imports may still be unnormalized ('TypecheckedOnly');
+--   hashed Code imports are beta-normal ('AlreadyNormalized').
+--   @loadImport@ handles the \"hot\" cache in @Status@ and defers to
+--   @loadImportWithSemanticCache@ for imports that aren't in the @Status@
 --   cache already.
 loadImport :: Chained -> StateT Status IO ImportSemantics
 loadImport import_ = do
@@ -538,6 +540,28 @@ loadImport import_ = do
             importSemantics <- loadImportWithSemanticCache import_
             zoom cache (State.modify (Dhall.Map.insert import_ importSemantics))
             return importSemantics
+
+-- | Force an import result to a normal form when a later path requires one
+--   (for example, semantic integrity checks for Code imports).
+ensureNormalized :: Chained -> ImportSemantics -> StateT Status IO ImportSemantics
+ensureNormalized _ importSemantics@ImportSemantics
+    { importNormalizationStatus = AlreadyNormalized } =
+        return importSemantics
+ensureNormalized import_ ImportSemantics { importSemantics } = do
+    Status { _normalizer } <- State.get
+
+    normalized <-
+        liftIO (Exception.evaluate (Core.normalizeWith _normalizer importSemantics))
+
+    let normalizedSemantics =
+            ImportSemantics
+                { importSemantics = normalized
+                , importNormalizationStatus = AlreadyNormalized
+                }
+
+    zoom cache (State.modify (Dhall.Map.insert import_ normalizedSemantics))
+
+    return normalizedSemantics
 
 -- | Load an import from the 'semantic cache'. Defers to
 --   @loadImportWithSemisemanticCache@ for imports that aren't frozen (and
@@ -573,7 +597,12 @@ loadImportWithSemanticCache
                         Left  err -> throwMissingImport (Imported _stack err)
                         Right e   -> return e
 
-                    return (ImportSemantics {..})
+                    return
+                        ( ImportSemantics
+                            { importSemantics
+                            , importNormalizationStatus = AlreadyNormalized
+                            }
+                        )
                 else do
                     liftIO $ _reportWarning $ Text.pack $
                         makeHashMismatchMessage semanticHash actualHash
@@ -587,7 +616,9 @@ loadImportWithSemanticCache
         fetch = do
             Status{ _reportWarning } <- State.get
 
-            ImportSemantics{ importSemantics } <- loadImportWithSemisemanticCache import_
+            importSemantics0 <- loadImportWithSemisemanticCache import_
+            ImportSemantics{ importSemantics } <-
+                ensureNormalized import_ importSemantics0
 
             let bytes = encodeExpression (Core.alphaNormalize importSemantics)
 
@@ -604,7 +635,12 @@ loadImportWithSemanticCache
 
                     throwMissingImport (Imported _stack HashMismatch{..})
 
-            return ImportSemantics{..}
+            return
+                ( ImportSemantics
+                    { importSemantics
+                    , importNormalizationStatus = AlreadyNormalized
+                    }
+                )
 
 
 
@@ -666,14 +702,14 @@ applyStatusSubstitutions expression = do
 
     return (Dhall.Substitution.substituteMany resolved expression)
 
--- Check the "semi-semantic" disk cache, otherwise typecheck and normalise from
--- scratch.
+-- Check the "semi-semantic" disk cache, otherwise typecheck from scratch.
 --
 -- For Code imports without an integrity hash, the cache key is a hash of this
 -- file's syntax plus hashes of the files it imports (see
--- 'computeMerkleSemisemanticHash'). A hit is either a small normal form (skip
--- typecheck and normalize) or a one-byte "already type-checked" marker (skip
--- typecheck only; still normalize the in-memory tree).
+-- 'computeMerkleSemisemanticHash'). A hit is either a small normal form from an
+-- older cache entry or a one-byte "already type-checked" marker. New delayed
+-- Code entries use the marker so cache hits and misses both return
+-- 'TypecheckedOnly'.
 --
 -- Those entries live under @dhall-haskell-v2/@, not the older
 -- @dhall-haskell/@ directory, because the keys and stored values are not
@@ -724,27 +760,29 @@ loadImportWithSemisemanticCache
 
     let hasCustomNormalizer = isJust _normalizer
 
-    importSemantics <- case mCached of
+    importSemantics0 <- case mCached of
         Just (SemisemanticCachedNF bytesStrict)
             | not hasCustomNormalizer -> do
             let bytesLazy = Data.ByteString.Lazy.fromStrict bytesStrict
 
             case Dhall.Binary.decodeExpression bytesLazy of
                 Left err  -> throwMissingImport (Imported _stack err)
-                Right sem -> return sem
+                Right sem -> return
+                    ( ImportSemantics
+                        { importSemantics = sem
+                        , importNormalizationStatus = AlreadyNormalized
+                        }
+                    )
 
         Just SemisemanticWellTyped -> do
             substitutedExpr <- applyStatusSubstitutions resolvedExpr
 
-            case Core.shallowDenote parsedImport of
-                Embed _ ->
-                    return (Core.denote substitutedExpr)
-
-                _ ->
-                    liftIO
-                        (Exception.evaluate
-                            (Core.normalizeWith _normalizer substitutedExpr)
-                        )
+            return
+                ( ImportSemantics
+                    { importSemantics = Core.denote substitutedExpr
+                    , importNormalizationStatus = TypecheckedOnly
+                    }
+                )
 
         -- Missing, corrupt, or NF payload under a custom normalizer: miss path.
         _ -> do
@@ -752,34 +790,33 @@ loadImportWithSemisemanticCache
 
             case Core.shallowDenote parsedImport of
                 Embed _ ->
-                    return (Core.denote substitutedExpr)
+                    return
+                        ( ImportSemantics
+                            { importSemantics = Core.denote substitutedExpr
+                            , importNormalizationStatus = TypecheckedOnly
+                            }
+                        )
 
                 _ -> do
                     case Dhall.TypeCheck.typeWith _startingContext substitutedExpr of
                         Left  err -> throwMissingImport (Imported _stack err)
                         Right _   -> return ()
 
-                    betaNormal <-
-                        liftIO (Exception.evaluate (Core.normalizeWith _normalizer substitutedExpr))
-
-                    let payload
-                            | hasCustomNormalizer =
-                                SemisemanticWellTyped
-                            | exceedsNFSizeThreshold betaNormal =
-                                SemisemanticWellTyped
-                            | otherwise =
-                                SemisemanticCachedNF (encodeExpression betaNormal)
-
                     zoom cacheWarning
                         (writeToSemisemanticCache
                             _reportWarning
                             semisemanticHash
-                            payload
+                            SemisemanticWellTyped
                         )
 
-                    return betaNormal
+                    return
+                        ( ImportSemantics
+                            { importSemantics = Core.denote substitutedExpr
+                            , importNormalizationStatus = TypecheckedOnly
+                            }
+                        )
 
-    return (ImportSemantics {..})
+    return importSemantics0
 
 -- `as Text` and `as Bytes` imports aren't cached since they are well-typed and
 -- normal by construction
@@ -793,7 +830,12 @@ loadImportWithSemisemanticCache import_@(Chained (Import (ImportHashed _ importT
 
     zoom merkleHashCache (State.modify (Dhall.Map.insert import_ edgeHash))
 
-    return (ImportSemantics {..})
+    return
+        ( ImportSemantics
+            { importSemantics
+            , importNormalizationStatus = AlreadyNormalized
+            }
+        )
 loadImportWithSemisemanticCache import_@(Chained (Import (ImportHashed _ importType) RawBytes)) = do
     bytes <- fetchBytes importType
 
@@ -804,7 +846,12 @@ loadImportWithSemisemanticCache import_@(Chained (Import (ImportHashed _ importT
 
     zoom merkleHashCache (State.modify (Dhall.Map.insert import_ edgeHash))
 
-    return (ImportSemantics {..})
+    return
+        ( ImportSemantics
+            { importSemantics
+            , importNormalizationStatus = AlreadyNormalized
+            }
+        )
 
 -- `as Location` imports aren't cached since they are well-typed and normal by
 -- construction
@@ -833,17 +880,20 @@ loadImportWithSemisemanticCache import_@(Chained (Import (ImportHashed _ importT
 
     zoom merkleHashCache (State.modify (Dhall.Map.insert import_ edgeHash))
 
-    return (ImportSemantics {..})
+    return
+        ( ImportSemantics
+            { importSemantics
+            , importNormalizationStatus = AlreadyNormalized
+            }
+        )
 
--- | If a result is larger than this (AST nodes plus text/bytes payload), the
--- disk cache stores only an "already type-checked" marker instead of the
--- normal form, so huge expressions are not encoded to or decoded from CBOR.
+-- | Legacy threshold for older semisemantic NF payloads and tests. The delayed
+-- normalization path writes typed markers for new Code entries.
 semisemanticNFSizeThreshold :: Int
 semisemanticNFSizeThreshold = 64 * 1024
 
 -- | Full-tree size estimate: AST nodes plus 'Text' / 'Bytes' payloads. Does
--- not CBOR-encode. Used as the naive baseline for size-walk tests; production
--- cache decisions use 'exceedsNFSizeThreshold'.
+-- not CBOR-encode. Used as the naive baseline for size-walk tests.
 estimateExprSize :: Expr s a -> Int
 estimateExprSize expression =
     case expression of
@@ -1514,7 +1564,7 @@ loadWith expr₀ = case expr₀ of
     let stackWithChild = NonEmpty.cons child _stack
 
     zoom stack (State.put stackWithChild)
-    ImportSemantics {..} <- loadImport child
+    ImportSemantics { importSemantics } <- loadImport child
     zoom stack (State.put _stack)
 
     return (Core.renote importSemantics)
@@ -1566,9 +1616,18 @@ In any expression `p ? q` the opportunistic caching rule says:
               -- populate the semantic cache.
               case findImportHash a of
                 Just hash -> do
-                    Status { _reportWarning } <- State.get
+                    Status { _reportWarning, _normalizer } <- State.get
 
-                    let bytes = encodeExpression (Core.alphaNormalize (Core.denote result))
+                    -- Delayed unhashed Code inlining can leave `result`
+                    -- unnormalized. The semantic cache product is still the
+                    -- encoded alpha-beta-normal form.
+                    normalized <-
+                        liftIO
+                            ( Exception.evaluate
+                                (Core.normalizeWith _normalizer (Core.denote result))
+                            )
+
+                    let bytes = encodeExpression (Core.alphaNormalize normalized)
 
                     let actualHash = Dhall.Crypto.sha256Hash bytes
 

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -52,10 +52,22 @@ newtype Chained = Chained
 instance Pretty Chained where
     pretty (Chained import_) = pretty import_
 
--- | An import that has been fully interpeted
-newtype ImportSemantics = ImportSemantics
+-- | Whether an imported expression has already been beta-normalized.
+data NormalizationStatus
+    = AlreadyNormalized
+    -- ^ The expression is typechecked and beta-normal.
+    | TypecheckedOnly
+    -- ^ The expression is import-free and typechecked, but not necessarily
+    --   beta-normal.
+
+-- | An import that has been fully interpreted
+data ImportSemantics = ImportSemantics
     { importSemantics :: Expr Void Void
-    -- ^ The fully resolved import, typechecked and beta-normal.
+    -- ^ The import-free expression returned after loading and resolving all
+    --   remaining transitive imports.
+
+    , importNormalizationStatus :: NormalizationStatus
+    -- ^ Whether 'importSemantics' has already been beta-normalized.
     }
 
 -- | `parent` imports (i.e. depends on) `child`

--- a/dhall/tests/Dhall/Test/CacheFill.hs
+++ b/dhall/tests/Dhall/Test/CacheFill.hs
@@ -22,6 +22,7 @@ import qualified Data.Text              as Text
 import qualified Dhall
 import qualified Dhall.Core             as Core
 import qualified Dhall.Import           as Import
+import qualified Dhall.Parser           as Parser
 import qualified Lens.Micro
 import qualified System.Directory       as Directory
 import qualified System.Environment     as Environment
@@ -37,6 +38,7 @@ getTests = return
         , testCase "Hash mismatch does not fill cache" hashMismatchDoesNotFillTest
         , testCase "Hash on successful right branch is ignored" hashOnRightIsIgnoredTest
         , testCase "Opportunistic fill normalizes unhashed Code" fillFromUnnormalizedImportTest
+        , testCase "Matching fill returns the semantic-cache normal form" fillReturnsNormalizedTermTest
         ])
 
 -- | Isolate each test in a fresh semantic cache directory.
@@ -312,5 +314,43 @@ fillFromUnnormalizedImportTest = withTempCache $ \cacheDir -> do
         "after fill, resolution should come from the semantic cache"
         expr
         step2
+
+    Directory.removeFile tempFile
+
+-- | A matching opportunistic fill must return the same normal form a semantic
+-- cache hit would, not the delayed TypecheckedOnly fallback. Otherwise
+-- @dhall type@ of Prelude @missing sha256:… ? ./file@ wrappers infers
+-- anonymous @∀(_ : A) → B@ types instead of the named binders from the
+-- normalized lambda.
+fillReturnsNormalizedTermTest :: IO ()
+fillReturnsNormalizedTermTest = withTempCache $ \_cacheDir -> do
+    let source =
+            "let f : Natural → Natural = λ(n : Natural) → n in f"
+
+    tempFile <- writeTempImport source
+    let dir = takeDirectory tempFile
+    let importPath = relativeImport tempFile
+
+    parsedFile <- Core.throws (Parser.exprFromText mempty importPath)
+    loadedFile <-
+        Import.loadRelativeTo dir Import.UseSemanticCache parsedFile
+
+    let nf =
+            Core.alphaNormalize
+                (Core.normalize (Core.denote loadedFile) :: Core.Expr Void Void)
+
+    let hashCode = Import.hashExpressionToCode nf
+
+    parsedAlt <-
+        Core.throws
+            (Parser.exprFromText mempty ("missing " <> hashCode <> " ? " <> importPath))
+
+    resolved <-
+        Import.loadRelativeTo dir Import.UseSemanticCache parsedAlt
+
+    assertEqual
+        "matching fill should return the beta-normal form"
+        nf
+        (Core.alphaNormalize (Core.denote resolved :: Core.Expr Void Void))
 
     Directory.removeFile tempFile

--- a/dhall/tests/Dhall/Test/CacheFill.hs
+++ b/dhall/tests/Dhall/Test/CacheFill.hs
@@ -1,42 +1,114 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+-- | Unit tests for opportunistic semantic-cache fill.
+--
+-- This is a dhall-haskell implementation optimization (not part of the
+-- language standard): when resolving @p ? q@, if @p@ is a missing
+-- hash-protected import and @q@ succeeds with a matching semantic hash, the
+-- result is written to the semantic cache under that hash.
 module Dhall.Test.CacheFill where
 
-import Data.Foldable                    (traverse_)
+import Control.Exception                (bracket)
 import Control.Monad                    (void, when)
-import System.FilePath                  ((</>))
+import Data.Foldable                    (traverse_)
+import Data.Text                        (Text)
+import Data.Void                        (Void)
+import Dhall.Src                        (Src)
+import System.FilePath                  (takeDirectory, takeFileName, (</>))
 import Test.Tasty                       (TestTree)
-import Test.Tasty.HUnit                 (assertBool, testCase)
+import Test.Tasty.HUnit                 (assertBool, assertEqual, testCase)
 
+import qualified Data.Text              as Text
 import qualified Dhall
 import qualified Dhall.Core             as Core
 import qualified Dhall.Import           as Import
+import qualified Lens.Micro
 import qualified System.Directory       as Directory
 import qualified System.Environment     as Environment
 import qualified System.IO.Temp         as Temp
-import qualified Data.Text              as Text
+import qualified Test.Tasty             as Tasty
 
-cacheFillTest :: IO ()
-cacheFillTest = Temp.withSystemTempDirectory "dhall-cache" $ \cacheDir -> do
-    Environment.setEnv "XDG_CACHE_HOME" cacheDir
+getTests :: IO TestTree
+getTests = return
+    (Tasty.testGroup "Cache fill tests"
+        [ testCase "Cache write for fallbacks" cacheFillAssociativityTest
+        , testCase "Opportunistic fill then cache hit" fillThenHitTest
+        , testCase "Opportunistic fill from env import" envFillThenHitTest
+        , testCase "Hash mismatch does not fill cache" hashMismatchDoesNotFillTest
+        , testCase "Hash on successful right branch is ignored" hashOnRightIsIgnoredTest
+        , testCase "Opportunistic fill normalizes unhashed Code" fillFromUnnormalizedImportTest
+        ])
 
+-- | Isolate each test in a fresh semantic cache directory.
+withTempCache :: (FilePath -> IO a) -> IO a
+withTempCache action =
+    Temp.withSystemTempDirectory "dhall-cache" $ \cacheDir -> do
+        originalCache <- Environment.lookupEnv "XDG_CACHE_HOME"
+
+        let setCache = Environment.setEnv "XDG_CACHE_HOME" cacheDir
+
+        let restoreCache =
+                maybe
+                    (Environment.unsetEnv "XDG_CACHE_HOME")
+                    (Environment.setEnv "XDG_CACHE_HOME")
+                    originalCache
+
+        bracket setCache (const restoreCache) (\_ -> action cacheDir)
+
+semanticCacheFile :: FilePath -> Core.Expr s Void -> FilePath
+semanticCacheFile cacheDir expr =
+    let hash = Import.hashExpression (Core.denote expr)
+    in  cacheDir </> "dhall" </> ("1220" <> show hash)
+
+clearSemanticCache :: FilePath -> IO ()
+clearSemanticCache cacheDir = do
+    let semanticCacheDir = cacheDir </> "dhall"
+    exists <- Directory.doesDirectoryExist semanticCacheDir
+    when exists (Directory.removeDirectoryRecursive semanticCacheDir)
+
+writeTempImport :: Text -> IO FilePath
+writeTempImport contents =
+    Temp.writeTempFile "." "tmp.dhall" (Text.unpack contents)
+
+-- | Relative import of a temp file. Windows absolute paths such as
+-- @C:/Users/...@ are not valid Dhall syntax.
+relativeImport :: FilePath -> Text
+relativeImport path = "./" <> Text.pack (takeFileName path)
+
+-- | Evaluate an expression whose relative imports live next to @path@.
+inputExprNear :: FilePath -> Text -> IO (Core.Expr Src Void)
+inputExprNear path expr = do
+    let settings =
+            Lens.Micro.set Dhall.rootDirectory (takeDirectory path)
+                Dhall.defaultInputSettings
+    Dhall.inputExprWithSettings settings expr
+
+assertNormalizedEqual
+    :: String -> Core.Expr Src Void -> Core.Expr Src Void -> IO ()
+assertNormalizedEqual message expected actual =
+    assertEqual
+        message
+        (Core.normalize (Core.denote expected) :: Core.Expr Void Void)
+        (Core.normalize (Core.denote actual) :: Core.Expr Void Void)
+
+-- | Associativity of @?@: a matching hash anywhere to the left of a successful
+-- fallback should opportunistically populate the semantic cache.
+cacheFillAssociativityTest :: IO ()
+cacheFillAssociativityTest = withTempCache $ \cacheDir -> do
     let simpleValue = "True"
 
     expr <- Dhall.inputExpr simpleValue
 
-    let expectedHash = Import.hashExpression (Core.denote expr)
+    let cacheFile = semanticCacheFile cacheDir expr
 
-    let semanticCacheDir = cacheDir </> "dhall"
+    tempFile <- writeTempImport simpleValue
 
-    let cacheFile = semanticCacheDir </> "1220" <> show expectedHash
-
-    tempFile <- Temp.writeTempFile "." "tmp.dhall" (Text.unpack simpleValue)
-
-    let importPath = Text.replace "\\" "/" (Text.pack tempFile)
+    let importPath = relativeImport tempFile
 
     let alwaysFailing = "missing"
 
-    let missingWithHash = "missing " <> Import.hashExpressionToCode (Core.denote expr)
+    let missingWithHash =
+            "missing " <> Import.hashExpressionToCode (Core.denote expr)
 
     let cases =
             [ "(" <> missingWithHash <> " ? " <> alwaysFailing <> ") ? " <> importPath
@@ -45,22 +117,200 @@ cacheFillTest = Temp.withSystemTempDirectory "dhall-cache" $ \cacheDir -> do
             , alwaysFailing <> " ? (" <> missingWithHash <> " ? " <> importPath <> ")"
             ]
 
-    traverse_ (\exprText -> do
-        clearCache semanticCacheDir
+    traverse_
+        (\exprText -> do
+            clearSemanticCache cacheDir
 
-        void (Dhall.inputExpr exprText)
+            void (inputExprNear tempFile exprText)
 
-        cached <- Directory.doesFileExist cacheFile
+            cached <- Directory.doesFileExist cacheFile
 
-        assertBool ("The semantic cache entry for " <> Text.unpack exprText <> " was not written") cached)
-            cases
+            assertBool
+                ("The semantic cache entry for " <> Text.unpack exprText <> " was not written")
+                cached)
+        cases
 
     Directory.removeFile tempFile
 
-clearCache :: FilePath -> IO ()
-clearCache cacheDir = do
-    exists <- Directory.doesDirectoryExist cacheDir
-    when exists (Directory.removeDirectoryRecursive cacheDir)
+-- | After an opportunistic fill, a later @missing sha256:… ? fallback@ reads
+-- the cached value instead of evaluating the new fallback.
+fillThenHitTest :: IO ()
+fillThenHitTest = withTempCache $ \cacheDir -> do
+    let cachedValue = "123"
 
-getTests :: IO TestTree
-getTests = return (testCase "Cache write for fallbacks" cacheFillTest)
+    expr <- Dhall.inputExpr cachedValue
+
+    let hashCode = Import.hashExpressionToCode (Core.denote expr)
+    let cacheFile = semanticCacheFile cacheDir expr
+
+    tempFile <- writeTempImport cachedValue
+    let importPath = relativeImport tempFile
+
+    step1 <- Dhall.inputExpr ("missing " <> hashCode <> " ? 10")
+    assertNormalizedEqual
+        "cache miss should use the literal fallback"
+        (Core.NaturalLit 10)
+        step1
+
+    cachedBeforeFill <- Directory.doesFileExist cacheFile
+    assertBool "cache should be empty before opportunistic fill" (not cachedBeforeFill)
+
+    step2 <- inputExprNear tempFile ("missing " <> hashCode <> " ? " <> importPath)
+    assertNormalizedEqual
+        "opportunistic fill should resolve the matching fallback"
+        expr
+        step2
+
+    cachedAfterFill <- Directory.doesFileExist cacheFile
+    assertBool "matching fallback should write the semantic cache" cachedAfterFill
+
+    step3 <- Dhall.inputExpr ("missing " <> hashCode <> " ? 50")
+    assertNormalizedEqual
+        "after fill, resolution should come from the semantic cache"
+        expr
+        step3
+
+    Directory.removeFile tempFile
+
+-- | Opportunistic fill also works when the matching fallback is an env import.
+envFillThenHitTest :: IO ()
+envFillThenHitTest = withTempCache $ \cacheDir -> do
+    originalVar <- Environment.lookupEnv "DHALL_TEST_VAR"
+
+    let setVar = Environment.setEnv "DHALL_TEST_VAR" "42"
+
+    let restoreVar =
+            maybe
+                (Environment.unsetEnv "DHALL_TEST_VAR")
+                (Environment.setEnv "DHALL_TEST_VAR")
+                originalVar
+
+    bracket setVar (const restoreVar) $ \_ -> do
+        expr <- Dhall.inputExpr "42"
+
+        let hashCode = Import.hashExpressionToCode (Core.denote expr)
+        let cacheFile = semanticCacheFile cacheDir expr
+
+        step1 <- Dhall.inputExpr ("missing " <> hashCode <> " ? 10")
+        assertNormalizedEqual
+            "cache miss should use the literal fallback"
+            (Core.NaturalLit 10)
+            step1
+
+        step2 <- Dhall.inputExpr ("missing " <> hashCode <> " ? env:DHALL_TEST_VAR")
+        assertNormalizedEqual
+            "env fallback should opportunistically fill the cache"
+            expr
+            step2
+
+        cachedAfterFill <- Directory.doesFileExist cacheFile
+        assertBool "env fallback should write the semantic cache" cachedAfterFill
+
+        step3 <- Dhall.inputExpr ("missing " <> hashCode <> " ? 50")
+        assertNormalizedEqual
+            "after env fill, resolution should come from the semantic cache"
+            expr
+            step3
+
+-- | A successful fallback whose hash does not match must not poison the cache.
+hashMismatchDoesNotFillTest :: IO ()
+hashMismatchDoesNotFillTest = withTempCache $ \cacheDir -> do
+    expr <- Dhall.inputExpr "123"
+
+    let wrongHashCode =
+            "sha256:0000000000000000000000000000000000000000000000000000000011111111"
+
+    tempFile <- writeTempImport "123"
+    let importPath = relativeImport tempFile
+
+    step1 <- Dhall.inputExpr ("missing " <> wrongHashCode <> " ? 10")
+    assertNormalizedEqual
+        "cache miss should use the literal fallback"
+        (Core.NaturalLit 10)
+        step1
+
+    step2 <- inputExprNear tempFile ("missing " <> wrongHashCode <> " ? " <> importPath)
+    assertNormalizedEqual
+        "mismatched fallback should still resolve"
+        expr
+        step2
+
+    let wrongCacheFile =
+            cacheDir </> "dhall" </>
+            "122000000000000000000000000000000000000000000000000000000011111111"
+
+    cachedWrongHash <- Directory.doesFileExist wrongCacheFile
+    assertBool "mismatched hash must not write a cache entry" (not cachedWrongHash)
+
+    step3 <- Dhall.inputExpr ("missing " <> wrongHashCode <> " ? 50")
+    assertNormalizedEqual
+        "without a cache fill, the new fallback should be used"
+        (Core.NaturalLit 50)
+        step3
+
+    Directory.removeFile tempFile
+
+-- | A hash attached to the right of an already-successful alternative must not
+-- be used for opportunistic caching.
+hashOnRightIsIgnoredTest :: IO ()
+hashOnRightIsIgnoredTest = withTempCache $ \cacheDir -> do
+    expr <- Dhall.inputExpr "[ 123, 1 ]"
+
+    let hashCode = Import.hashExpressionToCode (Core.denote expr)
+    let cacheFile = semanticCacheFile cacheDir expr
+
+    tempFile <- writeTempImport "[ 123, 1 ]"
+    let importPath = relativeImport tempFile
+
+    -- Left alternative succeeds, so the hash on the right is irrelevant.
+    step2 <- inputExprNear tempFile (importPath <> " ? missing " <> hashCode)
+    assertNormalizedEqual
+        "successful left alternative should win"
+        expr
+        step2
+
+    cached <- Directory.doesFileExist cacheFile
+    assertBool
+        "hash on the right of a successful alternative must not fill the cache"
+        (not cached)
+
+    expectedMiss <- Dhall.inputExpr "[ 50, 1 ]"
+    step3 <- Dhall.inputExpr ("missing " <> hashCode <> " ? [ 50, 1 ]")
+    assertNormalizedEqual
+        "without a cache fill, the new fallback should be used"
+        expectedMiss
+        step3
+
+    Directory.removeFile tempFile
+
+-- | Unhashed Code fallbacks are no longer beta-normalized before inlining.
+-- Opportunistic fill must still hash the normal form, or it would miss the
+-- semantic cache (or write the wrong product).
+fillFromUnnormalizedImportTest :: IO ()
+fillFromUnnormalizedImportTest = withTempCache $ \cacheDir -> do
+    expr <- Dhall.inputExpr "123"
+
+    let hashCode = Import.hashExpressionToCode (Core.denote expr)
+    let cacheFile = semanticCacheFile cacheDir expr
+
+    tempFile <- writeTempImport "let x = 123 in x"
+    let importPath = relativeImport tempFile
+
+    step1 <- inputExprNear tempFile ("missing " <> hashCode <> " ? " <> importPath)
+    assertNormalizedEqual
+        "unnormalized fallback should still resolve to the semantic value"
+        expr
+        step1
+
+    cachedAfterFill <- Directory.doesFileExist cacheFile
+    assertBool
+        "unnormalized matching fallback should write the semantic cache"
+        cachedAfterFill
+
+    step2 <- Dhall.inputExpr ("missing " <> hashCode <> " ? 50")
+    assertNormalizedEqual
+        "after fill, resolution should come from the semantic cache"
+        expr
+        step2
+
+    Directory.removeFile tempFile

--- a/dhall/tests/Dhall/Test/SemisemanticCache.hs
+++ b/dhall/tests/Dhall/Test/SemisemanticCache.hs
@@ -3,14 +3,14 @@
 -- | Unit tests for the disk cache used by Code imports without integrity
 -- checks (@$XDG_CACHE_HOME/dhall-haskell-v2/@).
 --
--- Imports still typecheck and normalize in memory. The on-disk entry is either
--- a small encoded normal form or a one-byte "already type-checked" marker.
+-- Imports still typecheck in memory. The on-disk entry is a one-byte
+-- "already type-checked" marker. Older cache files may still contain a small
+-- encoded normal form, which the loader still accepts.
 module Dhall.Test.SemisemanticCache where
 
 import Control.Exception            (bracket)
 import Control.Monad                (void)
 import Data.Foldable                (traverse_)
-import Data.Text                    (Text)
 import Data.Void                    (Void)
 import Dhall.Src                    (Src)
 import System.FilePath              (takeDirectory, takeFileName, (</>))
@@ -32,7 +32,7 @@ import qualified Test.Tasty         as Tasty
 getTests :: IO TestTree
 getTests = return
     (Tasty.testGroup "Semisemantic cache"
-        [ testCase "Small NF is cached and reused" smallNFCachedTest
+        [ testCase "Typechecked marker is cached and reused" typecheckedMarkerCachedTest
         , testCase "Large NF stores a well-typed marker only" largeNFMarkerTest
         , testCase "Early-abort size check agrees with full walk" earlyAbortAgreesWithFullWalkTest
         , testCase "Child change invalidates parent cache" childChangeInvalidatesParentTest
@@ -84,9 +84,10 @@ assertNormalizedEqual message expected actual =
         (Core.normalize (Core.denote expected) :: Core.Expr Void Void)
         (Core.normalize (Core.denote actual) :: Core.Expr Void Void)
 
--- | Small expression: second load should hit a cached NF (tag byte 0).
-smallNFCachedTest :: IO ()
-smallNFCachedTest = withTempCache $ \cacheDir -> do
+-- | Code imports store a typed marker (tag byte 1); normalization is delayed
+--   until the whole resolved expression is evaluated.
+typecheckedMarkerCachedTest :: IO ()
+typecheckedMarkerCachedTest = withTempCache $ \cacheDir -> do
     tempFile <- Temp.writeTempFile "." "small.dhall" "1 + 1"
 
     void (inputFile tempFile)
@@ -95,7 +96,7 @@ smallNFCachedTest = withTempCache $ \cacheDir -> do
         "first load should write a semisemantic cache entry"
         (not (null filesAfterFirst))
 
-    traverse_ checkNFTag filesAfterFirst
+    traverse_ checkTypedTag filesAfterFirst
 
     result1 <- inputFile tempFile
     result2 <- inputFile tempFile
@@ -103,13 +104,12 @@ smallNFCachedTest = withTempCache $ \cacheDir -> do
 
     Directory.removeFile tempFile
   where
-    checkNFTag file = do
+    checkTypedTag file = do
         bytes <- ByteString.readFile file
-        case ByteString.uncons bytes of
-            Just (0, rest) ->
-                assertBool "NF payload should be non-empty CBOR" (not (ByteString.null rest))
-            _ ->
-                assertBool ("expected NF tag 0 in " <> file) False
+        assertEqual
+            ("Code imports should be stored as typed markers in " <> file)
+            (ByteString.singleton 1)
+            bytes
 
 -- | Large Text payload: store only a well-typed marker (tag byte 1, tiny file).
 largeNFMarkerTest :: IO ()


### PR DESCRIPTION
Inlining a full normal form for every unhashed import is expensive when the parent only uses a small part of a large import. For non-hash-protected imports, it is unnecessary to compute and insert the full normal form of each import into the parent expression. 

The new code will stop after typechecking, cache a typed marker on disk, and possibly normalize later when the normal form is actually needed: for computing a semantic hash of an import, or for full normalization.

Opportunistic `missing sha256:… ? p` fill now beta-normalizes before hashing so the correct semantic-cache product is still computed even with delayed import inlining.

The `large4` benchmark now completes:

```
  large4
    resolve:    OK
      356  ms ±  29 ms
    typecheck:  OK
      273  ms ±  26 ms
    evaluation: OK
      930  μs ±  89 μs
```

whereas before it could not complete due to OOM while trying to compute the full normal form.