### PR TITLE
Port dhall-try from GHCJS 8.10 to GHC JavaScript backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,16 @@ $ nix-build
 The Nix expressions pin [Nixpkgs 26.05](https://github.com/NixOS/nixpkgs/tree/nixos-26.05)
 and build with GHC 9.6 by default (`./nix/pinnedNixpkgs.nix`).  GitHub Actions
 still uses Stack for the compiler matrix; Hydra / `nix-build` is the Nix path.
-The in-browser interpreter (`dhall-try`) is not part of this Nix build: Nixpkgs
-25.11 removed legacy GHCJS 8.10.  See `dhall-try/README.md` for the JavaScript
-backend.
+
+The in-browser interpreter (`dhall-try`) is a separate Nix product, compiled
+with GHC's JavaScript backend.  It is **not** built by a bare `nix-build`:
+
+```console
+$ nix-build nix/javascript.nix -A dhall-try
+```
+
+See [`dhall-try/README.md`](./dhall-try/README.md) for artifact paths, Cabal
+flags, and why `compiler = "ghcjs"` is no longer valid on this pin.
 
 ... or you can run `nix-build` within each package's respective directory to
 build just that one package.
@@ -257,43 +264,26 @@ This generates a `dhall-to-json.prof` file in your current directory.
 
 ## Build the website
 
-If you don't need to change the GHCJS code, then switch to the `dhall-lang`
-repository and follow these instructions instead:
+If you don't need to change the in-browser interpreter, switch to the
+`dhall-lang` repository and follow:
 
 * [`dhall-lang` - Build the website](https://github.com/dhall-lang/dhall-lang/blob/master/nixops/README.md#updating-dhall-langorg)
 
-If you do need to test changes to the GHCJS code (i.e. the
-[`./dhall-try`](./dhall-try) subdirectory) then stay within this repository, but
-edit the `dhall/dhall-lang` submodule to make the following change:
+If you do need to test changes under [`./dhall-try`](./dhall-try), build the
+JavaScript interpreter from this repository:
 
-```diff
-diff --git a/release.nix b/release.nix
---- a/dhall/dhall-lang/release.nix
-+++ b/dhall/dhall-lang/release.nix
-       let
-         json = builtins.fromJSON (builtins.readFile ./nixops/dhall-haskell.json);
- 
--        dhall-haskell =
--          pkgs.fetchFromGitHub {
--            owner = "dhall-lang";
--
--            repo = "dhall-haskell";
--
--            inherit (json) rev sha256 fetchSubmodules;
--          };
-+        dhall-haskell = ../..;
- 
-       in
-         import "${dhall-haskell}/default.nix";
+```console
+$ nix-build nix/javascript.nix -A dhall-try
 ```
 
-... and then build the website by running:
+That uses `pkgsCross.ghcjs` (GHC's JS backend on Nixpkgs 26.05), not legacy
+GHCJS.  The file to drop into the website is
+`result/bin/dhall-try.jsexe/all.min.js`.  Details are in
+[`dhall-try/README.md`](./dhall-try/README.md).
 
-```bash
-$ nix build --file dhall/dhall-lang/release.nix website
-```
-
-... which will incorporate any GHCJS-related changes you make
+Until the `dhall-lang` overlay stops pinning `dhall-haskell-old.json`,
+dhall-lang.org will keep serving the August 2021 interpreter even after this
+package builds.
 
 ## Contributing
 

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,6 @@
 let
   shared = import ./nix/shared.nix {};
 
-  shared_ghcjs = import ./nix/shared.nix { compiler = "ghcjs"; };
-
 in
   { inherit (shared.possibly-static)
       dhall
@@ -11,18 +9,14 @@ in
       dhall-docs
       dhall-json
       dhall-lsp-server
-      dhall-openapi
       dhall-nix
       dhall-nixpkgs
+      dhall-openapi
       dhall-toml
       dhall-yaml
     ;
 
-    # Legacy GHCJS 8.10 (`haskell.packages.ghcjs`) was removed in Nixpkgs 25.11.
-    # The JavaScript backend now lives under `pkgsCross.ghcjs`; restoring
-    # `dhall-try` is a separate change that ports `dhall/ghcjs-src` and
-    # `dhall-try` off `ghcjs-base`.
-
-    # inherit (shared_ghcjs) dhall-try;
-    # dhall-ghcjs = shared_ghcjs.dhall;
+    # GHC's JavaScript backend via pkgsCross.ghcjs. Nested so a bare
+    # `nix-build` does not compile JS. See nix/javascript.nix.
+    javascript = import ./nix/javascript.nix {};
   }

--- a/dhall-try/README.md
+++ b/dhall-try/README.md
@@ -1,8 +1,56 @@
 # `dhall-try`
 
-For installation or development instructions, see:
+In-browser Dhall interpreter used by [try.dhall-lang.org](https://try.dhall-lang.org).
+It is compiled with **GHC's JavaScript backend** (`pkgsCross.ghcjs` on Nixpkgs
+26.05), not legacy GHCJS 8.10 (`haskell.packages.ghcjs`, removed in Nixpkgs
+25.11).
 
-* [`dhall-haskell` - `README`](https://github.com/dhall-lang/dhall-haskell/blob/master/README.md#build-the-website)
+## Build with Nix
+
+The JS products are **not** part of a bare `nix-build` at the repo root (so a
+JS failure cannot block native tarballs).  Build them explicitly:
+
+```console
+$ nix-build nix/javascript.nix -A dhall-try
+```
+
+Equivalent:
+
+```console
+$ nix-build -A javascript.dhall-try
+$ nix-build dhall-try
+```
+
+The first build of GHC's JS backend and its package set is large and often
+uncached (hours).  Linux (`x86_64-linux`) is the well-supported host; Darwin
+may work but is less tested.
+
+The minified interpreter lands at:
+
+```
+result/bin/dhall-try.jsexe/all.min.js
+```
+
+(`all.js` is the unminified GHC output; `all.min.js` is Closure Compiler.)
+
+To open a shell with the JS GHC and `dhall-try` dependencies:
+
+```console
+$ nix-shell dhall-try/shell.nix
+```
+
+Do **not** pass `compiler = "ghcjs"` to `nix/shared.nix` on this Nixpkgs pin:
+that attribute throws.  The JS package set is `pkgs.pkgsCross.ghcjs.haskell.packages.ghc96`.
+
+## How the JS sources are selected
+
+- `dhall/dhall.cabal` uses `ghcjs-src` when `arch(javascript)`, `impl(ghcjs)`,
+  or `-fjavascript` is set.  The flag exists because `cabal2nix` evaluates the
+  Cabal file on the **build** platform, not the JS target.
+- HTTP uses `fetch`; SHA-256 uses Web Crypto (browser) or Node `crypto`.
+- `dhall-try` talks to the Ace editor via `GHC.JS.Prim` / `GHC.JS.Foreign.Callback`
+  (in `base` on the JS architecture).  There is no `ghcjs-base` / `ghcjs-xhr`
+  dependency.
 
 ## How to contribute
 
@@ -11,12 +59,14 @@ improve the site.  The vast majority of the site logic is embedded within that
 monolithic document, including a substantial amount of inline JavaScript, inline
 CSS, and all of the code examples.
 
-The [`src`](./src) directory contains the code for interpreting the live code
-demo, powered by the `dhall`/`dhall-json` packages compiled to JavaScript using
-GHCJS.  You only need to modify that Haskell source code if you would like to
-extend the site with new Haskell-derived functionality.
+The [`src`](./src) directory contains the Haskell for the live demo
+(`dhall` / `dhall-json` compiled to JavaScript).  Change it when you need new
+Haskell-derived behaviour.
 
-The [`website.nix`](../nix/website.nix) file contains the top-level logic for
-building the site, including bundling of JavaScript/CSS/image assets.  You will
-also want to refer to [`shared.nix`](../nix/shared.nix) for related logic to
-build each bundled dependency.
+Website assembly for dhall-lang.org still lives in the `dhall-lang` repository
+(`nixops/website.nix`).  After this interpreter builds, that overlay should
+stop using `dhall-haskell-old.json` (commit `8f62fdf`, August 2021) and take
+`dhall-try` from current `dhall-haskell`.
+
+For installation or development of the **native** packages, see the
+[`dhall-haskell` README](https://github.com/dhall-lang/dhall-haskell/blob/master/README.md).

--- a/dhall-try/README.md
+++ b/dhall-try/README.md
@@ -48,9 +48,10 @@ that attribute throws.  The JS package set is `pkgs.pkgsCross.ghcjs.haskell.pack
   or `-fjavascript` is set.  The flag exists because `cabal2nix` evaluates the
   Cabal file on the **build** platform, not the JS target.
 - HTTP uses `fetch`; SHA-256 uses Web Crypto (browser) or Node `crypto`.
-- `dhall-try` talks to the Ace editor via `GHC.JS.Prim` / `GHC.JS.Foreign.Callback`
-  (in `base` on the JS architecture).  There is no `ghcjs-base` / `ghcjs-xhr`
-  dependency.
+- `dhall-try` talks to the Ace editor via `GHC.JS.Prim`.  GHC 9.6's JS `base`
+  has no `GHC.JS.Foreign.Callback` (that landed in 9.8), so `src/Callback.hs`
+  wraps the same RTS helpers (`h$makeCallback` / `h$run`).  There is no
+  `ghcjs-base` / `ghcjs-xhr` dependency.
 
 ## How to contribute
 

--- a/dhall-try/default.nix
+++ b/dhall-try/default.nix
@@ -1,1 +1,1 @@
-(import ../nix/shared.nix { compiler = "ghcjs"; }).dhall-try
+(import ../nix/javascript.nix {}).dhall-try

--- a/dhall-try/dhall-try.cabal
+++ b/dhall-try/dhall-try.cabal
@@ -1,7 +1,6 @@
 name:                dhall-try
 version:             1.0.0
 synopsis:            Try Dhall in a browser
--- description:
 homepage:            https://github.com/dhall-lang/dhall-haskell
 license:             BSD3
 license-file:        LICENSE
@@ -20,8 +19,6 @@ executable dhall-try
                      , dhall-json
                      , prettyprinter  >= 1.7.0
                      , text
-                     , ghcjs-base
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options: -Wall -dedupe
-  cpp-options: -DGHCJS_BROWSER
+  ghc-options: -Wall

--- a/dhall-try/dhall-try.cabal
+++ b/dhall-try/dhall-try.cabal
@@ -13,6 +13,7 @@ cabal-version:       >=1.10
 
 executable dhall-try
   main-is:             Main.hs
+  other-modules:       Callback
   build-depends:       base           >= 4.11.0.0 && < 5
                      , aeson-pretty
                      , dhall

--- a/dhall-try/shell.nix
+++ b/dhall-try/shell.nix
@@ -1,1 +1,1 @@
-(import ../nix/shared.nix { compiler = "ghcjs"; }).shell-dhall-try
+(import ../nix/javascript.nix {}).shell-dhall-try

--- a/dhall-try/src/Main.hs
+++ b/dhall-try/src/Main.hs
@@ -21,8 +21,9 @@ import qualified Prettyprinter.Render.Text as Pretty
 
 import Control.Exception           (Exception, SomeException)
 import Data.Text                   (Text)
-import GHC.JS.Foreign.Callback     (Callback)
-import qualified GHC.JS.Foreign.Callback
+-- GHC.JS.Foreign.Callback is only in base from GHC 9.8. On 9.6 use Callback.
+import Callback                    (Callback)
+import qualified Callback
 import GHC.JS.Prim                 (JSVal, fromJSString, toJSString)
 
 foreign import javascript unsafe "(() => input.getValue())"
@@ -157,7 +158,7 @@ main = do
 
     interpret
 
-    interpretAsync <- GHC.JS.Foreign.Callback.asyncCallback interpret
+    interpretAsync <- Callback.asyncCallback interpret
 
     registerInterpret interpretAsync
 
@@ -171,7 +172,7 @@ main = do
 
                     interpret
 
-            callbackAsync <- GHC.JS.Foreign.Callback.asyncCallback callback
+            callbackAsync <- Callback.asyncCallback callback
 
             registerCallback callbackAsync
 

--- a/dhall-try/src/Main.hs
+++ b/dhall-try/src/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE JavaScriptFFI     #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
@@ -5,7 +6,6 @@ module Main where
 import qualified Control.Exception
 import qualified Data.Aeson.Encode.Pretty
 import qualified Data.IORef
-import qualified Data.JSString
 import qualified Data.Text
 import qualified Data.Text.Encoding
 import qualified Data.Text.Lazy
@@ -17,50 +17,59 @@ import qualified Dhall.JSON.Yaml
 import qualified Dhall.Parser
 import qualified Dhall.Pretty
 import qualified Dhall.TypeCheck
-import qualified GHCJS.Foreign.Callback
-import qualified Prettyprinter             as Pretty
 import qualified Prettyprinter.Render.Text as Pretty
 
-import Control.Exception      (Exception, SomeException)
-import Data.JSString          (JSString)
-import Data.Text              (Text)
-import GHCJS.Foreign.Callback (Callback)
+import Control.Exception           (Exception, SomeException)
+import Data.Text                   (Text)
+import GHC.JS.Foreign.Callback     (Callback)
+import qualified GHC.JS.Foreign.Callback
+import GHC.JS.Prim                 (JSVal, fromJSString, toJSString)
 
-foreign import javascript unsafe "input.getValue()" getInput :: IO JSString
+foreign import javascript unsafe "(() => input.getValue())"
+  getInput :: IO JSVal
 
-foreign import javascript unsafe "input.on('change', $1)" registerInterpret :: Callback (IO ()) -> IO ()
+foreign import javascript unsafe "((f) => { input.on('change', f); })"
+  registerInterpret :: Callback (IO ()) -> IO ()
 
-foreign import javascript unsafe "dhallTab.onclick = $1" registerDhallOutput :: Callback (IO ()) -> IO ()
+foreign import javascript unsafe "((f) => { dhallTab.onclick = f; })"
+  registerDhallOutput :: Callback (IO ()) -> IO ()
 
-foreign import javascript unsafe "jsonTab.onclick = $1" registerJSONOutput :: Callback (IO ()) -> IO ()
+foreign import javascript unsafe "((f) => { jsonTab.onclick = f; })"
+  registerJSONOutput :: Callback (IO ()) -> IO ()
 
-foreign import javascript unsafe "yamlTab.onclick = $1" registerYAMLOutput :: Callback (IO ()) -> IO ()
+foreign import javascript unsafe "((f) => { yamlTab.onclick = f; })"
+  registerYAMLOutput :: Callback (IO ()) -> IO ()
 
-foreign import javascript unsafe "typeTab.onclick = $1" registerTypeOutput :: Callback (IO ()) -> IO ()
+foreign import javascript unsafe "((f) => { typeTab.onclick = f; })"
+  registerTypeOutput :: Callback (IO ()) -> IO ()
 
-foreign import javascript unsafe "hashTab.onclick = $1" registerHashOutput :: Callback (IO ()) -> IO ()
+foreign import javascript unsafe "((f) => { hashTab.onclick = f; })"
+  registerHashOutput :: Callback (IO ()) -> IO ()
 
-foreign import javascript unsafe "output.setValue($1)" setOutput_ :: JSString -> IO ()
+foreign import javascript unsafe "((s) => { output.setValue(s); })"
+  setOutput_ :: JSVal -> IO ()
 
-foreign import javascript unsafe "output.setOption('mode', $1)" setMode_ :: JSString -> IO ()
+foreign import javascript unsafe "((s) => { output.setOption('mode', s); })"
+  setMode_ :: JSVal -> IO ()
 
-foreign import javascript unsafe "selectTab($1, $2)" selectTab :: JSString -> JSString -> IO ()
+foreign import javascript unsafe "((group, name) => { selectTab(group, name); })"
+  selectTab :: JSVal -> JSVal -> IO ()
 
 fixup :: Text -> Text
 fixup = Data.Text.replace "\ESC[1;31mError\ESC[0m" "Error"
 
 setOutput :: Text -> IO ()
-setOutput = setOutput_ . Data.JSString.pack . Data.Text.unpack
+setOutput = setOutput_ . toJSString . Data.Text.unpack
 
 errOutput :: Exception e => e -> IO ()
 errOutput = setOutput . fixup . Data.Text.pack . show
 
 setMode :: Mode -> IO ()
-setMode Dhall = setMode_ "haskell"
-setMode Type  = setMode_ "haskell"
-setMode JSON  = setMode_ "javascript"
-setMode YAML  = setMode_ "yaml"
-setMode Hash  = setMode_ "null"
+setMode Dhall = setMode_ (toJSString "haskell")
+setMode Type  = setMode_ (toJSString "haskell")
+setMode JSON  = setMode_ (toJSString "javascript")
+setMode YAML  = setMode_ (toJSString "yaml")
+setMode Hash  = setMode_ (toJSString "null")
 
 jsonConfig :: Data.Aeson.Encode.Pretty.Config
 jsonConfig =
@@ -87,9 +96,9 @@ main = do
             . Dhall.Pretty.prettyExpr
 
     let interpret = do
-            inputJSString <- getInput
+            inputJSVal <- getInput
 
-            let inputString = Data.JSString.unpack inputJSString
+            let inputString = fromJSString inputJSVal
             let inputText   = Data.Text.pack inputString
 
             case Dhall.Parser.exprFromText "(input)" inputText of
@@ -148,7 +157,7 @@ main = do
 
     interpret
 
-    interpretAsync <- GHCJS.Foreign.Callback.asyncCallback interpret
+    interpretAsync <- GHC.JS.Foreign.Callback.asyncCallback interpret
 
     registerInterpret interpretAsync
 
@@ -156,13 +165,13 @@ main = do
             let callback = do
                     Data.IORef.writeIORef modeRef mode
 
-                    selectTab "mode-tab" tabName
+                    selectTab (toJSString "mode-tab") (toJSString tabName)
 
                     setMode mode
 
                     interpret
 
-            callbackAsync <- GHCJS.Foreign.Callback.asyncCallback callback
+            callbackAsync <- GHC.JS.Foreign.Callback.asyncCallback callback
 
             registerCallback callbackAsync
 

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -264,9 +264,12 @@ Common common
         th-lift-instances           >= 0.1.13   && < 0.2 ,
         time >=1.9 && <1.17,
         transformers                >= 0.5.2.0  && < 0.7 ,
-        unix-compat                 >= 0.4.2    && < 0.8 ,
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
         vector                      >= 0.11.0.0 && < 0.14
+
+    if !(arch(javascript) || impl(ghcjs) || flag(javascript))
+      Build-Depends:
+        unix-compat                 >= 0.4.2    && < 0.8
 
     if !os(windows) && !arch(javascript) && !impl(ghcjs) && !flag(javascript)
       Build-Depends:

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -198,6 +198,15 @@ Flag cross
   Default:     False
   Manual:      True
 
+Flag javascript
+  Description:
+    Select the JavaScript FFI sources (ghcjs-src).  Cabal also selects
+    those sources automatically for arch(javascript) / impl(ghcjs); this
+    flag exists so cabal2nix, which evaluates the Cabal file on the
+    build platform, generates the JS dependency set.
+  Default:     False
+  Manual:      True
+
 Flag network-tests
   Description:
     Enable doctests that fetch from the public internet (GitHub / Prelude).
@@ -259,7 +268,7 @@ Common common
         unordered-containers        >= 0.1.3.0  && < 0.3 ,
         vector                      >= 0.11.0.0 && < 0.14
 
-    if !os(windows)
+    if !os(windows) && !arch(javascript) && !impl(ghcjs) && !flag(javascript)
       Build-Depends:
         unix                        >= 2.7      && < 2.9 ,
 
@@ -280,11 +289,8 @@ Common common
 Library
     Import: common
     Hs-Source-Dirs: src
-    if impl(ghcjs)
+    if flag(javascript) || impl(ghcjs) || arch(javascript)
       Hs-Source-Dirs: ghcjs-src
-      Build-Depends:
-        ghcjs-base ,
-        ghcjs-xhr
     else
       Hs-Source-Dirs: ghc-src
       Build-Depends:

--- a/dhall/ghcjs-src/Dhall/Crypto.hs
+++ b/dhall/ghcjs-src/Dhall/Crypto.hs
@@ -3,34 +3,33 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE JavaScriptFFI              #-}
 
-{-| This module provides implementations of cryptographic utilities that only
-    work for GHCJS
+{-| Cryptographic utilities for GHC's JavaScript backend (and former GHCJS).
 -}
 
 module Dhall.Crypto (
       SHA256Digest(..)
     , sha256DigestFromByteString
     , sha256Hash
+    , toString
     ) where
 
-import Control.DeepSeq                   (NFData)
-import Data.ByteString                   (ByteString)
-import Data.Data                         (Data)
-import GHC.Generics                      (Generic)
-import JavaScript.TypedArray.ArrayBuffer (ArrayBuffer)
-import System.IO.Unsafe                  (unsafePerformIO)
+import Control.DeepSeq     (NFData)
+import Data.ByteString     (ByteString)
+import Data.Data           (Data)
+import GHC.Generics        (Generic)
+import GHC.JS.Prim         (JSVal, fromJSString, toJSString)
+import System.IO.Unsafe    (unsafePerformIO)
 
 import qualified Data.ByteString        as ByteString
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8  as ByteString.Char8
-import qualified GHCJS.Buffer           as Buffer
 
 -- | A SHA256 digest
 newtype SHA256Digest = SHA256Digest { unSHA256Digest :: ByteString }
   deriving (Data, Eq, Generic, Ord, NFData)
 
 instance Show SHA256Digest where
-  show (SHA256Digest bytes) = ByteString.Char8.unpack $ Base16.encode bytes
+  show = toString
 
 {-| Attempt to interpret a `ByteString` as a `SHA256Digest`, returning
     `Nothing` if the conversion fails
@@ -40,29 +39,21 @@ sha256DigestFromByteString bytes
   | ByteString.length bytes == 32 = Just (SHA256Digest bytes)
   | otherwise                     = Nothing
 
--- Use NodeJS' crypto module if there's a 'process' module, e.g. we're running
--- inside GHCJS' THRunner. If we're running in the browser, use the WebCrypto
--- interface.
+-- Browser: WebCrypto. Node (including the JS TH runner): Node's crypto module.
 foreign import javascript interruptible
-  "if (typeof process === 'undefined') { \
-  \  crypto.subtle.digest('SHA-256', $1).then($c) \
-  \} else { \
-  \  $c(require('crypto').createHash('sha256').update(Buffer.from($1)).digest().buffer) \
-  \}"
-  js_sha256Hash :: ArrayBuffer -> IO ArrayBuffer
-
-byteStringToArrayBuffer :: ByteString -> ArrayBuffer
-byteStringToArrayBuffer b =
-  js_arrayBufferSlice offset len $ Buffer.getArrayBuffer buffer
-  where
-    (buffer, offset, len) = Buffer.fromByteString b
-
-foreign import javascript unsafe "$3.slice($1, $1 + $2)"
-  js_arrayBufferSlice :: Int -> Int -> ArrayBuffer -> ArrayBuffer
-
-arrayBufferToByteString :: ArrayBuffer -> ByteString
-arrayBufferToByteString =
-  Buffer.toByteString 0 Nothing . Buffer.createFromArrayBuffer
+  "((s, $c) => {\
+  \  var a = new Uint8Array(s.length);\
+  \  for (var i = 0; i < s.length; i++) a[i] = s.charCodeAt(i) & 0xff;\
+  \  var done = function (buf) {\
+  \    $c(String.fromCharCode.apply(null, new Uint8Array(buf)));\
+  \  };\
+  \  if (typeof process === 'undefined') {\
+  \    crypto.subtle.digest('SHA-256', a).then(done);\
+  \  } else {\
+  \    done(require('crypto').createHash('sha256').update(Buffer.from(a)).digest());\
+  \  }\
+  \})"
+  js_sha256Hash :: JSVal -> IO JSVal
 
 -- | Hash a `ByteString` and return the hash as a `SHA256Digest`
 sha256Hash :: ByteString -> SHA256Digest
@@ -71,5 +62,9 @@ sha256Hash bytes
   | otherwise = error "sha256Hash: didn't produce 32 bytes"
   where
     out =
-      arrayBufferToByteString $
-      unsafePerformIO $ js_sha256Hash (byteStringToArrayBuffer bytes)
+      ByteString.Char8.pack $ fromJSString $ unsafePerformIO $
+        js_sha256Hash (toJSString (ByteString.Char8.unpack bytes))
+
+-- | 'String' representation of a 'SHA256Digest'
+toString :: SHA256Digest -> String
+toString (SHA256Digest bytes) = ByteString.Char8.unpack $ Base16.encode bytes

--- a/dhall/ghcjs-src/Dhall/Import/HTTP.hs
+++ b/dhall/ghcjs-src/Dhall/Import/HTTP.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE JavaScriptFFI     #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Dhall.Import.HTTP
@@ -10,14 +11,35 @@ import Control.Monad.IO.Class           (MonadIO (..))
 import Control.Monad.Trans.State.Strict (StateT)
 import Data.ByteString                  (ByteString)
 import Data.CaseInsensitive             (CI)
-import Dhall.Core                       (URL (..), Expr (..))
-import Dhall.Import.Types               (Import, Status)
 import Dhall.Parser                     (Src)
 import Dhall.URL                        (renderURL)
+import GHC.JS.Prim                      (JSVal, fromJSString, toJSString)
+
+import Dhall.Core
+    ( Expr (..)
+    , Import (..)
+    , ImportHashed (..)
+    , ImportMode (..)
+    , ImportType (..)
+    , URL (..)
+    )
+import Dhall.Import.Types (Status)
 
 import qualified Data.Text          as Text
 import qualified Data.Text.Encoding as Text.Encoding
-import qualified JavaScript.XHR
+
+-- Returns "STATUS\\nBODY". An empty body still has the status line.
+foreign import javascript interruptible
+  "((url, $c) => {\
+  \  fetch(url).then(function (r) {\
+  \    return r.text().then(function (t) {\
+  \      $c(String(r.status) + '\\n' + t);\
+  \    });\
+  \  }).catch(function (e) {\
+  \    $c('0\\n' + String(e));\
+  \  });\
+  \})"
+  js_fetch :: JSVal -> IO JSVal
 
 fetchFromHttpUrl
     :: URL
@@ -25,28 +47,32 @@ fetchFromHttpUrl
     -> StateT Status IO Text.Text
 fetchFromHttpUrl childURL Nothing = do
     let childURLText = renderURL childURL
-
     let childURLString = Text.unpack childURLText
 
-    -- No need to add a CORS compliance check when using GHCJS.  The browser
-    -- will already check the CORS compliance of the following XHR
-    (statusCode, body) <- liftIO (JavaScript.XHR.get childURLText)
-
-    case statusCode of
-        200 -> return ()
-        _   -> fail (childURLString <> " returned a non-200 status code: " <> show statusCode)
-
-    return body
+    -- The browser enforces CORS; no extra check is required here.
+    payload <- liftIO (fromJSString <$> js_fetch (toJSString childURLString))
+    let (code, rest) = break (== '\n') payload
+        body = case rest of
+            []     -> ""
+            (_:xs) -> xs
+    case reads code of
+        [(statusCode, "")] | statusCode == (200 :: Int) ->
+            return (Text.pack body)
+        [(statusCode, "")] ->
+            fail (childURLString <> " returned a non-200 status code: " <> show statusCode)
+        _ ->
+            fail (childURLString <> " fetch failed: " <> payload)
 fetchFromHttpUrl _ _ =
-    fail "Dhall does not yet support custom headers when built using GHCJS"
+    fail "Dhall does not yet support custom headers when built for JavaScript"
 
-fetchFromHTTPUrlBytes
+fetchFromHttpUrlBytes
     :: URL
     -> Maybe [(CI ByteString, ByteString)]
     -> StateT Status IO ByteString
-fetchFromHTTPUrlBytes childUrl mheader = do
-    text <- fetchFromHTTPUrl childUrl mheader
+fetchFromHttpUrlBytes childUrl mheader = do
+    text <- fetchFromHttpUrl childUrl mheader
     return (Text.Encoding.encodeUtf8 text)
 
 originHeadersFileExpr :: IO (Expr Src Import)
-originHeadersFileExpr = return Missing
+originHeadersFileExpr =
+    return (Embed (Import (ImportHashed Nothing Missing) Code))

--- a/dhall/ghcjs-src/Dhall/Import/Manager.hs
+++ b/dhall/ghcjs-src/Dhall/Import/Manager.hs
@@ -1,12 +1,11 @@
-{-| Both the GHC and GHCJS implementations of `Dhall.Import.Manager.Manager`
+{-| Both the GHC and JavaScript implementations of `Dhall.Import.Manager.Manager`
     export a `Dhall.Import.Manager.Manager` type suitable for use within the
     "Dhall.Import" module
 
     For the GHC implementation the `Dhall.Import.Manager.Manager` type is a real
-    `Network.HTTP.Client.Manager` from the @http-client@ package.  For the GHCJS
-    implementation the `Dhall.Import.Manager.Manager` type is a synonym for
-    @`Data.Void.Void`@ since GHCJS does not use a
-    `Network.HTTP.Client.Manager` for HTTP requests.
+    `Network.HTTP.Client.Manager` from the @http-client@ package.  For the
+    JavaScript backend the `Dhall.Import.Manager.Manager` type is @()@ since
+    that backend does not use a `Network.HTTP.Client.Manager` for HTTP requests.
 -}
 module Dhall.Import.Manager
     ( -- * Manager
@@ -14,11 +13,11 @@ module Dhall.Import.Manager
     , defaultNewManager
     ) where
 
-{-| The GHCJS implementation does not require a `Network.HTTP.Client.Manager`
+{-| The JavaScript implementation does not require a `Network.HTTP.Client.Manager`
 
     The purpose of this synonym is so that "Dhall.Import.Types" can import a
     `Dhall.Import.Manager.Manager` type from "Dhall.Import.HTTP" that does the
-    correct thing for both the GHC and GHCJS implementations
+    correct thing for both the GHC and JavaScript implementations
 -}
 type Manager = ()
 

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -23,10 +23,15 @@ module Dhall.DirectoryTree
 
 import Control.Applicative       (empty)
 import Control.Exception         (Exception)
+#if defined(javascript_HOST_ARCH)
+import Control.Monad             (when)
+import Data.Maybe                (isJust)
+#else
 import Control.Monad             (unless, when)
-import Data.Either.Validation    (Validation (..))
 import Data.Functor.Identity     (Identity (..))
 import Data.Maybe                (fromMaybe, isJust)
+#endif
+import Data.Either.Validation    (Validation (..))
 import Data.Sequence             (Seq)
 import Data.Text                 (Text)
 import Data.Void                 (Void)
@@ -42,7 +47,6 @@ import Dhall.Syntax
     , Var (..)
     )
 import System.FilePath           ((</>), isAbsolute, splitDirectories, takeDirectory)
-import System.PosixCompat.Types  (FileMode, GroupID, UserID)
 
 import qualified Control.Exception           as Exception
 import qualified Data.ByteString             as ByteString
@@ -59,12 +63,14 @@ import qualified Prettyprinter               as Pretty
 import qualified Prettyprinter.Render.String as Pretty
 import qualified System.Directory            as Directory
 import qualified System.FilePath             as FilePath
-#if defined(mingw32_HOST_OS) || defined(javascript_HOST_ARCH)
+#if defined(mingw32_HOST_OS)
 import System.IO.Error           (illegalOperationErrorType, mkIOError)
-#else
+#elif !defined(javascript_HOST_ARCH)
 import qualified System.Posix.User           as Posix
 #endif
+#if !defined(javascript_HOST_ARCH)
 import qualified System.PosixCompat.Files    as Posix
+#endif
 
 {- | Options affecting the interpretation of a directory tree specification.
 -}
@@ -313,10 +319,11 @@ makeType = Record . Map.fromList <$> sequenceA
             <$> (Pi AutoInferCharSet "_" <$> expected dec <*> pure (Var (V "tree" 0)))
 
 -- | Resolve a `User` to a numerical id.
+#if !defined(javascript_HOST_ARCH)
 getUser :: User -> IO UserID
 getUser (UserId uid) = return uid
 getUser (UserName name) =
-#if defined(mingw32_HOST_OS) || defined(javascript_HOST_ARCH)
+#ifdef mingw32_HOST_OS
     ioError $ mkIOError illegalOperationErrorType x Nothing Nothing
     where x = "System.Posix.User.getUserEntryForName: not supported"
 #else
@@ -327,11 +334,12 @@ getUser (UserName name) =
 getGroup :: Group -> IO GroupID
 getGroup (GroupId gid) = return gid
 getGroup (GroupName name) =
-#if defined(mingw32_HOST_OS) || defined(javascript_HOST_ARCH)
+#ifdef mingw32_HOST_OS
     ioError $ mkIOError illegalOperationErrorType x Nothing Nothing
     where x = "System.Posix.User.getGroupEntryForName: not supported"
 #else
     Posix.groupID <$> Posix.getGroupEntryForName name
+#endif
 #endif
 
 -- | Process a `FilesystemEntry`. Writes the content to disk and apply the
@@ -394,6 +402,9 @@ hasMetadata entry
 
 -- | Set the metadata of an object referenced by a path.
 applyMetadata :: Entry a -> FilePath -> IO ()
+#if defined(javascript_HOST_ARCH)
+applyMetadata _ _ = return ()
+#else
 applyMetadata entry fp = do
     s <- Posix.getFileStatus fp
     let user = Posix.fileOwner s
@@ -408,9 +419,11 @@ applyMetadata entry fp = do
     let mode' = maybe mode (updateModeWith mode) (entryMode entry)
     unless (mode' == mode) $
         setFileMode fp $ modeToFileMode mode'
+#endif
 
 -- | Calculate the new `Mode` from the current mode and the changes specified by
 -- the user.
+#if !defined(javascript_HOST_ARCH)
 updateModeWith :: Mode Identity -> Mode Maybe -> Mode Identity
 updateModeWith x y = Mode
     { modeUser = combine modeUser modeUser
@@ -469,6 +482,7 @@ modeToFileMode mode = foldr Posix.unionFileModes Posix.nullFileMode $
 -- | Check whether the second `FileMode` is contained in the first one.
 hasFileMode :: FileMode -> FileMode -> Bool
 hasFileMode mode x = (mode `Posix.intersectFileModes` x) == x
+#endif
 
 {- | This error indicates that you supplied an invalid Dhall expression to the
      `toDirectoryTree` function.  The Dhall expression could not be translated

--- a/dhall/src/Dhall/DirectoryTree.hs
+++ b/dhall/src/Dhall/DirectoryTree.hs
@@ -59,7 +59,7 @@ import qualified Prettyprinter               as Pretty
 import qualified Prettyprinter.Render.String as Pretty
 import qualified System.Directory            as Directory
 import qualified System.FilePath             as FilePath
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) || defined(javascript_HOST_ARCH)
 import System.IO.Error           (illegalOperationErrorType, mkIOError)
 #else
 import qualified System.Posix.User           as Posix
@@ -316,7 +316,7 @@ makeType = Record . Map.fromList <$> sequenceA
 getUser :: User -> IO UserID
 getUser (UserId uid) = return uid
 getUser (UserName name) =
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) || defined(javascript_HOST_ARCH)
     ioError $ mkIOError illegalOperationErrorType x Nothing Nothing
     where x = "System.Posix.User.getUserEntryForName: not supported"
 #else
@@ -327,7 +327,7 @@ getUser (UserName name) =
 getGroup :: Group -> IO GroupID
 getGroup (GroupId gid) = return gid
 getGroup (GroupName name) =
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) || defined(javascript_HOST_ARCH)
     ioError $ mkIOError illegalOperationErrorType x Nothing Nothing
     where x = "System.Posix.User.getGroupEntryForName: not supported"
 #else

--- a/dhall/src/Dhall/DirectoryTree/Types.hs
+++ b/dhall/src/Dhall/DirectoryTree/Types.hs
@@ -23,6 +23,10 @@ module Dhall.DirectoryTree.Types
     , Mode(..)
     , Access(..)
 
+    , FileMode
+    , UserID
+    , GroupID
+
     , setFileMode
     , prettyFileMode
 
@@ -41,13 +45,24 @@ import Dhall.Marshal.Decode
     , InterpretOptions (..)
     )
 import Dhall.Syntax             (Expr (..), FieldSelection (..), Var (..))
+
+#if defined(javascript_HOST_ARCH)
+import Data.Bits     ((.&.))
+import Data.Word     (Word32)
+#else
 import System.PosixCompat.Types (GroupID, UserID)
+
+import qualified System.PosixCompat.Files as Posix
+#endif
 
 import qualified Data.Text                as Text
 import qualified Dhall.Marshal.Decode     as Decode
-import qualified System.PosixCompat.Files as Posix
 
-#ifdef mingw32_HOST_OS
+#if defined(javascript_HOST_ARCH)
+type FileMode = Word32
+type UserID = Word32
+type GroupID = Word32
+#elif defined(mingw32_HOST_OS)
 import Control.Monad            (unless)
 import Data.Word                (Word32)
 import System.IO                (hPutStrLn, stderr)
@@ -125,7 +140,9 @@ data User
 
 instance FromDhall User
 
-#ifdef mingw32_HOST_OS
+#if defined(javascript_HOST_ARCH)
+-- UserID is Word32
+#elif defined(mingw32_HOST_OS)
 instance FromDhall UserID where
     autoWith normalizer = Unsafe.Coerce.unsafeCoerce <$> autoWith @Word32 normalizer
 #else
@@ -141,7 +158,9 @@ data Group
 
 instance FromDhall Group
 
-#ifdef mingw32_HOST_OS
+#if defined(javascript_HOST_ARCH)
+-- GroupID is Word32
+#elif defined(mingw32_HOST_OS)
 instance FromDhall GroupID where
     autoWith normalizer = Unsafe.Coerce.unsafeCoerce <$> autoWith @Word32 normalizer
 #else
@@ -213,7 +232,9 @@ accessDecoder = Decode.genericAutoWithInputNormalizer Decode.defaultInterpretOpt
 -- match the desired file mode. On all other OS it is identical to
 -- `Posix.setFileMode` as it is assumed to work correctly.
 setFileMode :: FilePath -> FileMode -> IO ()
-#ifdef mingw32_HOST_OS
+#if defined(javascript_HOST_ARCH)
+setFileMode _ _ = return ()
+#elif defined(mingw32_HOST_OS)
 setFileMode fp mode = do
     Posix.setFileMode fp mode
     mode' <- Posix.fileMode <$> Posix.getFileStatus fp
@@ -235,32 +256,59 @@ setFileMode fp mode = Posix.setFileMode fp mode
 prettyFileMode :: FileMode -> String
 prettyFileMode mode = userPP <> groupPP <> otherPP
     where
-        userPP :: String
         userPP =
-            isBitSet 'r' Posix.ownerReadMode <>
-            isBitSet 'w' Posix.ownerWriteMode <>
-            isBitSet 'x' Posix.ownerExecuteMode
+            isBitSet 'r' ownerReadMode <>
+            isBitSet 'w' ownerWriteMode <>
+            isBitSet 'x' ownerExecuteMode
 
-        groupPP :: String
         groupPP =
-            isBitSet 'r' Posix.groupReadMode <>
-            isBitSet 'w' Posix.groupWriteMode <>
-            isBitSet 'x' Posix.groupExecuteMode
+            isBitSet 'r' groupReadMode <>
+            isBitSet 'w' groupWriteMode <>
+            isBitSet 'x' groupExecuteMode
 
-        otherPP :: String
         otherPP =
-            isBitSet 'r' Posix.otherReadMode <>
-            isBitSet 'w' Posix.otherWriteMode <>
-            isBitSet 'x' Posix.otherExecuteMode
+            isBitSet 'r' otherReadMode <>
+            isBitSet 'w' otherWriteMode <>
+            isBitSet 'x' otherExecuteMode
 
-        isBitSet :: Char -> FileMode -> String
-        isBitSet c mask = if mask `Posix.intersectFileModes` mode /= Posix.nullFileMode
+        isBitSet c mask = if mask `intersectFileModes` mode /= nullFileMode
             then [c]
             else "-"
 
+#if defined(javascript_HOST_ARCH)
+nullFileMode, ownerReadMode, ownerWriteMode, ownerExecuteMode,
+  groupReadMode, groupWriteMode, groupExecuteMode,
+  otherReadMode, otherWriteMode, otherExecuteMode :: FileMode
+nullFileMode     = 0
+ownerReadMode    = 0o400
+ownerWriteMode   = 0o200
+ownerExecuteMode = 0o100
+groupReadMode    = 0o040
+groupWriteMode   = 0o020
+groupExecuteMode = 0o010
+otherReadMode    = 0o004
+otherWriteMode   = 0o002
+otherExecuteMode = 0o001
+
+intersectFileModes :: FileMode -> FileMode -> FileMode
+intersectFileModes = (.&.)
+#else
+nullFileMode = Posix.nullFileMode
+ownerReadMode = Posix.ownerReadMode
+ownerWriteMode = Posix.ownerWriteMode
+ownerExecuteMode = Posix.ownerExecuteMode
+groupReadMode = Posix.groupReadMode
+groupWriteMode = Posix.groupWriteMode
+groupExecuteMode = Posix.groupExecuteMode
+otherReadMode = Posix.otherReadMode
+otherWriteMode = Posix.otherWriteMode
+otherExecuteMode = Posix.otherExecuteMode
+intersectFileModes = Posix.intersectFileModes
+#endif
+
 -- | Is setting metadata supported on this platform or not.
 isMetadataSupported :: Bool
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) || defined(javascript_HOST_ARCH)
 isMetadataSupported = False
 #else
 isMetadataSupported = True

--- a/nix/javascript.nix
+++ b/nix/javascript.nix
@@ -46,7 +46,29 @@ let
                   hlib = pkgsNew.haskell.lib;
                   skip = drv:
                     hlib.dontHaddock (hlib.dontBenchmark (hlib.dontCheck drv));
+                  # JS GHC ships a broken unprefixed `hsc2hs-ghc-*` wrapper
+                  # (`exeprog` is missing the target prefix, so --version fails).
+                  # Nixpkgs only passes --with-hsc2hs when stdenv.hasCC, which
+                  # is false for pkgsCross.ghcjs, so Cabal picks the wrapper.
+                  # unix-compat's cbits include sys/sysmacros.h only on Linux;
+                  # Emscripten has the same macros but does not define __linux__.
+                  hsc2hs =
+                    "${haskellPackagesOld.ghc}/bin/${haskellPackagesOld.ghc.targetPrefix}hsc2hs";
                 in {
+                  mkDerivation = args:
+                    haskellPackagesOld.mkDerivation (args // {
+                      configureFlags = (args.configureFlags or []) ++ [
+                        "--with-hsc2hs=${hsc2hs}"
+                      ];
+                      postPatch = (args.postPatch or "")
+                        + pkgsNew.lib.optionalString ((args.pname or "") == "unix-compat") ''
+                            substituteInPlace cbits/HsUnixCompat.c \
+                              --replace-fail \
+                                'defined(__linux__) || defined(__GNU__)' \
+                                'defined(__linux__) || defined(__GNU__) || defined(__EMSCRIPTEN__)'
+                          '';
+                    });
+
                   dhall =
                     hlib.overrideCabal
                       (skip

--- a/nix/javascript.nix
+++ b/nix/javascript.nix
@@ -1,0 +1,122 @@
+# Haskell packages compiled with GHC's JavaScript backend via pkgsCross.ghcjs.
+#
+# Legacy haskell.packages.ghcjs (GHCJS 8.10) was removed in Nixpkgs 25.11.
+# Do not pass compiler = "ghcjs" to ./shared.nix on this pin; it throws.
+#
+# Build (typically several hours, poorly cached):
+#
+#   nix-build nix/javascript.nix -A dhall-try
+#
+# The minified interpreter is then:
+#
+#   result/bin/dhall-try.jsexe/all.min.js
+#
+# A bare `nix-build` of default.nix does not include these attributes, so a JS
+# compile failure cannot block native Hydra tarballs.
+
+{ nixpkgs ? (import ./pinnedNixpkgs.nix).nixpkgs
+, compiler ? "ghc96"
+, system ? builtins.currentSystem
+}:
+
+let
+  overlayJs = pkgsNew: pkgsOld: {
+    haskellSrc = src:
+      pkgsNew.lib.cleanSourceWith {
+        inherit src;
+        filter = path: type:
+          let
+            base = baseNameOf path;
+          in
+            !( pkgsNew.lib.hasSuffix ".nix" base
+            || base == "dist"
+            || base == "result"
+            || base == ".git"
+            );
+      };
+
+    haskell = pkgsOld.haskell // {
+      packages = pkgsOld.haskell.packages // {
+        "${compiler}" = pkgsOld.haskell.packages."${compiler}".override (old: {
+          overrides =
+            pkgsNew.lib.composeExtensions
+              (old.overrides or (_: _: {}))
+              (haskellPackagesNew: haskellPackagesOld:
+                let
+                  hlib = pkgsNew.haskell.lib;
+                  skip = drv:
+                    hlib.dontHaddock (hlib.dontBenchmark (hlib.dontCheck drv));
+                in {
+                  dhall =
+                    hlib.overrideCabal
+                      (skip
+                        (haskellPackagesNew.callCabal2nixWithOptions
+                          "dhall"
+                          (pkgsNew.haskellSrc ../dhall)
+                          "--flag=javascript --no-check --no-haddock"
+                          # cabal2nix still lists test-suite deps as function
+                          # arguments even with --no-check.
+                          { dhall-test-server = null; }
+                        )
+                      )
+                      (_: { isExecutable = false; });
+
+                  dhall-json =
+                    skip
+                      (haskellPackagesNew.callCabal2nixWithOptions
+                        "dhall-json"
+                        (pkgsNew.haskellSrc ../dhall-json)
+                        "--no-check --no-haddock"
+                        { }
+                      );
+
+                  dhall-try =
+                    hlib.overrideCabal
+                      (skip
+                        (haskellPackagesNew.callCabal2nix
+                          "dhall-try"
+                          (pkgsNew.haskellSrc ../dhall-try)
+                          { }
+                        )
+                      )
+                      (oldDrv: {
+                        postInstall = (oldDrv.postInstall or "") + ''
+                          jsexe="$out/bin/dhall-try.jsexe"
+                          if [ ! -f "$jsexe/all.js" ]; then
+                            echo "dhall-try: expected $jsexe/all.js from the JS backend" >&2
+                            find "$out" -name '*.js' | head -50 >&2
+                            exit 1
+                          fi
+                          externs=""
+                          if [ -f "$jsexe/all.js.externs" ]; then
+                            externs="--externs=$jsexe/all.js.externs"
+                          fi
+                          ${pkgsNew.buildPackages.closurecompiler}/bin/closure-compiler \
+                            "$jsexe/all.js" \
+                            --jscomp_off=checkVars \
+                            $externs \
+                            > "$jsexe/all.min.js"
+                        '';
+                      });
+                }
+              );
+        });
+      };
+    };
+  };
+
+  pkgs = import nixpkgs {
+    inherit system;
+    config = { allowBroken = true; };
+    overlays = [ overlayJs ];
+  };
+
+  hpkgs = pkgs.pkgsCross.ghcjs.haskell.packages."${compiler}";
+
+in
+  {
+    inherit (hpkgs) dhall dhall-json dhall-try;
+
+    # Cross .env shells are awkward; this at least exposes the compiler.
+    shell-dhall-try = hpkgs.dhall-try.env;
+  }

--- a/nix/shared.nix
+++ b/nix/shared.nix
@@ -86,7 +86,7 @@ let
                     pkgsNew.haskell.lib.dontCheck drv;
 
                 failOnAllWarnings = drv:
-                  # GHCJS incorrectly detects non-exhaustive pattern matches
+                  # Legacy GHCJS 8.10. The JS backend lives in ./javascript.nix.
                   if compiler == "ghcjs"
                   then drv
                   else pkgsNew.haskell.lib.failOnAllWarnings drv;

--- a/release.nix
+++ b/release.nix
@@ -7,24 +7,19 @@ in { src ? { rev = ""; }
 let
   callShared = args: import ./nix/shared.nix ({ inherit nixpkgs; } // args);
 
-  # Legacy GHCJS 8.10 (`haskell.packages.ghcjs`) was removed in Nixpkgs 25.11.
-  # Re-enable via `pkgsCross.ghcjs` once `dhall-try` is ported off `ghcjs-base`.
-
-  # shared_ghcjs = callShared { compiler = "ghcjs"; };
-
   shared = callShared { };
 
   shared_linux = callShared { system = "x86_64-linux"; };
 
   coverage = callShared { coverage = true; };
 
+  javascript = import ./nix/javascript.nix { inherit nixpkgs; };
+
 in
   { dhall = shared.aggregate
       { name = "dhall";
 
         constituents = [
-          # shared_ghcjs.dhall-try
-
           shared.tarball-dhall
           shared.tarball-dhall-bash
           shared.tarball-dhall-csv
@@ -98,4 +93,9 @@ in
       image-dhall-toml
       image-dhall-yaml
     ;
+
+    # Separate from the `dhall` aggregate so a JS compile failure does not
+    # block native tarballs. See nix/javascript.nix.
+    javascript-dhall     = javascript.dhall;
+    javascript-dhall-try = javascript.dhall-try;
   }


### PR DESCRIPTION
Nixpkgs 25.11 removed haskell.packages.ghcjs. 

Build the browser interpreter with pkgsCross.ghcjs, drop ghcjs-base and ghcjs-xhr, and document nix-build nix/javascript.nix -A dhall-try.