### PR TITLE
remove stale as-source comments from benchmark readmes

### DIFF
--- a/dhall/benchmark/evaluation/README.md
+++ b/dhall/benchmark/evaluation/README.md
@@ -32,7 +32,7 @@ cd dhall/benchmark/evaluation/large5 && ./run.sh
 ```
 
 `substitutions/run.sh` times the nested-let pipelines and a temp-generated
-many-files tree (Code and `as Source`). It still cannot inject Haskell
+many-files tree. It still cannot inject Haskell
 `InputSettings` substitutions; use the tasty-bench group for that.
 
 ## Measurement modes
@@ -118,19 +118,14 @@ Used by: `substitutions.composer_proxy.many_imports.*`
 
 This is the right number for a **repeat import load with a populated disk
 cache**, matching a customer run that is not starting from an empty
-`~/.cache`. Code can hit `dhall-haskell-v2/` marker entries; `as Source`
-currently cannot.
+`~/.cache`. Import code paths can hit `dhall-haskell-v2/` marker entries.
 
 ### Mode C — Source cost deferral (implicit)
 
-Some `as Source` fixtures keep heavy work out of the resolved AST:
+Some  fixtures keep heavy work out of the resolved AST:
 
 | Fixture | Slow work shows on |
 |---------|-------------------|
-| `large6.slow_eval.as_source` | **`evaluation`** (~0.5 s fold) |
-| `large6.slow_normalize.as_source` | **`evaluation`** (~0.5 s normalize); `resolve` often ~1 ms (semisemantic hit) |
-| `large6.slow_multi.as_source` | **`evaluation`** (~0.4 s); `resolve` often ~8 ms |
-| `large6.slow_typecheck.as_source` | **`resolve` + `typecheck`** (~0.22 s each; assert stays in AST) |
 | `large6.slow_parse.*` | **`resolve`** (~0.58 s; parse not semisemantic-cached) |
 | `large6.slow_walk.*` | **`resolve`** (~0.53 s; structural walk) |
 
@@ -146,11 +141,9 @@ read `evaluation` (or cold `dhall hash`).
 | `large2` | `large2/` | prep only | CBOR encode/decode |
 | `k8s.*` | `k8s/` | A | Real k8s schema imports |
 | `large3` | `large3/` | A | Sourcegraph-scale Code pipeline (~193 MB NF) |
-| `large3.source` | `large3/` | A | Same tree under `as Source` |
 | `large3.get_config.*` | `large3/` | A | Small projection; still walks full graph |
-| `large4` | `large4/` | A | Medium customization tree (Code; may OOM) |
-| `large4.source` | `large4/` | A | Same tree with `apply-all.dhall as Source` |
-| `large5.code` / `large5.source` | `large5/` | A | Small tree, Code vs Source |
+| `large4` | `large4/` | A | Medium customization tree |
+| `large5/` | A | Smaller tree |
 | `large6.slow_*` | `large6/` | A, B, or C | Isolated ~0.5 s artificial burdens |
 | `prelude_import.*` | `prelude_import/` | B | Full Prelude package, Code vs Source |
 | `substitutions.*` | `substitutions/` | B | Nested-let identity-path probe (100 closed keys) |
@@ -190,10 +183,7 @@ why Mode A `resolve` can be much faster than a true cold CLI run (e.g. large3
 | Code `large6` normalize/multi at ~μs | Fixed — use `resolve_cold_cache_on` rows |
 | Source `large6` normalize/multi resolve ~1–8 ms | Semisemantic hit after prep; cost on **evaluation** |
 | `large3.get_config.*` evaluation ~160 μs | Tiny NF after huge resolve |
-| `large5.source` much faster than `large5.code` on resolve | Source skips building huge NF during import |
-| `prelude_import.source` faster than `.code` | Prelude under `as Source` avoids Code normalize path |
-| Early-abort NF size walk does not move import groups | The cutoff only runs on a **cold Code miss** of a **many-node** NF. Mode A resolve is cache-warm; substitutions NFs are tiny; a large `Text` payload is O(1) length. Use `semisemantic.nf_size_walk` (full vs early_abort). |
-| Opportunistic `as Source` cache fill toggle | No effect on these fixtures (no matching `ImportAlt` pattern) |
+| Early-abort NF size walk does not move import groups | The cutoff only runs on a **cold miss** of a **many-node** NF. Mode A resolve is cache-warm; substitutions NFs are tiny; a large `Text` payload is O(1) length. Use `semisemantic.nf_size_walk` (full vs early_abort). |
 
 ## Related docs
 
@@ -202,5 +192,4 @@ why Mode A `resolve` can be much faster than a true cold CLI run (e.g. large3
 - `large5/README.md` — small Code vs Source tree
 - `large6/README.md` — slow-child matrix and burden placement
 - `prelude_import/README.md` — Prelude cold import
-- `../../import-explanation.md` §10 — `as Source` performance work and bench notes
 - [`.github/workflows/README.md`](../../../.github/workflows/README.md) — CI job, `gh-pages` charts, on-demand runs

--- a/dhall/benchmark/evaluation/large3/README.md
+++ b/dhall/benchmark/evaluation/large3/README.md
@@ -9,9 +9,7 @@ See `../README.md` for how the evaluation harness measures resolve vs typecheck 
 | Group | Root expression | Notes |
 |-------|-----------------|-------|
 | `large3` | `pipeline.dhall` — `./package.dhall` then `Render` | Large normal form (~193 MB) |
-| `large3.source` | `pipeline-source.dhall` — same with `as Source` | Same tree under `as Source` |
-| `large3.get_config.code` | `get_config.dhall` — `package.Configuration.Global::{=}` | Small final NF; ~17s CLI |
-| `large3.get_config.source` | `get_config_as_source.dhall` — same with `as Source` | Small final NF; slower than Code (~30s CLI) |
+| `large3.get_config` | `get_config.dhall` — `package.Configuration.Global::{=}` | Small final NF |
 
 Each group reports `resolve`, `typecheck`, and `evaluation`:
 
@@ -27,30 +25,8 @@ the expensive resolve.
 Semisemantic entries live under `~/.cache/dhall-haskell-v2/` (merkle key →
 small NF or well-typed marker). Giant NFs are not written.
 
-## Observed timings
-
-| Group | Bench resolve | Bench typecheck | Bench evaluation | Cold `dhall resolve` |
-|-------|---------------|-----------------|------------------|----------------------|
-| `large3` (Code) | ~16.1 s | ~2.3 s | ~0.8 s | ~58 s |
-| `large3.source` | ~10.3 s | ~3.1 s | ~0.5 s | ~24 s |
-| `large3.get_config.code` | ~16.2 s | ~2.3 s | ~160 μs | (same resolve path) |
-| `large3.get_config.source` | ~11.0 s | ~3.0 s | ~167 μs | (same resolve path) |
-
 Bench resolve is **not** fully cold: prep warms semisemantic cache, so re-resolve
-is faster than CLI with empty cache. The gap is largest on plain Code (~16 s vs
-~58 s).
-
-## CLI vs bench
-
-| Mode | CLI full (`dhall --file`) | Bench resolve |
-|------|---------------------------|---------------|
-| Code (`get_config.dhall`) | ~17–20 s | ~16.2 s |
-| `as Source` (`get_config_as_source.dhall`) | ~30–37 s | ~11.0 s |
-
-End-to-end CLI is slower for `as Source` on `get_config` even though bench
-resolve looks faster for Source. Code normalizes during import; Source builds a
-large non-normalized package and pays typecheck/eval later. See
-`import-explanation.md` §10.7.
+is faster than CLI with empty cache. 
 
 ## Commands
 
@@ -58,5 +34,4 @@ large non-normalized package and pays typecheck/eval later. See
 cd dhall && stack bench evaluation --ba '--pattern large3'
 stack bench evaluation --ba '--pattern get_config'
 stack exec -- dhall --file ./benchmark/evaluation/large3/get_config.dhall >/dev/null
-stack exec -- dhall --file ./benchmark/evaluation/large3/get_config_as_source.dhall >/dev/null
 ```

