### PR TITLE
Bugfix: freeze cache product correctly and document delayed NF of unhashed imports

### DIFF
--- a/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
+++ b/dhall-lsp-server/src/Dhall/LSP/Backend/Dhall.hs
@@ -80,8 +80,9 @@ newtype Normal = Normal {fromNormal :: Expr Src Void}
 -- An import graph, represented by list of import dependencies.
 type ImportGraph = [Import.Depends]
 
--- | A cache maps Dhall imports to fully normalised expressions. By reusing
---   caches we can speeds up diagnostics etc. significantly!
+-- | A cache maps Dhall imports to loaded 'Import.ImportSemantics'. Unhashed
+--   Code imports may be typechecked but not β-normal; hashed Code imports are
+--   β-normal. By reusing caches we can speed up diagnostics etc. significantly!
 data Cache = Cache ImportGraph (Dhall.Map.Map Import.Chained Import.ImportSemantics)
 
 -- | The initial cache.

--- a/dhall/dhall.cabal
+++ b/dhall/dhall.cabal
@@ -433,6 +433,7 @@ Test-Suite tasty
     Main-Is: Dhall/Test/Main.hs
     Other-Modules:
         Dhall.Test.CacheFill
+        Dhall.Test.DelayedNormalization
         Dhall.Test.Dhall
         Dhall.Test.Diff
         Dhall.Test.DirectoryTree

--- a/dhall/src/Dhall.hs
+++ b/dhall/src/Dhall.hs
@@ -258,7 +258,11 @@ expectWithSettings settings Decoder{..} expression = do
 {-| Resolve an expression, using the supplied `InputSettings`
 
     Note that this also applies any substitutions specified in the
-    `InputSettings`
+    `InputSettings`.
+
+    The result is import-free and type-checked, but not necessarily
+    β-normal: unhashed @Code@ imports may still contain @let@s.  Use
+    'normalizeWithSettings' when a normal form is required.
 -}
 resolveWithSettings :: InputSettings -> Expr Src Import -> IO (Expr Src Void)
 resolveWithSettings settings expression =

--- a/dhall/src/Dhall/Freeze.hs
+++ b/dhall/src/Dhall/Freeze.hs
@@ -202,8 +202,10 @@ freezeImportWithSettings settings directory import_ = do
 
     let normalizedExpression = Core.alphaNormalize (Core.normalizeWith (view Dhall.normalizer settings) expression)
 
-    -- make sure the frozen import is present in the semantic cache
-    Dhall.Import.writeExpressionToSemanticCache (Core.denote expression)
+    -- The semantic cache product is the encoded αβ-normal form.  Unhashed
+    -- Code imports are no longer β-normalized by `loadWith`, so we must
+    -- write `normalizedExpression` rather than the raw load product.
+    Dhall.Import.writeExpressionToSemanticCache normalizedExpression
 
     let expressionHash = Dhall.Import.hashExpression normalizedExpression
 

--- a/dhall/src/Dhall/Import.hs
+++ b/dhall/src/Dhall/Import.hs
@@ -1531,7 +1531,12 @@ remoteStatusWithManager newManager url =
 {-| Generalized version of `load`
 
     You can configure the desired behavior through the initial `Status` that you
-    supply
+    supply.
+
+    The result is import-free and type-checked.  Unhashed @Code@ imports are
+    not necessarily β-normal ('Dhall.Import.Types.TypecheckedOnly'); hashed
+    @Code@ imports are β-normal.  Callers that need a normal form (integrity
+    hashes, evaluation) should normalize the result themselves.
 -}
 loadWith :: Expr Src Import -> StateT Status IO (Expr Src Void)
 loadWith expr₀ = case expr₀ of
@@ -1673,6 +1678,12 @@ In any expression `p ? q` the opportunistic caching rule says:
   expression           -> Syntax.unsafeSubExpressions loadWith expression
 
 -- | Resolve all imports within an expression
