### PR TITLE
Add Stack and CI coverage for GHC 9.12.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,9 @@ jobs:
           - os:
               runner: "ubuntu-latest"
             stack-yaml: "stack.ghc-9.10.yaml"
+          - os:
+              runner: "ubuntu-latest"
+            stack-yaml: "stack.ghc-9.12.yaml"
       fail-fast: false
     name: ${{ matrix.os.runner }} - ${{ matrix.stack-yaml }}
     runs-on: ${{ matrix.os.runner }}
@@ -92,6 +95,9 @@ jobs:
             if [ '${{matrix.stack-yaml}}' == 'stack.ghc-9.10.yaml' ] && [ "${package}" == 'dhall-nix' ]; then
               continue
             fi
+            if [ '${{matrix.stack-yaml}}' == 'stack.ghc-9.12.yaml' ] && [ "${package}" == 'dhall-nix' ]; then
+              continue
+            fi
             if [ '${{matrix.os.runner}}' == 'windows-latest' ] && [ "${package}" == 'dhall-nix' ]; then
               continue
             fi
@@ -121,6 +127,9 @@ jobs:
               continue
             fi
             if [ '${{matrix.stack-yaml}}' == 'stack.ghc-9.10.yaml' ] && [ "${package}" == 'dhall-nix' ]; then
+              continue
+            fi
+            if [ '${{matrix.stack-yaml}}' == 'stack.ghc-9.12.yaml' ] && [ "${package}" == 'dhall-nix' ]; then
               continue
             fi
             if [ '${{matrix.os.runner}}' == 'windows-latest' ] && [ "${package}" == 'dhall-nix' ]; then

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -105,6 +105,10 @@ main = do
     -- https://github.com/feuerbach/tasty/issues/273#issuecomment-657054281
     System.Environment.setEnv "TASTY_HIDE_SUCCESSES" "true"
 
+    -- Import tests share process-wide DHALL_HEADERS. tasty-1.5.4's default -j
+    -- is getNumProcessors (and it raises +RTS -N), so RTS -N1 is not enough.
+    System.Environment.setEnv "TASTY_NUM_THREADS" "1"
+
     Dhall.Test.Server.withServers $ do
         allTests <- getAllTests
 

--- a/stack.ghc-9.12.yaml
+++ b/stack.ghc-9.12.yaml
@@ -1,0 +1,29 @@
+# GHC 9.12 is on Stackage Nightly; LTS 25 is not released yet.
+resolver: nightly-2026-08-20
+packages:
+  - dhall-test-server
+  - dhall
+  - dhall-bash
+  - dhall-csv
+  - dhall-docs
+  - dhall-json
+  - dhall-lsp-server
+  # - dhall-nix
+  - dhall-openapi
+  - dhall-toml
+  - dhall-yaml
+extra-deps:
+  - turtle-1.6.2
+# turtle is not on Nightly and still upper-bounds optparse-applicative < 0.19
+# and ansi-wl-pprint < 1.1; Nightly has newer versions of both.
+allow-newer: true
+allow-newer-deps:
+  - turtle
+nix:
+  packages:
+    - ncurses
+    - zlib
+flags:
+  # https://github.com/RyanGlScott/mintty/issues/4
+  mintty:
+    Win32-2-13-1: false


### PR DESCRIPTION
Stackage has no LTS 25 yet, so use a Nightly snapshot. Exclude dhall-nix as with 9.8/9.10 because hnix does not build.