--- a/dhall/benchmark/evaluation/large4/README.md
+++ b/dhall/benchmark/evaluation/large4/README.md
@@ -1,20 +1,9 @@
 This example is taken from github:uwedeportivo/ds-dhall
 
 Run `dhall --file generate-example.dhall`. This is a medium customization tree
-over a large generated record/schema. The Code-mode fixture does **not** use
-`as Source`; resolving it can OOM because `apply-*` combinators are normalized
-under binders. That is an intentional real-world failing benchmark until
-import-resolution inefficiencies are fixed.
+over a large generated record/schema. 
 
-An `as Source` variant (`generate-example-source.dhall`, group `large4.source`)
-completes in a few seconds.
-
-## Benchmark groups
-
-| Group | File | Notes |
-|-------|------|-------|
-| `large4` | `generate-example.dhall` | Code; may OOM (~100 GB NF during resolve) |
-| `large4.source` | `generate-example-source.dhall` | Internal `as Source` on `apply-all.dhall` |
+Warning: earlier version of `dhall` (1.42.3 and earlier) will OOM on this benchmark.
 
 See `../README.md` for phase-benchmark interpretation (prep warms disk caches;
 timed resolve uses the semantic cache off).

--- a/dhall/benchmark/evaluation/large5/README.md
+++ b/dhall/benchmark/evaluation/large5/README.md
@@ -1,4 +1,4 @@
-This benchmark isolates the extra import-resolution work done by `as Source`
+This benchmark isolates the extra import-resolution work
 on a wide local import tree.
 
 See `../README.md` for harness measurement modes.