+--
+-- The result is import-free and type-checked, but not necessarily β-normal:
+-- unhashed @Code@ imports may still contain @let@s and unsaturated
+-- applications.  Hashed @Code@ imports are β-normal.  Use
+-- 'Dhall.Core.normalize' (or @dhall normalize@) when a normal form is
+-- required.
 load :: Expr Src Import -> IO (Expr Src Void)
 load = loadWithManager defaultNewManager
 
@@ -1685,6 +1696,8 @@ loadWithManager newManager =
 
 -- | Resolve all imports within an expression, importing relative to the given
 -- directory.
+--
+-- See 'load' for the β-normalization status of the result.
 loadRelativeTo :: FilePath -> SemanticCacheMode -> Expr Src Import -> IO (Expr Src Void)
 loadRelativeTo parentDirectory = loadWithStatus
     (makeEmptyStatus defaultNewManager defaultOriginHeaders parentDirectory)
@@ -1710,15 +1723,23 @@ encodeExpression expression = bytesStrict
 
     bytesStrict = Write.toStrictByteString encoding
 
--- | Hash a fully resolved expression
+-- | Hash a fully resolved, αβ-normal expression
+--
+-- The argument must already be β-normalized and α-normalized.  The semantic
+-- integrity check is defined as the SHA-256 of the binary encoding of that
+-- αβ-normal form.  Hashing a typechecked-but-unreduced tree (for example the
+-- result of 'load' of an unhashed @Code@ import) produces a value that is
+-- __not__ a valid integrity hash.
 hashExpression :: Expr Void Void -> Dhall.Crypto.SHA256Digest
 hashExpression = Dhall.Crypto.sha256Hash . encodeExpression
 
