### PR TITLE
Reuse one HTTP Manager per import run via Status._newManager.

### DIFF
--- a/dhall/CHANGELOG.md
+++ b/dhall/CHANGELOG.md
@@ -1,5 +1,8 @@
 1.42.3
 
+* Reuse a single HTTP `Manager` per import run by replacing `Status`'s
+  `_newManager` factory with `pure manager` after the first request, instead
+  of keeping a separate `_manager` field.
 * Faster disk cache for local imports without integrity checks. Cache keys
   hash this file's syntax plus hashes of its imports, instead of hashing the
   fully resolved tree. Entries go in `dhall-haskell-v2/` so they are not mixed

--- a/dhall/ghc-src/Dhall/Import/HTTP.hs
+++ b/dhall/ghc-src/Dhall/Import/HTTP.hs
@@ -162,20 +162,18 @@ renderPrettyHttpException url (HttpExceptionRequest _ e) =
       <>  "\n"
       <>  "URL: " <> url <> "\n"
 
+-- | Get a shared HTTP 'Manager', creating one on the first call.
+--
+-- 'Status' stores an @IO Manager@ factory in '_newManager'. Before the
+-- first request that factory creates a manager (typically
+-- 'defaultNewManager'). After we have a manager we replace the factory
+-- with @'pure' manager@ so later calls reuse it.
 newManager :: StateT Status IO Manager
 newManager = do
-    Status { _manager = oldManager, ..} <- State.get
-
-    case oldManager of
-        Nothing -> do
-            manager <- liftIO _newManager
-
-            State.put (Status { _manager = Just manager , ..})
-
-            return manager
-
-        Just manager ->
-            return manager
+    Status { _newManager = makeManager } <- State.get
+    manager <- liftIO makeManager
+    State.modify (\s -> s { _newManager = pure manager })
+    return manager
 
 data NotCORSCompliant = NotCORSCompliant
     { expectedOrigins :: [ByteString]

--- a/dhall/src/Dhall/Import/Types.hs
+++ b/dhall/src/Dhall/Import/Types.hs
@@ -138,9 +138,11 @@ data Status = Status
     --   '_substitutions' is replaced.
 
     , _newManager :: IO Manager
-    , _manager :: Maybe Manager
-    -- ^ Used to cache the `Dhall.Import.Manager.Manager` when making multiple
-    -- requests
+    -- ^ How to obtain an HTTP 'Manager'. This is an @IO@ action, not the
+    --   manager itself: initially it *creates* a manager (see
+    --   'defaultNewManager'); after the first successful HTTP request that
+    --   action is replaced with @'pure' manager@ so later requests reuse
+    --   the same manager.
 
     , _loadOriginHeaders :: StateT Status IO OriginHeaders
     -- ^ Load the origin headers from environment or configuration file.
@@ -202,8 +204,6 @@ emptyStatusWith _newManager _loadOriginHeaders _remote _remoteBytes rootImport =
     _merkleContextFingerprint = Nothing
 
     _merkleSubstitutionsFingerprint = Nothing
-
-    _manager = Nothing
 
     _substitutions = Dhall.Substitution.empty
 


### PR DESCRIPTION
Drop the extra _manager field and, after the first request, replace the _newManager factory with `pure manager` so later HTTP imports reuse it. Leave Status lenses and the public Status constructor unchanged.