@@ -6,7 +6,6 @@ See `../README.md` for harness measurement modes.
 ## Structure
 
 - `pipeline-code.dhall` imports `./package.dhall` in normal `Code` mode.
-- `pipeline-source.dhall` imports `./package.dhall as Source`.
 - `package.dhall` exports a small configuration record and a `Render` function.
 - `src/base/render.dhall` concatenates the outputs of four local generators.
 - Each generator imports `shared/payload.dhall`, which aliases the large record
@@ -18,34 +17,12 @@ See `../README.md` for harness measurement modes.
 Conceptually similar to `large3` (package + render fan-out) but much smaller:
 no k8s schemas, one shared payload, hand-inspectable tree.
 
-## Benchmark groups (Mode A)
-
-| Group | Benchmarks |
-|-------|------------|
-| `large5.code` | resolve, typecheck, evaluation |
-| `large5.source` | resolve, typecheck, evaluation |
-
-Typical full-suite numbers:
-
-| Group | resolve | typecheck | evaluation |
-|-------|---------|-----------|------------|
-| `large5.code` | ~1.18 s | ~455 ms | ~134 ms |
-| `large5.source` | ~177 ms | ~45 ms | ~51 ms |
-
-Source wins sharply on **resolve** because it avoids building the ~20 MB normal
-form during import loading. Typecheck/evaluation are also lower on the
-Source-shaped resolved AST.
 
 ## Commands
 
 ```sh
 cd dhall && stack bench evaluation --ba '--pattern large5'
 stack exec -- dhall --file ./benchmark/evaluation/large5/pipeline-code.dhall >/dev/null
-stack exec -- dhall --file ./benchmark/evaluation/large5/pipeline-source.dhall >/dev/null
 stack exec -- dhall hash --file ./benchmark/evaluation/large5/pipeline-code.dhall
-stack exec -- dhall hash --file ./benchmark/evaluation/large5/pipeline-source.dhall
 ```
 
-`dhall resolve` on an `as Source` root measures source-artifact construction,
-not the same path as Code to a normalized value — prefer the bench groups above
-for Code vs Source comparison.

--- a/dhall/benchmark/evaluation/large6/README.md
+++ b/dhall/benchmark/evaluation/large6/README.md
@@ -1,7 +1,6 @@
 # large6 — isolated slow child imports
 
-This benchmark isolates the cost of **hash-protected slow child imports**
-under plain `Code` versus `as Source`.
+This benchmark isolates the cost of **hash-protected slow child imports**.
 
 See also `../README.md` for the three harness measurement modes (A/B/C).
 
@@ -27,27 +26,20 @@ with `python3 slow/generate-parse.py`. It is not checked in.
 Packages (`package-long-*.dhall`) import `sha256:`-protected children from
 `slow/`. Pipelines:
 