-{-| Convenience utility to hash a fully resolved expression and return the
-    base-16 encoded hash with the @sha256:@ prefix
+{-| Convenience utility to hash a fully resolved, αβ-normal expression and
+    return the base-16 encoded hash with the @sha256:@ prefix
 
     In other words, the output of this function can be pasted into Dhall
-    source code to add an integrity check to an import
+    source code to add an integrity check to an import.
+
+    As with 'hashExpression', the argument must already be αβ-normal.
 -}
 hashExpressionToCode :: Expr Void Void -> Text
 hashExpressionToCode expr =

--- a/dhall/src/Dhall/Main.hs
+++ b/dhall/src/Dhall/Main.hs
@@ -282,12 +282,12 @@ parseMode =
     <|> subcommand
             Interpret
             "resolve"
-            "Resolve an expression's imports"
+            "Resolve an expression's imports (import-free, not necessarily β-normal)"
             (Resolve <$> parseFile <*> parseResolveMode <*> parseSemanticCacheMode)
     <|> subcommand
             Interpret
             "type"
-            "Infer an expression's type"
+            "Infer an expression's type (after resolving imports; types may reflect unreduced lets)"
             (Type <$> parseFile <*> parseQuiet <*> parseSemanticCacheMode)
     <|> subcommand
             Interpret
@@ -802,6 +802,8 @@ command (Options {..}) = do
                  $   _cache
 
         Resolve { resolveMode = Nothing, ..} -> do
+            -- Unhashed Code imports are not β-normalized; this prints the
+            -- import-free typechecked tree, which may still contain lets.
             (expression, characterSet) <- getExpressionAndCharacterSet file
 
             resolvedExpression <-
@@ -826,6 +828,9 @@ command (Options {..}) = do
             render System.IO.stdout characterSet alphaNormalizedExpression
 
         Type {..} -> do
+            -- Inference sees the resolved (possibly unreduced) tree, so
+            -- pretty-printed binder names may differ from a fully
+            -- normalized import.
             (expression, characterSet) <- getExpressionAndCharacterSet file
 
             resolvedExpression <-

--- a/dhall/tests/Dhall/Test/DelayedNormalization.hs
+++ b/dhall/tests/Dhall/Test/DelayedNormalization.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Haskell-specific tests for delayed β-normalization of unhashed Code
+-- imports. The language standard permits (but does not require) this
+-- behavior; these cases lock in dhall-haskell's choice.
+module Dhall.Test.DelayedNormalization where
+
+import Control.Exception            (bracket)
+import Data.Void                    (Void)
+import Dhall.Src                    (Src)
+import System.FilePath              (takeDirectory, takeFileName, (</>))
+import Test.Tasty                   (TestTree)
+import Test.Tasty.HUnit             (assertBool, assertEqual, assertFailure, testCase)
+
+import qualified Data.ByteString        as ByteString
+import qualified Data.ByteString.Lazy   as ByteString.Lazy
+import qualified Data.Text              as Text
+import qualified Dhall.Binary           as Binary
+import qualified Dhall.Core             as Core
+import qualified Dhall.Freeze           as Freeze
+import qualified Dhall.Import           as Import
+import qualified Dhall.Parser           as Parser
+import qualified System.Directory       as Directory
+import qualified System.Environment     as Environment
+import qualified System.IO.Temp         as Temp
+import qualified Test.Tasty             as Tasty
+
+getTests :: IO TestTree
+getTests = return
+    (Tasty.testGroup "Delayed normalization of unhashed imports"
+        [ testCase "Unhashed Code is not β-normalized at resolve time"
+            unhashedResolveIsNotNormalTest
+        , testCase "Hashed Code is still inlined as β-normal form"
+            hashedResolveIsNormalTest
+        , testCase "freeze writes the αβ-normal form to the semantic cache"
+            freezeWritesNormalizedCacheTest
+        ])
+
+withTempCache :: (FilePath -> IO a) -> IO a
+withTempCache action =
+    Temp.withSystemTempDirectory "dhall-delayed-nf" $ \cacheDir -> do
+        originalCache <- Environment.lookupEnv "XDG_CACHE_HOME"
+
+        let setCache = Environment.setEnv "XDG_CACHE_HOME" cacheDir
+
+        let restoreCache =
+                maybe
+                    (Environment.unsetEnv "XDG_CACHE_HOME")
+                    (Environment.setEnv "XDG_CACHE_HOME")
+                    originalCache
+
+        bracket setCache (const restoreCache) (\_ -> action cacheDir)
+
+writeTempImport :: Text.Text -> IO FilePath
+writeTempImport contents =
+    Temp.writeTempFile "." "tmp.dhall" (Text.unpack contents)
+
+relativeImport :: FilePath -> Text.Text
+relativeImport path = "./" <> Text.pack (takeFileName path)
+
+loadNear :: FilePath -> Text.Text -> IO (Core.Expr Src Void)
+loadNear path exprText = do
+    parsed <- Core.throws (Parser.exprFromText mempty exprText)
+    Import.loadRelativeTo (takeDirectory path) Import.UseSemanticCache parsed
+
+reducibleSource :: Text.Text
+reducibleSource = "let x = 1 + 1 in x"
+
+expectedNF :: Core.Expr Void Void
+expectedNF = Core.NaturalLit 2
+
+-- | Unhashed @Code@ inlines the typechecked tree, so @let x = 1 + 1 in x@
+-- is still a @let@ after resolve. It is β-equivalent to @2@.
+unhashedResolveIsNotNormalTest :: IO ()
+unhashedResolveIsNotNormalTest = withTempCache $ \_cacheDir -> do
+    tempFile <- writeTempImport reducibleSource
+    loaded <- loadNear tempFile (relativeImport tempFile)
+
+    let denoted = Core.denote loaded :: Core.Expr Void Void
+    let nf = Core.normalize denoted :: Core.Expr Void Void
+
+    assertBool
+        "unhashed Code should still contain the let after resolve"
+        (denoted /= nf)
+    assertEqual
+        "unhashed Code should be β-equivalent to 2"
+        expectedNF
+        nf
+
+    Directory.removeFile tempFile
+
+-- | The same file with a matching integrity check is reduced before inlining,
+-- so resolve yields the β-normal form.
+hashedResolveIsNormalTest :: IO ()
+hashedResolveIsNormalTest = withTempCache $ \_cacheDir -> do
+    tempFile <- writeTempImport reducibleSource
+
+    let hashCode =
+            Import.hashExpressionToCode (Core.alphaNormalize expectedNF)
+
+    loaded <- loadNear tempFile (relativeImport tempFile <> " " <> hashCode)
+
+    let denoted = Core.denote loaded :: Core.Expr Void Void
+
+    assertEqual
+        "hashed Code should be inlined as the β-normal form"
+        expectedNF
+        (Core.alphaNormalize denoted)
+
+    Directory.removeFile tempFile
+
+-- | @dhall freeze@ must store the αβ-normal form under the frozen hash, even
+-- though @loadWith@ of the unprotected import is no longer β-normal.
+freezeWritesNormalizedCacheTest :: IO ()
+freezeWritesNormalizedCacheTest = withTempCache $ \cacheDir -> do
+    tempFile <- writeTempImport reducibleSource
+
+    let import_ =
+            Core.Import
+                { Core.importHashed =
+                    Core.ImportHashed
+                        { Core.hash = Nothing
+                        , Core.importType =
+                            Core.Local Core.Here Core.File
+                                { Core.directory = Core.Directory []
+                                , Core.file = Text.pack (takeFileName tempFile)
+                                }
+                        }
+                , Core.importMode = Core.Code
+                }
+
+    frozen <- Freeze.freezeImport (takeDirectory tempFile) import_
+
+    let expectedHash = Import.hashExpression (Core.alphaNormalize expectedNF)
+
+    assertEqual
+        "frozen hash should be the hash of the αβ-normal form"
+        (Just expectedHash)
+        (Core.hash (Core.importHashed frozen))
+
+    let cacheFile =
+            cacheDir </> "dhall" </> ("1220" <> show expectedHash)
+
+    exists <- Directory.doesFileExist cacheFile
+    assertBool
+        "freeze should write a semantic-cache file"
+        exists
+
+    bytes <- ByteString.readFile cacheFile
+    decoded <- case Binary.decodeExpression (ByteString.Lazy.fromStrict bytes) of
+        Left err ->
+            assertFailure ("failed to decode semantic-cache product: " <> show err)
+        Right expression ->
+            return (expression :: Core.Expr Void Void)
+
+    assertEqual
+        "semantic-cache product should be the αβ-normal form, not the let"
+        expectedNF
+        decoded
+
+    Directory.removeFile tempFile

--- a/dhall/tests/Dhall/Test/Main.hs
+++ b/dhall/tests/Dhall/Test/Main.hs
@@ -5,6 +5,7 @@ import System.FilePath ((</>))
 import Test.Tasty      (TestTree)
 
 import qualified Dhall.Test.CacheFill
+import qualified Dhall.Test.DelayedNormalization
 import qualified Dhall.Test.Dhall
 import qualified Dhall.Test.Diff
 import qualified Dhall.Test.DirectoryTree
@@ -48,6 +49,8 @@ getAllTests = do
 
     cacheFillTests <- Dhall.Test.CacheFill.getTests
 
+    delayedNormalizationTests <- Dhall.Test.DelayedNormalization.getTests
+
     semisemanticCacheTests <- Dhall.Test.SemisemanticCache.getTests
 
     lintTests <- Dhall.Test.Lint.getTests
@@ -68,6 +71,7 @@ getAllTests = do
                 , parsingTests
                 , importingTests
                 , cacheFillTests
+                , delayedNormalizationTests
                 , semisemanticCacheTests
                 , typeinferenceTests
                 , formattingTests


### PR DESCRIPTION
Unhashed Code is no longer β-normalized at resolve time, so freeze must write the αβ-normal form to the semantic cache. Haddocks, CLI help, and Haskell-only tests lock in that policy; the dhall-lang submodule is bumped to the matching spec clarification.

Previously the freeze command did not write the normal form to the cache; this was a bug. New unit tests prevent the freeze bug from occurring in the future.