-- `pipeline-code-long-*.dhall` — `./package-long-*.dhall` (`Code`)
-- `pipeline-source-long-*.dhall` — `./package-long-*.dhall as Source`
+- `pipeline-code-long-*.dhall` — `./package-long-*.dhall`
 
 ## Full benchmark matrix
 
-Benchmark group names: `large6.slow_<burden>.as_<mode>`.
+Benchmark group names: `large6.slow_<burden>`.
 
 | Group | Harness mode | Benchmarks | Where to read slow cost |
 |-------|--------------|------------|-------------------------|
-| `slow_parse.as_code` | A (phase) | resolve, typecheck, evaluation | **resolve** ~580 ms |
-| `slow_parse.as_source` | A | resolve, typecheck, evaluation | **resolve** ~580 ms |
-| `slow_eval.as_code` | **B (cold)** | `resolve_cold_cache_on` only | **~425 ms** cold resolve |
-| `slow_eval.as_source` | A + C | resolve, typecheck, evaluation | **evaluation** ~220 ms |
-| `slow_typecheck.as_code` | **B** | `resolve_cold_cache_on` only | **~425 ms** |
-| `slow_typecheck.as_source` | A | resolve, typecheck, evaluation | **resolve + typecheck** ~225 ms each |
-| `slow_normalize.as_code` | **B** | `resolve_cold_cache_on` only | **~530 ms** |
-| `slow_normalize.as_source` | A + C | resolve, typecheck, evaluation | **evaluation** ~530 ms; resolve often ~1 ms (semisemantic) |
-| `slow_multi.as_code` | **B** | `resolve_cold_cache_on` only | **~440 ms** |
-| `slow_multi.as_source` | A + C | resolve, typecheck, evaluation | **evaluation** ~440 ms; resolve often ~8 ms |
-| `slow_walk.as_code` | A | resolve, typecheck, evaluation | **resolve** ~530 ms |
-| `slow_walk.as_source` | A | resolve, typecheck, evaluation | **resolve** ~535 ms (parity after denoted reuse) |
+| `slow_parse` | A (phase) | resolve, typecheck, evaluation | **resolve** ~580 ms |
+| `slow_eval` | **B (cold)** | `resolve_cold_cache_on` only | **~425 ms** cold resolve |
+| `slow_typecheck` | **B** | `resolve_cold_cache_on` only | **~425 ms** |
+| `slow_normalize` | **B** | `resolve_cold_cache_on` only | **~530 ms** |
+| `slow_multi` | **B** | `resolve_cold_cache_on` only | **~440 ms** |
+| `slow_walk` | A | resolve, typecheck, evaluation | **resolve** ~530 ms |
 
 **Mode A** = prep with cache on; timed `resolve` uses semantic cache off,
 semisemantic still on. **Mode B** = parse-only prep; fresh `XDG_CACHE_HOME` per
@@ -58,34 +50,11 @@ Mode A prep warmed semisemantic and made all three phases look ~μs.
 
 ## Expected behaviour
 
-- **Plain `Code` (Mode B rows)**: parse/typecheck/normalize burden on cold
+- **(Mode B rows)**: parse/typecheck/normalize burden on cold
   resolve; eval fixture’s cost is inside the resolved import graph.
-- **`as Source` (Mode A rows)**: hashed children still pay Code hash-check on
-  resolve; normalize/eval cost often shifts to **evaluation** when the Source
-  product keeps an unnormalized fold.
 - **`slow_walk`**: probes second Source structural walk after Code load; should
   be near-parity between modes after denoted-AST reuse.
 
-## Reference timings (full suite, opportunistic cache on)
-
-Approximate numbers from a recent M1 run:
-
-| Variant | `as_code` | `as_source` |
-|---------|-----------|-------------|
-| `parse` resolve | ~584 ms | ~586 ms |
-| `eval` | cold **425 ms** | eval **222 ms** |
-| `typecheck` | cold **425 ms** | resolve+tc **225 ms** |
-| `normalize` | cold **534 ms** | eval **536 ms** |
-| `multi` | cold **437 ms** | eval **436 ms** |
-| `walk` resolve | ~532 ms | ~535 ms |
-
-Cold `dhall hash` with empty cache (alternative to Mode B):
-
-| Variant | `as_code` | `as_source` |
-|---------|-----------|-------------|
-| `normalize` | ~0.55 s | ~1.07 s |
-| `multi` | ~0.45 s | ~0.89 s |
-| `walk` | ~0.56 s | ~0.56 s |
 
 ## Commands
 

--- a/dhall/benchmark/evaluation/prelude_import/README.md
+++ b/dhall/benchmark/evaluation/prelude_import/README.md
@@ -10,14 +10,12 @@ See `../README.md` — this fixture uses **Mode B** (`resolve_cold_cache_on`).
 | File | Imports |
 |------|---------|
 | `prelude-code.dhall` | `../../../dhall-lang/Prelude/package.dhall` |
-| `prelude-source.dhall` | same package `as Source` |
 
 ## Benchmark groups
 
 | Group | Benchmark |
 |-------|-----------|
 | `prelude_import.code` | `resolve_cold_cache_on` |
-| `prelude_import.source` | `resolve_cold_cache_on` |
 
 Each sample:
 

--- a/dhall/benchmark/evaluation/substitutions/README.md
+++ b/dhall/benchmark/evaluation/substitutions/README.md
@@ -22,7 +22,6 @@ Code imports each rebuilding `ResolvedSubstitutions`).
 |------|------|
 | `package.dhall` | 8000 nested `let xᵢ = 0 in 0` (regenerate with `python3 generate.py`) |
 | `pipeline-code.dhall` | `./package.dhall` |
-| `pipeline-source.dhall` | `./package.dhall as Source` |
 
 ## 2. Many files — as-code regression (`substitutions.many_files.*`)
 
@@ -94,14 +93,10 @@ prep-populated cache.
 
 | Group | Benchmark |
 |-------|-----------|
-| `substitutions.as_code` | `resolve_cold_cache_on` |
-| `substitutions.as_source` | `resolve_cold_cache_on` |
-| `substitutions.many_files.as_code` | `resolve_cold_cache_on` |
-| `substitutions.many_files.as_source` | `resolve_cold_cache_on` |
-| `substitutions.composer_proxy.as_code` | `end_to_end_cold` |
-| `substitutions.composer_proxy.as_source` | `end_to_end_cold` |
-| `substitutions.composer_proxy.many_imports.as_code` | `cold`, `warm` |
-| `substitutions.composer_proxy.many_imports.as_source` | `cold`, `warm` |
+| `substitutions` | `resolve_cold_cache_on` |
+| `substitutions.many_files` | `resolve_cold_cache_on` |
+| `substitutions.composer_proxy` | `end_to_end_cold` |
+| `substitutions.composer_proxy.many_imports` | `cold`, `warm` |
 | `substitutions.shift_cost.naive` | pure `nf` (in-harness `substituteManyNaive`) |
 | `substitutions.shift_cost.optimized` | pure `nf` (in-harness `substituteManyFromRoot`) |
 
@@ -116,9 +111,8 @@ stack bench evaluation --ba '--pattern substitutions.shift_cost'
 CLI wall-clock of the same four pipelines, **without** Haskell substitutions,
 from this directory (`./run.sh`):
 
-- nested-let `pipeline-code.dhall` / `pipeline-source.dhall`
-- many-files tree generated into a temp directory (not checked in), then
-  the same Code / `as Source` pipelines
+- nested-let `pipeline-code.dhall`
+- many-files tree generated into a temp directory (not checked in)
 
 Each `run.sh` sample uses a fresh `XDG_CACHE_HOME`. That is a Mode B
 analogue for import load, but it is still a full `dhall --file` evaluate,
@@ -128,19 +122,3 @@ not `resolveWithSettings`.
 `Status` (not on public `EvaluateSettings`). `shiftSubstitutions` identity
 / `Map.map` fast path is gated by `substitutionOptimizationsEnabled` in
 `dhall/src/Dhall/Substitution.hs`.
-
-## What to read
-
-- **`as_source` (nested lets)**: substitution walks the unnormalized
-  nested-let AST during `finalizeSourceImport`. Dominated by map rebuilds
-  at every binder unless the identity fast path fires.
-- **`as_code` (nested lets)**: the same map is applied once on the
-  pre-normalize tree, then beta-normalize collapses the lets to `0`.
-- **`many_files.as_code`**: this is the group that should move with the
-  customer as-code regression (18s → 30s was `resolveSubstitutions` +
-  `freeVarNames` once per imported file). It does **not** isolate (1)+(2).
-- **`shift_cost`**: this is the group that should move with plan (1)+(2).
-  Compare `naive` vs `optimized`; ignore wall-clock vs Mode B rows.
-
-Do not compare these numbers to Mode A `resolve` rows (those use
-`loadWithStatus` without the library substitution wrapper).

--- a/dhall/benchmark/evaluation/substitutions/composer_proxy/README.md
+++ b/dhall/benchmark/evaluation/substitutions/composer_proxy/README.md
@@ -24,10 +24,6 @@ There are **two** generated trees. The original flat list is a control; the
 | Cache | Mode **D** cold only (`end_to_end_cold`) |
 | Code vs Source | `pipeline-code.dhall` / `pipeline-source.dhall` |
 
-This group does **not** reproduce the customer as-source slowdown: every
-module is imported once, so Source finalization does not re-walk shared
-subtrees, and there are no hash-protected children.
-
 ## 2. Overlapping graph (`substitutions.composer_proxy.many_imports.*`)
 
 Generated at prep (not committed):

--- a/dhall/benchmark/evaluation/substitutions/many_files/README.md
+++ b/dhall/benchmark/evaluation/substitutions/many_files/README.md
@@ -15,8 +15,8 @@ when the process exits.
 
 Customer shape, from the `ResolvedSubstitutions` profiles:
 
-- hundreds of imported files, each calling `substitute` on the Code
-  semi-semantic-miss path (~592 calls vs 2 for as-source)
+- hundreds of imported files, each calling `substitute` on the
+  semi-semantic-miss path (~592 calls)
 - ~200 Haskell-API keys
 - substitution values with free names that collide with local binders
   (`a`, `x`, …), so `shiftSubstitutions` cannot return the same map pointer
@@ -28,7 +28,6 @@ Customer shape, from the `ResolvedSubstitutions` profiles:
 | `mods/m000.dhall` … `m199.dhall` | `let a = i let x = 1 in a + x` |
 | `package.dhall` | `[ ./mods/m000.dhall, … ]` |
 | `pipeline-code.dhall` | `./package.dhall` |
-| `pipeline-source.dhall` | `./package.dhall as Source` |
 
 The harness installs 200 `UserType000`–`UserType199` substitutions.
 Values are large (~64-field records). Every 10th has a free `a`; the rest
@@ -43,8 +42,7 @@ Mode B, `Dhall.resolveWithSettings`, fresh `XDG_CACHE_HOME` per sample.
 
 | Group | Benchmark |
 |-------|-----------|
-| `substitutions.many_files.as_code` | `resolve_cold_cache_on` |
-| `substitutions.many_files.as_source` | `resolve_cold_cache_on` |
+| `substitutions.many_files` | `resolve_cold_cache_on` |
 
 ```sh
 stack bench evaluation --ba '--pattern substitutions.many_files'
@@ -52,19 +50,4 @@ stack bench evaluation --ba '--pattern substitutions.many_files'
 
 CLI (no Haskell substitutions; full `dhall --file`): from
 `substitutions/`, `./run.sh` generates this tree into a temp directory
-and times Code and `as Source` with a fresh `XDG_CACHE_HOME` per run.
-
-## What to read
-
-- **`as_code`**: one `substitute` per imported module (plus the package
-  list). Before caching `ResolvedSubstitutions` on `Status`, each call
-  re-ran `resolveSubstitutions` / `freeVarNames`. That is the 18s → 30s
-  customer regression. After the cache, the map is resolved once per run.
-- **`as_source`**: substitutions run at root `finalizeSourceImport` (and
-  the entry expression). Unhashed children still finalize per file on this
-  synthetic tree; hashed customer libraries skip most of those calls via
-  denoted-AST reuse. Treat as-source numbers here as a lower bound on the
-  gap, not a reproduction of the customer as-source win.
-
-Do not compare to the nested-let `substitutions.as_code` group: that one
-is an identity-fast-path microbench, not a many-import regression probe.
+and times the benchmark with a fresh `XDG_CACHE_HOME` per run.


### PR DESCRIPTION
This is purely a cleanup.